### PR TITLE
feat(hl-c170): grammar lessons can realize a spine concept, and B2 opens

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,6 +69,42 @@ is checked on warning counts and not just on its exit code.
 **Applies to every non-Latin track**, not just Sanskrit. Add both keys whenever a
 new chapter target is registered.
 
+## HL-C170 — grammar lessons can realize a spine concept now; HL-C169 was half a diagnosis
+
+HL-C169 called the 73 unclaimed Spanish concepts a **tagging** problem. Measuring
+the mechanism rather than the symptom found the larger half:
+`CONTENT_TYPES = {word, phrase}` gated realization, so **a `grammar` lesson could
+never realize a concept at all** — and half the spine's concepts *are* grammar
+(`TENSE-BACKSHIFT`, `RELATIVE-CLAUSE`, `VOICE-PASSIVE`, `CONNECTIVE-IF`). No
+`word` lesson will ever teach those. A node declaring them read as unrealized no
+matter how completely the corpus taught it.
+
+Fixed with a **separate `REALIZING_TYPES` set**, not by widening `CONTENT_TYPES`
+— that set is read by eight call sites meaning the narrower thing, and widening
+it raised 33 validation errors across other tracks on lessons that legitimately
+carry no `concept_tag`.
+
+The tagging half is real too, and is handled by `conceptAliases` in a track's
+`curriculum.json`: the spine names concepts language-neutrally, a track names
+lessons in its own terms, and an alias lets the second answer the first without
+retagging and discarding the specific name.
+
+**Result: B2 opens at 1/4 and the spine goes 21/33 → 22/33, with no lesson
+written.**
+
+**Still to do, and now cheap:**
+
+* Three declared aliases so far (`CONNECTIVE-IF`, `CONDITIONAL-REAL`,
+  `TENSE-BACKSHIFT`). Sweep the remaining ~70 the same way.
+* **Cross-node aliases are not yet supported.** `VOICE-PASSIVE` and
+  `RELATIVE-CLAUSE` are taught by `ES-C52-se-venden` and `ES-C53-que-relativo`,
+  which sit under `SPINE-GIVE-REASONS` rather than the node declaring the
+  concept, and aliasing across nodes would trip the relocation ledger. Either the
+  lessons move to the declaring node or the relocation rule learns about aliases.
+  Those two alone open `SPINE-READ-EXTENDED-PROSE`.
+* `MODAL-WOULD` is the same case: `ES-C17-condicional` (*hablaría*) sits under
+  `SPINE-TALK-ABOUT-FUTURE`. It is the last omission on `SPINE-EXPRESS-CONDITION`.
+
 ## HL-C169 — the spine's concept names and the corpus's tags were never reconciled
 
 **Measured 2026-08-14. Spanish claims 88 of 161 spine concept names; 73 are

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -3486,8 +3486,6 @@
         "ES-PATH-210-DEPENDS"
       ],
       "omits": [
-        "CONDITIONAL-REAL",
-        "CONNECTIVE-IF",
         "MODAL-WOULD"
       ],
       "relocates": {}
@@ -3518,7 +3516,6 @@
       ],
       "omits": [
         "REPORTED-SPEECH",
-        "TENSE-BACKSHIFT",
         "SPEECH-ACT-REPORT",
         "QUOTATION-DIRECT"
       ],
@@ -6548,5 +6545,16 @@
         "ES-C267-negar-preguntar"
       ]
     }
-  ]
+  ],
+  "conceptAliases": {
+    "CONNECTIVE-IF": [
+      "ES-CONDITION-SI-REAL"
+    ],
+    "CONDITIONAL-REAL": [
+      "ES-CONDITION-SI-FUTURE"
+    ],
+    "TENSE-BACKSHIFT": [
+      "ES-REPORT-BACKSHIFT"
+    ]
+  }
 }

--- a/code/packages/typescript/human-language-data/src/constants.ts
+++ b/code/packages/typescript/human-language-data/src/constants.ts
@@ -49,6 +49,28 @@ export const LANGUAGE_SCRIPT: Record<string, Script> = {
 /** Lesson types that teach a real concept and take part in the cross-language join. */
 export const CONTENT_TYPES = new Set(["word", "phrase"]);
 
+// Lesson types that can REALIZE a spine concept.
+//
+// Deliberately WIDER than CONTENT_TYPES, and the difference is the point.
+// CONTENT_TYPES answers "is this a lesson that teaches an item of language" --
+// it drives book generation, the level gate, and the rule that a content lesson
+// must carry a concept_tag. Realization answers a different question: "can this
+// lesson be the thing that makes a spine node true?"
+//
+// Half the spine's concepts ARE grammar -- TENSE-BACKSHIFT, RELATIVE-CLAUSE,
+// VOICE-PASSIVE, CONNECTIVE-IF -- and no `word` lesson will ever teach them. With
+// realization restricted to word/phrase, a node declaring them read as
+// unrealized no matter how completely the corpus taught it:
+// SPINE-EXPRESS-CONDITION had ELEVEN lessons behind it and reported 0 of 4
+// (HL-C169). That is a category error, not a content gap, and it sent four
+// separate attempts off to author lessons the corpus already had.
+//
+// Kept separate rather than widening CONTENT_TYPES because that set is read by
+// eight call sites that mean the narrower thing; widening it raised 33
+// validation errors across other tracks on lessons that legitimately carry no
+// concept_tag.
+export const REALIZING_TYPES = new Set(["word", "phrase", "grammar"]);
+
 /**
  * Lesson types that carry a session/orthography label, not a cross-language
  * concept — exempt from the join.

--- a/code/packages/typescript/human-language-data/src/curriculum.ts
+++ b/code/packages/typescript/human-language-data/src/curriculum.ts
@@ -1,6 +1,6 @@
 // Pure validation for the structured HL04 language registry and shared spine.
 
-import { CONTENT_TYPES, hasOwn } from "./constants.js";
+import { CONTENT_TYPES, REALIZING_TYPES, hasOwn } from "./constants.js";
 import { DURATION_THRESHOLD_SECONDS, estimateLessonDuration } from "./report.js";
 import { activityContractErrors } from "./activity.js";
 import type {
@@ -299,11 +299,35 @@ export function validateCurriculum(input: CurriculumValidationInput): Issue[] {
             .filter(
               (lesson) =>
                 lesson.language === curriculum.language &&
-                CONTENT_TYPES.has(lesson.realization.type),
+                REALIZING_TYPES.has(lesson.realization.type),
             )
             .map((lesson) => lesson.realization.concept),
         );
-        const expectedOmits = node.concepts.filter((concept) => !realizedConcepts.has(concept));
+        // A track may declare that one of its own tags satisfies a spine concept.
+        // The spine names concepts language-neutrally (TENSE-BACKSHIFT); a track
+        // names its lessons in its own terms (ES-REPORT-BACKSHIFT). Aliases let
+        // the second answer the first WITHOUT retagging the lesson and throwing
+        // away the specific name, which carries real information (HL-C169).
+        // `hasOwn` cuts the prototype chain, and Array.isArray closes the
+        // malformed-value case. Both matter because validateCurriculum is a
+        // PUBLIC export: a consumer validating a curriculum it did not author
+        // should get an Issue back, not an uncaught TypeError from `.some`.
+        const aliasesRaw: unknown = curriculum.conceptAliases;
+        const aliases: Record<string, unknown> =
+          aliasesRaw && typeof aliasesRaw === "object"
+            ? (aliasesRaw as Record<string, unknown>)
+            : {};
+        const aliasesFor = (concept: string): string[] => {
+          if (!hasOwn(aliases, concept)) return [];
+          const value = aliases[concept];
+          return Array.isArray(value)
+            ? value.filter((tag): tag is string => typeof tag === "string")
+            : [];
+        };
+        const conceptIsRealized = (concept: string) =>
+          realizedConcepts.has(concept) ||
+          aliasesFor(concept).some((tag) => realizedConcepts.has(tag));
+        const expectedOmits = node.concepts.filter((concept) => !conceptIsRealized(concept));
         if (JSON.stringify(realization.omits) !== JSON.stringify(expectedOmits)) {
           error(
             "curriculum-omission-ledger-drift",

--- a/code/packages/typescript/human-language-data/src/types.ts
+++ b/code/packages/typescript/human-language-data/src/types.ts
@@ -215,6 +215,15 @@ export interface LanguageCurriculum {
   /** Every shared node is explicit, including empty/planned coverage. */
   spine: Record<string, SpineRealizationMap>;
   extensions: CurriculumExtensionNode[];
+  /**
+   * Track-local tags that satisfy a language-neutral spine concept.
+   *
+   * The spine names a concept once for all 22 tracks (`TENSE-BACKSHIFT`); a
+   * track names its lessons in its own terms (`ES-REPORT-BACKSHIFT`). This lets
+   * the second answer the first without retagging the lesson and discarding the
+   * specific name, which carries information the spine name does not.
+   */
+  conceptAliases?: Record<string, string[]>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
HL-C169 called Spanish's 73 unclaimed spine concepts a **tagging** problem.
That was half a diagnosis.

Measuring the mechanism rather than the symptom found the larger half:
`CONTENT_TYPES = {word, phrase}` gated realization, so **a `grammar` lesson could
never realize a concept at all** — and half the spine's concepts *are* grammar.
`TENSE-BACKSHIFT`, `RELATIVE-CLAUSE`, `VOICE-PASSIVE`, `CONNECTIVE-IF`: no `word`
lesson will ever teach those.

A node declaring them read as unrealized no matter how completely the corpus
taught it. That's how `SPINE-EXPRESS-CONDITION` reported **0 of 4** with
**eleven lessons** standing behind it — and why four separate attempts this
session set out to author content that already existed.

## Fixed with a separate set, not by widening the existing one

`CONTENT_TYPES` is read by eight call sites meaning the narrower thing — "is this
a lesson that teaches an item of language" — which drives book generation, the
level gate, and the rule that a content lesson must carry a `concept_tag`.
Widening it raised **33 validation errors** across other tracks on lessons that
legitimately carry no tag.

Realization is a different question, so it gets its own answer: `REALIZING_TYPES`.

The tagging half is real too, handled by `conceptAliases` on a track's
curriculum — the spine names a concept once for all 22 tracks, a track names its
lessons in its own terms, and an alias lets the second answer the first without
retagging and discarding the specific name.

## Result

```
B2      0/4  →  1/4
spine  21/33 → 22/33      no lesson written
```

## Security review

Found the alias lookup could crash on malformed input. `validateCurriculum` is a
**public export**, so a consumer validating a curriculum it didn't author should
get an `Issue` back, not an uncaught `TypeError`.

Fixed with `hasOwn` (cuts the prototype chain) and `Array.isArray` with a string
filter; `conceptAliases` is now declared on `LanguageCurriculum`, so the cast is
gone. Verified against the four inputs the reviewer named:

| input | TypeError |
|---|---|
| string in place of array | no |
| number | no |
| object | no |
| `constructor` / `__proto__` / `toString` as concept names | no |

Second review round: **PASSED**.

## Still to do, now cheap (in the backlog)

- Sweep the remaining ~70 concepts the same way.
- **Cross-node aliases aren't supported yet.** `VOICE-PASSIVE` and
  `RELATIVE-CLAUSE` are taught by lessons sitting under `SPINE-GIVE-REASONS`
  rather than the declaring node, and aliasing across nodes would trip the
  relocation ledger. Those two alone open `SPINE-READ-EXTENDED-PROSE`.
- `MODAL-WOULD` is the same case, and it's the last omission on
  `SPINE-EXPRESS-CONDITION`.

## Verification

- Spanish builds at `exit=0`, zero overfull/underfull/missing characters
- Full suite, `tsc --noEmit`, and `language-ladder` (downstream) all green
- Five byte gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)