### PR TITLE
feat(hl-c171): cross-node aliases work — B2 doubles, and B1 is complete

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,6 +69,47 @@ is checked on warning counts and not just on its exit code.
 **Applies to every non-Latin track**, not just Sanskrit. Add both keys whenever a
 new chapter target is registered.
 
+## HL-C171 — cross-node aliases work; the relocation worry was unfounded
+
+HL-C170 left cross-node aliasing as blocked, on the reasoning that pointing a
+concept at a lesson filed under a *different* spine node would trip the
+relocation ledger. **Tested, and it does not.** The relocation check fires when a
+lesson's own `concept_tag` appears in `node.concepts` while its `spine_node`
+differs — and an aliased lesson's tag is a track-local name that is never in
+`node.concepts`, so the two mechanisms do not meet.
+
+Five aliases added on that basis:
+
+| concept | satisfied by | note |
+|---|---|---|
+| `REPORTED-SPEECH` | `ES-REPORT-QUE-OBLIGATORY` | *dice que* — he says THAT |
+| `SPEECH-ACT-REPORT` | `ES-REPORT-DECIR-PRETERITE` | *dijo* |
+| `MODAL-WOULD` | `ES-CONDITIONAL` | *hablaría*, cross-node |
+| `VOICE-PASSIVE` | `ES-GRAMMAR-SE-PASSIVE-AGREEMENT` | cross-node |
+| `RELATIVE-CLAUSE` | `ES-GRAMMAR-RELATIVE-QUE` | cross-node |
+
+**`SPINE-EXPRESS-CONDITION` is now complete — omissions empty.**
+**`SPINE-READ-EXTENDED-PROSE` opens. B2 goes 1/4 → 2/4, the spine 22/33 → 23/33,
+and B1 is complete at the CONCEPT level, not just the node level.** No lesson
+written.
+
+**Deliberately NOT aliased**, because the match would have been wishful rather
+than true — each of these needs authoring:
+
+* `CONNECTIVE-HOWEVER` / `CONNECTIVE-ALTHOUGH` (`SPINE-ARGUE-A-VIEW`). The track
+  has *pero*, *también*, *tampoco*. **`pero` is "but", not "however"** —
+  *sin embargo* and *aunque* are genuinely absent. Aliasing `pero` here would
+  have made the ledger lie.
+* `GREETING-EVENING` (`SPINE-TIME-OF-DAY`) against `GREETING-GOODNIGHT`: evening
+  is not night.
+* `QUOTATION-DIRECT`: the track's `ES-REPORT-WH-ACCENT` and `ES-REPORT-YESNO-SI`
+  are INDIRECT questions. Direct quotation is untaught.
+
+The rule this establishes: an alias asserts *this lesson teaches that concept*.
+Where it does not, the concept stays in `omits` and gets authored. The remaining
+~65 unclaimed concepts should be swept with that test applied one at a time, not
+pattern-matched in bulk.
+
 ## HL-C170 — grammar lessons can realize a spine concept now; HL-C169 was half a diagnosis
 
 HL-C169 called the 73 unclaimed Spanish concepts a **tagging** problem. Measuring

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -3485,9 +3485,7 @@
         "ES-PATH-B1-SYNTH-COND",
         "ES-PATH-210-DEPENDS"
       ],
-      "omits": [
-        "MODAL-WOULD"
-      ],
+      "omits": [],
       "relocates": {}
     },
     "SPINE-ARGUE-A-VIEW": {
@@ -3515,8 +3513,6 @@
         "ES-PATH-B2-SYNTH-REPORT"
       ],
       "omits": [
-        "REPORTED-SPEECH",
-        "SPEECH-ACT-REPORT",
         "QUOTATION-DIRECT"
       ],
       "relocates": {}
@@ -3525,8 +3521,6 @@
       "segments": [],
       "omits": [
         "DISCOURSE-TOPIC-SENTENCE",
-        "RELATIVE-CLAUSE",
-        "VOICE-PASSIVE",
         "VOCAB-FIELD-SPECIFIC"
       ],
       "relocates": {}
@@ -6555,6 +6549,21 @@
     ],
     "TENSE-BACKSHIFT": [
       "ES-REPORT-BACKSHIFT"
+    ],
+    "REPORTED-SPEECH": [
+      "ES-REPORT-QUE-OBLIGATORY"
+    ],
+    "SPEECH-ACT-REPORT": [
+      "ES-REPORT-DECIR-PRETERITE"
+    ],
+    "MODAL-WOULD": [
+      "ES-CONDITIONAL"
+    ],
+    "VOICE-PASSIVE": [
+      "ES-GRAMMAR-SE-PASSIVE-AGREEMENT"
+    ],
+    "RELATIVE-CLAUSE": [
+      "ES-GRAMMAR-RELATIVE-QUE"
     ]
   }
 }


### PR DESCRIPTION
HL-C170 left cross-node aliasing blocked, on my reasoning that pointing a concept
at a lesson filed under a *different* spine node would trip the relocation
ledger. **Tested — it doesn't.** The relocation check fires when a lesson's own
`concept_tag` appears in `node.concepts` while its `spine_node` differs, and an
aliased lesson's tag is a track-local name that is never in `node.concepts`. The
two mechanisms never meet. The worry was mine and it was unfounded.

## Five aliases

| concept | satisfied by | |
|---|---|---|
| `REPORTED-SPEECH` | `ES-REPORT-QUE-OBLIGATORY` | *dice que* |
| `SPEECH-ACT-REPORT` | `ES-REPORT-DECIR-PRETERITE` | *dijo* |
| `MODAL-WOULD` | `ES-CONDITIONAL` | *hablaría* — cross-node |
| `VOICE-PASSIVE` | `ES-GRAMMAR-SE-PASSIVE-AGREEMENT` | cross-node |
| `RELATIVE-CLAUSE` | `ES-GRAMMAR-RELATIVE-QUE` | cross-node |

```
SPINE-EXPRESS-CONDITION    complete — omissions empty
SPINE-READ-EXTENDED-PROSE  opens

B2      1/4 → 2/4
spine  22/33 → 23/33
B1      complete at the CONCEPT level, not just the node level
```

**No lesson was written.**

## Three matches refused

An alias asserts *this lesson teaches that concept*. These would have made the
ledger lie, so they stay in `omits` and get authored:

- **`CONNECTIVE-HOWEVER` / `CONNECTIVE-ALTHOUGH`** — the track has *pero*,
  *también*, *tampoco*. **`pero` is "but", not "however."** *Sin embargo* and
  *aunque* are genuinely absent.
- **`GREETING-EVENING`** against `GREETING-GOODNIGHT` — evening is not night.
- **`QUOTATION-DIRECT`** — the track's WH-accent and yes/no lessons are
  *indirect* questions. Direct quotation is untaught.

The remaining ~65 unclaimed concepts should be swept with that test applied one
at a time, not pattern-matched in bulk. The backlog says so.

## Verification

- Full suite green by exit code; `language-ladder` (downstream) checked
- Five byte gates clean; security review passed
- A wrong alias can't hide: `expectedOmits` is recomputed and compared exactly,
  so it surfaces as `curriculum-omission-ledger-drift` rather than silently
  disabling a check

🤖 Generated with [Claude Code](https://claude.com/claude-code)