### PR TITLE
feat(chief): add durable epoch activation

### DIFF
--- a/code/fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json
+++ b/code/fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json
@@ -1,0 +1,162 @@
+{
+  "fixture_format": "D18T-durable-epoch-activation-fixtures-v1",
+  "spec": "code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md",
+  "generator_blob_sha1": "f93ea88a7fbb4dd5df245eab03b878ed808a42df",
+  "warning": "The test_only_secrets object contains deterministic conformance-only secrets. Never log or use them outside tests.",
+  "constants": {
+    "state_magic_ascii": "D18S",
+    "state_version": "2",
+    "plan_magic_ascii": "D18T",
+    "plan_version": "1",
+    "state_content_type": "application/vnd.coding-adventures.chief-channel-state-v2",
+    "plan_content_type": "application/vnd.coding-adventures.chief-channel-epoch-activation-v1",
+    "max_cas_attempts": "16"
+  },
+  "test_only_secrets": {
+    "current_cmk_hex": "2222222222222222222222222222222222222222222222222222222222222222",
+    "next_cmk_hex": "3333333333333333333333333333333333333333333333333333333333333333",
+    "originator_signing_seed_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+    "receiver_a_private_key_hex": "4141414141414141414141414141414141414141414141414141414141414141",
+    "receiver_b_private_key_hex": "4242424242424242424242424242424242424242424242424242424242424242",
+    "ephemeral_private_key_hex": "5151515151515151515151515151515151515151515151515151515151515151",
+    "wrapping_nonce_hex": "616161616161616161616161616161616161616161616161"
+  },
+  "state_migrations": [
+    {
+      "name": "no-pending",
+      "d18s_v1_b64": "RDE4UwEAAAAAAAAAAAA=",
+      "d18s_v2_b64": "RDE4UwIAAAAAAAAAAAAAAAAAAAAAAA==",
+      "active_epoch": "0",
+      "next_sequence": "0"
+    },
+    {
+      "name": "pending-d18h",
+      "d18s_v1_b64": "RDE4UwEAAAAAAAAACAEAAACHRDE4SAEHBwcHBwd3B4cHBwcHBwcHF/BuXE2MgAcAAAAKb3JpZ2luYXRvcgGPR6CbbH3vkjRWeJq83vAAAAAAAAAABwAAAAAAAAAAAAAAGGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbfQD6dTNsluIAHQ+UrIku31HxmTQcg0/Ie7BsZlcX+Oc",
+      "d18s_v2_b64": "RDE4UwIAAAAAAAAAAAAAAAAAAAAIAQAAAIdEMThIAQcHBwcHB3cHhwcHBwcHBwcX8G5cTYyABwAAAApvcmlnaW5hdG9yAY9HoJtsfe+SNFZ4mrze8AAAAAAAAAAHAAAAAAAAAAAAAAAYYXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt9APp1M2yW4gAdD5SsiS7fUfGZNByDT8h7sGxmVxf45w=",
+      "active_epoch": "0",
+      "next_sequence": "8"
+    }
+  ],
+  "activation_case": {
+    "name": "receivers-a-plus-b-to-b-only",
+    "base_epoch": "0",
+    "new_epoch": "1",
+    "plan_record_key": "018f47a09b6c7def923456789abcdef0/epochs/00000000000000000001/activation",
+    "plan_content_type": "application/vnd.coding-adventures.chief-channel-epoch-activation-v1",
+    "plan_b64": "RDE4VAEBj0egm2x975I0VniavN7wAAAAAAAAAAAAAAAAAAAAAQAAAAFukbjadFX3YVYcZcnRBJEnQqCJVYOfBQq2WwBwYvPOWKVPWeA7Pdrz8CW0Dmda+55oPRH+jqisdMJy17OBxAl+",
+    "grant_b64": [
+      "RDE4RwEAAAAKb3JpZ2luYXRvcgAAAApyZWNlaXZlci1iAY9HoJtsfe+SNFZ4mrze8AAAAAAAAAABrZCKinCKygdYjNp8TtPkTUlmqAqauy8eS7rFPGdBTjRhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWHPKvDh+MW695UdTpX3HJTs8KeV7pfxTA9SZKP65YxiZkTsjtt7s9V0gzirD6ba/3VsrFXoTSe7+sVtluq26n1EG0gcrC7pA6PvuPYcpJBBcVIm+3TyM007zfSufOrqZ7Z93xpRJKbl9DGBZKl0owAE"
+    ],
+    "receiver_a_retains_epochs": [
+      "0"
+    ],
+    "receiver_b_retains_epochs": [
+      "0",
+      "1"
+    ],
+    "receiver_a_new_grant": null
+  },
+  "crash_replay_traces": [
+    {
+      "name": "after-custody-selection",
+      "operation": "replay-plan-and-all-grants",
+      "expected": "prepared"
+    },
+    {
+      "name": "after-plan-write",
+      "operation": "replay-all-grants",
+      "expected": "prepared"
+    },
+    {
+      "name": "after-first-grant",
+      "operation": "replay-remaining-grants",
+      "expected": "prepared"
+    },
+    {
+      "name": "after-all-grants",
+      "operation": "verify-and-activate",
+      "expected": "activated"
+    },
+    {
+      "name": "after-activation-cas",
+      "operation": "verify-exact-plan",
+      "expected": "idempotent"
+    }
+  ],
+  "race_traces": [
+    {
+      "name": "publish-reservation-wins",
+      "operation": "activation",
+      "expected": "pending_append"
+    },
+    {
+      "name": "activation-wins",
+      "operation": "next-publish",
+      "expected": "epoch-1-sequence-preserved"
+    },
+    {
+      "name": "same-candidate-retry",
+      "operation": "custody-selection",
+      "expected": "idempotent"
+    },
+    {
+      "name": "different-candidate-loses",
+      "operation": "custody-selection",
+      "expected": "conflicting_preparation"
+    }
+  ],
+  "stable_error_codes": [
+    "not_initialized",
+    "channel_destroyed",
+    "invalid_plan",
+    "corrupt_record",
+    "pending_append",
+    "unactivated_epoch",
+    "active_key_missing",
+    "conflicting_active_key",
+    "preparation_missing",
+    "conflicting_preparation",
+    "conflicting_plan",
+    "conflicting_grant",
+    "unexpected_epoch",
+    "decreasing_epoch",
+    "epoch_exhausted",
+    "concurrent_update",
+    "storage_error",
+    "custody_error",
+    "crypto_error"
+  ],
+  "negative_scenarios": [
+    {
+      "name": "pending-append",
+      "operation": "activation",
+      "expected": "pending_append"
+    },
+    {
+      "name": "corrupt-public-record",
+      "operation": "recovery",
+      "expected": "corrupt_record"
+    },
+    {
+      "name": "missing-custody",
+      "operation": "activation",
+      "expected": "preparation_missing"
+    },
+    {
+      "name": "destroyed-channel",
+      "operation": "activation",
+      "expected": "channel_destroyed"
+    },
+    {
+      "name": "epoch-exhaustion",
+      "operation": "preparation",
+      "expected": "epoch_exhausted"
+    },
+    {
+      "name": "sixteen-cas-conflicts",
+      "operation": "activation",
+      "expected": "concurrent_update"
+    }
+  ],
+  "secret_erasure_capability": "guaranteed"
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1095,4 +1095,5 @@ members = [
   "vault-pm-config",
   "vault-pm-cli-host",
   "vault-pm-cli",
+  "chief-of-staff-channel-epoch-activation",
 ]

--- a/code/packages/rust/chief-of-staff-channel-crypto/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-channel-crypto/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add signature-only D18G grant verification for durable activation
+  orchestrators that must validate provenance without receiver private keys or
+  opening the wrapped CMK.
 - Add the portable D18Q grant adapter with high-level field validation,
   explicit-material sealing, stable errors, immutable grants, receiver epoch
   state, deterministic rotation planning, honest erasure reporting, and the

--- a/code/packages/rust/chief-of-staff-channel-crypto/README.md
+++ b/code/packages/rust/chief-of-staff-channel-crypto/README.md
@@ -29,6 +29,8 @@ rules; crash-safe activation of a rotated epoch remains a caller-owned durable
 composition boundary.
 
 The `grant_profile` module adds validated immutable grant values,
+signature-only provenance verification for orchestration layers that do not
+hold receiver private keys,
 explicit-material sealing, stable cross-language errors, receiver epoch
 installation, pure ordered rotation planning, and the Rust `guaranteed`
 controlled-destruction declaration without changing D18G version 1 bytes. The

--- a/code/packages/rust/chief-of-staff-channel-crypto/src/grant_profile.rs
+++ b/code/packages/rust/chief-of-staff-channel-crypto/src/grant_profile.rs
@@ -12,9 +12,10 @@ use coding_adventures_zeroize::Zeroizing;
 use crate::wire::{self, MAX_IDENTITY_BYTES};
 use crate::{
     open_channel_key_grant as open_raw_grant, seal_channel_key as seal_raw_grant,
-    seal_channel_key_with_material_raw, ChannelCryptoError, ChannelId, ChannelMasterKey,
-    GrantInstallOutcome, KeyEpoch, OriginatorSigningKey, ReceiverEpochKeys as RawReceiverEpochKeys,
-    ReceiverKeyPair, SealedChannelKeyGrant,
+    seal_channel_key_with_material_raw,
+    verify_channel_key_grant_signature as verify_raw_grant_signature, ChannelCryptoError,
+    ChannelId, ChannelMasterKey, GrantInstallOutcome, KeyEpoch, OriginatorSigningKey,
+    ReceiverEpochKeys as RawReceiverEpochKeys, ReceiverKeyPair, SealedChannelKeyGrant,
 };
 
 /// Stable machine-readable failures defined by D18Q.
@@ -321,6 +322,26 @@ pub fn open_channel_key_grant(
         receiver_key_pair,
         originator_public_key,
     )?)
+}
+
+/// Verify a D18G signature and its expected public identities without opening
+/// the receiver-bound CMK.
+pub fn verify_grant_signature(
+    grant: &PortableKeyGrant,
+    expected_originator_id: &[u8],
+    expected_receiver_id: &[u8],
+    expected_channel_id: ChannelId,
+    originator_public_key: &[u8; 32],
+) -> Result<(), KeyGrantProfileError> {
+    validate_grant(&grant.grant)?;
+    verify_raw_grant_signature(
+        &grant.grant,
+        expected_originator_id,
+        expected_receiver_id,
+        expected_channel_id,
+        originator_public_key,
+    )?;
+    Ok(())
 }
 
 /// Receiver-local D18Q epoch state with immutable grant inputs.

--- a/code/packages/rust/chief-of-staff-channel-crypto/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-channel-crypto/src/lib.rs
@@ -294,15 +294,17 @@ pub(crate) fn seal_channel_key_with_material_raw(
     })
 }
 
-/// Verify and unwrap a receiver-bound channel-key grant.
-pub fn open_channel_key_grant(
+/// Verify one receiver-bound grant without requiring receiver private material.
+///
+/// This is the originator-side validation boundary used before a durable D18T
+/// activation can expose the grant to publishers.
+pub fn verify_channel_key_grant_signature(
     grant: &SealedChannelKeyGrant,
     expected_originator_id: &[u8],
     expected_receiver_id: &[u8],
     expected_channel_id: ChannelId,
-    receiver_key_pair: &ReceiverKeyPair,
     originator_public_key: &[u8; 32],
-) -> Result<ChannelMasterKey, ChannelCryptoError> {
+) -> Result<(), ChannelCryptoError> {
     if grant.originator_id != expected_originator_id {
         return Err(ChannelCryptoError::UnexpectedOriginator);
     }
@@ -328,6 +330,25 @@ pub fn open_channel_key_grant(
     ) {
         return Err(ChannelCryptoError::InvalidGrantSignature);
     }
+    Ok(())
+}
+
+/// Verify and unwrap a receiver-bound channel-key grant.
+pub fn open_channel_key_grant(
+    grant: &SealedChannelKeyGrant,
+    expected_originator_id: &[u8],
+    expected_receiver_id: &[u8],
+    expected_channel_id: ChannelId,
+    receiver_key_pair: &ReceiverKeyPair,
+    originator_public_key: &[u8; 32],
+) -> Result<ChannelMasterKey, ChannelCryptoError> {
+    verify_channel_key_grant_signature(
+        grant,
+        expected_originator_id,
+        expected_receiver_id,
+        expected_channel_id,
+        originator_public_key,
+    )?;
     let shared_secret = Zeroizing::new(
         x25519(&receiver_key_pair.private_key, &grant.ephemeral_public_key)
             .map_err(|_| ChannelCryptoError::InvalidKeyAgreement)?,

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/BUILD
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-channel-epoch-activation --all-targets -- --nocapture

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- Add strict D18S version 2 and D18T version 1 canonical codecs.
+- Add an injected atomic originator-custody contract with redacted handles,
+  deterministic non-durable test custody, conflict-safe preparation, and
+  channel destruction.
+- Compose production D18C membership, D18P storage, D18Q grants, and D18F
+  publication into crash-safe prepare, replay, activate, reserve, commit, and
+  recovery operations.
+- Add deterministic shared fixtures with generator Git blob provenance and
+  clearly isolated test-only secrets.
+- Cover migration, every public replay crash boundary, concurrent candidate
+  selection, pending publication races, corruption, custody loss, channel
+  destruction, redacted diagnostics, and sixteen-attempt CAS exhaustion.

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "chief-of-staff-channel-epoch-activation"
+version = "0.1.0"
+edition = "2021"
+description = "Crash-safe durable D18T channel epoch activation"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-channel-store = { path = "../chief-of-staff-channel-store" }
+coding-adventures-json-serializer = { path = "../json-serializer" }
+coding-adventures-json-value = { path = "../json-value" }
+coding_adventures_ct_compare = { path = "../ct-compare" }
+coding_adventures_sha256 = { path = "../sha256" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+coding-adventures-json-parser = { path = "../json-parser" }
+coding_adventures_sha1 = { path = "../sha1" }

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/README.md
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/README.md
@@ -1,0 +1,46 @@
+# chief-of-staff-channel-epoch-activation
+
+Crash-safe durable D18T channel epoch activation over the production Rust
+D18P channel store, D18Q grants, and D18C membership definition.
+
+The package adds the version 2 D18S state record, whose `active_epoch` is
+serialized by the same revision CAS as the next sequence and optional pending
+D18H reservation. A rotation first selects one complete successor bundle in
+injected originator custody, then idempotently replays its immutable D18T plan
+and exact D18G grants. Only after every public record verifies does one CAS
+advance the active epoch.
+
+`EpochActivationStore::new` accepts only custody that reports itself durable.
+`new_for_testing` is an explicit escape hatch for the included deterministic
+`InMemoryKeyCustody`; it must not be used in production. Opaque
+`EpochKeyHandle` values and error displays never reveal CMKs or custody
+locators.
+
+The canonical language-neutral transition corpus is checked in at
+`code/fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json`. It
+contains exact state migrations, activation-plan and grant bytes, crash/replay
+and race traces, the closed stable error vocabulary, and clearly isolated
+test-only secrets. The Rust tests prove that it is byte-identical to the
+generator whose Git blob SHA-1 it records.
+
+The normative contract lives in
+`code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md`.
+
+## Dependencies
+
+- chief-of-staff-channel-crypto
+- chief-of-staff-channel-store
+- chief-of-staff-channel-endpoints
+- storage-core
+- json-value
+- sha256
+- ct-compare
+
+## Development
+
+```bash
+bash BUILD
+```
+
+The build runs all package targets, including the fixture generator and
+language-neutral manifest checks.

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/examples/generate_d18t_fixtures.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/examples/generate_d18t_fixtures.rs
@@ -1,0 +1,340 @@
+//! Generate the deterministic shared D18T version 1 fixture manifest.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+
+use chief_of_staff_channel_crypto::grant_profile::{plan_rotation, RotationReceiver};
+use chief_of_staff_channel_crypto::{
+    prepare_message_header, ChannelId, ChannelMasterKey, KeyEpoch, MessageFields,
+    OriginatorSigningKey, ReceiverKeyPair, Sequence,
+};
+use chief_of_staff_channel_endpoints::{
+    AgentId, ChannelDefinition, OriginatorIdentity, ReceiverIdentity,
+};
+use chief_of_staff_channel_epoch_activation::{
+    activation_plan_record_key, epoch_state_serialize, prepare_rotation_candidate, EpochState,
+    ACTIVATION_PLAN_CONTENT_TYPE, EPOCH_STATE_CONTENT_TYPE,
+};
+use chief_of_staff_channel_store::profile::channel_state_serialize;
+use chief_of_staff_channel_store::ChannelState;
+use coding_adventures_json_serializer::{serialize_pretty, SerializerConfig};
+use coding_adventures_json_value::JsonValue;
+
+const BASE64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const CHANNEL_ID: [u8; 16] = [
+    0x01, 0x8f, 0x47, 0xa0, 0x9b, 0x6c, 0x7d, 0xef, 0x92, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+];
+const CURRENT_CMK: [u8; 32] = [0x22; 32];
+const NEXT_CMK: [u8; 32] = [0x33; 32];
+const SIGNING_SEED: [u8; 32] = [0x11; 32];
+const RECEIVER_A_PRIVATE: [u8; 32] = [0x41; 32];
+const RECEIVER_B_PRIVATE: [u8; 32] = [0x42; 32];
+
+#[allow(dead_code)]
+fn main() {
+    let mut arguments = env::args().skip(1);
+    let output = arguments
+        .next()
+        .expect("usage: generate_d18t_fixtures OUTPUT GENERATOR_BLOB_SHA1");
+    let generator_blob_sha1 = arguments
+        .next()
+        .expect("usage: generate_d18t_fixtures OUTPUT GENERATOR_BLOB_SHA1");
+    assert!(arguments.next().is_none(), "unexpected extra argument");
+    let encoded = generate_manifest(&generator_blob_sha1);
+    if let Some(parent) = Path::new(&output).parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(output, encoded).unwrap();
+}
+
+/// Generate the complete canonical D18T fixture manifest.
+pub fn generate_manifest(generator_blob_sha1: &str) -> Vec<u8> {
+    assert_eq!(generator_blob_sha1.len(), 40);
+    let signer = OriginatorSigningKey::from_seed(SIGNING_SEED);
+    let receiver_a_key = ReceiverKeyPair::from_private_key(RECEIVER_A_PRIVATE).unwrap();
+    let receiver_b_key = ReceiverKeyPair::from_private_key(RECEIVER_B_PRIVATE).unwrap();
+    let receiver_a = ReceiverIdentity {
+        agent_id: AgentId::new(b"receiver-a".to_vec()).unwrap(),
+        public_key: receiver_a_key.public_key(),
+    };
+    let receiver_b = ReceiverIdentity {
+        agent_id: AgentId::new(b"receiver-b".to_vec()).unwrap(),
+        public_key: receiver_b_key.public_key(),
+    };
+    let definition = ChannelDefinition::new(
+        ChannelId(CHANNEL_ID),
+        OriginatorIdentity {
+            agent_id: AgentId::new(b"originator".to_vec()).unwrap(),
+            public_key: signer.public_key(),
+        },
+        vec![receiver_a, receiver_b.clone()],
+        1_725_000_000_000_000_000,
+        KeyEpoch(0),
+    )
+    .unwrap();
+    let pending = prepare_message_header(
+        MessageFields::new(
+            message_id(7),
+            1_725_000_000_000_000_007,
+            b"originator".to_vec(),
+            ChannelId(CHANNEL_ID),
+            Sequence(7),
+            KeyEpoch(0),
+            "application/octet-stream".to_owned(),
+        ),
+        b"pending-before-activation",
+    );
+    let no_pending_v1 = channel_state_serialize(&ChannelState {
+        next_sequence: Sequence(0),
+        pending_header: None,
+    })
+    .unwrap();
+    let no_pending_v2 = epoch_state_serialize(
+        &EpochState::new(ChannelId(CHANNEL_ID), KeyEpoch(0), Sequence(0), None).unwrap(),
+    )
+    .unwrap();
+    let pending_v1 = channel_state_serialize(&ChannelState {
+        next_sequence: Sequence(8),
+        pending_header: Some(pending.clone()),
+    })
+    .unwrap();
+    let pending_v2 = epoch_state_serialize(
+        &EpochState::new(
+            ChannelId(CHANNEL_ID),
+            KeyEpoch(0),
+            Sequence(8),
+            Some(pending),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let rotation = plan_rotation(
+        b"originator",
+        ChannelId(CHANNEL_ID),
+        KeyEpoch(0),
+        ChannelMasterKey::from_bytes(NEXT_CMK),
+        vec![RotationReceiver::with_material(
+            b"receiver-b".to_vec(),
+            receiver_b.public_key,
+            [0x51; 32],
+            [0x61; 24],
+        )
+        .unwrap()],
+        &signer,
+    )
+    .unwrap();
+    let prepared = prepare_rotation_candidate(
+        &definition,
+        KeyEpoch(0),
+        std::slice::from_ref(&receiver_b),
+        rotation,
+    )
+    .unwrap();
+    let public = prepared.public();
+
+    let manifest = JsonValue::Object(vec![
+        (
+            "fixture_format".into(),
+            string("D18T-durable-epoch-activation-fixtures-v1"),
+        ),
+        (
+            "spec".into(),
+            string("code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md"),
+        ),
+        (
+            "generator_blob_sha1".into(),
+            string(generator_blob_sha1),
+        ),
+        (
+            "warning".into(),
+            string("The test_only_secrets object contains deterministic conformance-only secrets. Never log or use them outside tests."),
+        ),
+        (
+            "constants".into(),
+            object(vec![
+                ("state_magic_ascii", string("D18S")),
+                ("state_version", string("2")),
+                ("plan_magic_ascii", string("D18T")),
+                ("plan_version", string("1")),
+                ("state_content_type", string(EPOCH_STATE_CONTENT_TYPE)),
+                ("plan_content_type", string(ACTIVATION_PLAN_CONTENT_TYPE)),
+                ("max_cas_attempts", string("16")),
+            ]),
+        ),
+        (
+            "test_only_secrets".into(),
+            object(vec![
+                ("current_cmk_hex", string(encode_hex(&CURRENT_CMK))),
+                ("next_cmk_hex", string(encode_hex(&NEXT_CMK))),
+                ("originator_signing_seed_hex", string(encode_hex(&SIGNING_SEED))),
+                ("receiver_a_private_key_hex", string(encode_hex(&RECEIVER_A_PRIVATE))),
+                ("receiver_b_private_key_hex", string(encode_hex(&RECEIVER_B_PRIVATE))),
+                ("ephemeral_private_key_hex", string(encode_hex(&[0x51; 32]))),
+                ("wrapping_nonce_hex", string(encode_hex(&[0x61; 24]))),
+            ]),
+        ),
+        (
+            "state_migrations".into(),
+            JsonValue::Array(vec![
+                migration("no-pending", &no_pending_v1, &no_pending_v2, "0", "0"),
+                migration("pending-d18h", &pending_v1, &pending_v2, "0", "8"),
+            ]),
+        ),
+        (
+            "activation_case".into(),
+            object(vec![
+                ("name", string("receivers-a-plus-b-to-b-only")),
+                ("base_epoch", string("0")),
+                ("new_epoch", string("1")),
+                (
+                    "plan_record_key",
+                    string(activation_plan_record_key(ChannelId(CHANNEL_ID), KeyEpoch(1))),
+                ),
+                ("plan_content_type", string(ACTIVATION_PLAN_CONTENT_TYPE)),
+                ("plan_b64", string(encode_base64(public.plan_bytes()))),
+                (
+                    "grant_b64",
+                    JsonValue::Array(
+                        public
+                            .grants()
+                            .iter()
+                            .map(|grant| string(encode_base64(grant)))
+                            .collect(),
+                    ),
+                ),
+                (
+                    "receiver_a_retains_epochs",
+                    JsonValue::Array(vec![string("0")]),
+                ),
+                (
+                    "receiver_b_retains_epochs",
+                    JsonValue::Array(vec![string("0"), string("1")]),
+                ),
+                ("receiver_a_new_grant", JsonValue::Null),
+            ]),
+        ),
+        (
+            "crash_replay_traces".into(),
+            JsonValue::Array(vec![
+                trace("after-custody-selection", "replay-plan-and-all-grants", "prepared"),
+                trace("after-plan-write", "replay-all-grants", "prepared"),
+                trace("after-first-grant", "replay-remaining-grants", "prepared"),
+                trace("after-all-grants", "verify-and-activate", "activated"),
+                trace("after-activation-cas", "verify-exact-plan", "idempotent"),
+            ]),
+        ),
+        (
+            "race_traces".into(),
+            JsonValue::Array(vec![
+                trace("publish-reservation-wins", "activation", "pending_append"),
+                trace("activation-wins", "next-publish", "epoch-1-sequence-preserved"),
+                trace("same-candidate-retry", "custody-selection", "idempotent"),
+                trace("different-candidate-loses", "custody-selection", "conflicting_preparation"),
+            ]),
+        ),
+        (
+            "stable_error_codes".into(),
+            JsonValue::Array(
+                [
+                    "not_initialized", "channel_destroyed", "invalid_plan", "corrupt_record",
+                    "pending_append", "unactivated_epoch", "active_key_missing",
+                    "conflicting_active_key", "preparation_missing", "conflicting_preparation",
+                    "conflicting_plan", "conflicting_grant", "unexpected_epoch",
+                    "decreasing_epoch", "epoch_exhausted", "concurrent_update", "storage_error",
+                    "custody_error", "crypto_error",
+                ]
+                .into_iter()
+                .map(string)
+                .collect(),
+            ),
+        ),
+        (
+            "negative_scenarios".into(),
+            JsonValue::Array(vec![
+                trace("pending-append", "activation", "pending_append"),
+                trace("corrupt-public-record", "recovery", "corrupt_record"),
+                trace("missing-custody", "activation", "preparation_missing"),
+                trace("destroyed-channel", "activation", "channel_destroyed"),
+                trace("epoch-exhaustion", "preparation", "epoch_exhausted"),
+                trace("sixteen-cas-conflicts", "activation", "concurrent_update"),
+            ]),
+        ),
+        ("secret_erasure_capability".into(), string("guaranteed")),
+    ]);
+    let mut encoded = serialize_pretty(&manifest, &SerializerConfig::default())
+        .unwrap()
+        .into_bytes();
+    encoded.push(b'\n');
+    encoded
+}
+
+fn migration(name: &str, v1: &[u8], v2: &[u8], epoch: &str, sequence: &str) -> JsonValue {
+    object(vec![
+        ("name", string(name)),
+        ("d18s_v1_b64", string(encode_base64(v1))),
+        ("d18s_v2_b64", string(encode_base64(v2))),
+        ("active_epoch", string(epoch)),
+        ("next_sequence", string(sequence)),
+    ])
+}
+
+fn trace(name: &str, operation: &str, expected: &str) -> JsonValue {
+    object(vec![
+        ("name", string(name)),
+        ("operation", string(operation)),
+        ("expected", string(expected)),
+    ])
+}
+
+fn object(fields: Vec<(&str, JsonValue)>) -> JsonValue {
+    JsonValue::Object(
+        fields
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value))
+            .collect(),
+    )
+}
+
+fn string(value: impl Into<String>) -> JsonValue {
+    JsonValue::String(value.into())
+}
+
+fn message_id(byte: u8) -> [u8; 16] {
+    let mut bytes = [byte; 16];
+    bytes[6] = 0x70 | (byte & 0x0f);
+    bytes[8] = 0x80 | (byte & 0x3f);
+    bytes
+}
+
+fn encode_base64(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let word = ((chunk[0] as u32) << 16)
+            | ((chunk.get(1).copied().unwrap_or(0) as u32) << 8)
+            | chunk.get(2).copied().unwrap_or(0) as u32;
+        output.push(BASE64[((word >> 18) & 0x3f) as usize] as char);
+        output.push(BASE64[((word >> 12) & 0x3f) as usize] as char);
+        output.push(if chunk.len() > 1 {
+            BASE64[((word >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        output.push(if chunk.len() > 2 {
+            BASE64[(word & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    output
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-channel-epoch-activation",
+  "capabilities": [],
+  "justification": "Pure D18T orchestration over injected storage, key custody, and production channel cryptography. The package directly performs no filesystem, network, process, environment, clock, or random access."
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/src/custody.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/src/custody.rs
@@ -1,0 +1,406 @@
+//! Injected originator-key custody for D18T.
+//!
+//! The public contract selects one complete candidate atomically and exposes
+//! only redacted handles to the orchestration layer. The included memory
+//! implementation is deterministic test infrastructure and reports itself as
+//! non-durable, so the production constructor rejects it.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use chief_of_staff_channel_crypto::{ChannelId, ChannelMasterKey, KeyEpoch};
+use coding_adventures_ct_compare::ct_eq_fixed;
+
+/// The result of an atomic create-if-absent custody operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CustodySelection {
+    /// The complete candidate became the durable owner.
+    Selected,
+    /// The exact public bundle and secret key already own the slot.
+    Idempotent,
+    /// Different bytes already own the slot.
+    Conflict,
+}
+
+/// Opaque secret-custody failures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CustodyError {
+    /// The custody implementation is unavailable.
+    Unavailable,
+    /// A handle does not resolve to retained key material.
+    MissingKey,
+}
+
+impl core::fmt::Display for CustodyError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Unavailable => "originator key custody unavailable",
+            Self::MissingKey => "originator key is unavailable",
+        })
+    }
+}
+
+impl std::error::Error for CustodyError {}
+
+/// Redacted reference to one retained epoch key.
+#[derive(Clone, PartialEq, Eq)]
+pub struct EpochKeyHandle {
+    channel_id: ChannelId,
+    epoch: KeyEpoch,
+}
+
+impl EpochKeyHandle {
+    /// Return the public channel identity associated with this handle.
+    pub const fn channel_id(&self) -> ChannelId {
+        self.channel_id
+    }
+
+    /// Return the public epoch associated with this handle.
+    pub const fn epoch(&self) -> KeyEpoch {
+        self.epoch
+    }
+}
+
+impl core::fmt::Debug for EpochKeyHandle {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("EpochKeyHandle([REDACTED])")
+    }
+}
+
+/// Secret-free recovery bundle returned after process restart.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicPreparation {
+    channel_id: ChannelId,
+    base_epoch: KeyEpoch,
+    new_epoch: KeyEpoch,
+    plan_bytes: Vec<u8>,
+    grants: Vec<Vec<u8>>,
+}
+
+impl PublicPreparation {
+    /// Construct an exact secret-free replay bundle.
+    pub fn new(
+        channel_id: ChannelId,
+        base_epoch: KeyEpoch,
+        new_epoch: KeyEpoch,
+        plan_bytes: Vec<u8>,
+        grants: Vec<Vec<u8>>,
+    ) -> Self {
+        Self {
+            channel_id,
+            base_epoch,
+            new_epoch,
+            plan_bytes,
+            grants,
+        }
+    }
+
+    /// Return the public channel identity.
+    pub const fn channel_id(&self) -> ChannelId {
+        self.channel_id
+    }
+
+    /// Return the public base epoch.
+    pub const fn base_epoch(&self) -> KeyEpoch {
+        self.base_epoch
+    }
+
+    /// Return the public successor epoch.
+    pub const fn new_epoch(&self) -> KeyEpoch {
+        self.new_epoch
+    }
+
+    /// Borrow the exact canonical D18T plan bytes.
+    pub fn plan_bytes(&self) -> &[u8] {
+        &self.plan_bytes
+    }
+
+    /// Borrow exact canonical D18G bytes in raw receiver-ID order.
+    pub fn grants(&self) -> &[Vec<u8>] {
+        &self.grants
+    }
+}
+
+/// One indivisible candidate offered to secret custody.
+pub struct PreparedEpoch {
+    public: PublicPreparation,
+    cmk: ChannelMasterKey,
+}
+
+impl PreparedEpoch {
+    /// Own one complete public recovery bundle and its secret CMK.
+    pub fn new(public: PublicPreparation, cmk: ChannelMasterKey) -> Self {
+        Self { public, cmk }
+    }
+
+    /// Borrow the secret-free recovery portion.
+    pub fn public(&self) -> &PublicPreparation {
+        &self.public
+    }
+
+    /// Borrow the CMK only for an immediate custody operation.
+    pub fn cmk(&self) -> &ChannelMasterKey {
+        &self.cmk
+    }
+
+    fn into_parts(self) -> (PublicPreparation, ChannelMasterKey) {
+        (self.public, self.cmk)
+    }
+}
+
+impl core::fmt::Debug for PreparedEpoch {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("PreparedEpoch")
+            .field("channel_id", &self.public.channel_id)
+            .field("base_epoch", &self.public.base_epoch)
+            .field("new_epoch", &self.public.new_epoch)
+            .field("plan_bytes", &self.public.plan_bytes)
+            .field("grant_count", &self.public.grants.len())
+            .field("cmk", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Atomic originator-key custody required by D18T.
+pub trait OriginatorKeyCustody: Send + Sync {
+    /// Report whether values survive process and machine restart.
+    fn is_durable(&self) -> bool;
+
+    /// Atomically import the CMK for an already-active version 1 channel.
+    fn import_active_if_absent(
+        &self,
+        channel_id: ChannelId,
+        epoch: KeyEpoch,
+        cmk: &ChannelMasterKey,
+    ) -> Result<CustodySelection, CustodyError>;
+
+    /// Resolve one public channel/epoch to an opaque handle.
+    fn resolve_handle(
+        &self,
+        channel_id: ChannelId,
+        epoch: KeyEpoch,
+    ) -> Result<Option<EpochKeyHandle>, CustodyError>;
+
+    /// Atomically select one complete prepared-epoch bundle.
+    fn prepare_if_absent(&self, prepared: PreparedEpoch) -> Result<CustodySelection, CustodyError>;
+
+    /// Reload the exact public recovery bundle after restart.
+    fn load_preparation(
+        &self,
+        channel_id: ChannelId,
+        new_epoch: KeyEpoch,
+    ) -> Result<Option<PublicPreparation>, CustodyError>;
+
+    /// Use a resolved CMK without returning its bytes to the caller.
+    fn with_key<T>(
+        &self,
+        handle: &EpochKeyHandle,
+        operation: impl FnOnce(&ChannelMasterKey) -> T,
+    ) -> Result<T, CustodyError>;
+
+    /// Apply configured logical secret destruction for one channel.
+    fn destroy_channel(&self, channel_id: ChannelId) -> Result<(), CustodyError>;
+}
+
+#[derive(Default)]
+struct MemoryCustodyState {
+    keys: BTreeMap<(ChannelId, KeyEpoch), ChannelMasterKey>,
+    preparations: BTreeMap<(ChannelId, KeyEpoch), PublicPreparation>,
+}
+
+/// Deterministic non-durable custody for tests and fixture generation only.
+#[derive(Default)]
+pub struct InMemoryKeyCustody {
+    state: Mutex<MemoryCustodyState>,
+}
+
+impl InMemoryKeyCustody {
+    /// Create empty test-only custody.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the number of retained secret epoch keys for test assertions.
+    pub fn retained_key_count(&self) -> Result<usize, CustodyError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| CustodyError::Unavailable)?
+            .keys
+            .len())
+    }
+}
+
+impl OriginatorKeyCustody for InMemoryKeyCustody {
+    fn is_durable(&self) -> bool {
+        false
+    }
+
+    fn import_active_if_absent(
+        &self,
+        channel_id: ChannelId,
+        epoch: KeyEpoch,
+        cmk: &ChannelMasterKey,
+    ) -> Result<CustodySelection, CustodyError> {
+        let mut state = self.state.lock().map_err(|_| CustodyError::Unavailable)?;
+        match state.keys.get(&(channel_id, epoch)) {
+            Some(existing) if ct_eq_fixed(existing.as_bytes(), cmk.as_bytes()) => {
+                Ok(CustodySelection::Idempotent)
+            }
+            Some(_) => Ok(CustodySelection::Conflict),
+            None => {
+                state.keys.insert(
+                    (channel_id, epoch),
+                    ChannelMasterKey::from_bytes(*cmk.as_bytes()),
+                );
+                Ok(CustodySelection::Selected)
+            }
+        }
+    }
+
+    fn resolve_handle(
+        &self,
+        channel_id: ChannelId,
+        epoch: KeyEpoch,
+    ) -> Result<Option<EpochKeyHandle>, CustodyError> {
+        let state = self.state.lock().map_err(|_| CustodyError::Unavailable)?;
+        Ok(state
+            .keys
+            .contains_key(&(channel_id, epoch))
+            .then_some(EpochKeyHandle { channel_id, epoch }))
+    }
+
+    fn prepare_if_absent(&self, prepared: PreparedEpoch) -> Result<CustodySelection, CustodyError> {
+        let key = (prepared.public.channel_id, prepared.public.new_epoch);
+        let mut state = self.state.lock().map_err(|_| CustodyError::Unavailable)?;
+        match (state.preparations.get(&key), state.keys.get(&key)) {
+            (Some(public), Some(cmk))
+                if public == &prepared.public
+                    && ct_eq_fixed(cmk.as_bytes(), prepared.cmk.as_bytes()) =>
+            {
+                Ok(CustodySelection::Idempotent)
+            }
+            (None, None) => {
+                let (public, cmk) = prepared.into_parts();
+                state.preparations.insert(key, public);
+                state.keys.insert(key, cmk);
+                Ok(CustodySelection::Selected)
+            }
+            _ => Ok(CustodySelection::Conflict),
+        }
+    }
+
+    fn load_preparation(
+        &self,
+        channel_id: ChannelId,
+        new_epoch: KeyEpoch,
+    ) -> Result<Option<PublicPreparation>, CustodyError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| CustodyError::Unavailable)?
+            .preparations
+            .get(&(channel_id, new_epoch))
+            .cloned())
+    }
+
+    fn with_key<T>(
+        &self,
+        handle: &EpochKeyHandle,
+        operation: impl FnOnce(&ChannelMasterKey) -> T,
+    ) -> Result<T, CustodyError> {
+        let state = self.state.lock().map_err(|_| CustodyError::Unavailable)?;
+        let cmk = state
+            .keys
+            .get(&(handle.channel_id, handle.epoch))
+            .ok_or(CustodyError::MissingKey)?;
+        Ok(operation(cmk))
+    }
+
+    fn destroy_channel(&self, channel_id: ChannelId) -> Result<(), CustodyError> {
+        let mut state = self.state.lock().map_err(|_| CustodyError::Unavailable)?;
+        state
+            .keys
+            .retain(|(candidate, _), _| *candidate != channel_id);
+        state
+            .preparations
+            .retain(|(candidate, _), _| *candidate != channel_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel_id() -> ChannelId {
+        ChannelId([
+            0x01, 0x8f, 0x47, 0xa0, 0x9b, 0x6c, 0x7d, 0xef, 0x92, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+            0xde, 0xf0,
+        ])
+    }
+
+    #[test]
+    fn active_import_is_constant_time_idempotent_and_conflicting() {
+        let custody = InMemoryKeyCustody::new();
+        let key = ChannelMasterKey::from_bytes([0x11; 32]);
+        assert_eq!(
+            custody
+                .import_active_if_absent(channel_id(), KeyEpoch(4), &key)
+                .unwrap(),
+            CustodySelection::Selected
+        );
+        assert_eq!(
+            custody
+                .import_active_if_absent(channel_id(), KeyEpoch(4), &key)
+                .unwrap(),
+            CustodySelection::Idempotent
+        );
+        assert_eq!(
+            custody
+                .import_active_if_absent(
+                    channel_id(),
+                    KeyEpoch(4),
+                    &ChannelMasterKey::from_bytes([0x22; 32]),
+                )
+                .unwrap(),
+            CustodySelection::Conflict
+        );
+        let handle = custody
+            .resolve_handle(channel_id(), KeyEpoch(4))
+            .unwrap()
+            .unwrap();
+        assert_eq!(format!("{handle:?}"), "EpochKeyHandle([REDACTED])");
+        assert!(custody
+            .with_key(&handle, |cmk| cmk.as_bytes() == &[0x11; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn preparation_selects_one_complete_bundle_and_destruction_erases_keys() {
+        let custody = InMemoryKeyCustody::new();
+        let public = PublicPreparation::new(
+            channel_id(),
+            KeyEpoch(4),
+            KeyEpoch(5),
+            b"plan".to_vec(),
+            vec![b"grant".to_vec()],
+        );
+        let prepared = PreparedEpoch::new(public.clone(), ChannelMasterKey::from_bytes([0x33; 32]));
+        let diagnostic = format!("{prepared:?}");
+        assert!(diagnostic.contains("[REDACTED]"));
+        assert!(!diagnostic.contains("3333333333333333"));
+        assert_eq!(
+            custody.prepare_if_absent(prepared).unwrap(),
+            CustodySelection::Selected
+        );
+        assert_eq!(
+            custody.load_preparation(channel_id(), KeyEpoch(5)).unwrap(),
+            Some(public)
+        );
+        assert_eq!(custody.retained_key_count().unwrap(), 1);
+        custody.destroy_channel(channel_id()).unwrap();
+        assert_eq!(custody.retained_key_count().unwrap(), 0);
+    }
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/src/lib.rs
@@ -1,0 +1,1005 @@
+//! Crash-safe durable D18T channel epoch activation.
+//!
+//! The crate composes production D18P storage records and D18Q grants without
+//! assuming a multi-record storage transaction. Secret custody selects and
+//! durably retains one complete successor bundle first; immutable public
+//! records are then replayable until one CAS advances the same D18S record used
+//! by publish reservations.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::grant_profile::{
+    grant_deserialize, grant_serialize, verify_grant_signature, KeyGrantProfileError, RotationPlan,
+};
+use chief_of_staff_channel_crypto::wire::{
+    decode_message, encode_message, key_grant_record_key, message_record_key,
+    sequence_state_record_key, CHANNEL_STORAGE_NAMESPACE,
+};
+use chief_of_staff_channel_crypto::{
+    encrypt_message_with_header, prepare_message_header, ChannelCryptoError, ChannelId,
+    ChannelMasterKey, EncryptedMessage, KeyEpoch, MessageFields, MessageHeader,
+    OriginatorSigningKey, Sequence,
+};
+use chief_of_staff_channel_endpoints::{
+    ChannelDefinition, ChannelDefinitionStore, ChannelEndpointError, ChannelLifecycle,
+    ReceiverIdentity,
+};
+use chief_of_staff_channel_store::profile::{
+    channel_state_deserialize, CHANNEL_STATE_CONTENT_TYPE,
+};
+use coding_adventures_json_value::JsonValue;
+use coding_adventures_sha256::sha256;
+use storage_core::{StorageBackend, StorageError, StoragePutInput, StorageRecord};
+
+pub mod custody;
+pub mod wire;
+
+pub use custody::{
+    CustodyError, CustodySelection, EpochKeyHandle, InMemoryKeyCustody, OriginatorKeyCustody,
+    PreparedEpoch, PublicPreparation,
+};
+pub use wire::{
+    activation_plan_deserialize, activation_plan_record_key, activation_plan_serialize,
+    epoch_state_deserialize, epoch_state_serialize, ActivationPlan, ActivationPlanEntry,
+    EpochState, EpochWireError, ACTIVATION_PLAN_CONTENT_TYPE, EPOCH_STATE_CONTENT_TYPE,
+    MAX_PENDING_HEADER_BYTES, MAX_PLAN_RECEIVERS,
+};
+
+const MAX_CAS_ATTEMPTS: usize = 16;
+const MESSAGE_CONTENT_TYPE: &str = "application/vnd.coding-adventures.chief-channel-message-v1";
+const GRANT_CONTENT_TYPE: &str = "application/vnd.coding-adventures.chief-channel-key-grant-v1";
+
+/// Stable D18T failures. Display strings never include secret values.
+#[derive(Debug)]
+pub enum EpochActivationError {
+    /// The injected public backend failed.
+    Storage(StorageError),
+    /// A public D18T record failed structural validation.
+    Wire(EpochWireError),
+    /// D18Q rejected grant bytes or cryptographic provenance.
+    Grant(KeyGrantProfileError),
+    /// D18F message cryptography failed.
+    Crypto(ChannelCryptoError),
+    /// Injected custody failed without exposing secret details.
+    Custody(CustodyError),
+    /// Production construction received non-durable custody.
+    NonDurableCustody,
+    /// No durable channel definition or state exists.
+    NotInitialized,
+    /// The immutable definition has been destroyed.
+    ChannelDestroyed,
+    /// A candidate violates D18T/D18Q or target-roster invariants.
+    InvalidPlan,
+    /// A stored envelope, key, metadata, or body is inconsistent.
+    CorruptRecord,
+    /// A publish reservation prevents activation or another reservation.
+    PendingAppend,
+    /// A caller named an epoch that is not active.
+    UnactivatedEpoch,
+    /// Custody cannot resolve the public active epoch.
+    ActiveKeyMissing,
+    /// Active-key import conflicts with retained bytes.
+    ConflictingActiveKey,
+    /// No selected recovery bundle exists for the requested epoch.
+    PreparationMissing,
+    /// Another prepared bundle owns the epoch slot.
+    ConflictingPreparation,
+    /// Another immutable activation plan owns its public key.
+    ConflictingPlan,
+    /// Another immutable D18G grant owns its public key.
+    ConflictingGrant,
+    /// A selected plan is not exactly the current successor.
+    UnexpectedEpoch,
+    /// Activation targeted an epoch older than the public current epoch.
+    DecreasingEpoch,
+    /// The public epoch cannot advance beyond `u64::MAX`.
+    EpochExhausted,
+    /// Sixteen revision-CAS attempts did not converge.
+    ConcurrentUpdate,
+}
+
+impl EpochActivationError {
+    /// Return the portable machine-readable error code.
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Storage(_) => "storage_error",
+            Self::Wire(_) | Self::CorruptRecord => "corrupt_record",
+            Self::Grant(_) | Self::Crypto(_) => "crypto_error",
+            Self::Custody(_) | Self::NonDurableCustody => "custody_error",
+            Self::NotInitialized => "not_initialized",
+            Self::ChannelDestroyed => "channel_destroyed",
+            Self::InvalidPlan => "invalid_plan",
+            Self::PendingAppend => "pending_append",
+            Self::UnactivatedEpoch => "unactivated_epoch",
+            Self::ActiveKeyMissing => "active_key_missing",
+            Self::ConflictingActiveKey => "conflicting_active_key",
+            Self::PreparationMissing => "preparation_missing",
+            Self::ConflictingPreparation => "conflicting_preparation",
+            Self::ConflictingPlan => "conflicting_plan",
+            Self::ConflictingGrant => "conflicting_grant",
+            Self::UnexpectedEpoch => "unexpected_epoch",
+            Self::DecreasingEpoch => "decreasing_epoch",
+            Self::EpochExhausted => "epoch_exhausted",
+            Self::ConcurrentUpdate => "concurrent_update",
+        }
+    }
+}
+
+impl core::fmt::Display for EpochActivationError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(self.code())
+    }
+}
+
+impl std::error::Error for EpochActivationError {}
+
+impl From<StorageError> for EpochActivationError {
+    fn from(error: StorageError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+impl From<EpochWireError> for EpochActivationError {
+    fn from(error: EpochWireError) -> Self {
+        Self::Wire(error)
+    }
+}
+
+impl From<KeyGrantProfileError> for EpochActivationError {
+    fn from(error: KeyGrantProfileError) -> Self {
+        Self::Grant(error)
+    }
+}
+
+impl From<ChannelCryptoError> for EpochActivationError {
+    fn from(error: ChannelCryptoError) -> Self {
+        Self::Crypto(error)
+    }
+}
+
+impl From<CustodyError> for EpochActivationError {
+    fn from(error: CustodyError) -> Self {
+        Self::Custody(error)
+    }
+}
+
+/// Result of preparing or replaying one successor epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreparationOutcome {
+    /// This call selected the complete bundle and persisted public records.
+    Prepared,
+    /// The same selected bundle and public records already existed.
+    Idempotent,
+}
+
+/// Result of the one active-epoch CAS.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivationOutcome {
+    /// This call advanced the active epoch.
+    Activated,
+    /// The exact selected plan had already advanced it.
+    Idempotent,
+}
+
+/// Caller-owned publish metadata without a caller-selected key epoch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActiveEpochAppendRequest {
+    /// Canonical message UUID v7 bytes.
+    pub message_id: [u8; 16],
+    /// Injected monotonic timestamp in nanoseconds.
+    pub timestamp_ns: u64,
+    /// Authorized originator identity.
+    pub originator_id: Vec<u8>,
+    /// MIME content type authenticated with the message.
+    pub content_type: String,
+}
+
+/// Exact reserved D18H plus a redacted handle for its active CMK.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EpochReservation {
+    header: MessageHeader,
+    key_handle: EpochKeyHandle,
+}
+
+impl EpochReservation {
+    /// Borrow the exact durable D18H reservation.
+    pub fn header(&self) -> &MessageHeader {
+        &self.header
+    }
+
+    /// Borrow the redacted active-key handle.
+    pub fn key_handle(&self) -> &EpochKeyHandle {
+        &self.key_handle
+    }
+}
+
+/// D18T orchestration over injected public storage and secret custody.
+pub struct EpochActivationStore<'a, C: OriginatorKeyCustody> {
+    backend: &'a dyn StorageBackend,
+    custody: &'a C,
+    channel_id: ChannelId,
+}
+
+impl<'a, C: OriginatorKeyCustody> EpochActivationStore<'a, C> {
+    /// Construct a production D18T store, rejecting non-durable custody.
+    pub fn new(
+        backend: &'a dyn StorageBackend,
+        custody: &'a C,
+        channel_id: ChannelId,
+    ) -> Result<Self, EpochActivationError> {
+        if !custody.is_durable() {
+            return Err(EpochActivationError::NonDurableCustody);
+        }
+        backend.initialize()?;
+        Ok(Self {
+            backend,
+            custody,
+            channel_id,
+        })
+    }
+
+    /// Construct a deterministic fixture/test store with explicitly
+    /// non-durable custody. Production code MUST use [`Self::new`].
+    pub fn new_for_testing(
+        backend: &'a dyn StorageBackend,
+        custody: &'a C,
+        channel_id: ChannelId,
+    ) -> Result<Self, EpochActivationError> {
+        backend.initialize()?;
+        Ok(Self {
+            backend,
+            custody,
+            channel_id,
+        })
+    }
+
+    /// Upgrade absent or D18S version 1 state after proving current-key
+    /// custody. An already-valid version 2 state is idempotent.
+    pub fn migrate_epoch_state(
+        &self,
+        definition: &ChannelDefinition,
+        current_cmk: Option<&ChannelMasterKey>,
+    ) -> Result<EpochState, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let record = self.state_record()?;
+            if let Some(record) = &record {
+                if record.content_type == EPOCH_STATE_CONTENT_TYPE {
+                    let state = self.decode_v2_state_record(record)?;
+                    if self
+                        .custody
+                        .resolve_handle(self.channel_id, state.active_epoch())?
+                        .is_none()
+                    {
+                        return Err(EpochActivationError::ActiveKeyMissing);
+                    }
+                    return Ok(state);
+                }
+            }
+
+            self.ensure_initial_key(definition.key_epoch(), current_cmk)?;
+            let state = match &record {
+                None => {
+                    EpochState::new(self.channel_id, definition.key_epoch(), Sequence(0), None)?
+                }
+                Some(record) => {
+                    self.require_record_envelope(
+                        record,
+                        &sequence_state_record_key(self.channel_id),
+                        CHANNEL_STATE_CONTENT_TYPE,
+                    )?;
+                    let prior = channel_state_deserialize(&record.body, self.channel_id)
+                        .map_err(|_| EpochActivationError::CorruptRecord)?;
+                    EpochState::new(
+                        self.channel_id,
+                        definition.key_epoch(),
+                        prior.next_sequence,
+                        prior.pending_header,
+                    )?
+                }
+            };
+            let mut input = public_put(
+                sequence_state_record_key(self.channel_id),
+                EPOCH_STATE_CONTENT_TYPE,
+                epoch_state_serialize(&state)?,
+            )?;
+            input = match &record {
+                None => input.with_if_absent(),
+                Some(record) => input.with_if_revision(Some(record.revision.clone())),
+            };
+            match self.backend.put(input) {
+                Ok(stored) => return self.decode_v2_state_record(&stored),
+                Err(StorageError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(EpochActivationError::ConcurrentUpdate)
+    }
+
+    /// Load the current D18S version 2 state.
+    pub fn state(&self) -> Result<EpochState, EpochActivationError> {
+        let record = self
+            .state_record()?
+            .ok_or(EpochActivationError::NotInitialized)?;
+        self.decode_v2_state_record(&record)
+    }
+
+    /// Select one D18Q rotation in custody, then replay its exact immutable
+    /// plan and grants into public storage.
+    pub fn prepare_rotation(
+        &self,
+        definition: &ChannelDefinition,
+        target_roster: &[ReceiverIdentity],
+        rotation: RotationPlan,
+    ) -> Result<PreparationOutcome, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        let state = self.state()?;
+        if state.pending_header().is_some() {
+            return Err(EpochActivationError::PendingAppend);
+        }
+        let expected = state
+            .active_epoch()
+            .0
+            .checked_add(1)
+            .map(KeyEpoch)
+            .ok_or(EpochActivationError::EpochExhausted)?;
+        if rotation.new_epoch() != expected {
+            return Err(EpochActivationError::UnexpectedEpoch);
+        }
+        let prepared =
+            prepare_rotation_candidate(definition, state.active_epoch(), target_roster, rotation)?;
+        let selection = self.custody.prepare_if_absent(prepared)?;
+        let outcome = match selection {
+            CustodySelection::Selected => PreparationOutcome::Prepared,
+            CustodySelection::Idempotent => PreparationOutcome::Idempotent,
+            CustodySelection::Conflict => return Err(EpochActivationError::ConflictingPreparation),
+        };
+        self.replay_preparation(definition, expected)?;
+        Ok(outcome)
+    }
+
+    /// Replay one custody-selected plan and every exact grant after restart.
+    pub fn recover_preparation(
+        &self,
+        definition: &ChannelDefinition,
+        new_epoch: KeyEpoch,
+    ) -> Result<PreparationOutcome, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        let active_epoch = self.state()?.active_epoch();
+        if new_epoch < active_epoch {
+            return Err(EpochActivationError::DecreasingEpoch);
+        }
+        if new_epoch != active_epoch {
+            let successor = active_epoch
+                .0
+                .checked_add(1)
+                .map(KeyEpoch)
+                .ok_or(EpochActivationError::EpochExhausted)?;
+            if new_epoch != successor {
+                return Err(EpochActivationError::UnexpectedEpoch);
+            }
+        }
+        self.replay_preparation(definition, new_epoch)?;
+        Ok(PreparationOutcome::Idempotent)
+    }
+
+    /// Advance the active epoch exactly once after replaying and verifying the
+    /// selected public bundle.
+    pub fn activate_prepared_epoch(
+        &self,
+        definition: &ChannelDefinition,
+        new_epoch: KeyEpoch,
+    ) -> Result<ActivationOutcome, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        let prepared = self
+            .custody
+            .load_preparation(self.channel_id, new_epoch)?
+            .ok_or(EpochActivationError::PreparationMissing)?;
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            self.require_definition(definition, false)?;
+            let record = self
+                .state_record()?
+                .ok_or(EpochActivationError::NotInitialized)?;
+            let state = self.decode_v2_state_record(&record)?;
+            if state.active_epoch() == new_epoch {
+                self.validate_and_replay(definition, &prepared)?;
+                if self
+                    .custody
+                    .resolve_handle(self.channel_id, new_epoch)?
+                    .is_none()
+                {
+                    return Err(EpochActivationError::ActiveKeyMissing);
+                }
+                return Ok(ActivationOutcome::Idempotent);
+            }
+            if state.active_epoch() > new_epoch {
+                return Err(EpochActivationError::DecreasingEpoch);
+            }
+            let expected = state
+                .active_epoch()
+                .0
+                .checked_add(1)
+                .map(KeyEpoch)
+                .ok_or(EpochActivationError::EpochExhausted)?;
+            if expected != new_epoch
+                || prepared.base_epoch() != state.active_epoch()
+                || prepared.new_epoch() != new_epoch
+            {
+                return Err(EpochActivationError::UnexpectedEpoch);
+            }
+            self.validate_and_replay(definition, &prepared)?;
+            if self
+                .custody
+                .resolve_handle(self.channel_id, new_epoch)?
+                .is_none()
+            {
+                return Err(EpochActivationError::ActiveKeyMissing);
+            }
+            if state.pending_header().is_some() {
+                return Err(EpochActivationError::PendingAppend);
+            }
+            let updated = state.with_active_epoch(self.channel_id, new_epoch)?;
+            let input = public_put(
+                sequence_state_record_key(self.channel_id),
+                EPOCH_STATE_CONTENT_TYPE,
+                epoch_state_serialize(&updated)?,
+            )?
+            .with_if_revision(Some(record.revision));
+            match self.backend.put(input) {
+                Ok(stored) => {
+                    let committed = self.decode_v2_state_record(&stored)?;
+                    if committed != updated {
+                        return Err(EpochActivationError::CorruptRecord);
+                    }
+                    return Ok(ActivationOutcome::Activated);
+                }
+                Err(StorageError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(EpochActivationError::ConcurrentUpdate)
+    }
+
+    /// Reserve one publish using only the epoch currently authoritative in
+    /// D18S version 2. No encryption occurs before the reservation CAS.
+    pub fn reserve_publish_using_active_epoch(
+        &self,
+        definition: &ChannelDefinition,
+        request: ActiveEpochAppendRequest,
+        plaintext: &[u8],
+    ) -> Result<EpochReservation, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        if request.originator_id != definition.originator().agent_id.as_bytes() {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let record = self
+                .state_record()?
+                .ok_or(EpochActivationError::NotInitialized)?;
+            let state = self.decode_v2_state_record(&record)?;
+            let key_handle = self
+                .custody
+                .resolve_handle(self.channel_id, state.active_epoch())?
+                .ok_or(EpochActivationError::ActiveKeyMissing)?;
+            if state.pending_header().is_some() {
+                return Err(EpochActivationError::PendingAppend);
+            }
+            let next_sequence = state
+                .next_sequence()
+                .0
+                .checked_add(1)
+                .map(Sequence)
+                .ok_or(ChannelCryptoError::SequenceExhausted)?;
+            let header = prepare_message_header(
+                MessageFields::new(
+                    request.message_id,
+                    request.timestamp_ns,
+                    request.originator_id.clone(),
+                    self.channel_id,
+                    state.next_sequence(),
+                    state.active_epoch(),
+                    request.content_type.clone(),
+                ),
+                plaintext,
+            );
+            let updated =
+                state.with_pending(self.channel_id, next_sequence, Some(header.clone()))?;
+            let input = public_put(
+                sequence_state_record_key(self.channel_id),
+                EPOCH_STATE_CONTENT_TYPE,
+                epoch_state_serialize(&updated)?,
+            )?
+            .with_if_revision(Some(record.revision));
+            match self.backend.put(input) {
+                Ok(_) => return Ok(EpochReservation { header, key_handle }),
+                Err(StorageError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(EpochActivationError::ConcurrentUpdate)
+    }
+
+    /// Encrypt, idempotently persist, and clear one exact D18T reservation.
+    pub fn commit_reserved(
+        &self,
+        definition: &ChannelDefinition,
+        reservation: &EpochReservation,
+        plaintext: &[u8],
+        signing_key: &OriginatorSigningKey,
+    ) -> Result<EncryptedMessage, EpochActivationError> {
+        self.require_definition(definition, false)?;
+        let header = reservation.header();
+        if header.fields().channel_id() != self.channel_id
+            || header.fields().key_epoch() != reservation.key_handle().epoch()
+            || reservation.key_handle().channel_id() != self.channel_id
+        {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        let state = self.state()?;
+        match state.pending_header() {
+            Some(pending) if pending == header => {}
+            Some(_) => return Err(EpochActivationError::InvalidPlan),
+            None => {
+                let stored = self
+                    .backend
+                    .get(
+                        CHANNEL_STORAGE_NAMESPACE,
+                        &message_record_key(self.channel_id, header.fields().sequence()),
+                    )?
+                    .ok_or(EpochActivationError::CorruptRecord)?;
+                self.require_record_envelope(
+                    &stored,
+                    &message_record_key(self.channel_id, header.fields().sequence()),
+                    MESSAGE_CONTENT_TYPE,
+                )?;
+                let message = decode_message(&stored.body)
+                    .map_err(|_| EpochActivationError::CorruptRecord)?;
+                if message.header() != header {
+                    return Err(EpochActivationError::CorruptRecord);
+                }
+                let expected = self.encrypt_with_handle(
+                    reservation.key_handle(),
+                    header.clone(),
+                    plaintext,
+                    signing_key,
+                )?;
+                if encode_message(&expected).map_err(|_| EpochActivationError::CorruptRecord)?
+                    != stored.body
+                {
+                    return Err(EpochActivationError::CorruptRecord);
+                }
+                return Ok(message);
+            }
+        }
+
+        let message = self.encrypt_with_handle(
+            reservation.key_handle(),
+            header.clone(),
+            plaintext,
+            signing_key,
+        )?;
+        self.put_immutable(
+            message_record_key(self.channel_id, header.fields().sequence()),
+            MESSAGE_CONTENT_TYPE,
+            encode_message(&message).map_err(|_| EpochActivationError::CorruptRecord)?,
+            EpochActivationError::CorruptRecord,
+        )?;
+        self.clear_pending(header)?;
+        Ok(message)
+    }
+
+    /// Clear a pending reservation without decrementing its consumed sequence.
+    pub fn abandon_pending(&self) -> Result<Option<MessageHeader>, EpochActivationError> {
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let record = self
+                .state_record()?
+                .ok_or(EpochActivationError::NotInitialized)?;
+            let state = self.decode_v2_state_record(&record)?;
+            let Some(header) = state.pending_header().cloned() else {
+                return Ok(None);
+            };
+            let updated = state.with_pending(self.channel_id, state.next_sequence(), None)?;
+            let input = public_put(
+                sequence_state_record_key(self.channel_id),
+                EPOCH_STATE_CONTENT_TYPE,
+                epoch_state_serialize(&updated)?,
+            )?
+            .with_if_revision(Some(record.revision));
+            match self.backend.put(input) {
+                Ok(_) => return Ok(Some(header)),
+                Err(StorageError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(EpochActivationError::ConcurrentUpdate)
+    }
+
+    /// Load one immutable public activation plan, if present.
+    pub fn activation_plan(
+        &self,
+        new_epoch: KeyEpoch,
+    ) -> Result<Option<ActivationPlan>, EpochActivationError> {
+        let key = activation_plan_record_key(self.channel_id, new_epoch);
+        let Some(record) = self.backend.get(CHANNEL_STORAGE_NAMESPACE, &key)? else {
+            return Ok(None);
+        };
+        self.require_record_envelope(&record, &key, ACTIVATION_PLAN_CONTENT_TYPE)?;
+        let plan = activation_plan_deserialize(&record.body)?;
+        if plan.channel_id() != self.channel_id || plan.new_epoch() != new_epoch {
+            return Err(EpochActivationError::CorruptRecord);
+        }
+        Ok(Some(plan))
+    }
+
+    /// Erase locally retained originator secrets after the durable definition
+    /// is destroyed. Public definitions, plans, grants, and messages remain.
+    pub fn apply_destruction(
+        &self,
+        definition: &ChannelDefinition,
+    ) -> Result<(), EpochActivationError> {
+        self.require_definition(definition, true)?;
+        self.custody.destroy_channel(self.channel_id)?;
+        Ok(())
+    }
+
+    fn ensure_initial_key(
+        &self,
+        epoch: KeyEpoch,
+        current_cmk: Option<&ChannelMasterKey>,
+    ) -> Result<(), EpochActivationError> {
+        if self
+            .custody
+            .resolve_handle(self.channel_id, epoch)?
+            .is_some()
+        {
+            return Ok(());
+        }
+        let cmk = current_cmk.ok_or(EpochActivationError::ActiveKeyMissing)?;
+        match self
+            .custody
+            .import_active_if_absent(self.channel_id, epoch, cmk)?
+        {
+            CustodySelection::Selected | CustodySelection::Idempotent => Ok(()),
+            CustodySelection::Conflict => Err(EpochActivationError::ConflictingActiveKey),
+        }
+    }
+
+    fn replay_preparation(
+        &self,
+        definition: &ChannelDefinition,
+        new_epoch: KeyEpoch,
+    ) -> Result<(), EpochActivationError> {
+        let prepared = self
+            .custody
+            .load_preparation(self.channel_id, new_epoch)?
+            .ok_or(EpochActivationError::PreparationMissing)?;
+        self.validate_and_replay(definition, &prepared)
+    }
+
+    fn validate_and_replay(
+        &self,
+        definition: &ChannelDefinition,
+        prepared: &PublicPreparation,
+    ) -> Result<(), EpochActivationError> {
+        let plan = validate_public_preparation(definition, prepared)?;
+        self.put_immutable(
+            activation_plan_record_key(self.channel_id, plan.new_epoch()),
+            ACTIVATION_PLAN_CONTENT_TYPE,
+            prepared.plan_bytes().to_vec(),
+            EpochActivationError::ConflictingPlan,
+        )?;
+        for bytes in prepared.grants() {
+            let grant = grant_deserialize(bytes)?;
+            self.put_immutable(
+                key_grant_record_key(self.channel_id, grant.key_epoch(), grant.receiver_id()),
+                GRANT_CONTENT_TYPE,
+                bytes.clone(),
+                EpochActivationError::ConflictingGrant,
+            )?;
+        }
+        let stored = self
+            .activation_plan(plan.new_epoch())?
+            .ok_or(EpochActivationError::CorruptRecord)?;
+        if stored != plan {
+            return Err(EpochActivationError::CorruptRecord);
+        }
+        for bytes in prepared.grants() {
+            let grant = grant_deserialize(bytes)?;
+            let key = key_grant_record_key(self.channel_id, grant.key_epoch(), grant.receiver_id());
+            let record = self
+                .backend
+                .get(CHANNEL_STORAGE_NAMESPACE, &key)?
+                .ok_or(EpochActivationError::CorruptRecord)?;
+            self.require_record_envelope(&record, &key, GRANT_CONTENT_TYPE)?;
+            if record.body != *bytes {
+                return Err(EpochActivationError::CorruptRecord);
+            }
+        }
+        Ok(())
+    }
+
+    fn encrypt_with_handle(
+        &self,
+        handle: &EpochKeyHandle,
+        header: MessageHeader,
+        plaintext: &[u8],
+        signing_key: &OriginatorSigningKey,
+    ) -> Result<EncryptedMessage, EpochActivationError> {
+        self.custody
+            .with_key(handle, |cmk| {
+                encrypt_message_with_header(header, plaintext, cmk, signing_key)
+            })?
+            .map_err(EpochActivationError::Crypto)
+    }
+
+    fn clear_pending(&self, expected: &MessageHeader) -> Result<(), EpochActivationError> {
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let record = self
+                .state_record()?
+                .ok_or(EpochActivationError::NotInitialized)?;
+            let state = self.decode_v2_state_record(&record)?;
+            match state.pending_header() {
+                None => return Ok(()),
+                Some(pending) if pending == expected => {}
+                Some(_) => return Err(EpochActivationError::InvalidPlan),
+            }
+            let updated = state.with_pending(self.channel_id, state.next_sequence(), None)?;
+            let input = public_put(
+                sequence_state_record_key(self.channel_id),
+                EPOCH_STATE_CONTENT_TYPE,
+                epoch_state_serialize(&updated)?,
+            )?
+            .with_if_revision(Some(record.revision));
+            match self.backend.put(input) {
+                Ok(_) => return Ok(()),
+                Err(StorageError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(EpochActivationError::ConcurrentUpdate)
+    }
+
+    fn require_definition(
+        &self,
+        expected: &ChannelDefinition,
+        require_destroyed: bool,
+    ) -> Result<(), EpochActivationError> {
+        if expected.channel_id() != self.channel_id {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        let actual = ChannelDefinitionStore::new(self.backend)
+            .load(self.channel_id)
+            .map_err(map_definition_error)?
+            .ok_or(EpochActivationError::NotInitialized)?;
+        if actual != *expected {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        match (actual.lifecycle(), require_destroyed) {
+            (ChannelLifecycle::Destroyed, false) => Err(EpochActivationError::ChannelDestroyed),
+            (ChannelLifecycle::Active, true) => Err(EpochActivationError::InvalidPlan),
+            _ => Ok(()),
+        }
+    }
+
+    fn state_record(&self) -> Result<Option<StorageRecord>, EpochActivationError> {
+        Ok(self.backend.get(
+            CHANNEL_STORAGE_NAMESPACE,
+            &sequence_state_record_key(self.channel_id),
+        )?)
+    }
+
+    fn decode_v2_state_record(
+        &self,
+        record: &StorageRecord,
+    ) -> Result<EpochState, EpochActivationError> {
+        self.require_record_envelope(
+            record,
+            &sequence_state_record_key(self.channel_id),
+            EPOCH_STATE_CONTENT_TYPE,
+        )?;
+        Ok(epoch_state_deserialize(&record.body, self.channel_id)?)
+    }
+
+    fn require_record_envelope(
+        &self,
+        record: &StorageRecord,
+        expected_key: &str,
+        expected_content_type: &str,
+    ) -> Result<(), EpochActivationError> {
+        if record.namespace != CHANNEL_STORAGE_NAMESPACE
+            || record.key != expected_key
+            || record.content_type != expected_content_type
+            || record.metadata != empty_metadata()
+        {
+            return Err(EpochActivationError::CorruptRecord);
+        }
+        Ok(())
+    }
+
+    fn put_immutable(
+        &self,
+        key: String,
+        content_type: &'static str,
+        body: Vec<u8>,
+        conflict: EpochActivationError,
+    ) -> Result<(), EpochActivationError> {
+        let input = public_put(key.clone(), content_type, body.clone())?.with_if_absent();
+        match self.backend.put(input) {
+            Ok(record) => {
+                self.require_record_envelope(&record, &key, content_type)?;
+                if record.body != body {
+                    return Err(EpochActivationError::CorruptRecord);
+                }
+                Ok(())
+            }
+            Err(StorageError::Conflict { .. }) => {
+                let Some(record) = self.backend.get(CHANNEL_STORAGE_NAMESPACE, &key)? else {
+                    return Err(EpochActivationError::CorruptRecord);
+                };
+                self.require_record_envelope(&record, &key, content_type)?;
+                if record.body == body {
+                    Ok(())
+                } else {
+                    Err(conflict)
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+/// Validate and construct one complete D18Q candidate before custody selection.
+///
+/// This pure helper is public so deterministic conformance generators can
+/// model crashes between custody selection and each public-record replay step.
+pub fn prepare_rotation_candidate(
+    definition: &ChannelDefinition,
+    base_epoch: KeyEpoch,
+    target_roster: &[ReceiverIdentity],
+    rotation: RotationPlan,
+) -> Result<PreparedEpoch, EpochActivationError> {
+    if target_roster.is_empty()
+        || target_roster.len() > MAX_PLAN_RECEIVERS
+        || target_roster.len() != rotation.grants().len()
+    {
+        return Err(EpochActivationError::InvalidPlan);
+    }
+    let mut roster = target_roster.to_vec();
+    roster.sort_by(|left, right| left.agent_id.cmp(&right.agent_id));
+    if roster
+        .windows(2)
+        .any(|pair| pair[0].agent_id == pair[1].agent_id)
+    {
+        return Err(EpochActivationError::InvalidPlan);
+    }
+    for (receiver, grant) in roster.iter().zip(rotation.grants()) {
+        if receiver.agent_id.as_bytes() != grant.receiver_id() {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        verify_grant_signature(
+            grant,
+            definition.originator().agent_id.as_bytes(),
+            receiver.agent_id.as_bytes(),
+            definition.channel_id(),
+            &definition.originator().public_key,
+        )?;
+        if grant.key_epoch() != rotation.new_epoch() {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+    }
+    let (new_epoch, cmk, grants) = rotation.into_parts();
+    if base_epoch.0.checked_add(1).map(KeyEpoch) != Some(new_epoch) {
+        return Err(EpochActivationError::UnexpectedEpoch);
+    }
+    let mut grant_bytes = Vec::with_capacity(grants.len());
+    let mut entries = Vec::with_capacity(grants.len());
+    for grant in &grants {
+        let encoded = grant_serialize(grant)?;
+        entries.push(ActivationPlanEntry::new(
+            sha256(grant.receiver_id()),
+            sha256(&encoded),
+        ));
+        grant_bytes.push(encoded);
+    }
+    let plan = ActivationPlan::new(definition.channel_id(), base_epoch, new_epoch, entries)?;
+    let public = PublicPreparation::new(
+        definition.channel_id(),
+        base_epoch,
+        new_epoch,
+        activation_plan_serialize(&plan),
+        grant_bytes,
+    );
+    Ok(PreparedEpoch::new(public, cmk))
+}
+
+fn validate_public_preparation(
+    definition: &ChannelDefinition,
+    prepared: &PublicPreparation,
+) -> Result<ActivationPlan, EpochActivationError> {
+    if prepared.channel_id() != definition.channel_id()
+        || prepared.new_epoch().0
+            != prepared
+                .base_epoch()
+                .0
+                .checked_add(1)
+                .ok_or(EpochActivationError::EpochExhausted)?
+        || prepared.grants().is_empty()
+        || prepared.grants().len() > MAX_PLAN_RECEIVERS
+    {
+        return Err(EpochActivationError::InvalidPlan);
+    }
+    let plan = activation_plan_deserialize(prepared.plan_bytes())?;
+    if plan.channel_id() != prepared.channel_id()
+        || plan.base_epoch() != prepared.base_epoch()
+        || plan.new_epoch() != prepared.new_epoch()
+        || plan.receivers().len() != prepared.grants().len()
+    {
+        return Err(EpochActivationError::InvalidPlan);
+    }
+    let mut prior_receiver: Option<Vec<u8>> = None;
+    let mut entries = Vec::with_capacity(prepared.grants().len());
+    for bytes in prepared.grants() {
+        let grant = grant_deserialize(bytes)?;
+        if grant.channel_id() != prepared.channel_id()
+            || grant.key_epoch() != prepared.new_epoch()
+            || prior_receiver
+                .as_deref()
+                .is_some_and(|prior| prior >= grant.receiver_id())
+        {
+            return Err(EpochActivationError::InvalidPlan);
+        }
+        verify_grant_signature(
+            &grant,
+            definition.originator().agent_id.as_bytes(),
+            grant.receiver_id(),
+            definition.channel_id(),
+            &definition.originator().public_key,
+        )?;
+        prior_receiver = Some(grant.receiver_id().to_vec());
+        entries.push(ActivationPlanEntry::new(
+            sha256(grant.receiver_id()),
+            sha256(bytes),
+        ));
+    }
+    let expected = ActivationPlan::new(
+        prepared.channel_id(),
+        prepared.base_epoch(),
+        prepared.new_epoch(),
+        entries,
+    )?;
+    if plan != expected {
+        return Err(EpochActivationError::InvalidPlan);
+    }
+    Ok(plan)
+}
+
+fn public_put(
+    key: String,
+    content_type: &'static str,
+    body: Vec<u8>,
+) -> Result<StoragePutInput, StorageError> {
+    StoragePutInput::new(
+        CHANNEL_STORAGE_NAMESPACE,
+        key,
+        content_type,
+        empty_metadata(),
+        body,
+    )
+}
+
+fn map_definition_error(error: ChannelEndpointError) -> EpochActivationError {
+    match error {
+        ChannelEndpointError::Storage(error) => EpochActivationError::Storage(error),
+        ChannelEndpointError::ChannelDestroyed => EpochActivationError::ChannelDestroyed,
+        ChannelEndpointError::DefinitionNotFound => EpochActivationError::NotInitialized,
+        ChannelEndpointError::CorruptDefinition(_) | ChannelEndpointError::Store(_) => {
+            EpochActivationError::CorruptRecord
+        }
+        _ => EpochActivationError::InvalidPlan,
+    }
+}
+
+fn empty_metadata() -> JsonValue {
+    JsonValue::Object(vec![])
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/src/wire.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/src/wire.rs
@@ -1,0 +1,493 @@
+//! Canonical D18S version 2 state and D18T version 1 plan codecs.
+//!
+//! D18T changes no D18F, D18G, or D18H bytes. It adds one active-epoch field
+//! to the D18P reservation record and one immutable public plan that commits
+//! the exact receiver grants selected before activation.
+
+use chief_of_staff_channel_crypto::wire::{decode_message_header, encode_message_header};
+use chief_of_staff_channel_crypto::{ChannelId, KeyEpoch, MessageHeader, Sequence};
+
+const STATE_MAGIC: &[u8; 4] = b"D18S";
+const STATE_VERSION: u8 = 2;
+const PLAN_MAGIC: &[u8; 4] = b"D18T";
+const PLAN_VERSION: u8 = 1;
+
+/// Maximum D18H bytes accepted inside D18S version 2.
+pub const MAX_PENDING_HEADER_BYTES: usize = 16 * 1024;
+/// Maximum receiver commitments in one activation plan.
+pub const MAX_PLAN_RECEIVERS: usize = 1024;
+/// D18S version 2 content type.
+pub const EPOCH_STATE_CONTENT_TYPE: &str =
+    "application/vnd.coding-adventures.chief-channel-state-v2";
+/// D18T version 1 activation-plan content type.
+pub const ACTIVATION_PLAN_CONTENT_TYPE: &str =
+    "application/vnd.coding-adventures.chief-channel-epoch-activation-v1";
+
+/// Strict structural failures for D18T public bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EpochWireError {
+    /// The record magic did not identify its declared kind.
+    InvalidMagic,
+    /// The record used another version.
+    UnsupportedVersion,
+    /// The record ended before a complete field was available.
+    Truncated,
+    /// Bytes remained after the complete canonical record.
+    TrailingBytes,
+    /// A bounded length or count was invalid.
+    LengthLimitExceeded,
+    /// A logical field relation was invalid.
+    InvalidField,
+    /// The embedded D18H record was invalid.
+    InvalidPendingHeader,
+}
+
+impl core::fmt::Display for EpochWireError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidMagic => "invalid D18T record magic",
+            Self::UnsupportedVersion => "unsupported D18T record version",
+            Self::Truncated => "truncated D18T record",
+            Self::TrailingBytes => "trailing D18T record bytes",
+            Self::LengthLimitExceeded => "D18T length limit exceeded",
+            Self::InvalidField => "invalid D18T field",
+            Self::InvalidPendingHeader => "invalid D18T pending header",
+        })
+    }
+}
+
+impl std::error::Error for EpochWireError {}
+
+/// Durable active epoch plus the D18P sequence/pending reservation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EpochState {
+    active_epoch: KeyEpoch,
+    next_sequence: Sequence,
+    pending_header: Option<MessageHeader>,
+}
+
+impl EpochState {
+    /// Create one validated D18S version 2 state value.
+    pub fn new(
+        channel_id: ChannelId,
+        active_epoch: KeyEpoch,
+        next_sequence: Sequence,
+        pending_header: Option<MessageHeader>,
+    ) -> Result<Self, EpochWireError> {
+        if let Some(header) = &pending_header {
+            if header.fields().channel_id() != channel_id
+                || header.fields().key_epoch() != active_epoch
+                || header.fields().sequence().0.checked_add(1).map(Sequence) != Some(next_sequence)
+            {
+                return Err(EpochWireError::InvalidField);
+            }
+            if encode_message_header(header)
+                .map_err(|_| EpochWireError::InvalidPendingHeader)?
+                .len()
+                > MAX_PENDING_HEADER_BYTES
+            {
+                return Err(EpochWireError::LengthLimitExceeded);
+            }
+        }
+        Ok(Self {
+            active_epoch,
+            next_sequence,
+            pending_header,
+        })
+    }
+
+    /// Return the only epoch allowed for a new publish.
+    pub fn active_epoch(&self) -> KeyEpoch {
+        self.active_epoch
+    }
+
+    /// Return the first sequence not yet reserved.
+    pub fn next_sequence(&self) -> Sequence {
+        self.next_sequence
+    }
+
+    /// Borrow the exact pending D18H reservation, if present.
+    pub fn pending_header(&self) -> Option<&MessageHeader> {
+        self.pending_header.as_ref()
+    }
+
+    pub(crate) fn with_pending(
+        &self,
+        channel_id: ChannelId,
+        next_sequence: Sequence,
+        pending_header: Option<MessageHeader>,
+    ) -> Result<Self, EpochWireError> {
+        Self::new(channel_id, self.active_epoch, next_sequence, pending_header)
+    }
+
+    pub(crate) fn with_active_epoch(
+        &self,
+        channel_id: ChannelId,
+        active_epoch: KeyEpoch,
+    ) -> Result<Self, EpochWireError> {
+        Self::new(
+            channel_id,
+            active_epoch,
+            self.next_sequence,
+            self.pending_header.clone(),
+        )
+    }
+}
+
+/// Serialize canonical D18S version 2 bytes.
+pub fn epoch_state_serialize(state: &EpochState) -> Result<Vec<u8>, EpochWireError> {
+    let mut bytes = Vec::with_capacity(22);
+    bytes.extend_from_slice(STATE_MAGIC);
+    bytes.push(STATE_VERSION);
+    bytes.extend_from_slice(&state.active_epoch.0.to_be_bytes());
+    bytes.extend_from_slice(&state.next_sequence.0.to_be_bytes());
+    match &state.pending_header {
+        None => bytes.push(0),
+        Some(header) => {
+            let header =
+                encode_message_header(header).map_err(|_| EpochWireError::InvalidPendingHeader)?;
+            if header.len() > MAX_PENDING_HEADER_BYTES {
+                return Err(EpochWireError::LengthLimitExceeded);
+            }
+            bytes.push(1);
+            bytes.extend_from_slice(&(header.len() as u32).to_be_bytes());
+            bytes.extend_from_slice(&header);
+        }
+    }
+    Ok(bytes)
+}
+
+/// Decode and validate canonical D18S version 2 bytes for one channel.
+pub fn epoch_state_deserialize(
+    bytes: &[u8],
+    channel_id: ChannelId,
+) -> Result<EpochState, EpochWireError> {
+    if bytes.len() < 5 {
+        return Err(EpochWireError::Truncated);
+    }
+    if &bytes[..4] != STATE_MAGIC {
+        return Err(EpochWireError::InvalidMagic);
+    }
+    if bytes[4] != STATE_VERSION {
+        return Err(EpochWireError::UnsupportedVersion);
+    }
+    if bytes.len() < 22 {
+        return Err(EpochWireError::Truncated);
+    }
+    let active_epoch = KeyEpoch(read_u64(bytes, 5)?);
+    let next_sequence = Sequence(read_u64(bytes, 13)?);
+    let pending_header = match bytes[21] {
+        0 => {
+            if bytes.len() != 22 {
+                return Err(EpochWireError::TrailingBytes);
+            }
+            None
+        }
+        1 => {
+            if bytes.len() < 26 {
+                return Err(EpochWireError::Truncated);
+            }
+            let length = read_u32(bytes, 22)? as usize;
+            if length > MAX_PENDING_HEADER_BYTES {
+                return Err(EpochWireError::LengthLimitExceeded);
+            }
+            let end = 26usize
+                .checked_add(length)
+                .ok_or(EpochWireError::LengthLimitExceeded)?;
+            if bytes.len() < end {
+                return Err(EpochWireError::Truncated);
+            }
+            if bytes.len() > end {
+                return Err(EpochWireError::TrailingBytes);
+            }
+            Some(
+                decode_message_header(&bytes[26..end])
+                    .map_err(|_| EpochWireError::InvalidPendingHeader)?,
+            )
+        }
+        _ => return Err(EpochWireError::InvalidField),
+    };
+    EpochState::new(channel_id, active_epoch, next_sequence, pending_header)
+}
+
+/// One receiver/grant commitment in an activation plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActivationPlanEntry {
+    receiver_id_hash: [u8; 32],
+    grant_hash: [u8; 32],
+}
+
+impl ActivationPlanEntry {
+    /// Construct one public commitment pair.
+    pub const fn new(receiver_id_hash: [u8; 32], grant_hash: [u8; 32]) -> Self {
+        Self {
+            receiver_id_hash,
+            grant_hash,
+        }
+    }
+
+    /// Return SHA-256 of the raw receiver identifier.
+    pub const fn receiver_id_hash(&self) -> [u8; 32] {
+        self.receiver_id_hash
+    }
+
+    /// Return SHA-256 of the exact canonical D18G bytes.
+    pub const fn grant_hash(&self) -> [u8; 32] {
+        self.grant_hash
+    }
+}
+
+/// Immutable canonical D18T version 1 plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActivationPlan {
+    channel_id: ChannelId,
+    base_epoch: KeyEpoch,
+    new_epoch: KeyEpoch,
+    receivers: Vec<ActivationPlanEntry>,
+}
+
+impl ActivationPlan {
+    /// Validate and own one activation plan, sorting commitments canonically.
+    pub fn new(
+        channel_id: ChannelId,
+        base_epoch: KeyEpoch,
+        new_epoch: KeyEpoch,
+        mut receivers: Vec<ActivationPlanEntry>,
+    ) -> Result<Self, EpochWireError> {
+        validate_channel_id(channel_id)?;
+        if base_epoch.0.checked_add(1).map(KeyEpoch) != Some(new_epoch)
+            || receivers.is_empty()
+            || receivers.len() > MAX_PLAN_RECEIVERS
+        {
+            return Err(EpochWireError::InvalidField);
+        }
+        receivers.sort_by_key(ActivationPlanEntry::receiver_id_hash);
+        for (index, entry) in receivers.iter().enumerate() {
+            if index > 0 && receivers[index - 1].receiver_id_hash == entry.receiver_id_hash
+                || receivers[..index]
+                    .iter()
+                    .any(|prior| prior.grant_hash == entry.grant_hash)
+            {
+                return Err(EpochWireError::InvalidField);
+            }
+        }
+        Ok(Self {
+            channel_id,
+            base_epoch,
+            new_epoch,
+            receivers,
+        })
+    }
+
+    /// Return the channel identifier.
+    pub const fn channel_id(&self) -> ChannelId {
+        self.channel_id
+    }
+
+    /// Return the epoch this plan advances from.
+    pub const fn base_epoch(&self) -> KeyEpoch {
+        self.base_epoch
+    }
+
+    /// Return the selected successor epoch.
+    pub const fn new_epoch(&self) -> KeyEpoch {
+        self.new_epoch
+    }
+
+    /// Borrow entries sorted by receiver-ID hash.
+    pub fn receivers(&self) -> &[ActivationPlanEntry] {
+        &self.receivers
+    }
+}
+
+/// Serialize canonical D18T version 1 plan bytes.
+pub fn activation_plan_serialize(plan: &ActivationPlan) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(41 + plan.receivers.len() * 64);
+    bytes.extend_from_slice(PLAN_MAGIC);
+    bytes.push(PLAN_VERSION);
+    bytes.extend_from_slice(&plan.channel_id.0);
+    bytes.extend_from_slice(&plan.base_epoch.0.to_be_bytes());
+    bytes.extend_from_slice(&plan.new_epoch.0.to_be_bytes());
+    bytes.extend_from_slice(&(plan.receivers.len() as u32).to_be_bytes());
+    for receiver in &plan.receivers {
+        bytes.extend_from_slice(&receiver.receiver_id_hash);
+        bytes.extend_from_slice(&receiver.grant_hash);
+    }
+    bytes
+}
+
+/// Decode and validate canonical D18T version 1 plan bytes.
+pub fn activation_plan_deserialize(bytes: &[u8]) -> Result<ActivationPlan, EpochWireError> {
+    if bytes.len() < 5 {
+        return Err(EpochWireError::Truncated);
+    }
+    if &bytes[..4] != PLAN_MAGIC {
+        return Err(EpochWireError::InvalidMagic);
+    }
+    if bytes[4] != PLAN_VERSION {
+        return Err(EpochWireError::UnsupportedVersion);
+    }
+    if bytes.len() < 41 {
+        return Err(EpochWireError::Truncated);
+    }
+    let channel_id = ChannelId(
+        bytes[5..21]
+            .try_into()
+            .map_err(|_| EpochWireError::Truncated)?,
+    );
+    let base_epoch = KeyEpoch(read_u64(bytes, 21)?);
+    let new_epoch = KeyEpoch(read_u64(bytes, 29)?);
+    let count = read_u32(bytes, 37)? as usize;
+    if count == 0 || count > MAX_PLAN_RECEIVERS {
+        return Err(EpochWireError::LengthLimitExceeded);
+    }
+    let expected = 41usize
+        .checked_add(
+            count
+                .checked_mul(64)
+                .ok_or(EpochWireError::LengthLimitExceeded)?,
+        )
+        .ok_or(EpochWireError::LengthLimitExceeded)?;
+    if bytes.len() < expected {
+        return Err(EpochWireError::Truncated);
+    }
+    if bytes.len() > expected {
+        return Err(EpochWireError::TrailingBytes);
+    }
+    let mut receivers = Vec::with_capacity(count);
+    for chunk in bytes[41..].chunks_exact(64) {
+        receivers.push(ActivationPlanEntry::new(
+            chunk[..32]
+                .try_into()
+                .map_err(|_| EpochWireError::Truncated)?,
+            chunk[32..]
+                .try_into()
+                .map_err(|_| EpochWireError::Truncated)?,
+        ));
+    }
+    if receivers
+        .windows(2)
+        .any(|pair| pair[0].receiver_id_hash >= pair[1].receiver_id_hash)
+        || receivers.iter().enumerate().any(|(index, entry)| {
+            receivers[..index]
+                .iter()
+                .any(|prior| prior.grant_hash == entry.grant_hash)
+        })
+    {
+        return Err(EpochWireError::InvalidField);
+    }
+    ActivationPlan::new(channel_id, base_epoch, new_epoch, receivers)
+}
+
+/// Return the deterministic public activation-plan storage key.
+pub fn activation_plan_record_key(channel_id: ChannelId, new_epoch: KeyEpoch) -> String {
+    format!(
+        "{}/epochs/{:020}/activation",
+        encode_hex(&channel_id.0),
+        new_epoch.0
+    )
+}
+
+fn validate_channel_id(channel_id: ChannelId) -> Result<(), EpochWireError> {
+    if channel_id.0[6] >> 4 != 7 || channel_id.0[8] >> 6 != 2 {
+        return Err(EpochWireError::InvalidField);
+    }
+    Ok(())
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, EpochWireError> {
+    Ok(u32::from_be_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .ok_or(EpochWireError::Truncated)?
+            .try_into()
+            .map_err(|_| EpochWireError::Truncated)?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, EpochWireError> {
+    Ok(u64::from_be_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .ok_or(EpochWireError::Truncated)?
+            .try_into()
+            .map_err(|_| EpochWireError::Truncated)?,
+    ))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_channel_crypto::{prepare_message_header, MessageFields};
+
+    fn channel_id() -> ChannelId {
+        ChannelId([
+            0x01, 0x8f, 0x47, 0xa0, 0x9b, 0x6c, 0x7d, 0xef, 0x92, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+            0xde, 0xf0,
+        ])
+    }
+
+    #[test]
+    fn state_round_trip_is_exact_and_rejects_epoch_mismatch() {
+        let header = prepare_message_header(
+            MessageFields::new(
+                [0x22; 16],
+                7,
+                b"originator".to_vec(),
+                channel_id(),
+                Sequence(3),
+                KeyEpoch(9),
+                "text/plain".into(),
+            ),
+            b"hello",
+        );
+        let state = EpochState::new(channel_id(), KeyEpoch(9), Sequence(4), Some(header)).unwrap();
+        let bytes = epoch_state_serialize(&state).unwrap();
+        assert_eq!(&bytes[..5], b"D18S\x02");
+        assert_eq!(
+            epoch_state_deserialize(&bytes, channel_id()).unwrap(),
+            state
+        );
+
+        let mut wrong = bytes;
+        wrong[12] = 8;
+        assert_eq!(
+            epoch_state_deserialize(&wrong, channel_id()),
+            Err(EpochWireError::InvalidField)
+        );
+    }
+
+    #[test]
+    fn plan_round_trip_sorts_commitments_and_rejects_trailing_bytes() {
+        let plan = ActivationPlan::new(
+            channel_id(),
+            KeyEpoch(9),
+            KeyEpoch(10),
+            vec![
+                ActivationPlanEntry::new([2; 32], [4; 32]),
+                ActivationPlanEntry::new([1; 32], [3; 32]),
+            ],
+        )
+        .unwrap();
+        assert_eq!(plan.receivers()[0].receiver_id_hash(), [1; 32]);
+        let bytes = activation_plan_serialize(&plan);
+        assert_eq!(&bytes[..5], b"D18T\x01");
+        assert_eq!(activation_plan_deserialize(&bytes).unwrap(), plan);
+        let mut padded = bytes;
+        padded.push(0);
+        assert_eq!(
+            activation_plan_deserialize(&padded),
+            Err(EpochWireError::TrailingBytes)
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/tests/d18t_fixtures.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/tests/d18t_fixtures.rs
@@ -1,0 +1,257 @@
+use std::fs;
+use std::path::PathBuf;
+
+use chief_of_staff_channel_crypto::{ChannelId, KeyEpoch, Sequence};
+use chief_of_staff_channel_epoch_activation::{
+    activation_plan_deserialize, epoch_state_deserialize, ACTIVATION_PLAN_CONTENT_TYPE,
+    EPOCH_STATE_CONTENT_TYPE,
+};
+use chief_of_staff_channel_store::profile::channel_state_deserialize;
+use coding_adventures_json_parser::try_parse_json;
+use coding_adventures_json_value::{from_ast, JsonValue};
+use coding_adventures_sha1::sum1;
+
+#[path = "../examples/generate_d18t_fixtures.rs"]
+mod fixture_generator;
+
+const CHANNEL_ID: [u8; 16] = [
+    0x01, 0x8f, 0x47, 0xa0, 0x9b, 0x6c, 0x7d, 0xef, 0x92, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+];
+
+#[test]
+fn checked_manifest_is_byte_identical_to_its_recorded_generator() {
+    let bytes = manifest_bytes();
+    let manifest = parse_manifest(&bytes);
+    let root = object(&manifest);
+    assert_eq!(
+        string(root, "fixture_format"),
+        "D18T-durable-epoch-activation-fixtures-v1"
+    );
+    let generator_blob_sha1 = string(root, "generator_blob_sha1");
+    let generator_source = include_bytes!("../examples/generate_d18t_fixtures.rs");
+    let mut git_blob = format!("blob {}\0", generator_source.len()).into_bytes();
+    git_blob.extend_from_slice(generator_source);
+    assert_eq!(encode_hex(&sum1(&git_blob)), generator_blob_sha1);
+    assert_eq!(
+        fixture_generator::generate_manifest(generator_blob_sha1),
+        bytes
+    );
+}
+
+#[test]
+fn migration_vectors_preserve_pending_header_and_add_only_active_epoch() {
+    let manifest = parse_manifest(&manifest_bytes());
+    let root = object(&manifest);
+    let migrations = array(field(root, "state_migrations"));
+    assert_eq!(migrations.len(), 2);
+    for migration in migrations {
+        let migration = object(migration);
+        let v1 = channel_state_deserialize(
+            &decode_base64(string(migration, "d18s_v1_b64")),
+            ChannelId(CHANNEL_ID),
+        )
+        .unwrap();
+        let v2 = epoch_state_deserialize(
+            &decode_base64(string(migration, "d18s_v2_b64")),
+            ChannelId(CHANNEL_ID),
+        )
+        .unwrap();
+        assert_eq!(v2.active_epoch(), KeyEpoch(0));
+        assert_eq!(v2.next_sequence(), v1.next_sequence);
+        assert_eq!(v2.pending_header(), v1.pending_header.as_ref());
+    }
+    let pending = object(&migrations[1]);
+    assert_eq!(string(pending, "next_sequence"), "8");
+    assert_eq!(
+        epoch_state_deserialize(
+            &decode_base64(string(pending, "d18s_v2_b64")),
+            ChannelId(CHANNEL_ID),
+        )
+        .unwrap()
+        .next_sequence(),
+        Sequence(8)
+    );
+}
+
+#[test]
+fn activation_vector_commits_exact_plan_and_b_only_successor_grant() {
+    let manifest = parse_manifest(&manifest_bytes());
+    let root = object(&manifest);
+    let constants = object(field(root, "constants"));
+    assert_eq!(
+        string(constants, "state_content_type"),
+        EPOCH_STATE_CONTENT_TYPE
+    );
+    assert_eq!(
+        string(constants, "plan_content_type"),
+        ACTIVATION_PLAN_CONTENT_TYPE
+    );
+    let activation = object(field(root, "activation_case"));
+    let plan = activation_plan_deserialize(&decode_base64(string(activation, "plan_b64"))).unwrap();
+    assert_eq!(plan.channel_id(), ChannelId(CHANNEL_ID));
+    assert_eq!(plan.base_epoch(), KeyEpoch(0));
+    assert_eq!(plan.new_epoch(), KeyEpoch(1));
+    assert_eq!(plan.receivers().len(), 1);
+    assert_eq!(array(field(activation, "grant_b64")).len(), 1);
+    assert!(matches!(
+        field(activation, "receiver_a_new_grant"),
+        JsonValue::Null
+    ));
+    assert_eq!(
+        array(field(activation, "receiver_a_retains_epochs"))
+            .iter()
+            .map(json_string)
+            .collect::<Vec<_>>(),
+        vec!["0"]
+    );
+    assert_eq!(
+        array(field(activation, "receiver_b_retains_epochs"))
+            .iter()
+            .map(json_string)
+            .collect::<Vec<_>>(),
+        vec!["0", "1"]
+    );
+}
+
+#[test]
+fn replay_races_errors_and_secret_boundary_are_closed() {
+    let bytes = manifest_bytes();
+    let text = std::str::from_utf8(&bytes).unwrap();
+    let manifest = parse_manifest(&bytes);
+    let root = object(&manifest);
+    assert!(string(root, "warning").contains("Never log"));
+    let crash_names = names(array(field(root, "crash_replay_traces")));
+    assert_eq!(
+        crash_names,
+        vec![
+            "after-custody-selection",
+            "after-plan-write",
+            "after-first-grant",
+            "after-all-grants",
+            "after-activation-cas",
+        ]
+    );
+    assert_eq!(names(array(field(root, "race_traces"))).len(), 4);
+    assert_eq!(names(array(field(root, "negative_scenarios"))).len(), 6);
+    assert_eq!(string(root, "secret_erasure_capability"), "guaranteed");
+    let errors = array(field(root, "stable_error_codes"))
+        .iter()
+        .map(json_string)
+        .collect::<Vec<_>>();
+    assert_eq!(errors.len(), 19);
+    assert!(errors.contains(&"concurrent_update"));
+    assert!(errors.contains(&"preparation_missing"));
+
+    for (_, value) in object(field(root, "test_only_secrets")) {
+        let secret = json_string(value);
+        assert_eq!(
+            text.matches(secret).count(),
+            1,
+            "test-only secret escaped its dedicated object"
+        );
+    }
+}
+
+fn manifest_bytes() -> Vec<u8> {
+    fs::read(manifest_path()).unwrap()
+}
+
+fn manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json")
+}
+
+fn parse_manifest(bytes: &[u8]) -> JsonValue {
+    let text = std::str::from_utf8(bytes).unwrap();
+    from_ast(&try_parse_json(text).unwrap()).unwrap()
+}
+
+fn object(value: &JsonValue) -> &Vec<(String, JsonValue)> {
+    match value {
+        JsonValue::Object(fields) => fields,
+        _ => panic!("expected object"),
+    }
+}
+
+fn array(value: &JsonValue) -> &Vec<JsonValue> {
+    match value {
+        JsonValue::Array(values) => values,
+        _ => panic!("expected array"),
+    }
+}
+
+fn field<'a>(fields: &'a [(String, JsonValue)], name: &str) -> &'a JsonValue {
+    fields
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value)
+        .unwrap_or_else(|| panic!("missing field {name}"))
+}
+
+fn string<'a>(fields: &'a [(String, JsonValue)], name: &str) -> &'a str {
+    json_string(field(fields, name))
+}
+
+fn json_string(value: &JsonValue) -> &str {
+    match value {
+        JsonValue::String(value) => value,
+        _ => panic!("expected string"),
+    }
+}
+
+fn names(values: &[JsonValue]) -> Vec<&str> {
+    values
+        .iter()
+        .map(|value| string(object(value), "name"))
+        .collect()
+}
+
+fn decode_base64(value: &str) -> Vec<u8> {
+    let bytes = value.as_bytes();
+    assert_eq!(bytes.len() % 4, 0);
+    let mut output = Vec::with_capacity(bytes.len() / 4 * 3);
+    for chunk in bytes.chunks_exact(4) {
+        let a = base64_value(chunk[0]);
+        let b = base64_value(chunk[1]);
+        let c = if chunk[2] == b'=' {
+            0
+        } else {
+            base64_value(chunk[2])
+        };
+        let d = if chunk[3] == b'=' {
+            0
+        } else {
+            base64_value(chunk[3])
+        };
+        let word = ((a as u32) << 18) | ((b as u32) << 12) | ((c as u32) << 6) | d as u32;
+        output.push((word >> 16) as u8);
+        if chunk[2] != b'=' {
+            output.push((word >> 8) as u8);
+        }
+        if chunk[3] != b'=' {
+            output.push(word as u8);
+        }
+    }
+    output
+}
+
+fn base64_value(byte: u8) -> u8 {
+    match byte {
+        b'A'..=b'Z' => byte - b'A',
+        b'a'..=b'z' => byte - b'a' + 26,
+        b'0'..=b'9' => byte - b'0' + 52,
+        b'+' => 62,
+        b'/' => 63,
+        _ => panic!("invalid base64"),
+    }
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/code/packages/rust/chief-of-staff-channel-epoch-activation/tests/orchestration.rs
+++ b/code/packages/rust/chief-of-staff-channel-epoch-activation/tests/orchestration.rs
@@ -1,0 +1,736 @@
+use chief_of_staff_channel_crypto::grant_profile::{
+    grant_deserialize, plan_rotation, RotationReceiver,
+};
+use chief_of_staff_channel_crypto::wire::{key_grant_record_key, CHANNEL_STORAGE_NAMESPACE};
+use chief_of_staff_channel_crypto::{
+    decrypt_message, ChannelId, ChannelMasterKey, KeyEpoch, OriginatorSigningKey, ReceiverKeyPair,
+    Sequence,
+};
+use chief_of_staff_channel_endpoints::{
+    AgentId, ChannelDefinition, ChannelDefinitionStore, OriginatorIdentity, ReceiverIdentity,
+};
+use chief_of_staff_channel_epoch_activation::{
+    activation_plan_record_key, prepare_rotation_candidate, ActivationOutcome,
+    ActiveEpochAppendRequest, CustodySelection, EpochActivationStore, InMemoryKeyCustody,
+    OriginatorKeyCustody, PreparationOutcome, ACTIVATION_PLAN_CONTENT_TYPE,
+};
+use chief_of_staff_channel_store::{AppendRequest, ChannelStore};
+use coding_adventures_json_value::JsonValue;
+use storage_core::{
+    InMemoryStorageBackend, Revision, StorageBackend, StorageError, StorageLease,
+    StorageListOptions, StoragePage, StoragePutInput, StorageRecord, StorageStat,
+};
+
+const CURRENT_CMK: [u8; 32] = [0x21; 32];
+const NEXT_CMK: [u8; 32] = [0x31; 32];
+const GRANT_CONTENT_TYPE: &str = "application/vnd.coding-adventures.chief-channel-key-grant-v1";
+
+#[derive(Default)]
+struct StateCasConflictBackend {
+    inner: InMemoryStorageBackend,
+    reject_state_cas: AtomicBool,
+}
+
+impl StateCasConflictBackend {
+    fn reject_state_cas(&self) {
+        self.reject_state_cas.store(true, Ordering::SeqCst);
+    }
+}
+
+impl StorageBackend for StateCasConflictBackend {
+    fn initialize(&self) -> Result<(), StorageError> {
+        self.inner.initialize()
+    }
+
+    fn get(&self, namespace: &str, key: &str) -> Result<Option<StorageRecord>, StorageError> {
+        self.inner.get(namespace, key)
+    }
+
+    fn put(&self, input: StoragePutInput) -> Result<StorageRecord, StorageError> {
+        if self.reject_state_cas.load(Ordering::SeqCst)
+            && input.key
+                == chief_of_staff_channel_crypto::wire::sequence_state_record_key(channel_id())
+            && input.if_revision.is_some()
+        {
+            return Err(StorageError::Conflict {
+                namespace: input.namespace,
+                key: input.key,
+                expected_revision: input.if_revision.map(|revision| revision.to_string()),
+                actual_revision: Some("forced-cas-race".to_owned()),
+            });
+        }
+        self.inner.put(input)
+    }
+
+    fn delete(
+        &self,
+        namespace: &str,
+        key: &str,
+        if_revision: Option<&Revision>,
+    ) -> Result<(), StorageError> {
+        self.inner.delete(namespace, key, if_revision)
+    }
+
+    fn list(
+        &self,
+        namespace: &str,
+        options: StorageListOptions,
+    ) -> Result<StoragePage, StorageError> {
+        self.inner.list(namespace, options)
+    }
+
+    fn stat(&self, namespace: &str, key: &str) -> Result<Option<StorageStat>, StorageError> {
+        self.inner.stat(namespace, key)
+    }
+
+    fn acquire_lease(&self, name: &str, ttl_ms: u64) -> Result<Option<StorageLease>, StorageError> {
+        self.inner.acquire_lease(name, ttl_ms)
+    }
+}
+
+struct Fixture {
+    backend: InMemoryStorageBackend,
+    custody: InMemoryKeyCustody,
+    definition: ChannelDefinition,
+    signer: OriginatorSigningKey,
+    receiver_a: ReceiverIdentity,
+    receiver_b: ReceiverIdentity,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let backend = InMemoryStorageBackend::new();
+        let signer = OriginatorSigningKey::from_seed([0x11; 32]);
+        let receiver_a_key = ReceiverKeyPair::from_private_key([0x41; 32]).unwrap();
+        let receiver_b_key = ReceiverKeyPair::from_private_key([0x42; 32]).unwrap();
+        let receiver_a = ReceiverIdentity {
+            agent_id: AgentId::new(b"receiver-a".to_vec()).unwrap(),
+            public_key: receiver_a_key.public_key(),
+        };
+        let receiver_b = ReceiverIdentity {
+            agent_id: AgentId::new(b"receiver-b".to_vec()).unwrap(),
+            public_key: receiver_b_key.public_key(),
+        };
+        let definition = ChannelDefinition::new(
+            channel_id(),
+            OriginatorIdentity {
+                agent_id: AgentId::new(b"originator".to_vec()).unwrap(),
+                public_key: signer.public_key(),
+            },
+            vec![receiver_a.clone(), receiver_b.clone()],
+            1_725_000_000_000_000_000,
+            KeyEpoch(0),
+        )
+        .unwrap();
+        ChannelDefinitionStore::new(&backend)
+            .create(&definition)
+            .unwrap();
+        Self {
+            backend,
+            custody: InMemoryKeyCustody::new(),
+            definition,
+            signer,
+            receiver_a,
+            receiver_b,
+        }
+    }
+
+    fn store(&self) -> EpochActivationStore<'_, InMemoryKeyCustody> {
+        EpochActivationStore::new_for_testing(&self.backend, &self.custody, channel_id()).unwrap()
+    }
+
+    fn rotation(
+        &self,
+        cmk: [u8; 32],
+        material: u8,
+    ) -> chief_of_staff_channel_crypto::grant_profile::RotationPlan {
+        plan_rotation(
+            self.definition.originator().agent_id.as_bytes(),
+            channel_id(),
+            KeyEpoch(0),
+            ChannelMasterKey::from_bytes(cmk),
+            vec![RotationReceiver::with_material(
+                self.receiver_b.agent_id.as_bytes().to_vec(),
+                self.receiver_b.public_key,
+                [material; 32],
+                [material.wrapping_add(1); 24],
+            )
+            .unwrap()],
+            &self.signer,
+        )
+        .unwrap()
+    }
+
+    fn two_receiver_rotation(&self) -> chief_of_staff_channel_crypto::grant_profile::RotationPlan {
+        plan_rotation(
+            self.definition.originator().agent_id.as_bytes(),
+            channel_id(),
+            KeyEpoch(0),
+            ChannelMasterKey::from_bytes(NEXT_CMK),
+            vec![
+                RotationReceiver::with_material(
+                    self.receiver_b.agent_id.as_bytes().to_vec(),
+                    self.receiver_b.public_key,
+                    [0x52; 32],
+                    [0x62; 24],
+                )
+                .unwrap(),
+                RotationReceiver::with_material(
+                    self.receiver_a.agent_id.as_bytes().to_vec(),
+                    self.receiver_a.public_key,
+                    [0x51; 32],
+                    [0x61; 24],
+                )
+                .unwrap(),
+            ],
+            &self.signer,
+        )
+        .unwrap()
+    }
+}
+
+fn channel_id() -> ChannelId {
+    ChannelId([
+        0x01, 0x8f, 0x47, 0xa0, 0x9b, 0x6c, 0x7d, 0xef, 0x92, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde,
+        0xf0,
+    ])
+}
+
+fn message_id(byte: u8) -> [u8; 16] {
+    let mut bytes = [byte; 16];
+    bytes[6] = 0x70 | (byte & 0x0f);
+    bytes[8] = 0x80 | (byte & 0x3f);
+    bytes
+}
+
+#[test]
+fn migrates_legacy_pending_state_without_changing_its_header() {
+    let fixture = Fixture::new();
+    let legacy = ChannelStore::new(&fixture.backend, channel_id());
+    let pending = legacy
+        .reserve_append(
+            AppendRequest {
+                message_id: message_id(1),
+                timestamp_ns: 11,
+                originator_id: b"originator".to_vec(),
+                key_epoch: KeyEpoch(0),
+                content_type: "text/plain".to_owned(),
+            },
+            b"already reserved",
+        )
+        .unwrap();
+
+    let state = fixture
+        .store()
+        .migrate_epoch_state(
+            &fixture.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    assert_eq!(state.active_epoch(), KeyEpoch(0));
+    assert_eq!(state.next_sequence(), Sequence(1));
+    assert_eq!(state.pending_header(), Some(&pending));
+    assert_eq!(
+        fixture
+            .store()
+            .migrate_epoch_state(&fixture.definition, None)
+            .unwrap(),
+        state
+    );
+}
+
+#[test]
+fn selection_replay_activation_and_active_epoch_publish_are_idempotent() {
+    let fixture = Fixture::new();
+    let store = fixture.store();
+    store
+        .migrate_epoch_state(
+            &fixture.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    assert_eq!(
+        store
+            .prepare_rotation(
+                &fixture.definition,
+                std::slice::from_ref(&fixture.receiver_b),
+                fixture.rotation(NEXT_CMK, 0x51),
+            )
+            .unwrap(),
+        PreparationOutcome::Prepared
+    );
+    assert_eq!(
+        store
+            .prepare_rotation(
+                &fixture.definition,
+                std::slice::from_ref(&fixture.receiver_b),
+                fixture.rotation(NEXT_CMK, 0x51),
+            )
+            .unwrap(),
+        PreparationOutcome::Idempotent
+    );
+    assert_eq!(
+        store
+            .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+            .unwrap(),
+        ActivationOutcome::Activated
+    );
+    assert_eq!(
+        store
+            .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+            .unwrap(),
+        ActivationOutcome::Idempotent
+    );
+
+    let reservation = store
+        .reserve_publish_using_active_epoch(
+            &fixture.definition,
+            ActiveEpochAppendRequest {
+                message_id: message_id(2),
+                timestamp_ns: 12,
+                originator_id: b"originator".to_vec(),
+                content_type: "text/plain".to_owned(),
+            },
+            b"epoch one",
+        )
+        .unwrap();
+    assert_eq!(reservation.header().fields().key_epoch(), KeyEpoch(1));
+    let message = store
+        .commit_reserved(
+            &fixture.definition,
+            &reservation,
+            b"epoch one",
+            &fixture.signer,
+        )
+        .unwrap();
+    assert_eq!(
+        decrypt_message(
+            &message,
+            &ChannelMasterKey::from_bytes(NEXT_CMK),
+            &fixture.signer.public_key(),
+        )
+        .unwrap(),
+        b"epoch one"
+    );
+    assert_eq!(store.state().unwrap().active_epoch(), KeyEpoch(1));
+    assert_eq!(store.state().unwrap().pending_header(), None);
+}
+
+#[test]
+fn one_candidate_wins_and_a_pending_publish_blocks_activation() {
+    let fixture = Fixture::new();
+    let store = fixture.store();
+    store
+        .migrate_epoch_state(
+            &fixture.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    store
+        .prepare_rotation(
+            &fixture.definition,
+            std::slice::from_ref(&fixture.receiver_b),
+            fixture.rotation(NEXT_CMK, 0x51),
+        )
+        .unwrap();
+    let conflict = store
+        .prepare_rotation(
+            &fixture.definition,
+            std::slice::from_ref(&fixture.receiver_b),
+            fixture.rotation([0x32; 32], 0x52),
+        )
+        .unwrap_err();
+    assert_eq!(conflict.code(), "conflicting_preparation");
+
+    let reservation = store
+        .reserve_publish_using_active_epoch(
+            &fixture.definition,
+            ActiveEpochAppendRequest {
+                message_id: message_id(3),
+                timestamp_ns: 13,
+                originator_id: b"originator".to_vec(),
+                content_type: "text/plain".to_owned(),
+            },
+            b"epoch zero first",
+        )
+        .unwrap();
+    assert_eq!(reservation.header().fields().key_epoch(), KeyEpoch(0));
+    let error = store
+        .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+        .unwrap_err();
+    assert_eq!(error.code(), "pending_append");
+    store
+        .commit_reserved(
+            &fixture.definition,
+            &reservation,
+            b"epoch zero first",
+            &fixture.signer,
+        )
+        .unwrap();
+    assert_eq!(
+        store
+            .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+            .unwrap(),
+        ActivationOutcome::Activated
+    );
+}
+
+#[test]
+fn production_rejects_memory_custody_and_destruction_erases_all_keys() {
+    let fixture = Fixture::new();
+    let error = match EpochActivationStore::new(&fixture.backend, &fixture.custody, channel_id()) {
+        Ok(_) => panic!("production accepted non-durable custody"),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), "custody_error");
+    let store = fixture.store();
+    store
+        .migrate_epoch_state(
+            &fixture.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    store
+        .prepare_rotation(
+            &fixture.definition,
+            std::slice::from_ref(&fixture.receiver_b),
+            fixture.rotation(NEXT_CMK, 0x51),
+        )
+        .unwrap();
+    assert_eq!(fixture.custody.retained_key_count().unwrap(), 2);
+    let destroyed = ChannelDefinitionStore::new(&fixture.backend)
+        .destroy(channel_id())
+        .unwrap();
+    store.apply_destruction(&destroyed).unwrap();
+    assert_eq!(fixture.custody.retained_key_count().unwrap(), 0);
+    assert_eq!(
+        store.state().unwrap().active_epoch(),
+        KeyEpoch(0),
+        "public history remains after logical secret destruction"
+    );
+}
+
+#[test]
+fn every_public_replay_crash_boundary_converges_to_the_selected_bundle() {
+    for records_written_before_restart in 0_usize..=3 {
+        let fixture = Fixture::new();
+        let store = fixture.store();
+        store
+            .migrate_epoch_state(
+                &fixture.definition,
+                Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+            )
+            .unwrap();
+        let prepared = prepare_rotation_candidate(
+            &fixture.definition,
+            KeyEpoch(0),
+            &[fixture.receiver_a.clone(), fixture.receiver_b.clone()],
+            fixture.two_receiver_rotation(),
+        )
+        .unwrap();
+        let public = prepared.public().clone();
+        assert_eq!(
+            fixture.custody.prepare_if_absent(prepared).unwrap(),
+            CustodySelection::Selected
+        );
+
+        if records_written_before_restart >= 1 {
+            fixture
+                .backend
+                .put(
+                    StoragePutInput::new(
+                        CHANNEL_STORAGE_NAMESPACE,
+                        activation_plan_record_key(channel_id(), KeyEpoch(1)),
+                        ACTIVATION_PLAN_CONTENT_TYPE,
+                        JsonValue::Object(vec![]),
+                        public.plan_bytes().to_vec(),
+                    )
+                    .unwrap()
+                    .with_if_absent(),
+                )
+                .unwrap();
+        }
+        for bytes in public
+            .grants()
+            .iter()
+            .take(records_written_before_restart.saturating_sub(1))
+        {
+            let grant = grant_deserialize(bytes).unwrap();
+            fixture
+                .backend
+                .put(
+                    StoragePutInput::new(
+                        CHANNEL_STORAGE_NAMESPACE,
+                        key_grant_record_key(channel_id(), grant.key_epoch(), grant.receiver_id()),
+                        GRANT_CONTENT_TYPE,
+                        JsonValue::Object(vec![]),
+                        bytes.clone(),
+                    )
+                    .unwrap()
+                    .with_if_absent(),
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            fixture
+                .store()
+                .recover_preparation(&fixture.definition, KeyEpoch(1))
+                .unwrap(),
+            PreparationOutcome::Idempotent,
+            "restart after {records_written_before_restart} public records"
+        );
+        assert_eq!(
+            fixture
+                .store()
+                .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+                .unwrap(),
+            ActivationOutcome::Activated
+        );
+    }
+}
+
+#[test]
+fn sixteen_state_cas_conflicts_return_the_portable_concurrent_update_error() {
+    let backend = StateCasConflictBackend::default();
+    let signer = OriginatorSigningKey::from_seed([0x11; 32]);
+    let receiver_key = ReceiverKeyPair::from_private_key([0x42; 32]).unwrap();
+    let receiver = ReceiverIdentity {
+        agent_id: AgentId::new(b"receiver-b".to_vec()).unwrap(),
+        public_key: receiver_key.public_key(),
+    };
+    let definition = ChannelDefinition::new(
+        channel_id(),
+        OriginatorIdentity {
+            agent_id: AgentId::new(b"originator".to_vec()).unwrap(),
+            public_key: signer.public_key(),
+        },
+        vec![receiver.clone()],
+        1,
+        KeyEpoch(0),
+    )
+    .unwrap();
+    ChannelDefinitionStore::new(&backend)
+        .create(&definition)
+        .unwrap();
+    let custody = InMemoryKeyCustody::new();
+    let store = EpochActivationStore::new_for_testing(&backend, &custody, channel_id()).unwrap();
+    store
+        .migrate_epoch_state(
+            &definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    let rotation = plan_rotation(
+        b"originator",
+        channel_id(),
+        KeyEpoch(0),
+        ChannelMasterKey::from_bytes(NEXT_CMK),
+        vec![RotationReceiver::with_material(
+            b"receiver-b".to_vec(),
+            receiver.public_key,
+            [0x51; 32],
+            [0x61; 24],
+        )
+        .unwrap()],
+        &signer,
+    )
+    .unwrap();
+    store
+        .prepare_rotation(&definition, &[receiver], rotation)
+        .unwrap();
+    backend.reject_state_cas();
+    let error = store
+        .activate_prepared_epoch(&definition, KeyEpoch(1))
+        .unwrap_err();
+    assert_eq!(error.code(), "concurrent_update");
+    assert_eq!(store.state().unwrap().active_epoch(), KeyEpoch(0));
+}
+
+#[test]
+fn missing_custody_corrupt_plan_and_destroyed_channel_fail_closed() {
+    let missing = Fixture::new();
+    missing
+        .store()
+        .migrate_epoch_state(
+            &missing.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    assert_eq!(
+        missing
+            .store()
+            .activate_prepared_epoch(&missing.definition, KeyEpoch(1))
+            .unwrap_err()
+            .code(),
+        "preparation_missing"
+    );
+
+    let corrupt = Fixture::new();
+    corrupt
+        .store()
+        .migrate_epoch_state(
+            &corrupt.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    let prepared = prepare_rotation_candidate(
+        &corrupt.definition,
+        KeyEpoch(0),
+        std::slice::from_ref(&corrupt.receiver_b),
+        corrupt.rotation(NEXT_CMK, 0x51),
+    )
+    .unwrap();
+    let plan_bytes = prepared.public().plan_bytes().to_vec();
+    corrupt.custody.prepare_if_absent(prepared).unwrap();
+    corrupt
+        .backend
+        .put(
+            StoragePutInput::new(
+                CHANNEL_STORAGE_NAMESPACE,
+                activation_plan_record_key(channel_id(), KeyEpoch(1)),
+                "application/octet-stream",
+                JsonValue::Object(vec![]),
+                plan_bytes,
+            )
+            .unwrap()
+            .with_if_absent(),
+        )
+        .unwrap();
+    assert_eq!(
+        corrupt
+            .store()
+            .recover_preparation(&corrupt.definition, KeyEpoch(1))
+            .unwrap_err()
+            .code(),
+        "corrupt_record"
+    );
+
+    let destroyed = Fixture::new();
+    destroyed
+        .store()
+        .migrate_epoch_state(
+            &destroyed.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    let retired = ChannelDefinitionStore::new(&destroyed.backend)
+        .destroy(channel_id())
+        .unwrap();
+    assert_eq!(
+        destroyed
+            .store()
+            .activate_prepared_epoch(&retired, KeyEpoch(1))
+            .unwrap_err()
+            .code(),
+        "channel_destroyed"
+    );
+}
+
+#[test]
+fn recovery_rejects_decreasing_epochs_and_preparation_reports_exhaustion() {
+    let fixture = Fixture::new();
+    let store = fixture.store();
+    store
+        .migrate_epoch_state(
+            &fixture.definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    store
+        .prepare_rotation(
+            &fixture.definition,
+            std::slice::from_ref(&fixture.receiver_b),
+            fixture.rotation(NEXT_CMK, 0x51),
+        )
+        .unwrap();
+    store
+        .activate_prepared_epoch(&fixture.definition, KeyEpoch(1))
+        .unwrap();
+    let epoch_two = plan_rotation(
+        b"originator",
+        channel_id(),
+        KeyEpoch(1),
+        ChannelMasterKey::from_bytes([0x32; 32]),
+        vec![RotationReceiver::with_material(
+            b"receiver-b".to_vec(),
+            fixture.receiver_b.public_key,
+            [0x53; 32],
+            [0x63; 24],
+        )
+        .unwrap()],
+        &fixture.signer,
+    )
+    .unwrap();
+    store
+        .prepare_rotation(
+            &fixture.definition,
+            std::slice::from_ref(&fixture.receiver_b),
+            epoch_two,
+        )
+        .unwrap();
+    store
+        .activate_prepared_epoch(&fixture.definition, KeyEpoch(2))
+        .unwrap();
+    assert_eq!(
+        store
+            .recover_preparation(&fixture.definition, KeyEpoch(1))
+            .unwrap_err()
+            .code(),
+        "decreasing_epoch"
+    );
+
+    let backend = InMemoryStorageBackend::new();
+    let signer = OriginatorSigningKey::from_seed([0x11; 32]);
+    let receiver_key = ReceiverKeyPair::from_private_key([0x42; 32]).unwrap();
+    let receiver = ReceiverIdentity {
+        agent_id: AgentId::new(b"receiver-b".to_vec()).unwrap(),
+        public_key: receiver_key.public_key(),
+    };
+    let definition = ChannelDefinition::new(
+        channel_id(),
+        OriginatorIdentity {
+            agent_id: AgentId::new(b"originator".to_vec()).unwrap(),
+            public_key: signer.public_key(),
+        },
+        vec![receiver.clone()],
+        1,
+        KeyEpoch(u64::MAX),
+    )
+    .unwrap();
+    ChannelDefinitionStore::new(&backend)
+        .create(&definition)
+        .unwrap();
+    let custody = InMemoryKeyCustody::new();
+    let exhausted =
+        EpochActivationStore::new_for_testing(&backend, &custody, channel_id()).unwrap();
+    exhausted
+        .migrate_epoch_state(
+            &definition,
+            Some(&ChannelMasterKey::from_bytes(CURRENT_CMK)),
+        )
+        .unwrap();
+    let irrelevant_rotation = plan_rotation(
+        b"originator",
+        channel_id(),
+        KeyEpoch(0),
+        ChannelMasterKey::from_bytes(NEXT_CMK),
+        vec![RotationReceiver::with_material(
+            b"receiver-b".to_vec(),
+            receiver.public_key,
+            [0x51; 32],
+            [0x61; 24],
+        )
+        .unwrap()],
+        &signer,
+    )
+    .unwrap();
+    assert_eq!(
+        exhausted
+            .prepare_rotation(&definition, &[receiver], irrelevant_rotation)
+            .unwrap_err()
+            .code(),
+        "epoch_exhausted"
+    );
+}
+use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
Closes #11782.

## Summary

- add the production Rust D18T durable epoch-activation adapter with strict D18S v2 and activation-plan v1 wire formats
- serialize preparation, recovery, activation, publication, and destruction through durable custody plus the existing D18P CAS boundary
- add canonical cross-language fixtures with generator Git-blob provenance and coverage for migration, every replay boundary, races, revocation, corruption, exhaustion, and redacted diagnostics
- expose signature-only D18G verification so activation never requires receiver private keys

## Validation

- `bash BUILD` (16 package tests)
- `cargo clippy -p chief-of-staff-channel-epoch-activation --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-channel-epoch-activation --no-deps`
- affected-package graph: 105/105 packages
