### PR TITLE
feat(ruby): add D18P durable channel store

### DIFF
--- a/code/packages/ruby/chief-of-staff-channel-store/BUILD
+++ b/code/packages/ruby/chief-of-staff-channel-store/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/chief-of-staff-channel-store/BUILD_windows
+++ b/code/packages/ruby/chief-of-staff-channel-store/BUILD_windows
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/chief-of-staff-channel-store/CHANGELOG.md
+++ b/code/packages/ruby/chief-of-staff-channel-store/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0 - 2026-08-14
+
+- Add exact D18P codecs, keys, durable transitions, and endpoint roles.
+- Consume the shared Rust-generated D18P conformance manifest.
+- Keep sealed-grant cryptography behind the explicit #141 provider boundary.

--- a/code/packages/ruby/chief-of-staff-channel-store/Gemfile
+++ b/code/packages/ruby/chief-of-staff-channel-store/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec
+
+gem "coding_adventures_chacha20_poly1305", path: "../chacha20-poly1305"
+gem "coding_adventures_chief_of_staff_channel_crypto", path: "../chief-of-staff-channel-crypto"
+gem "coding_adventures_ed25519", path: "../ed25519"
+gem "coding_adventures_sha256", path: "../sha256"
+gem "coding_adventures_sha512", path: "../sha512"

--- a/code/packages/ruby/chief-of-staff-channel-store/README.md
+++ b/code/packages/ruby/chief-of-staff-channel-store/README.md
@@ -1,0 +1,20 @@
+# Chief of Staff Channel Store (Ruby)
+
+This package implements the
+[D18P portable durable-channel profile](../../../specs/D18P-chief-of-staff-durable-channel-profile.md)
+for Ruby and consumes the single shared fixture at
+`code/fixtures/chief-of-staff-channel/v1/manifest.json`.
+
+It provides exact `D18C`, `D18H`, `D18S`, and `D18A` codecs, deterministic
+storage keys, an injected atomic CAS backend, reserve-before-encrypt recovery,
+ordered paging, independent receiver cursors, irreversible destruction, and
+separate durable originator and receiver APIs. `D18M` cryptography is delegated
+to the Ruby channel-crypto package. D18P stores D18G grants as opaque bytes and
+keeps grant creation, opening, and rotation behind the issue #141 key-provider
+boundary.
+
+Run the package checks with `bundle exec rake test`.
+
+Fixture secrets are public test-only material. Errors, records, and APIs must
+never log or serialize plaintext, channel master keys, private keys, or opened
+grant contents.

--- a/code/packages/ruby/chief-of-staff-channel-store/Rakefile
+++ b/code/packages/ruby/chief-of-staff-channel-store/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new do |task|
+  task.libs << "lib"
+  task.pattern = "test/test_*.rb"
+  task.verbose = true
+end
+
+task default: :test

--- a/code/packages/ruby/chief-of-staff-channel-store/coding_adventures_chief_of_staff_channel_store.gemspec
+++ b/code/packages/ruby/chief-of-staff-channel-store/coding_adventures_chief_of_staff_channel_store.gemspec
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "coding_adventures_chief_of_staff_channel_store"
+  spec.version = "0.1.0"
+  spec.authors = ["Adhithya Rajasekaran"]
+  spec.summary = "Portable D18P durable channels for Chief of Staff"
+  spec.homepage = "https://github.com/adhithyan15/coding-adventures"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+  spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+  spec.metadata = {
+    "source_code_uri" => spec.homepage,
+    "rubygems_mfa_required" => "true"
+  }
+  spec.add_dependency "coding_adventures_chief_of_staff_channel_crypto", ">= 0.1.0"
+  spec.add_dependency "coding_adventures_sha256", ">= 0.1.0"
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store.rb
+++ b/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require "coding_adventures_chief_of_staff_channel_crypto"
+require "coding_adventures_sha256"
+
+module CodingAdventures
+  module ChiefOfStaffChannelStore
+    VERSION = "0.1.0"
+
+    STORAGE_NAMESPACE = "chief-channels"
+    DEFINITION_CONTENT_TYPE = "application/vnd.coding-adventures.chief-channel-definition-v1"
+    STATE_CONTENT_TYPE = "application/vnd.coding-adventures.chief-channel-state-v1"
+    MESSAGE_CONTENT_TYPE = "application/vnd.coding-adventures.chief-channel-message-v1"
+    GRANT_CONTENT_TYPE = "application/vnd.coding-adventures.chief-channel-key-grant-v1"
+    ACK_CONTENT_TYPE = "application/vnd.coding-adventures.chief-channel-ack-v1"
+    MAX_IDENTITY_BYTES = 4 * 1024
+    MAX_CONTENT_TYPE_BYTES = 1024
+    MAX_RECEIVERS = 1024
+    MAX_PENDING_HEADER_BYTES = 16 * 1024
+    MAX_STORE_CAS_ATTEMPTS = 16
+    MAX_DEFINITION_CAS_ATTEMPTS = 16
+    MAX_U64 = (1 << 64) - 1
+    ERROR_CODES = %w[
+      invalid_definition invalid_message_id definition_not_found conflicting_definition
+      corrupt_definition definition_changed channel_destroyed unauthorized_originator
+      unauthorized_receiver public_key_mismatch missing_key_grant unknown_message_id
+      unauthorized_message not_initialized corrupt_record pending_append no_pending_append
+      pending_header_mismatch conflicting_record concurrent_update invalid_receiver_id
+      invalid_page_size acknowledgement_regression acknowledgement_ahead
+      acknowledgement_pending sequence_exhausted storage_error wire_error crypto_error
+      metadata_error
+    ].freeze
+
+    class ChannelProfileError < StandardError
+      attr_reader :code
+
+      def initialize(code)
+        raise ArgumentError, "unknown D18P error code" unless ERROR_CODES.include?(code)
+
+        @code = code.freeze
+        super(code)
+      end
+    end
+
+    class OriginatorIdentity
+      def initialize(agent_id:, public_key:)
+        @agent_id = Support.bytes(agent_id, "invalid_definition")
+        @public_key = Support.bytes(public_key, "invalid_definition")
+        Support.fail!("invalid_definition") unless @public_key.bytesize == 32
+        freeze
+      end
+
+      def agent_id = @agent_id.dup
+      def public_key = @public_key.dup
+      def __values = [@agent_id, @public_key]
+    end
+
+    class ReceiverIdentity
+      def initialize(agent_id:, public_key:)
+        @agent_id = Support.bytes(agent_id, "invalid_definition")
+        @public_key = Support.bytes(public_key, "invalid_definition")
+        Support.fail!("invalid_definition") unless @public_key.bytesize == 32
+        freeze
+      end
+
+      def agent_id = @agent_id.dup
+      def public_key = @public_key.dup
+      def __values = [@agent_id, @public_key]
+    end
+
+    class ChannelDefinition
+      def initialize(channel_id:, originator:, receivers:, created_at_ns:, key_epoch:, lifecycle: "active")
+        @channel_id = Support.bytes(channel_id, "invalid_definition")
+        Support.uuid_v7!(@channel_id, "invalid_definition")
+        Support.fail!("invalid_definition") unless originator.is_a?(OriginatorIdentity) && receivers.respond_to?(:to_a)
+        @originator = OriginatorIdentity.new(agent_id: originator.agent_id, public_key: originator.public_key)
+        Support.agent_id!(@originator.agent_id, "invalid_definition")
+        @receivers = receivers.to_a.map { |receiver| ReceiverIdentity.new(agent_id: receiver.agent_id, public_key: receiver.public_key) }
+        @receivers.sort_by!(&:agent_id)
+        Support.fail!("invalid_definition") unless @receivers.length.between?(1, MAX_RECEIVERS)
+        previous = nil
+        @receivers.each do |receiver|
+          id = receiver.agent_id
+          Support.agent_id!(id, "invalid_definition")
+          Support.fail!("invalid_definition") if id == @originator.agent_id || id == previous
+          previous = id
+        end
+        Support.u64!(created_at_ns, "invalid_definition")
+        Support.u64!(key_epoch, "invalid_definition")
+        Support.fail!("invalid_definition") unless %w[active destroyed].include?(lifecycle)
+        @created_at_ns = created_at_ns
+        @key_epoch = key_epoch
+        @lifecycle = lifecycle.dup.freeze
+        @receivers.freeze
+        freeze
+      end
+
+      def channel_id = @channel_id.dup
+      def originator = OriginatorIdentity.new(agent_id: @originator.agent_id, public_key: @originator.public_key)
+      def receivers = @receivers.map { |receiver| ReceiverIdentity.new(agent_id: receiver.agent_id, public_key: receiver.public_key) }.freeze
+      def created_at_ns = @created_at_ns
+      def key_epoch = @key_epoch
+      def lifecycle = @lifecycle.dup
+      def receiver(agent_id) = @receivers.find { |receiver| receiver.agent_id == agent_id }
+      def with_lifecycle(value) = ChannelDefinition.new(channel_id: @channel_id, originator: @originator, receivers: @receivers, created_at_ns: @created_at_ns, key_epoch: @key_epoch, lifecycle: value)
+      def ==(other) = other.is_a?(ChannelDefinition) && ChannelProfile.definition_serialize(self) == ChannelProfile.definition_serialize(other)
+      alias eql? ==
+    end
+
+    class MessageHeader
+      def initialize(message_id:, timestamp_ns:, originator_id:, channel_id:, sequence:, key_epoch:, content_type:, plaintext_hash:)
+        @message_id = Support.bytes(message_id, "wire_error")
+        @originator_id = Support.bytes(originator_id, "wire_error")
+        @channel_id = Support.bytes(channel_id, "wire_error")
+        @content_type = Support.text(content_type, "wire_error")
+        @plaintext_hash = Support.bytes(plaintext_hash, "wire_error")
+        Support.fail!("wire_error") unless @message_id.bytesize == 16 && @channel_id.bytesize == 16 && @plaintext_hash.bytesize == 32
+        Support.u64!(timestamp_ns, "wire_error")
+        Support.u64!(sequence, "wire_error")
+        Support.u64!(key_epoch, "wire_error")
+        Support.fail!("wire_error") if @originator_id.bytesize > MAX_IDENTITY_BYTES || @content_type.bytesize > MAX_CONTENT_TYPE_BYTES
+        @timestamp_ns = timestamp_ns
+        @sequence = sequence
+        @key_epoch = key_epoch
+        freeze
+      end
+
+      def message_id = @message_id.dup
+      def timestamp_ns = @timestamp_ns
+      def originator_id = @originator_id.dup
+      def channel_id = @channel_id.dup
+      def sequence = @sequence
+      def key_epoch = @key_epoch
+      def content_type = @content_type.dup
+      def plaintext_hash = @plaintext_hash.dup
+      def __values = [@message_id, @timestamp_ns, @originator_id, @channel_id, @sequence, @key_epoch, @content_type, @plaintext_hash]
+      def ==(other) = other.is_a?(MessageHeader) && ChannelProfile.header_serialize(self) == ChannelProfile.header_serialize(other)
+      alias eql? ==
+    end
+
+    class ChannelState
+      attr_reader :next_sequence, :pending_header
+
+      def initialize(next_sequence:, pending_header: nil)
+        Support.u64!(next_sequence, "corrupt_record")
+        Support.fail!("corrupt_record") unless pending_header.nil? || pending_header.is_a?(MessageHeader)
+        @next_sequence = next_sequence
+        @pending_header = pending_header
+        freeze
+      end
+    end
+
+    module Support
+      module_function
+
+      def fail!(code) = raise(ChannelProfileError, code)
+
+      def bytes(value, code)
+        fail!(code) unless value.is_a?(String)
+        value.b.dup.freeze
+      rescue Encoding::CompatibilityError
+        fail!(code)
+      end
+
+      def text(value, code)
+        fail!(code) unless value.is_a?(String)
+        copy = value.dup.force_encoding(Encoding::UTF_8)
+        fail!(code) unless copy.valid_encoding?
+        copy.freeze
+      end
+
+      def u64!(value, code)
+        fail!(code) unless value.is_a?(Integer) && value.between?(0, MAX_U64)
+      end
+
+      def agent_id!(value, code)
+        fail!(code) unless value.is_a?(String) && value.bytesize.between?(1, MAX_IDENTITY_BYTES)
+      end
+
+      def uuid_v7!(value, code)
+        fail!(code) unless value.bytesize == 16 && value.getbyte(6) >> 4 == 7 && value.getbyte(8) & 0xc0 == 0x80
+      end
+
+      def remap(code)
+        yield
+      rescue StandardError
+        fail!(code)
+      end
+
+      def digest(value) = CodingAdventures::Sha256.sha256(value)
+    end
+
+    class Writer
+      def initialize = @value = +"".b
+      def bytes(value) = (@value << value; self)
+      def u8(value) = bytes([value].pack("C"))
+      def u32(value) = bytes([value].pack("N"))
+      def u64(value) = bytes([value].pack("Q>"))
+      def sized(value) = u32(value.bytesize).bytes(value)
+      def finish = @value.dup.freeze
+    end
+
+    class Reader
+      def initialize(value, code)
+        @value = Support.bytes(value, code)
+        @position = 0
+        @code = code
+      end
+
+      def take(length)
+        Support.fail!(@code) unless length.is_a?(Integer) && length >= 0 && @position + length <= @value.bytesize
+        result = @value.byteslice(@position, length)
+        @position += length
+        result
+      end
+
+      def u8 = take(1).unpack1("C")
+      def u32 = take(4).unpack1("N")
+      def u64 = take(8).unpack1("Q>")
+      def sized(maximum) = (length = u32; Support.fail!(@code) if length > maximum; take(length))
+      def magic(value)
+        Support.fail!(@code) unless take(4) == value
+      end
+
+      def version
+        Support.fail!(@code) unless u8 == 1
+      end
+
+      def finish
+        Support.fail!(@code) unless @position == @value.bytesize
+      end
+    end
+
+    module ChannelProfile
+      module_function
+
+      def definition_serialize(definition)
+        writer = Writer.new.bytes("D18C".b).u8(1).bytes(definition.channel_id)
+        writer.sized(definition.originator.agent_id).bytes(definition.originator.public_key).u32(definition.receivers.length)
+        definition.receivers.each { |receiver| writer.sized(receiver.agent_id).bytes(receiver.public_key) }
+        writer.u64(definition.created_at_ns).u64(definition.key_epoch).u8(definition.lifecycle == "active" ? 0 : 1).finish
+      end
+
+      def definition_deserialize(value)
+        Support.remap("corrupt_definition") do
+          reader = Reader.new(value, "corrupt_definition")
+          reader.magic("D18C".b)
+          reader.version
+          channel_id = reader.take(16)
+          originator = OriginatorIdentity.new(agent_id: reader.sized(MAX_IDENTITY_BYTES), public_key: reader.take(32))
+          count = reader.u32
+          Support.fail!("corrupt_definition") unless count.between?(1, MAX_RECEIVERS)
+          receivers = Array.new(count) { ReceiverIdentity.new(agent_id: reader.sized(MAX_IDENTITY_BYTES), public_key: reader.take(32)) }
+          created_at_ns = reader.u64
+          key_epoch = reader.u64
+          lifecycle = reader.u8
+          Support.fail!("corrupt_definition") unless lifecycle.between?(0, 1)
+          reader.finish
+          ChannelDefinition.new(channel_id: channel_id, originator: originator, receivers: receivers, created_at_ns: created_at_ns, key_epoch: key_epoch, lifecycle: lifecycle.zero? ? "active" : "destroyed")
+        end
+      end
+
+      def header_serialize(header)
+        values = header.__values
+        Writer.new.bytes("D18H".b).u8(1).bytes(values[0]).u64(values[1]).sized(values[2]).bytes(values[3]).u64(values[4]).u64(values[5]).sized(values[6].b).bytes(values[7]).finish
+      end
+
+      def header_deserialize(value)
+        reader = Reader.new(value, "wire_error")
+        reader.magic("D18H".b)
+        reader.version
+        message_id = reader.take(16)
+        timestamp_ns = reader.u64
+        originator_id = reader.sized(MAX_IDENTITY_BYTES)
+        channel_id = reader.take(16)
+        sequence = reader.u64
+        key_epoch = reader.u64
+        content_type = reader.sized(MAX_CONTENT_TYPE_BYTES).force_encoding(Encoding::UTF_8)
+        Support.fail!("wire_error") unless content_type.valid_encoding?
+        plaintext_hash = reader.take(32)
+        reader.finish
+        MessageHeader.new(message_id: message_id, timestamp_ns: timestamp_ns, originator_id: originator_id, channel_id: channel_id, sequence: sequence, key_epoch: key_epoch, content_type: content_type, plaintext_hash: plaintext_hash)
+      end
+
+      def state_serialize(state)
+        writer = Writer.new.bytes("D18S".b).u8(1).u64(state.next_sequence)
+        return writer.u8(0).finish if state.pending_header.nil?
+
+        header = header_serialize(state.pending_header)
+        Support.fail!("corrupt_record") if header.bytesize > MAX_PENDING_HEADER_BYTES
+        writer.u8(1).u32(header.bytesize).bytes(header).finish
+      end
+
+      def state_deserialize(value, channel_id)
+        Support.remap("corrupt_record") do
+          reader = Reader.new(value, "corrupt_record")
+          reader.magic("D18S".b)
+          reader.version
+          next_sequence = reader.u64
+          flag = reader.u8
+          if flag.zero?
+            reader.finish
+            next ChannelState.new(next_sequence: next_sequence)
+          end
+          Support.fail!("corrupt_record") unless flag == 1
+          length = reader.u32
+          Support.fail!("corrupt_record") if length > MAX_PENDING_HEADER_BYTES
+          pending = header_deserialize(reader.take(length))
+          reader.finish
+          Support.fail!("corrupt_record") unless pending.channel_id == channel_id && pending.sequence != MAX_U64 && pending.sequence + 1 == next_sequence
+          ChannelState.new(next_sequence: next_sequence, pending_header: pending)
+        end
+      end
+
+      def cursor_serialize(first_unread) = (Support.u64!(first_unread, "corrupt_record"); "D18A".b + [1, first_unread].pack("CQ>"))
+
+      def cursor_deserialize(value)
+        reader = Reader.new(value, "corrupt_record")
+        reader.magic("D18A".b)
+        reader.version
+        result = reader.u64
+        reader.finish
+        result
+      end
+
+      def definition_key(channel_id) = checked_channel(channel_id, "invalid_definition") + "/definition"
+      def state_key(channel_id) = checked_channel(channel_id, "invalid_definition") + "/state/next-sequence"
+      def message_prefix(channel_id) = checked_channel(channel_id, "invalid_definition") + "/messages/"
+      def message_key(channel_id, sequence) = message_prefix(channel_id) + format("%020d", sequence)
+
+      def grant_key(channel_id, epoch, receiver_id)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        checked_channel(channel_id, "invalid_definition") + "/grants/#{format('%020d', epoch)}/#{Support.digest(receiver_id).unpack1('H*')}"
+      end
+
+      def ack_key(channel_id, receiver_id)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        checked_channel(channel_id, "invalid_definition") + "/receivers/#{Support.digest(receiver_id).unpack1('H*')}/ack"
+      end
+
+      def checked_channel(value, code)
+        bytes = Support.bytes(value, code)
+        Support.fail!(code) unless bytes.bytesize == 16
+        bytes.unpack1("H*")
+      end
+    end
+  end
+end
+
+require_relative "coding_adventures_chief_of_staff_channel_store/storage"
+require_relative "coding_adventures_chief_of_staff_channel_store/endpoints"

--- a/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store/endpoints.rb
+++ b/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store/endpoints.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module ChiefOfStaffChannelStore
+    MessageMetadata = Struct.new(:message_id, :timestamp_ns, keyword_init: true)
+    PublishedMessage = Struct.new(:message_id, :sequence, :timestamp_ns, keyword_init: true)
+    ReceivedMessage = Struct.new(:message_id, :sequence, :timestamp_ns, :content_type, :payload, keyword_init: true)
+
+    class ChannelDefinitionStore
+      def initialize(backend) = @backend = backend
+
+      def create(definition)
+        Support.fail!("invalid_definition") unless definition.lifecycle == "active"
+        backend { @backend.initialize_backend }
+        key = ChannelProfile.definition_key(definition.channel_id)
+        body = ChannelProfile.definition_serialize(definition)
+        begin
+          persisted = require_record(@backend.put(StoragePut.new(namespace: STORAGE_NAMESPACE, key: key, content_type: DEFINITION_CONTENT_TYPE, body: body, if_absent: true)), definition.channel_id)
+        rescue StorageConflictError
+          existing = backend { @backend.get(STORAGE_NAMESPACE, key) }
+          Support.fail!("definition_not_found") if existing.nil?
+          Support.fail!("corrupt_definition") unless existing.content_type == DEFINITION_CONTENT_TYPE
+          Support.fail!("conflicting_definition") unless existing.body == body
+          persisted = require_record(existing, definition.channel_id)
+        rescue StandardError => error
+          raise backend_error(error)
+        end
+        Support.fail!("conflicting_definition") unless persisted == definition
+        ChannelStore.new(@backend, definition.channel_id).initialize_store
+        require_current(definition)
+      end
+
+      def load(channel_id)
+        backend { @backend.initialize_backend }
+        loaded = load_record(channel_id)
+        loaded&.first
+      end
+
+      def destroy(channel_id)
+        backend { @backend.initialize_backend }
+        MAX_DEFINITION_CAS_ATTEMPTS.times do
+          loaded = load_record(channel_id)
+          Support.fail!("definition_not_found") if loaded.nil?
+          definition, revision = loaded
+          return definition if definition.lifecycle == "destroyed"
+
+          destroyed = definition.with_lifecycle("destroyed")
+          begin
+            record = @backend.put(StoragePut.new(namespace: STORAGE_NAMESPACE, key: ChannelProfile.definition_key(channel_id), content_type: DEFINITION_CONTENT_TYPE, body: ChannelProfile.definition_serialize(destroyed), if_revision: revision))
+            return require_record(record, channel_id)
+          rescue StorageConflictError
+            next
+          rescue StandardError => error
+            raise backend_error(error)
+          end
+        end
+        Support.fail!("concurrent_update")
+      end
+
+      def require_current(expected)
+        actual = load(expected.channel_id)
+        Support.fail!("definition_not_found") if actual.nil?
+        Support.fail!("channel_destroyed") if actual.lifecycle == "destroyed"
+        Support.fail!("definition_changed") unless actual == expected
+        actual
+      end
+
+      private
+
+      def load_record(channel_id)
+        key = ChannelProfile.definition_key(channel_id)
+        record = backend { @backend.get(STORAGE_NAMESPACE, key) }
+        return nil if record.nil?
+
+        [require_record(record, channel_id), record.revision]
+      end
+
+      def require_record(record, channel_id)
+        Support.fail!("corrupt_definition") unless record.content_type == DEFINITION_CONTENT_TYPE
+        definition = ChannelProfile.definition_deserialize(record.body)
+        Support.fail!("corrupt_definition") unless definition.channel_id == channel_id && record.key == ChannelProfile.definition_key(channel_id)
+        definition
+      end
+
+      def backend
+        yield
+      rescue ChannelProfileError, StorageConflictError
+        raise
+      rescue StandardError => error
+        raise backend_error(error)
+      end
+
+      def backend_error(error) = error.is_a?(ChannelProfileError) ? error : ChannelProfileError.new("storage_error")
+    end
+
+    class DurableOriginator
+      def self.open(backend:, channel_id:, agent_id:, signing_secret_key:, channel_master_key:, metadata_source:)
+        definition = EndpointSupport.active_definition(backend, channel_id)
+        Support.fail!("unauthorized_originator") unless definition.originator.agent_id == agent_id
+        Support.fail!("public_key_mismatch") unless signing_secret_key.is_a?(String) && signing_secret_key.bytesize == 64 && definition.originator.public_key == signing_secret_key.byteslice(32, 32)
+        Support.fail!("crypto_error") unless channel_master_key.is_a?(String) && channel_master_key.bytesize == 32
+        ChannelStore.new(backend, channel_id).initialize_store
+        new(backend, definition, signing_secret_key, channel_master_key, metadata_source)
+      end
+
+      def initialize(backend, definition, signing_secret_key, channel_master_key, metadata_source)
+        @backend = backend
+        @definition = definition
+        @signing_secret_key = signing_secret_key.b.dup.freeze
+        @channel_master_key = channel_master_key.b.dup.freeze
+        @metadata_source = metadata_source
+      end
+
+      def id = @definition.originator.agent_id
+      def channel_id = @definition.channel_id
+      def public_key = @definition.originator.public_key
+
+      def publish(payload, content_type)
+        metadata = @metadata_source.next
+        publish_with_metadata(metadata, payload, content_type)
+      rescue ChannelProfileError
+        raise
+      rescue StandardError
+        Support.fail!("metadata_error")
+      end
+
+      def publish_with_metadata(metadata, payload, content_type)
+        Support.uuid_v7!(metadata.message_id, "invalid_message_id")
+        ChannelDefinitionStore.new(@backend).require_current(@definition)
+        request = AppendRequest.new(message_id: metadata.message_id, timestamp_ns: metadata.timestamp_ns, originator_id: @definition.originator.agent_id, key_epoch: @definition.key_epoch, content_type: content_type)
+        message = ChannelStore.new(@backend, @definition.channel_id).append(request, payload, @channel_master_key, @signing_secret_key)
+        PublishedMessage.new(message_id: metadata.message_id.b.dup.freeze, sequence: message.sequence, timestamp_ns: metadata.timestamp_ns).freeze
+      end
+
+      def save_receiver_grant(receiver_id, grant_body)
+        definition = ChannelDefinitionStore.new(@backend).require_current(@definition)
+        Support.fail!("unauthorized_receiver") if definition.receiver(receiver_id).nil?
+        ChannelStore.new(@backend, definition.channel_id).save_key_grant(OpaqueKeyGrant.new(channel_id: definition.channel_id, key_epoch: definition.key_epoch, receiver_id: receiver_id.b.dup.freeze, body: grant_body.b.dup.freeze))
+      end
+    end
+
+    class DurableReceiver
+      def self.open(backend:, channel_id:, receiver_id:, key_provider:)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        definition = EndpointSupport.active_definition(backend, channel_id)
+        receiver = definition.receiver(receiver_id)
+        Support.fail!("unauthorized_receiver") if receiver.nil?
+        Support.fail!("public_key_mismatch") unless receiver.public_key == key_provider.public_key
+        ChannelStore.new(backend, channel_id).initialize_store
+        new(backend, definition, receiver_id, key_provider)
+      end
+
+      def initialize(backend, definition, receiver_id, key_provider)
+        @backend = backend
+        @definition = definition
+        @receiver_id = receiver_id.b.dup.freeze
+        @key_provider = key_provider
+        @delivered = {}
+      end
+
+      def id = @receiver_id.dup
+      def channel_id = @definition.channel_id
+      def public_key = @key_provider.public_key.b.dup
+
+      def receive(limit)
+        ChannelDefinitionStore.new(@backend).require_current(@definition)
+        store = ChannelStore.new(@backend, @definition.channel_id)
+        page = store.read_for_receiver(@receiver_id, limit)
+        page.messages.map do |message|
+          Support.fail!("unauthorized_message") unless message.channel_id == @definition.channel_id && message.originator_id == @definition.originator.agent_id && message.key_epoch <= @definition.key_epoch
+          grant = store.key_grant(message.key_epoch, @receiver_id)
+          Support.fail!("missing_key_grant") if grant.nil?
+          begin
+            channel_key = @key_provider.open_grant(message.key_epoch, grant)
+          rescue StandardError
+            Support.fail!("crypto_error")
+          end
+          Support.fail!("missing_key_grant") if channel_key.nil?
+          begin
+            payload = Crypto.message_verify(message, @definition.originator.public_key, channel_key)
+          rescue StandardError
+            Support.fail!("crypto_error")
+          end
+          Support.uuid_v7!(message.message_id, "invalid_message_id")
+          prior = @delivered[message.message_id]
+          Support.fail!("unauthorized_message") if !prior.nil? && prior != message.sequence
+          @delivered[message.message_id] = message.sequence
+          ReceivedMessage.new(message_id: message.message_id, sequence: message.sequence, timestamp_ns: message.timestamp_ns, content_type: message.content_type, payload: payload.b.dup.freeze).freeze
+        end.freeze
+      end
+
+      def acknowledge(message_id)
+        Support.uuid_v7!(message_id, "invalid_message_id")
+        ChannelDefinitionStore.new(@backend).require_current(@definition)
+        sequence = @delivered[message_id]
+        Support.fail!("unknown_message_id") if sequence.nil?
+        ChannelStore.new(@backend, @definition.channel_id).acknowledge(@receiver_id, sequence)
+      end
+    end
+
+    module EndpointSupport
+      module_function
+
+      def active_definition(backend, channel_id)
+        definition = ChannelDefinitionStore.new(backend).load(channel_id)
+        Support.fail!("definition_not_found") if definition.nil?
+        Support.fail!("channel_destroyed") if definition.lifecycle == "destroyed"
+        definition
+      end
+    end
+  end
+end

--- a/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store/storage.rb
+++ b/code/packages/ruby/chief-of-staff-channel-store/lib/coding_adventures_chief_of_staff_channel_store/storage.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+require "thread"
+
+module CodingAdventures
+  module ChiefOfStaffChannelStore
+    Crypto = CodingAdventures::ChiefOfStaffChannelCrypto
+
+    class StorageConflictError < StandardError; end
+
+    class StorageRecord
+      attr_reader :namespace, :key, :content_type, :revision
+
+      def initialize(namespace:, key:, content_type:, body:, revision:)
+        @namespace = namespace.dup.freeze
+        @key = key.dup.freeze
+        @content_type = content_type.dup.freeze
+        @body = Support.bytes(body, "storage_error")
+        @revision = revision.dup.freeze
+        freeze
+      end
+
+      def body = @body.dup
+    end
+
+    class StoragePut
+      attr_reader :namespace, :key, :content_type, :if_absent, :if_revision
+
+      def initialize(namespace:, key:, content_type:, body:, if_absent: false, if_revision: nil)
+        @namespace = namespace.dup.freeze
+        @key = key.dup.freeze
+        @content_type = content_type.dup.freeze
+        @body = Support.bytes(body, "storage_error")
+        @if_absent = if_absent
+        @if_revision = if_revision&.dup&.freeze
+        freeze
+      end
+
+      def body = @body.dup
+    end
+
+    class StoragePage
+      attr_reader :records, :next_cursor
+
+      def initialize(records:, next_cursor: nil)
+        @records = records.freeze
+        @next_cursor = next_cursor&.dup&.freeze
+        freeze
+      end
+    end
+
+    class MemoryChannelStorage
+      def initialize
+        @records = {}
+        @revision = 0
+        @mutex = Mutex.new
+      end
+
+      def initialize_backend = nil
+
+      def get(namespace, key)
+        @mutex.synchronize { clone_record(@records[[namespace, key]]) }
+      end
+
+      def put(value)
+        @mutex.synchronize do
+          raise ArgumentError, "exactly one storage condition is required" if value.if_absent == !value.if_revision.nil?
+
+          map_key = [value.namespace, value.key]
+          current = @records[map_key]
+          raise StorageConflictError if value.if_absent ? !current.nil? : current.nil? || current.revision != value.if_revision
+
+          @revision += 1
+          record = StorageRecord.new(namespace: value.namespace, key: value.key, content_type: value.content_type, body: value.body, revision: "r#{@revision}")
+          @records[map_key] = record
+          clone_record(record)
+        end
+      end
+
+      def list(namespace, prefix:, recursive:, page_size:, cursor: nil)
+        raise ArgumentError, "invalid backend list options" unless recursive && page_size.is_a?(Integer) && page_size.positive?
+
+        @mutex.synchronize do
+          records = @records.values.select do |record|
+            record.namespace == namespace && record.key.start_with?(prefix) && (cursor.nil? || record.key > cursor)
+          end.sort_by(&:key)
+          selected = records.first(page_size).map { |record| clone_record(record) }
+          next_cursor = records.length > selected.length ? selected.last.key : nil
+          StoragePage.new(records: selected, next_cursor: next_cursor)
+        end
+      end
+
+      def corrupt(record)
+        @mutex.synchronize { @records[[record.namespace, record.key]] = clone_record(record) }
+      end
+
+      private
+
+      def clone_record(record)
+        return nil if record.nil?
+
+        StorageRecord.new(namespace: record.namespace, key: record.key, content_type: record.content_type, body: record.body, revision: record.revision)
+      end
+    end
+
+    AppendRequest = Struct.new(:message_id, :timestamp_ns, :originator_id, :key_epoch, :content_type, keyword_init: true)
+    MessagePage = Struct.new(:messages, :next_start, keyword_init: true)
+    OpaqueKeyGrant = Struct.new(:channel_id, :key_epoch, :receiver_id, :body, keyword_init: true)
+
+    class ChannelStore
+      def initialize(backend, channel_id)
+        Support.uuid_v7!(channel_id, "corrupt_record")
+        @backend = backend
+        @channel_id = Support.bytes(channel_id, "corrupt_record")
+      end
+
+      def initialize_store
+        storage { @backend.initialize_backend }
+        record = state_record
+        return decode_state(record) unless record.nil?
+
+        body = ChannelProfile.state_serialize(ChannelState.new(next_sequence: 0))
+        begin
+          decode_state(@backend.put(put_input(ChannelProfile.state_key(@channel_id), STATE_CONTENT_TYPE, body, if_absent: true)))
+        rescue StorageConflictError
+          state
+        rescue StandardError => error
+          raise storage_error(error)
+        end
+      end
+
+      def state
+        record = state_record
+        Support.fail!("not_initialized") if record.nil?
+        decode_state(record)
+      end
+
+      def reserve_append(request, plaintext)
+        Support.uuid_v7!(request.message_id, "invalid_message_id")
+        begin
+          fields = Crypto::MessageFields.new(message_id: request.message_id, timestamp_ns: request.timestamp_ns, originator_id: request.originator_id, channel_id: @channel_id, sequence: 0, key_epoch: request.key_epoch, content_type: request.content_type)
+          Crypto.validate_message_fields(fields)
+        rescue StandardError
+          Support.fail!("crypto_error")
+        end
+        MAX_STORE_CAS_ATTEMPTS.times do
+          record = state_record
+          Support.fail!("not_initialized") if record.nil?
+          current = decode_state(record)
+          Support.fail!("pending_append") unless current.pending_header.nil?
+          Support.fail!("sequence_exhausted") if current.next_sequence == MAX_U64
+          header = MessageHeader.new(
+            message_id: request.message_id, timestamp_ns: request.timestamp_ns, originator_id: request.originator_id,
+            channel_id: @channel_id, sequence: current.next_sequence, key_epoch: request.key_epoch,
+            content_type: request.content_type, plaintext_hash: Support.digest(Support.bytes(plaintext, "crypto_error"))
+          )
+          body = ChannelProfile.state_serialize(ChannelState.new(next_sequence: current.next_sequence + 1, pending_header: header))
+          begin
+            @backend.put(put_input(ChannelProfile.state_key(@channel_id), STATE_CONTENT_TYPE, body, if_revision: record.revision))
+            return header
+          rescue StorageConflictError
+            next
+          rescue StandardError => error
+            raise storage_error(error)
+          end
+        end
+        Support.fail!("concurrent_update")
+      end
+
+      def commit_reserved(header, plaintext, channel_master_key, signing_secret_key)
+        Support.fail!("pending_header_mismatch") unless header.channel_id == @channel_id
+        current = state
+        key = ChannelProfile.message_key(@channel_id, header.sequence)
+        if current.pending_header.nil?
+          record = storage { @backend.get(STORAGE_NAMESPACE, key) }
+          Support.fail!("no_pending_append") if record.nil?
+          stored = decode_message(record)
+          Support.fail!("conflicting_record") unless message_matches?(stored, header)
+          expected = create_message(header, plaintext, signing_secret_key, channel_master_key)
+          Support.fail!("conflicting_record") unless Crypto.message_serialize(expected) == record.body
+          return stored
+        end
+        Support.fail!("pending_header_mismatch") unless current.pending_header == header
+        message = create_message(header, plaintext, signing_secret_key, channel_master_key)
+        put_idempotent(key, MESSAGE_CONTENT_TYPE, Crypto.message_serialize(message))
+        clear_pending(header)
+        message
+      end
+
+      def append(request, plaintext, channel_master_key, signing_secret_key)
+        commit_reserved(reserve_append(request, plaintext), plaintext, channel_master_key, signing_secret_key)
+      end
+
+      def abandon_pending
+        MAX_STORE_CAS_ATTEMPTS.times do
+          record = state_record
+          Support.fail!("not_initialized") if record.nil?
+          current = decode_state(record)
+          return nil if current.pending_header.nil?
+
+          body = ChannelProfile.state_serialize(ChannelState.new(next_sequence: current.next_sequence))
+          begin
+            @backend.put(put_input(ChannelProfile.state_key(@channel_id), STATE_CONTENT_TYPE, body, if_revision: record.revision))
+            return current.pending_header
+          rescue StorageConflictError
+            next
+          rescue StandardError => error
+            raise storage_error(error)
+          end
+        end
+        Support.fail!("concurrent_update")
+      end
+
+      def read_messages(start, page_size)
+        Support.u64!(start, "corrupt_record")
+        Support.fail!("invalid_page_size") unless page_size.is_a?(Integer) && page_size.positive?
+        cursor = start.positive? ? ChannelProfile.message_key(@channel_id, start - 1) : nil
+        page = storage { @backend.list(STORAGE_NAMESPACE, prefix: ChannelProfile.message_prefix(@channel_id), recursive: true, page_size: page_size, cursor: cursor) }
+        messages = []
+        page.records.each do |record|
+          message = decode_message(record)
+          Support.fail!("corrupt_record") unless message.channel_id == @channel_id && message.sequence >= start && record.key == ChannelProfile.message_key(@channel_id, message.sequence) && (messages.empty? || messages.last.sequence < message.sequence)
+          messages << message
+        end
+        next_start = nil
+        unless page.next_cursor.nil?
+          Support.fail!("corrupt_record") if messages.empty? || messages.last.sequence == MAX_U64
+          next_start = messages.last.sequence + 1
+        end
+        MessagePage.new(messages: messages.freeze, next_start: next_start)
+      end
+
+      def read_for_receiver(receiver_id, page_size) = read_messages(receiver_cursor(receiver_id), page_size)
+
+      def receiver_cursor(receiver_id)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        record = storage { @backend.get(STORAGE_NAMESPACE, ChannelProfile.ack_key(@channel_id, receiver_id)) }
+        return 0 if record.nil?
+
+        require_content_type(record, ACK_CONTENT_TYPE)
+        ChannelProfile.cursor_deserialize(record.body)
+      end
+
+      def acknowledge(receiver_id, acknowledged)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        Support.u64!(acknowledged, "acknowledgement_ahead")
+        current_state = state
+        Support.fail!("acknowledgement_ahead") if acknowledged >= current_state.next_sequence
+        Support.fail!("acknowledgement_pending") if !current_state.pending_header.nil? && acknowledged >= current_state.pending_header.sequence
+        Support.fail!("sequence_exhausted") if acknowledged == MAX_U64
+        desired = acknowledged + 1
+        key = ChannelProfile.ack_key(@channel_id, receiver_id)
+        MAX_STORE_CAS_ATTEMPTS.times do
+          record = storage { @backend.get(STORAGE_NAMESPACE, key) }
+          if record.nil?
+            begin
+              @backend.put(put_input(key, ACK_CONTENT_TYPE, ChannelProfile.cursor_serialize(desired), if_absent: true))
+              return desired
+            rescue StorageConflictError
+              next
+            rescue StandardError => error
+              raise storage_error(error)
+            end
+          end
+          require_content_type(record, ACK_CONTENT_TYPE)
+          current = ChannelProfile.cursor_deserialize(record.body)
+          Support.fail!("acknowledgement_regression") if desired < current
+          return current if desired == current
+
+          begin
+            @backend.put(put_input(key, ACK_CONTENT_TYPE, ChannelProfile.cursor_serialize(desired), if_revision: record.revision))
+            return desired
+          rescue StorageConflictError
+            next
+          rescue StandardError => error
+            raise storage_error(error)
+          end
+        end
+        Support.fail!("concurrent_update")
+      end
+
+      def save_key_grant(grant)
+        Support.fail!("corrupt_record") unless grant.channel_id == @channel_id
+        Support.agent_id!(grant.receiver_id, "invalid_receiver_id")
+        put_idempotent(ChannelProfile.grant_key(@channel_id, grant.key_epoch, grant.receiver_id), GRANT_CONTENT_TYPE, grant.body)
+      end
+
+      def key_grant(key_epoch, receiver_id)
+        Support.agent_id!(receiver_id, "invalid_receiver_id")
+        record = storage { @backend.get(STORAGE_NAMESPACE, ChannelProfile.grant_key(@channel_id, key_epoch, receiver_id)) }
+        return nil if record.nil?
+
+        require_content_type(record, GRANT_CONTENT_TYPE)
+        record.body
+      end
+
+      private
+
+      def state_record = storage { @backend.get(STORAGE_NAMESPACE, ChannelProfile.state_key(@channel_id)) }
+      def decode_state(record) = (require_content_type(record, STATE_CONTENT_TYPE); ChannelProfile.state_deserialize(record.body, @channel_id))
+
+      def decode_message(record)
+        require_content_type(record, MESSAGE_CONTENT_TYPE)
+        Crypto.message_deserialize(record.body)
+      rescue Crypto::MessageProfileError
+        Support.fail!("wire_error")
+      end
+
+      def create_message(header, plaintext, signing_secret_key, channel_master_key)
+        plain = Support.bytes(plaintext, "crypto_error")
+        Support.fail!("crypto_error") unless Support.digest(plain) == header.plaintext_hash
+        values = header.__values
+        fields = Crypto::MessageFields.new(message_id: values[0], timestamp_ns: values[1], originator_id: values[2], channel_id: values[3], sequence: values[4], key_epoch: values[5], content_type: values[6])
+        Crypto.message_create(fields, plain, signing_secret_key, channel_master_key)
+      rescue ChannelProfileError
+        raise
+      rescue StandardError
+        Support.fail!("crypto_error")
+      end
+
+      def message_matches?(message, header)
+        values = header.__values
+        [message.message_id, message.timestamp_ns, message.originator_id, message.channel_id, message.sequence, message.key_epoch, message.content_type, message.plaintext_hash] == values
+      end
+
+      def clear_pending(expected)
+        MAX_STORE_CAS_ATTEMPTS.times do
+          record = state_record
+          Support.fail!("not_initialized") if record.nil?
+          current = decode_state(record)
+          return if current.pending_header.nil?
+          Support.fail!("pending_header_mismatch") unless current.pending_header == expected
+
+          body = ChannelProfile.state_serialize(ChannelState.new(next_sequence: current.next_sequence))
+          begin
+            @backend.put(put_input(ChannelProfile.state_key(@channel_id), STATE_CONTENT_TYPE, body, if_revision: record.revision))
+            return
+          rescue StorageConflictError
+            next
+          rescue StandardError => error
+            raise storage_error(error)
+          end
+        end
+        Support.fail!("concurrent_update")
+      end
+
+      def put_idempotent(key, content_type, body)
+        @backend.put(put_input(key, content_type, body, if_absent: true))
+      rescue StorageConflictError
+        current = storage { @backend.get(STORAGE_NAMESPACE, key) }
+        Support.fail!("conflicting_record") if current.nil? || current.content_type != content_type || current.body != body
+      rescue StandardError => error
+        raise storage_error(error)
+      end
+
+      def require_content_type(record, expected)
+        Support.fail!("corrupt_record") unless record.content_type == expected
+      end
+
+      def put_input(key, content_type, body, if_absent: false, if_revision: nil)
+        StoragePut.new(namespace: STORAGE_NAMESPACE, key: key, content_type: content_type, body: body, if_absent: if_absent, if_revision: if_revision)
+      end
+
+      def storage
+        yield
+      rescue ChannelProfileError, StorageConflictError
+        raise
+      rescue StandardError => error
+        raise storage_error(error)
+      end
+
+      def storage_error(error) = error.is_a?(ChannelProfileError) ? error : ChannelProfileError.new("storage_error")
+    end
+  end
+end

--- a/code/packages/ruby/chief-of-staff-channel-store/required_capabilities.json
+++ b/code/packages/ruby/chief-of-staff-channel-store/required_capabilities.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "package": "ruby/chief-of-staff-channel-store",
+  "capabilities": [],
+  "justification": "Pure durable-channel codecs and transitions over caller-supplied bytes, atomic storage, message crypto, identifiers, clocks, and key providers."
+}

--- a/code/packages/ruby/chief-of-staff-channel-store/test/test_d18p_fixtures.rb
+++ b/code/packages/ruby/chief-of-staff-channel-store/test/test_d18p_fixtures.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "minitest/autorun"
+require "coding_adventures_chief_of_staff_channel_store"
+
+class TestD18PFixtures < Minitest::Test
+  Store = CodingAdventures::ChiefOfStaffChannelStore
+  Crypto = CodingAdventures::ChiefOfStaffChannelCrypto
+  FIXTURE_PATH = File.expand_path("../../../../fixtures/chief-of-staff-channel/v1/manifest.json", __dir__)
+  FIXTURE = JSON.parse(File.read(FIXTURE_PATH, encoding: "UTF-8"))
+  ACTIVE_BYTES = Base64.strict_decode64(FIXTURE["definition_cases"][0]["d18c_b64"])
+  DEFINITION = Store::ChannelProfile.definition_deserialize(ACTIVE_BYTES)
+  CHANNEL_ID = DEFINITION.channel_id
+  ORIGINATOR_ID = DEFINITION.originator.agent_id
+  BINARY_RECEIVER_ID = Base64.strict_decode64(FIXTURE["definition_cases"][0]["canonical_receiver_ids_b64"][0])
+  TEXT_RECEIVER_ID = Base64.strict_decode64(FIXTURE["definition_cases"][0]["canonical_receiver_ids_b64"][1])
+  SIGNING_SEED = [FIXTURE.dig("test_keys", "originator_signing_seed_hex")].pack("H*")
+  PUBLIC_KEY, SIGNING_SECRET_KEY = CodingAdventures::Ed25519.generate_keypair(SIGNING_SEED)
+  MASTER_KEY = [FIXTURE.dig("test_keys", "channel_master_key_hex")].pack("H*")
+
+  def decode(value) = Base64.strict_decode64(value)
+
+  def assert_profile_error(code)
+    error = assert_raises(Store::ChannelProfileError) { yield }
+    assert_equal code, error.code
+    assert_equal code, error.message
+  end
+
+  def operation(name) = FIXTURE["operation_cases"].find { |item| item["name"] == name }
+
+  def test_fixture_provenance_constants_and_closed_error_roster
+    assert_equal "D18P-durable-channel-fixtures-v1", FIXTURE["fixture_format"]
+    assert_equal 40, FIXTURE["generator_blob_sha1"].length
+    assert_equal Store::STORAGE_NAMESPACE, FIXTURE.dig("constants", "storage_namespace")
+    assert_equal Store::DEFINITION_CONTENT_TYPE, FIXTURE.dig("constants", "content_types", "definition")
+    assert_equal Store::STATE_CONTENT_TYPE, FIXTURE.dig("constants", "content_types", "state")
+    assert_equal Store::MESSAGE_CONTENT_TYPE, FIXTURE.dig("constants", "content_types", "message")
+    assert_equal Store::GRANT_CONTENT_TYPE, FIXTURE.dig("constants", "content_types", "grant")
+    assert_equal Store::ACK_CONTENT_TYPE, FIXTURE.dig("constants", "content_types", "ack")
+    assert_equal Store::MAX_RECEIVERS.to_s, FIXTURE.dig("constants", "max_receivers")
+    assert_equal Store::MAX_PENDING_HEADER_BYTES.to_s, FIXTURE.dig("constants", "max_pending_header_bytes")
+    assert_equal Store::MAX_STORE_CAS_ATTEMPTS.to_s, FIXTURE.dig("constants", "max_store_cas_attempts")
+    assert_equal Store::MAX_DEFINITION_CAS_ATTEMPTS.to_s, FIXTURE.dig("constants", "max_definition_cas_attempts")
+    assert_equal Store::ERROR_CODES, FIXTURE["stable_error_codes"]
+    expected_operations = {
+      "conflicting-definition" => "conflicting_definition", "session-delivery-enforcement" => "unknown_message_id",
+      "unauthorized-originator" => "unauthorized_originator", "unauthorized-receiver" => "unauthorized_receiver",
+      "receiver-public-key-mismatch" => "public_key_mismatch", "channel-destroyed" => "channel_destroyed",
+      "missing-key-grant" => "missing_key_grant", "pending-append" => "pending_append",
+      "acknowledgement-pending" => "acknowledgement_pending", "pending-header-mismatch" => "pending_header_mismatch",
+      "no-pending-append" => "no_pending_append", "invalid-page-size" => "invalid_page_size",
+      "invalid-receiver-id" => "invalid_receiver_id", "acknowledgement-ahead" => "acknowledgement_ahead",
+      "acknowledgement-regression" => "acknowledgement_regression", "message-key-body-mismatch" => "corrupt_record",
+      "message-content-type-mismatch" => "corrupt_record"
+    }
+    assert_equal expected_operations, FIXTURE["operation_negative_cases"].to_h { |item| [item["name"], item["expected_error"]] }
+    assert_equal PUBLIC_KEY, [FIXTURE.dig("test_keys", "originator_public_key_hex")].pack("H*")
+  end
+
+  def test_all_codec_and_storage_key_cases_are_exact
+    FIXTURE["definition_cases"].each do |item|
+      encoded = decode(item["d18c_b64"])
+      definition = Store::ChannelProfile.definition_deserialize(encoded)
+      assert_equal item["lifecycle"], definition.lifecycle
+      assert_equal encoded, Store::ChannelProfile.definition_serialize(definition)
+    end
+    assert_equal FIXTURE["definition_cases"][0]["canonical_receiver_ids_b64"], DEFINITION.receivers.map { |receiver| Base64.strict_encode64(receiver.agent_id) }
+    FIXTURE["state_cases"].each do |item|
+      encoded = decode(item["d18s_b64"])
+      state = Store::ChannelProfile.state_deserialize(encoded, CHANNEL_ID)
+      assert_equal Integer(item["next_sequence"], 10), state.next_sequence
+      assert_equal item["pending"], !state.pending_header.nil?
+      assert_equal encoded, Store::ChannelProfile.state_serialize(state)
+    end
+    FIXTURE["cursor_cases"].each do |item|
+      encoded = decode(item["d18a_b64"])
+      cursor = Store::ChannelProfile.cursor_deserialize(encoded)
+      assert_equal Integer(item["first_unread_sequence"], 10), cursor
+      assert_equal encoded, Store::ChannelProfile.cursor_serialize(cursor)
+    end
+    keys = {
+      "definition" => Store::ChannelProfile.definition_key(CHANNEL_ID),
+      "state" => Store::ChannelProfile.state_key(CHANNEL_ID),
+      "message-zero" => Store::ChannelProfile.message_key(CHANNEL_ID, 0),
+      "message-max" => Store::ChannelProfile.message_key(CHANNEL_ID, Store::MAX_U64),
+      "message-prefix" => Store::ChannelProfile.message_prefix(CHANNEL_ID),
+      "grant" => Store::ChannelProfile.grant_key(CHANNEL_ID, 7, BINARY_RECEIVER_ID),
+      "ack-binary-receiver" => Store::ChannelProfile.ack_key(CHANNEL_ID, BINARY_RECEIVER_ID)
+    }
+    FIXTURE["storage_key_cases"].each { |item| assert_equal item["expected_key"], keys[item["name"]], item["name"] }
+  end
+
+  def test_every_malformed_codec_case_maps_to_its_stable_error
+    FIXTURE["codec_negative_cases"].each do |item|
+      assert_profile_error(item["expected_error"]) do
+        value = decode(item["record_b64"])
+        case item["kind"]
+        when "definition" then Store::ChannelProfile.definition_deserialize(value)
+        when "state" then Store::ChannelProfile.state_deserialize(value, CHANNEL_ID)
+        else Store::ChannelProfile.cursor_deserialize(value)
+        end
+      end
+    end
+  end
+
+  def test_compact_oversize_recipes_are_enforced
+    oversized_originator = Store::OriginatorIdentity.new(agent_id: "\0" * (Store::MAX_IDENTITY_BYTES + 1), public_key: DEFINITION.originator.public_key)
+    assert_profile_error("invalid_definition") do
+      Store::ChannelDefinition.new(channel_id: CHANNEL_ID, originator: oversized_originator, receivers: DEFINITION.receivers, created_at_ns: 0, key_epoch: 0)
+    end
+    receivers = Array.new(Store::MAX_RECEIVERS + 1) do |index|
+      Store::ReceiverIdentity.new(agent_id: [index].pack("n"), public_key: "\0" * 32)
+    end
+    assert_profile_error("invalid_definition") do
+      Store::ChannelDefinition.new(channel_id: CHANNEL_ID, originator: DEFINITION.originator, receivers: receivers, created_at_ns: 0, key_epoch: 0)
+    end
+    oversized_state = [68, 49, 56, 83, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 64, 1].pack("C*")
+    assert_profile_error("corrupt_record") { Store::ChannelProfile.state_deserialize(oversized_state, CHANNEL_ID) }
+  end
+
+  def test_definition_create_is_idempotent_and_conflicting
+    backend = Store::MemoryChannelStorage.new
+    definitions = Store::ChannelDefinitionStore.new(backend)
+    assert_equal DEFINITION, definitions.create(DEFINITION)
+    assert_equal DEFINITION, definitions.create(DEFINITION)
+    assert_equal 0, Store::ChannelStore.new(backend, CHANNEL_ID).state.next_sequence
+    conflict = Store::ChannelDefinition.new(channel_id: CHANNEL_ID, originator: DEFINITION.originator, receivers: DEFINITION.receivers, created_at_ns: DEFINITION.created_at_ns + 1, key_epoch: DEFINITION.key_epoch)
+    assert_profile_error("conflicting_definition") { definitions.create(conflict) }
+  end
+
+  def test_recovery_retry_abandon_gap_paging_and_acknowledgement_trace
+    backend = Store::MemoryChannelStorage.new
+    store = Store::ChannelStore.new(backend, CHANNEL_ID)
+    store.initialize_store
+    header = store.reserve_append(request(20, 20_000_000_020), "recoverable".b)
+    recovered = Store::ChannelStore.new(backend, CHANNEL_ID)
+    assert_equal header, recovered.initialize_store.pending_header
+    assert_profile_error("pending_append") { store.reserve_append(request(21, 20_000_000_021), "pending".b) }
+    assert_profile_error("acknowledgement_pending") { store.acknowledge(BINARY_RECEIVER_ID, 0) }
+    mismatch = Store::MessageHeader.new(message_id: uuid7(22), timestamp_ns: 20_000_000_022, originator_id: ORIGINATOR_ID, channel_id: CHANNEL_ID, sequence: 0, key_epoch: 0, content_type: "text/plain", plaintext_hash: header.plaintext_hash)
+    assert_profile_error("pending_header_mismatch") { recovered.commit_reserved(mismatch, "recoverable".b, MASTER_KEY, SIGNING_SECRET_KEY) }
+    first = recovered.commit_reserved(header, "recoverable".b, MASTER_KEY, SIGNING_SECRET_KEY)
+    retry_message = recovered.commit_reserved(header, "recoverable".b, MASTER_KEY, SIGNING_SECRET_KEY)
+    expected = operation("reserve-recover-complete-retry-abandon-gap")
+    assert_equal decode(expected["first_d18m_b64"]), Crypto.message_serialize(first)
+    assert_equal Crypto.message_serialize(first), Crypto.message_serialize(retry_message)
+    abandoned = recovered.reserve_append(request(23, 20_000_000_023), "abandoned".b)
+    assert_equal 1, recovered.abandon_pending.sequence
+    assert_profile_error("no_pending_append") { recovered.commit_reserved(abandoned, "abandoned".b, MASTER_KEY, SIGNING_SECRET_KEY) }
+    assert_equal 2, recovered.append(request(24, 20_000_000_024), "after gap".b, MASTER_KEY, SIGNING_SECRET_KEY).sequence
+    assert_equal [0, 2], recovered.read_messages(0, 10).messages.map(&:sequence)
+    page = recovered.read_messages(0, 1)
+    assert_equal [0], page.messages.map(&:sequence)
+    assert_equal 1, page.next_start
+    assert_equal [2], recovered.read_messages(page.next_start, 1).messages.map(&:sequence)
+    assert_equal [2], recovered.read_messages(2, 10).messages.map(&:sequence)
+    assert_empty recovered.read_messages(3, 10).messages
+    assert_profile_error("invalid_page_size") { recovered.read_messages(0, 0) }
+    assert_profile_error("acknowledgement_ahead") { recovered.acknowledge(BINARY_RECEIVER_ID, 3) }
+    assert_equal 1, recovered.acknowledge(BINARY_RECEIVER_ID, 0)
+    assert_equal 3, recovered.acknowledge(BINARY_RECEIVER_ID, 2)
+    assert_profile_error("acknowledgement_regression") { recovered.acknowledge(BINARY_RECEIVER_ID, 0) }
+    assert_profile_error("invalid_receiver_id") { recovered.receiver_cursor("".b) }
+  end
+
+  class MetadataSource
+    def initialize(values) = @values = values.dup
+    def next = @values.shift || raise("metadata exhausted")
+  end
+
+  class KeyProvider
+    attr_reader :public_key
+
+    def initialize(public_key, fail_open: false)
+      @public_key = public_key
+      @fail_open = fail_open
+    end
+
+    def open_grant(_epoch, _body)
+      raise "provider details must not escape" if @fail_open
+      MASTER_KEY
+    end
+  end
+
+  def provider(receiver_id, fail_open: false)
+    KeyProvider.new(DEFINITION.receiver(receiver_id).public_key, fail_open: fail_open)
+  end
+
+  def test_encrypted_endpoints_independent_cursors_sessions_and_destruction
+    backend = Store::MemoryChannelStorage.new
+    definitions = Store::ChannelDefinitionStore.new(backend)
+    definitions.create(DEFINITION)
+    metadata = MetadataSource.new([
+      Store::MessageMetadata.new(message_id: uuid7(1), timestamp_ns: 10_000_000_001),
+      Store::MessageMetadata.new(message_id: uuid7(2), timestamp_ns: 10_000_000_002)
+    ])
+    originator = Store::DurableOriginator.open(backend: backend, channel_id: CHANNEL_ID, agent_id: ORIGINATOR_ID, signing_secret_key: SIGNING_SECRET_KEY, channel_master_key: MASTER_KEY, metadata_source: metadata)
+    assert_equal ORIGINATOR_ID, originator.id
+    assert_equal CHANNEL_ID, originator.channel_id
+    assert_equal PUBLIC_KEY, originator.public_key
+    originator.save_receiver_grant(BINARY_RECEIVER_ID, "\1".b)
+    originator.save_receiver_grant(TEXT_RECEIVER_ID, "\2".b)
+    first = originator.publish("message zero".b, "text/plain")
+    second = originator.publish("message one".b, "application/octet-stream")
+    assert_equal [0, 1], [first.sequence, second.sequence]
+    assert_profile_error("metadata_error") { originator.publish("exhausted".b, "text/plain") }
+
+    binary = Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: BINARY_RECEIVER_ID, key_provider: provider(BINARY_RECEIVER_ID))
+    assert_equal BINARY_RECEIVER_ID, binary.id
+    assert_equal CHANNEL_ID, binary.channel_id
+    assert_equal DEFINITION.receiver(BINARY_RECEIVER_ID).public_key, binary.public_key
+    zero = binary.receive(1)
+    assert_equal [0], zero.map(&:sequence)
+    assert_equal "message zero".b, zero.first.payload
+    assert_equal 1, binary.acknowledge(zero.first.message_id)
+    one = binary.receive(10)
+    assert_equal [1], one.map(&:sequence)
+    assert_equal 2, binary.acknowledge(one.first.message_id)
+    assert_equal 2, binary.acknowledge(one.first.message_id)
+    assert_empty binary.receive(10)
+
+    text = Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: TEXT_RECEIVER_ID, key_provider: provider(TEXT_RECEIVER_ID))
+    text_messages = text.receive(10)
+    assert_equal [0, 1], text_messages.map(&:sequence)
+    assert_equal 1, text.acknowledge(text_messages.first.message_id)
+    store = Store::ChannelStore.new(backend, CHANNEL_ID)
+    assert_equal 2, store.receiver_cursor(BINARY_RECEIVER_ID)
+    assert_equal 1, store.receiver_cursor(TEXT_RECEIVER_ID)
+
+    failing = Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: TEXT_RECEIVER_ID, key_provider: provider(TEXT_RECEIVER_ID, fail_open: true))
+    assert_profile_error("crypto_error") { failing.receive(1) }
+    fresh = Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: BINARY_RECEIVER_ID, key_provider: provider(BINARY_RECEIVER_ID))
+    assert_profile_error("unknown_message_id") { fresh.acknowledge(first.message_id) }
+    assert_profile_error("unauthorized_originator") do
+      Store::DurableOriginator.open(backend: backend, channel_id: CHANNEL_ID, agent_id: "intruder".b, signing_secret_key: SIGNING_SECRET_KEY, channel_master_key: MASTER_KEY, metadata_source: metadata)
+    end
+    assert_profile_error("unauthorized_receiver") do
+      Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: "intruder".b, key_provider: provider(BINARY_RECEIVER_ID))
+    end
+    assert_profile_error("public_key_mismatch") do
+      Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: BINARY_RECEIVER_ID, key_provider: KeyProvider.new("\0" * 32))
+    end
+
+    destroyed = definitions.destroy(CHANNEL_ID)
+    assert_equal "destroyed", destroyed.lifecycle
+    assert_equal destroyed, definitions.destroy(CHANNEL_ID)
+    assert_equal 2, store.read_messages(0, 10).messages.length
+    assert_profile_error("channel_destroyed") do
+      originator.publish_with_metadata(Store::MessageMetadata.new(message_id: uuid7(9), timestamp_ns: 9), "denied".b, "text/plain")
+    end
+  end
+
+  def test_missing_grants_corrupt_envelopes_and_backend_conditions_fail_closed
+    backend = Store::MemoryChannelStorage.new
+    Store::ChannelDefinitionStore.new(backend).create(DEFINITION)
+    originator = Store::DurableOriginator.open(
+      backend: backend, channel_id: CHANNEL_ID, agent_id: ORIGINATOR_ID,
+      signing_secret_key: SIGNING_SECRET_KEY, channel_master_key: MASTER_KEY,
+      metadata_source: MetadataSource.new([Store::MessageMetadata.new(message_id: uuid7(9), timestamp_ns: 9)])
+    )
+    originator.publish("no grant".b, "text/plain")
+    receiver = Store::DurableReceiver.open(backend: backend, channel_id: CHANNEL_ID, receiver_id: BINARY_RECEIVER_ID, key_provider: provider(BINARY_RECEIVER_ID))
+    assert_profile_error("missing_key_grant") { receiver.receive(1) }
+    assert_profile_error("unauthorized_receiver") { originator.save_receiver_grant("intruder".b, "x".b) }
+
+    key_backend = backend_with_message
+    zero_key = Store::ChannelProfile.message_key(CHANNEL_ID, 0)
+    record = key_backend.get(Store::STORAGE_NAMESPACE, zero_key)
+    key_backend.corrupt(Store::StorageRecord.new(namespace: record.namespace, key: Store::ChannelProfile.message_key(CHANNEL_ID, 1), content_type: record.content_type, body: record.body, revision: record.revision))
+    assert_profile_error("corrupt_record") { Store::ChannelStore.new(key_backend, CHANNEL_ID).read_messages(0, 10) }
+
+    type_backend = backend_with_message
+    record = type_backend.get(Store::STORAGE_NAMESPACE, zero_key)
+    type_backend.corrupt(Store::StorageRecord.new(namespace: record.namespace, key: record.key, content_type: "application/octet-stream", body: record.body, revision: record.revision))
+    assert_profile_error("corrupt_record") { Store::ChannelStore.new(type_backend, CHANNEL_ID).read_messages(0, 10) }
+
+    condition_backend = Store::MemoryChannelStorage.new
+    assert_raises(ArgumentError) { condition_backend.put(Store::StoragePut.new(namespace: "n", key: "k", content_type: "c", body: "".b)) }
+    body = "a".b
+    stored = condition_backend.put(Store::StoragePut.new(namespace: "n", key: "k", content_type: "c", body: body, if_absent: true))
+    body.setbyte(0, 98)
+    assert_equal "a".b, condition_backend.get("n", "k").body
+    assert_raises(Store::StorageConflictError) { condition_backend.put(Store::StoragePut.new(namespace: "n", key: "k", content_type: "c", body: "".b, if_absent: true)) }
+    changed = condition_backend.put(Store::StoragePut.new(namespace: "n", key: "k", content_type: "c", body: "b".b, if_revision: stored.revision))
+    refute_equal stored.revision, changed.revision
+  end
+
+  def backend_with_message
+    backend = Store::MemoryChannelStorage.new
+    store = Store::ChannelStore.new(backend, CHANNEL_ID)
+    store.initialize_store
+    store.append(request(30, 30), "record".b, MASTER_KEY, SIGNING_SECRET_KEY)
+    backend
+  end
+
+  def request(value, timestamp)
+    Store::AppendRequest.new(message_id: uuid7(value), timestamp_ns: timestamp, originator_id: ORIGINATOR_ID, key_epoch: 0, content_type: "text/plain")
+  end
+
+  def uuid7(value)
+    result = ([value].pack("C") * 16).b
+    result.setbyte(6, 0x70 | value & 0x0f)
+    result.setbyte(8, 0x80 | value & 0x3f)
+    result
+  end
+end


### PR DESCRIPTION
## Summary

- add the Ruby D18P durable-channel profile with exact D18C/D18H/D18S/D18A codecs and deterministic storage keys
- add an injected atomic CAS backend, reserve-before-encrypt recovery, ordered paging, receiver cursors, opaque grants, and irreversible destruction
- add structurally separate durable originator/receiver roles while keeping D18G grant cryptography behind the issue #141 provider boundary
- consume the shared Rust-generated fixture for every codec record, storage key, transition trace, and stable error roster

## Validation

- `bundle exec rake test` (210 assertions)
- Ruby standard-library line coverage: 94.6%
- committed-head affected build: 6/6 packages built
- Ruby 3.4 syntax checks
- `git diff --check`

Closes #11710
Progresses #131
Progresses #128
