### PR TITLE
feat(hl-c184a): lead the report with vocabulary, not spine coverage

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -9,6 +9,62 @@ Last prioritized: 2026-08-12 (second pass), after the CEFR climb reached B2 and
 three measurements changed what the top of this list should be. See
 **Prioritization, 2026-08-12** below for the current order and the numbers behind it.
 
+## HL-C183 — VOCABULARY MASS is the dominant remaining cost, and the gate already said so
+
+**Owner, 2026-08-14:** *"a native speaker knows something like 10K words … I want
+at least 500 verbs covered. Lot more adjectives, adverbs and others. This feels
+woefully inadequate."* Measured, and correct.
+
+`LEVEL_VOCABULARY` (`level-gate.ts:42`) already sets the targets:
+
+| level | target | Spanish |
+|---|---:|---:|
+| pre-A1 | 300 | **267 — FAILS** |
+| A1 | 600 | |
+| A2 | 1,200 | |
+| B1 | 2,500 | |
+| B2 | 4,000 | |
+| C1 | 8,000 | |
+| **C2** | **16,000** | **1.7% of it** |
+
+Spanish teaches **267 distinct word tokens** across **211** word/phrase lessons,
+and ~46 look like infinitives against an owner target of **500 verbs** (9%). It
+does not clear pre-A1 — which is exactly why `attained` is null.
+
+**The reframing this forces.** Closing the spine at 33/33 measured **functional
+coverage**: a rung for every can-do statement. It says nothing about **lexical
+mass**, the words needed to stand on those rungs. All 33 nodes were closed with
+211 word lessons, which should have read as a warning rather than a milestone —
+and every progress report in that session led with the spine number.
+
+It also explains something noticed but not understood at the time: three of four
+C1 "gaps" were satisfiable by alias. **A 33-node functional spine is too coarse
+to drive authoring.** Vocabulary is the real cost, and it has a real target.
+
+**Scale.** ~15,700 more words for Spanish alone to reach C2, and the same again
+across 21 other tracks. HL09 §3's estimate of ~8,000 lessons for a complete track
+is consistent; Spanish has 463.
+
+**Order of work:**
+
+1. **Lead with the vocabulary number in every report** — `vocabulary /
+   LEVEL_VOCABULARY[next level]` per track, beside `attained`. Free, and it stops
+   "33/33" reading as completeness. Do this *before* authoring anything.
+2. **Close the `word_class` classifier** (~23% of Spanish lexical lessons today,
+   per [[feedback_measure_before_building_it_redefines_the_task]]) so the
+   verb/adjective/adverb census the owner asked for can exist at all. Prerequisite,
+   not a side quest.
+3. **Plan authoring against the deficit**, cheapest rung first: pre-A1 needs only
+   **33 more words**, A1 another 300. The corpus is nearer a *usable* A1 than the
+   C2 headline suggests.
+4. **Examine the lesson-to-word ratio.** 463 lessons yielding 267 words means most
+   lessons carry no new vocabulary. That may be correct for a gentle ramp, but it
+   is the lever deciding whether 16,000 is reachable at all, and it has never been
+   looked at.
+
+Related: HL-C182 (nothing measures whether a reader could pass anything) — this
+row is the concrete, already-instrumented half of that gap.
+
 ## HL-C166 — CLOSED 2026-08-14. `data/scripts/repin_tests.py`
 
 Committed, documented, and verified by breaking a pin on purpose: the dry run

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -9,6 +9,67 @@ Last prioritized: 2026-08-12 (second pass), after the CEFR climb reached B2 and
 three measurements changed what the top of this list should be. See
 **Prioritization, 2026-08-12** below for the current order and the numbers behind it.
 
+## HL-C184 — THE COMPLETION PLAN: 22 tracks to C2, driven by vocabulary
+
+Measured 2026-08-14, once the report finally printed the right number:
+
+```
+VOCABULARY vs HL09 §3.1 targets: spanish 211/300 (pre-A1), hindi 97/300,
+tamil 97/300, malayalam 95/300, french 94/300;
+22 of 22 tracks short of the level they are working on
+```
+
+**Every track fails pre-A1.** The strongest is at 70% of the *first* rung. This
+row is the ordered plan from here to C2 across all 22, and it is deliberately
+long-horizon: the owner's budget is **50,000 lessons**, and at the corpus's
+current density (~0.58 new words per lesson) reaching C2 on one track costs
+~27,600 lessons. Nothing here is a sprint.
+
+### Phase 0 — make the target visible (in progress)
+
+* **HL-C184a. Print vocabulary in the report.** DONE — this row exists because of it.
+* **HL-C184b. Make the vocabulary floor a REPORT-ONLY gate first**, per the HL05
+  precedent: a gate that fails on inherited debt teaches authors to route around
+  it. It becomes blocking per track as that track clears pre-A1.
+* **HL-C184c. Close the `word_class` classifier** (~23% of Spanish lexical
+  lessons). Without it the verb/adjective/adverb census the owner asked for
+  cannot be computed at all, and "500 verbs" has no measurement.
+
+### Phase 1 — clear pre-A1 on one track, and learn the real cost
+
+* **HL-C184d. Spanish pre-A1: 211 → 300.** Eighty-nine words. Do it as one
+  vocabulary tranche and **measure what it actually costs** — lessons written,
+  wall-clock, how many ceilings move. Every later estimate depends on this
+  number, and it is currently a guess.
+* **HL-C184e. Write down the density that results.** Words per lesson, and
+  whether the ramp gates (R1, atom budget) bind before the target does.
+
+### Phase 2 — the ladder, cheapest rung first
+
+Per track, in order: pre-A1 300 → A1 600 → A2 1,200 → B1 2,500 → B2 4,000 →
+C1 8,000 → C2 16,000. **Author against the vocabulary deficit, not against spine
+nodes** — the spine is 33 functional rungs and is already closed on Spanish while
+the corpus fails pre-A1, which is exactly how coarse it is.
+
+Sequencing across tracks is the owner's alternation rule: Spanish and the Indic
+six move together, and no track is left to rot.
+
+### Phase 3 — what vocabulary alone will not buy
+
+Recorded now so it is not discovered late: HL-C182 lists what none of this
+measures — retention, production under time pressure, listening at natural speed,
+exam task formats. **A track at 16,000 words is a corpus claim, not a learner
+claim.** The honest test needs a human sitting a past paper.
+
+### Standing rules for every item above
+
+* **A gentle ramp caps new atoms PER LESSON, never lesson count.** Chapters are
+  sized to carry vocabulary at that density; a spine node closes when it closes.
+  See [[feedback_gentle_ramp_means_few_atoms_per_lesson_not_few_lessons]].
+* **Lead every report with `vocabulary / target`**, never spine coverage.
+* A ratio going over means the ramp got worse — revert the content, do not
+  re-seat (HL-C167).
+
 ## HL-C183 — VOCABULARY MASS is the dominant remaining cost, and the gate already said so
 
 **Owner, 2026-08-14:** *"a native speaker knows something like 10K words … I want

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -57,10 +57,31 @@ is consistent; Spanish has 463.
 3. **Plan authoring against the deficit**, cheapest rung first: pre-A1 needs only
    **33 more words**, A1 another 300. The corpus is nearer a *usable* A1 than the
    C2 headline suggests.
-4. **Examine the lesson-to-word ratio.** 463 lessons yielding 267 words means most
-   lessons carry no new vocabulary. That may be correct for a gentle ramp, but it
-   is the lever deciding whether 16,000 is reachable at all, and it has never been
-   looked at.
+4. **The lesson-to-word ratio — and the answer to "is 16,000 even reachable".**
+   463 lessons yield 267 words: **~0.58 new words per lesson.** Holding that
+   density, 16,000 words needs **~27,600 lessons** for Spanish.
+
+   **Owner, 2026-08-14, on being shown the deficit:** *"This is why I kept telling
+   you to ignore the page count and lesson count and focus on teaching with a very
+   gentle ramp. If we end up 50K lessons, that is fine with me. We can split them
+   up later."*
+
+   So the answer is **yes, and without touching the ramp.** 27,600 sits inside the
+   stated budget with room to spare. **The gentle ramp and the vocabulary target
+   were never in tension** — and the sessions that treated them as if they were
+   made a category error worth naming, because it will recur:
+
+   > A gentle ramp means **few new atoms per lesson**. It does NOT mean few
+   > lessons, small chapters, or a compact book. Closing a spine node with a tidy
+   > four-lesson chapter optimises the wrong quantity. The budget that must stay
+   > small is per-lesson load; the quantity that must grow without limit is the
+   > number of lessons.
+
+   Practical consequence: **stop sizing chapters to close nodes.** Size them to
+   carry vocabulary at the density the ramp allows, and let the node close when it
+   closes. See [[feedback_page_count_is_never_a_constraint]] — the instruction was
+   already recorded; what was missing was the arithmetic showing it is the *only*
+   way the target is reachable.
 
 Related: HL-C182 (nothing measures whether a reader could pass anything) — this
 row is the concrete, already-instrumented half of that gap.

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -668,6 +668,28 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
     `forward references: ${report.continuity.summary.forwardReferences} uses of material a later lesson teaches`,
     ...(report.levelGate
       ? [
+          // VOCABULARY FIRST, and deliberately so (HL-C183). Spine coverage was
+          // being quoted as the headline for a corpus that had not cleared
+          // pre-A1: Spanish read "33/33 spine nodes" while teaching 267 words
+          // against a 300-word pre-A1 floor and a 16,000-word C2 one. Spine
+          // coverage measures FUNCTIONAL reach — a rung per can-do statement.
+          // This measures whether there are enough words to stand on the rungs.
+          // Printing it above the level line is what stops the wrong number
+          // being read as completeness.
+          `VOCABULARY vs HL09 §3.1 targets: ` +
+            [...report.levelGate.tracks]
+              .sort((a, b) => b.vocabulary - a.vocabulary || a.language.localeCompare(b.language))
+              .slice(0, 5)
+              .map((t) => {
+                const next = t.inProgressAt ?? "C2";
+                const target = report.levelGate!.vocabularyTargets[next];
+                return `${t.language} ${t.vocabulary}/${target} (${next})`;
+              })
+              .join(", ") +
+            `; ${report.levelGate.tracks.filter((t) => {
+              const next = t.inProgressAt ?? "C2";
+              return t.vocabulary < report.levelGate!.vocabularyTargets[next];
+            }).length} of ${report.levelGate.tracks.length} tracks short of the level they are working on`,
           `levels ATTAINED (HL09 §3.1): ${CEFR_LEVELS.filter((l) => report.levelGate!.summary.attainedByLevel[l] > 0)
             .map((l) => `${report.levelGate!.summary.attainedByLevel[l]} tracks at ${l}`)
             .join(", ") || "none"}; ` +


### PR DESCRIPTION
Spine coverage was being quoted as the headline for a corpus that **has not
cleared pre-A1**. Spanish read "33/33 spine nodes" while teaching **211 distinct
headwords** against a 300-word pre-A1 floor and a 16,000-word C2 one.

The gate computed all of this already. Nothing printed it.

```
VOCABULARY vs HL09 §3.1 targets: spanish 211/300 (pre-A1), hindi 97/300,
tamil 97/300, malayalam 95/300, french 94/300;
22 of 22 tracks short of the level they are working on
```

**Every track fails pre-A1.** The strongest is at 70% of the *first* rung.

The line sits **above** the ATTAINED line deliberately. Spine coverage measures
*functional reach* — a rung per can-do statement. This measures whether there are
enough words to stand on the rungs. Printing the second one first is what stops
the first being read as completeness.

## Also logs HL-C184 — the completion plan

Ordered, for 22 tracks to C2, and deliberately long-horizon: at current density
(~0.58 new words per lesson) one track to C2 costs **~27,600 lessons**, inside
the owner's **50,000-lesson** budget.

- **Phase 0** — make the target visible; close the `word_class` classifier so
  "500 verbs" can be measured at all
- **Phase 1** — clear pre-A1 on *one* track (Spanish, 211 → 300) and **measure
  what it actually cost**; every later estimate is currently a guess
- **Phase 2** — climb cheapest rung first, authoring against the vocabulary
  deficit rather than spine nodes
- **Phase 3** — what vocabulary alone won't buy (HL-C182), recorded now so it
  isn't discovered late

## A correction to my own number

I quoted **267** earlier — that was tokens across headwords. The gate counts
**211 distinct headwords**, and the gate's definition governs attainment.

## Verification

- Full suite green by exit code; five byte gates clean; `tsc --noEmit` clean
- Security review passed, including that the `vocabularyTargets` index cannot
  reach a prototype member and that the sort copies rather than mutating the
  shared report

🤖 Generated with [Claude Code](https://claude.com/claude-code)