### PR TITLE
feat(chief): add TypeScript D18T epoch activation

### DIFF
--- a/code/packages/typescript/chief-of-staff-channel-crypto/CHANGELOG.md
+++ b/code/packages/typescript/chief-of-staff-channel-crypto/CHANGELOG.md
@@ -11,6 +11,10 @@
   receiver-state transition, and prospective-revocation fixture.
 - Make the package-native BUILD run this package after installing local crypto
   dependencies, and fix HKDF typed-array compatibility under current TypeScript.
+- Add receiver-key-free D18G signature verification and D18F creation through
+  an injected non-exportable signer callback for D18T orchestration.
+- Seal `RotationPlan` construction behind the trusted D18Q planner boundary so
+  D18T cannot receive a caller-assembled plan.
 
 ## 0.1.0
 

--- a/code/packages/typescript/chief-of-staff-channel-crypto/src/grant-profile.ts
+++ b/code/packages/typescript/chief-of-staff-channel-crypto/src/grant-profile.ts
@@ -18,6 +18,7 @@ const MAX_IDENTITY_BYTES = 4096;
 const MAX_U64 = (1n << 64n) - 1n;
 const KEY_GRANT_CONTEXT = new TextEncoder().encode("chief-channel-key-grant-v1");
 const KEY_WRAP_CONTEXT = new TextEncoder().encode("chief-channel-key-wrap-v1");
+const ROTATION_PLAN_FACTORY = Symbol("trusted-rotation-plan-factory");
 
 /** Stable D18Q error codes shared by every portable implementation. */
 export const KEY_GRANT_ERROR_CODES = [
@@ -361,6 +362,30 @@ export function grantSerialize(grant: PortableKeyGrant): Uint8Array {
   );
 }
 
+/** Verify one grant's public bindings and originator signature without a receiver private key. */
+export function verifyGrantSignature(
+  grant: PortableKeyGrant,
+  expectedOriginatorId: Uint8Array,
+  expectedReceiverId: Uint8Array,
+  expectedChannelId: Uint8Array,
+  originatorPublicKey: Uint8Array,
+): void {
+  validateGrant(grant);
+  requireLength(expectedChannelId, 16);
+  requireLength(originatorPublicKey, 32);
+  if (!equalBytes(grant.originatorId, expectedOriginatorId)) fail("unexpected_originator");
+  if (!equalBytes(grant.receiverId, expectedReceiverId)) fail("unexpected_receiver");
+  if (!equalBytes(grant.channelId, expectedChannelId)) fail("unexpected_channel");
+  const signatureInput = grantSignatureInput(
+    grant.originatorId, grant.receiverId, grant.channelId, grant.keyEpoch,
+    grant.ephemeralPublicKey, grant.wrappingNonce, grant.wrappedCmk,
+  );
+  let valid = false;
+  try { valid = verify(signatureInput, grant.originatorSignature, originatorPublicKey); }
+  catch { /* Invalid encoded points are one portable signature failure. */ }
+  if (!valid) fail("invalid_signature");
+}
+
 /** Seal with independently generated ephemeral private-key and nonce material. */
 export function sealChannelKey(
   fields: KeyGrantFields,
@@ -449,19 +474,9 @@ export function openChannelKeyGrant(
   receiverKeyPair: ReceiverKeyPair,
   originatorPublicKey: Uint8Array,
 ): ChannelMasterKey {
-  validateGrant(grant);
-  requireLength(expectedChannelId, 16);
-  requireLength(originatorPublicKey, 32);
-  if (!equalBytes(grant.originatorId, expectedOriginatorId)) fail("unexpected_originator");
-  if (!equalBytes(grant.receiverId, expectedReceiverId)) fail("unexpected_receiver");
-  if (!equalBytes(grant.channelId, expectedChannelId)) fail("unexpected_channel");
-  const signatureInput = grantSignatureInput(
-    grant.originatorId, grant.receiverId, grant.channelId, grant.keyEpoch,
-    grant.ephemeralPublicKey, grant.wrappingNonce, grant.wrappedCmk,
+  verifyGrantSignature(
+    grant, expectedOriginatorId, expectedReceiverId, expectedChannelId, originatorPublicKey,
   );
-  if (!verify(signatureInput, grant.originatorSignature, originatorPublicKey)) {
-    fail("invalid_signature");
-  }
   let sharedSecret: Uint8Array | undefined;
   let wrappingKey: Uint8Array | undefined;
   let plaintext: Uint8Array | undefined;
@@ -630,7 +645,7 @@ export class RotationPlan {
   readonly #newCmk: ChannelMasterKey;
   readonly #grants: readonly PortableKeyGrant[];
 
-  constructor(newEpoch: bigint, newCmk: ChannelMasterKey, grants: readonly PortableKeyGrant[]) {
+  private constructor(newEpoch: bigint, newCmk: ChannelMasterKey, grants: readonly PortableKeyGrant[]) {
     this.newEpoch = newEpoch;
     this.#newCmk = newCmk.clone();
     this.#grants = Object.freeze([...grants]);
@@ -640,6 +655,14 @@ export class RotationPlan {
   get newCmk(): ChannelMasterKey { return this.#newCmk.clone(); }
   get grants(): readonly PortableKeyGrant[] { return this.#grants; }
   destroy(): void { this.#newCmk.destroy(); }
+
+  static [ROTATION_PLAN_FACTORY](
+    newEpoch: bigint,
+    newCmk: ChannelMasterKey,
+    grants: readonly PortableKeyGrant[],
+  ): RotationPlan {
+    return new RotationPlan(newEpoch, newCmk, grants);
+  }
 }
 
 /** Create a complete receiver-sorted next-epoch plan or no plan at all. */
@@ -670,7 +693,7 @@ export function planRotation(
       const fields = new KeyGrantFields(originatorId, receiverId, channelId, currentEpoch + 1n);
       grants.push(receiver.seal(fields, newCmk, signingKey));
     }
-    return new RotationPlan(currentEpoch + 1n, newCmk, grants);
+    return RotationPlan[ROTATION_PLAN_FACTORY](currentEpoch + 1n, newCmk, grants);
   } finally {
     for (const receiver of ordered) receiver.destroy();
   }

--- a/code/packages/typescript/chief-of-staff-channel-crypto/src/index.ts
+++ b/code/packages/typescript/chief-of-staff-channel-crypto/src/index.ts
@@ -226,9 +226,19 @@ export function messageCreate(
   signingSecretKey: Uint8Array,
   channelMasterKey: Uint8Array,
 ): D18Message {
+  requireLength(signingSecretKey, 64);
+  return messageCreateWithSigner(fields, plaintext, (message) => sign(message, signingSecretKey), channelMasterKey);
+}
+
+/** Validate, hash, encrypt, and sign using an injected non-exportable signing boundary. */
+export function messageCreateWithSigner(
+  fields: MessageFields,
+  plaintext: Uint8Array,
+  signer: (message: Uint8Array) => Uint8Array,
+  channelMasterKey: Uint8Array,
+): D18Message {
   validateMessageFields(fields);
   if (plaintext.length > MAX_CIPHERTEXT_BYTES) fail("length_limit_exceeded");
-  requireLength(signingSecretKey, 64);
   requireLength(channelMasterKey, 32);
 
   const plaintextHash = sha256(plaintext);
@@ -240,7 +250,8 @@ export function messageCreate(
     nonce,
     header,
   );
-  const originatorSignature = sign(header, signingSecretKey);
+  const originatorSignature = signer(header);
+  requireLength(originatorSignature, 64);
   return new D18Message({
     ...copyFields(fields),
     plaintextHash,

--- a/code/packages/typescript/chief-of-staff-channel-crypto/tests/d18f-fixtures.test.ts
+++ b/code/packages/typescript/chief-of-staff-channel-crypto/tests/d18f-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { generateKeypair } from "@coding-adventures/ed25519";
+import { generateKeypair, sign } from "@coding-adventures/ed25519";
 import { describe, expect, it } from "vitest";
 import {
   D18Message,
@@ -9,6 +9,7 @@ import {
   MonotonicUuidV7Generator,
   messageAuthenticatedHeader,
   messageCreate,
+  messageCreateWithSigner,
   messageCreateWithSources,
   messageDeserialize,
   messageFromJson,
@@ -121,6 +122,9 @@ describe("D18F shared fixture", () => {
         key!,
       );
       expect(messageSerialize(recreated), testCase.name).toEqual(binary);
+      expect(messageSerialize(messageCreateWithSigner(
+        fieldsOf(message), plaintext, (header) => sign(header, signingSecretKey), key!,
+      )), testCase.name).toEqual(binary);
     }
   });
 

--- a/code/packages/typescript/chief-of-staff-channel-crypto/tests/d18q-fixtures.test.ts
+++ b/code/packages/typescript/chief-of-staff-channel-crypto/tests/d18q-fixtures.test.ts
@@ -23,6 +23,7 @@ import {
   sealChannelKey,
   sealChannelKeyWithMaterial,
   secretErasureCapability,
+  verifyGrantSignature,
   type KeyGrantErrorCode,
   type SecureRandomSource,
 } from "../src/index.js";
@@ -236,6 +237,9 @@ describe("D18Q shared grant fixture", () => {
       expect(keyGrantSignatureInput(grant)).toEqual(fromBase64(testCase.signature_input_b64));
       const decoded = grantDeserialize(record);
       expect(grantSerialize(decoded), `${testCase.name}: round trip`).toEqual(record);
+      expect(() => verifyGrantSignature(
+        decoded, originatorId, receiverId, testChannelId, originatorPublicKey,
+      )).not.toThrow();
       expect(openChannelKeyGrant(
         decoded, originatorId, receiverId, testChannelId, receiver, originatorPublicKey,
       ).bytes).toEqual(fromHex(testCase.expected_opened_cmk_hex));
@@ -312,6 +316,26 @@ describe("D18Q shared grant fixture", () => {
       ), testCase.expected_error, testCase.name);
       receiver.destroy();
     }
+  });
+
+  it("verifies public D18G provenance without receiver private-key custody", () => {
+    const positive = fixture.positive_cases[0]!;
+    const grant = grantDeserialize(fromBase64(positive.d18g_b64));
+    expect(() => verifyGrantSignature(
+      grant,
+      fromBase64(positive.originator_id_b64),
+      fromBase64(positive.receiver_id_b64),
+      fromHex(positive.channel_id_hex),
+      originatorPublicKey,
+    )).not.toThrow();
+    const invalid = fixture.opening_negative_cases.find(({ name }) => name === "invalid-signature")!;
+    expectCode(() => verifyGrantSignature(
+      grantDeserialize(fromBase64(invalid.d18g_b64)),
+      fromBase64(invalid.expected_originator_id_b64),
+      fromBase64(invalid.expected_receiver_id_b64),
+      fromHex(invalid.expected_channel_id_hex),
+      originatorPublicKey,
+    ), invalid.expected_error);
   });
 
   it("installs grants atomically, monotonically, and with skipped epochs", () => {

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/BUILD
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/BUILD
@@ -1,0 +1,15 @@
+npm --prefix ../sha256 install --silent
+npm --prefix ../sha512 install --silent
+npm --prefix ../hmac install --silent
+npm --prefix ../hkdf install --silent
+npm --prefix ../ed25519 install --silent
+npm --prefix ../x25519 install --silent
+npm --prefix ../chacha20-poly1305 install --silent
+npm --prefix ../md5 install --silent
+npm --prefix ../sha1 install --silent
+npm --prefix ../uuid install --silent
+npm --prefix ../chief-of-staff-channel-crypto install --silent
+npm --prefix ../chief-of-staff-channel-store install --silent
+npm ci --quiet
+npx vitest run --coverage
+npx tsc --noEmit

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-08-14
+
+### Added
+
+- Exact D18S v2 and D18T v1 codecs, keys, content types, and validation.
+- Atomic originator-key custody interface with redacted handles and non-durable
+  deterministic test custody.
+- State migration, custody-first preparation, immutable public replay,
+  activation, current-epoch publication, abandonment, and destruction flows.
+- Canonical fixture, crash-recovery, race, corruption, exhaustion, and bounded
+  CAS conformance tests.

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/README.md
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/README.md
@@ -1,0 +1,51 @@
+# chief-of-staff-channel-epoch-activation
+
+Portable D18T durable epoch activation orchestrator.
+
+This package closes the transaction boundary between the existing D18P durable
+channel store, D18Q key-grant planning, and injected originator key custody. It
+selects one complete successor bundle in custody before publishing any public
+record, replays the exact immutable activation plan and grants after a crash,
+and advances the active epoch with the same state-record CAS used by message
+publication.
+
+## Guarantees
+
+- exact `D18S` version 2 state and `D18T` version 1 activation-plan codecs;
+- migration from D18P state without clearing reservations or substituting keys;
+- custody-first candidate selection with redacted handles and a durable
+  production boundary;
+- byte-identical plan/grant recovery across every public-write crash boundary;
+- bounded activation and publish CAS loops with stable D18T errors;
+- current-epoch message reservation, encryption, commit, and abandonment;
+- append-only public history and explicit secret destruction after retirement;
+- direct consumption of the canonical Rust-authored D18T fixture manifest.
+
+`InMemoryKeyCustody` is deterministic test infrastructure and reports itself as
+non-durable. `EpochActivationStore.open()` rejects it; production callers must
+inject restart-safe custody. Tests must opt in with `openForTesting()`.
+
+## Composition
+
+```text
+D18Q RotationPlan -> custody selection -> D18T plan + D18G replay
+                                          |
+D18P D18S v2 publish reservation <--------+--------> activation CAS
+```
+
+## Dependencies
+
+- chief-of-staff-channel-store
+- chief-of-staff-channel-crypto
+- sha256
+
+The package also adds two narrow primitives to the shared crypto package:
+receiver-key-free D18G signature verification and D18F creation through an
+injected non-exportable signer callback.
+
+## Development
+
+```bash
+# Run tests
+bash BUILD
+```

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/package-lock.json
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/package-lock.json
@@ -1,0 +1,2561 @@
+{
+  "name": "@coding-adventures/chief-of-staff-channel-epoch-activation",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/chief-of-staff-channel-epoch-activation",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/chief-of-staff-channel-crypto": "file:../chief-of-staff-channel-crypto",
+        "@coding-adventures/chief-of-staff-channel-store": "file:../chief-of-staff-channel-store",
+        "@coding-adventures/sha256": "file:../sha256"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../chief-of-staff-channel-crypto": {
+      "name": "@coding-adventures/chief-of-staff-channel-crypto",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/chacha20-poly1305": "file:../chacha20-poly1305",
+        "@coding-adventures/ed25519": "file:../ed25519",
+        "@coding-adventures/hkdf": "file:../hkdf",
+        "@coding-adventures/sha256": "file:../sha256",
+        "@coding-adventures/uuid": "file:../uuid",
+        "@coding-adventures/x25519": "file:../x25519"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../chief-of-staff-channel-store": {
+      "name": "@coding-adventures/chief-of-staff-channel-store",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/chief-of-staff-channel-crypto": "file:../chief-of-staff-channel-crypto",
+        "@coding-adventures/sha256": "file:../sha256"
+      },
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../sha256": {
+      "name": "@coding-adventures/sha256",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/chief-of-staff-channel-crypto": {
+      "resolved": "../chief-of-staff-channel-crypto",
+      "link": true
+    },
+    "node_modules/@coding-adventures/chief-of-staff-channel-store": {
+      "resolved": "../chief-of-staff-channel-store",
+      "link": true
+    },
+    "node_modules/@coding-adventures/sha256": {
+      "resolved": "../sha256",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/package.json
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@coding-adventures/chief-of-staff-channel-epoch-activation",
+  "version": "0.1.0",
+  "description": "Portable D18T durable epoch activation orchestrator",
+  "type": "module",
+  "main": "src/index.ts",
+  "files": [
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "BUILD"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/chief-of-staff-channel-store": "file:../chief-of-staff-channel-store",
+    "@coding-adventures/chief-of-staff-channel-crypto": "file:../chief-of-staff-channel-crypto",
+    "@coding-adventures/sha256": "file:../sha256"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
+  }
+}

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/custody.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/custody.ts
@@ -1,0 +1,169 @@
+/** Injected atomic originator-key custody for D18T. */
+
+import { ChannelMasterKey } from "@coding-adventures/chief-of-staff-channel-crypto";
+import { bytesEqual } from "@coding-adventures/chief-of-staff-channel-store";
+
+export type CustodySelection = "selected" | "idempotent" | "conflict";
+
+export class CustodyError extends Error {
+  readonly code = "custody_error" as const;
+  constructor() { super("custody_error"); this.name = "CustodyError"; }
+}
+
+/** Opaque, redacted reference to one retained epoch key. */
+export class EpochKeyHandle {
+  readonly #channelId: Uint8Array;
+  readonly epoch: bigint;
+  constructor(channelId: Uint8Array, epoch: bigint) {
+    this.#channelId = channelId.slice(); this.epoch = epoch; Object.freeze(this);
+  }
+  get channelId(): Uint8Array { return this.#channelId.slice(); }
+  toString(): string { return "EpochKeyHandle([REDACTED])"; }
+  toJSON(): string { return "EpochKeyHandle([REDACTED])"; }
+}
+
+/** Exact secret-free recovery bundle retained beside a prepared CMK. */
+export class PublicPreparation {
+  readonly #channelId: Uint8Array;
+  readonly baseEpoch: bigint;
+  readonly newEpoch: bigint;
+  readonly #planBytes: Uint8Array;
+  readonly #grants: readonly Uint8Array[];
+
+  constructor(
+    channelId: Uint8Array,
+    baseEpoch: bigint,
+    newEpoch: bigint,
+    planBytes: Uint8Array,
+    grants: readonly Uint8Array[],
+  ) {
+    this.#channelId = channelId.slice();
+    this.baseEpoch = baseEpoch;
+    this.newEpoch = newEpoch;
+    this.#planBytes = planBytes.slice();
+    this.#grants = Object.freeze(grants.map((grant) => grant.slice()));
+    Object.freeze(this);
+  }
+
+  get channelId(): Uint8Array { return this.#channelId.slice(); }
+  get planBytes(): Uint8Array { return this.#planBytes.slice(); }
+  get grants(): readonly Uint8Array[] { return this.#grants.map((grant) => grant.slice()); }
+
+  equals(other: PublicPreparation): boolean {
+    return bytesEqual(this.#channelId, other.#channelId) &&
+      this.baseEpoch === other.baseEpoch && this.newEpoch === other.newEpoch &&
+      bytesEqual(this.#planBytes, other.#planBytes) &&
+      this.#grants.length === other.#grants.length &&
+      this.#grants.every((grant, index) => bytesEqual(grant, other.#grants[index]!));
+  }
+
+  clone(): PublicPreparation {
+    return new PublicPreparation(this.#channelId, this.baseEpoch, this.newEpoch, this.#planBytes, this.#grants);
+  }
+}
+
+/** One indivisible candidate offered to custody. */
+export class PreparedEpoch {
+  readonly publicPreparation: PublicPreparation;
+  readonly #cmk: ChannelMasterKey;
+  constructor(publicPreparation: PublicPreparation, cmk: ChannelMasterKey) {
+    this.publicPreparation = publicPreparation.clone();
+    this.#cmk = cmk.clone();
+  }
+  cloneCmk(): ChannelMasterKey { return this.#cmk.clone(); }
+  destroy(): void { this.#cmk.destroy(); }
+  toString(): string { return "PreparedEpoch([REDACTED])"; }
+  toJSON(): string { return "PreparedEpoch([REDACTED])"; }
+}
+
+/** Atomic, restart-safe custody boundary. Production implementations must be durable. */
+export interface OriginatorKeyCustody {
+  readonly durable: boolean;
+  importActiveIfAbsent(
+    channelId: Uint8Array, epoch: bigint, cmk: ChannelMasterKey,
+  ): Promise<CustodySelection>;
+  resolveHandle(channelId: Uint8Array, epoch: bigint): Promise<EpochKeyHandle | undefined>;
+  prepareIfAbsent(prepared: PreparedEpoch): Promise<CustodySelection>;
+  loadPreparation(channelId: Uint8Array, newEpoch: bigint): Promise<PublicPreparation | undefined>;
+  withKey<T>(
+    handle: EpochKeyHandle,
+    operation: (cmk: ChannelMasterKey) => T | Promise<T>,
+  ): Promise<T>;
+  destroyChannel(channelId: Uint8Array): Promise<void>;
+}
+
+/** Deterministic, explicitly non-durable custody for conformance tests only. */
+export class InMemoryKeyCustody implements OriginatorKeyCustody {
+  readonly durable = false;
+  readonly #keys = new Map<string, ChannelMasterKey>();
+  readonly #preparations = new Map<string, PublicPreparation>();
+
+  async importActiveIfAbsent(
+    channelId: Uint8Array, epoch: bigint, cmk: ChannelMasterKey,
+  ): Promise<CustodySelection> {
+    const key = slot(channelId, epoch);
+    const current = this.#keys.get(key);
+    if (current === undefined) { this.#keys.set(key, cmk.clone()); return "selected"; }
+    return sameCmk(current, cmk) ? "idempotent" : "conflict";
+  }
+
+  async resolveHandle(channelId: Uint8Array, epoch: bigint): Promise<EpochKeyHandle | undefined> {
+    return this.#keys.has(slot(channelId, epoch)) ? new EpochKeyHandle(channelId, epoch) : undefined;
+  }
+
+  async prepareIfAbsent(prepared: PreparedEpoch): Promise<CustodySelection> {
+    const publicPreparation = prepared.publicPreparation;
+    const key = slot(publicPreparation.channelId, publicPreparation.newEpoch);
+    const currentPublic = this.#preparations.get(key);
+    const currentCmk = this.#keys.get(key);
+    if (currentPublic === undefined && currentCmk === undefined) {
+      const cmk = prepared.cloneCmk();
+      this.#preparations.set(key, publicPreparation.clone());
+      this.#keys.set(key, cmk);
+      return "selected";
+    }
+    if (currentPublic === undefined || currentCmk === undefined || !currentPublic.equals(publicPreparation)) {
+      return "conflict";
+    }
+    const candidate = prepared.cloneCmk();
+    try { return sameCmk(currentCmk, candidate) ? "idempotent" : "conflict"; }
+    finally { candidate.destroy(); }
+  }
+
+  async loadPreparation(channelId: Uint8Array, newEpoch: bigint): Promise<PublicPreparation | undefined> {
+    return this.#preparations.get(slot(channelId, newEpoch))?.clone();
+  }
+
+  async withKey<T>(
+    handle: EpochKeyHandle,
+    operation: (cmk: ChannelMasterKey) => T | Promise<T>,
+  ): Promise<T> {
+    const cmk = this.#keys.get(slot(handle.channelId, handle.epoch));
+    if (cmk === undefined) throw new CustodyError();
+    const transient = cmk.clone();
+    try { return await operation(transient); } finally { transient.destroy(); }
+  }
+
+  async destroyChannel(channelId: Uint8Array): Promise<void> {
+    const prefix = `${hex(channelId)}:`;
+    for (const [key, cmk] of this.#keys) {
+      if (key.startsWith(prefix)) { cmk.destroy(); this.#keys.delete(key); }
+    }
+    for (const key of this.#preparations.keys()) {
+      if (key.startsWith(prefix)) this.#preparations.delete(key);
+    }
+  }
+
+  get retainedKeyCount(): number { return this.#keys.size; }
+}
+
+function sameCmk(left: ChannelMasterKey, right: ChannelMasterKey): boolean {
+  const leftBytes = left.bytes;
+  const rightBytes = right.bytes;
+  try { return bytesEqual(leftBytes, rightBytes); }
+  finally { leftBytes.fill(0); rightBytes.fill(0); }
+}
+function slot(channelId: Uint8Array, epoch: bigint): string { return `${hex(channelId)}:${epoch}`; }
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/index.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/index.ts
@@ -1,0 +1,710 @@
+/** Portable D18T durable epoch-activation orchestration. */
+
+import {
+  ChannelMasterKey,
+  type D18Message,
+  OriginatorSigningKey,
+  type PortableKeyGrant,
+  type RotationPlan,
+  grantDeserialize,
+  grantSerialize,
+  messageCreateWithSigner,
+  messageDeserialize,
+  messageSerialize,
+  secretErasureCapability,
+  verifyGrantSignature,
+} from "@coding-adventures/chief-of-staff-channel-crypto";
+import {
+  CHANNEL_GRANT_CONTENT_TYPE,
+  CHANNEL_MESSAGE_CONTENT_TYPE,
+  CHANNEL_STATE_CONTENT_TYPE,
+  CHANNEL_STORAGE_NAMESPACE,
+  ChannelDefinition,
+  ChannelDefinitionStore,
+  ChannelProfileError,
+  type ChannelState,
+  type ChannelStorageBackend,
+  MAX_U64,
+  MessageHeader,
+  type ReceiverIdentity,
+  StorageConflictError,
+  type StorageRecord,
+  bytesEqual,
+  channelStateDeserialize,
+  keyGrantRecordKey,
+  messageRecordKey,
+  sequenceStateRecordKey,
+} from "@coding-adventures/chief-of-staff-channel-store";
+import { sha256 } from "@coding-adventures/sha256";
+import {
+  type CustodySelection,
+  EpochKeyHandle,
+  InMemoryKeyCustody,
+  type OriginatorKeyCustody,
+  PreparedEpoch,
+  PublicPreparation,
+} from "./custody.js";
+import {
+  ACTIVATION_PLAN_CONTENT_TYPE,
+  ActivationPlan,
+  ActivationPlanEntry,
+  EPOCH_STATE_CONTENT_TYPE,
+  EpochState,
+  MAX_PLAN_RECEIVERS,
+  activationPlanDeserialize,
+  activationPlanRecordKey,
+  activationPlanSerialize,
+  epochStateDeserialize,
+  epochStateSerialize,
+} from "./wire.js";
+
+export * from "./custody.js";
+export * from "./wire.js";
+
+export const MAX_EPOCH_CAS_ATTEMPTS = 16;
+export const EPOCH_ACTIVATION_ERROR_CODES = [
+  "not_initialized", "channel_destroyed", "invalid_plan", "corrupt_record",
+  "pending_append", "unactivated_epoch", "active_key_missing",
+  "conflicting_active_key", "preparation_missing", "conflicting_preparation",
+  "conflicting_plan", "conflicting_grant", "unexpected_epoch", "decreasing_epoch",
+  "epoch_exhausted", "concurrent_update", "storage_error", "custody_error", "crypto_error",
+] as const;
+export type EpochActivationErrorCode = (typeof EPOCH_ACTIVATION_ERROR_CODES)[number];
+
+/** Stable D18T failure whose message never contains secret data. */
+export class EpochActivationError extends Error {
+  readonly code: EpochActivationErrorCode;
+  constructor(code: EpochActivationErrorCode) {
+    super(code); this.name = "EpochActivationError"; this.code = code;
+  }
+}
+
+export type PreparationOutcome = "prepared" | "idempotent";
+export type ActivationOutcome = "activated" | "idempotent";
+
+/** Honest D18Q/TypeScript secret-erasure capability for this composition. */
+export function epochActivationSecretErasureCapability() {
+  return secretErasureCapability();
+}
+
+export interface ActiveEpochAppendRequest {
+  readonly messageId: Uint8Array;
+  readonly timestampNs: bigint;
+  readonly originatorId: Uint8Array;
+  readonly contentType: string;
+  /** If supplied, it must equal the authoritative D18S v2 epoch. */
+  readonly keyEpoch?: bigint;
+}
+
+/** Exact reserved D18H plus the redacted handle for its selected active CMK. */
+export class EpochReservation {
+  readonly header: MessageHeader;
+  readonly keyHandle: EpochKeyHandle;
+  constructor(header: MessageHeader, keyHandle: EpochKeyHandle) {
+    this.header = header; this.keyHandle = keyHandle; Object.freeze(this);
+  }
+}
+
+/** D18T coordinator over injected public storage and secret custody. */
+export class EpochActivationStore {
+  readonly #backend: ChannelStorageBackend;
+  readonly #custody: OriginatorKeyCustody;
+  readonly #channelId: Uint8Array;
+
+  private constructor(
+    backend: ChannelStorageBackend,
+    custody: OriginatorKeyCustody,
+    channelId: Uint8Array,
+  ) {
+    this.#backend = backend; this.#custody = custody; this.#channelId = channelId.slice();
+  }
+
+  static async open(
+    backend: ChannelStorageBackend,
+    custody: OriginatorKeyCustody,
+    channelId: Uint8Array,
+  ): Promise<EpochActivationStore> {
+    if (!custody.durable) fail("custody_error");
+    await backendCall(() => backend.initialize());
+    return new EpochActivationStore(backend, custody, channelId);
+  }
+
+  static async openForTesting(
+    backend: ChannelStorageBackend,
+    custody: OriginatorKeyCustody,
+    channelId: Uint8Array,
+  ): Promise<EpochActivationStore> {
+    await backendCall(() => backend.initialize());
+    return new EpochActivationStore(backend, custody, channelId);
+  }
+
+  /** Custody-first creation of a D18T-aware channel and its initial v2 state. */
+  async createEpochChannel(
+    definition: ChannelDefinition,
+    initialCmk: ChannelMasterKey,
+  ): Promise<EpochState> {
+    if (!bytesEqual(definition.channelId, this.#channelId) || definition.lifecycle !== "active") {
+      initialCmk.destroy();
+      fail("invalid_plan");
+    }
+    await this.#importInitialKey(definition.keyEpoch, initialCmk);
+    const definitions = new ChannelDefinitionStore(this.#backend);
+    try {
+      const existing = await definitions.load(this.#channelId);
+      if (existing === undefined) await definitions.create(definition);
+      else if (existing.lifecycle === "destroyed") fail("channel_destroyed");
+      else if (!existing.equals(definition)) fail("invalid_plan");
+    }
+    catch (error) {
+      if (error instanceof EpochActivationError) throw error;
+      if (error instanceof ChannelProfileError) {
+        if (error.code === "channel_destroyed") fail("channel_destroyed");
+        if (error.code === "conflicting_definition") fail("invalid_plan");
+        fail("corrupt_record");
+      }
+      throw storageError(error);
+    }
+    return this.migrateEpochState(definition);
+  }
+
+  /** Upgrade absent or D18S v1 state only after the current CMK is resolvable. */
+  async migrateEpochState(
+    definition: ChannelDefinition,
+    currentCmk?: ChannelMasterKey,
+  ): Promise<EpochState> {
+    await this.#requireDefinition(definition, false);
+    for (let attempt = 0; attempt < MAX_EPOCH_CAS_ATTEMPTS; attempt += 1) {
+      const record = await this.#stateRecord();
+      if (record?.contentType === EPOCH_STATE_CONTENT_TYPE) {
+        const state = this.#decodeV2StateRecord(record);
+        if (await custodyCall(() => this.#custody.resolveHandle(this.#channelId, state.activeEpoch)) === undefined) {
+          fail("active_key_missing");
+        }
+        return state;
+      }
+
+      await this.#ensureInitialKey(definition.keyEpoch, currentCmk);
+      let state: EpochState;
+      if (record === undefined) {
+        state = new EpochState(this.#channelId, {
+          activeEpoch: definition.keyEpoch, nextSequence: 0n,
+        });
+      } else {
+        this.#requireEnvelope(record, sequenceStateRecordKey(this.#channelId), CHANNEL_STATE_CONTENT_TYPE);
+        let prior: ChannelState;
+        try { prior = channelStateDeserialize(record.body, this.#channelId); }
+        catch { fail("corrupt_record"); }
+        if (prior.pendingHeader !== undefined && prior.pendingHeader.keyEpoch !== definition.keyEpoch) {
+          fail("corrupt_record");
+        }
+        state = new EpochState(this.#channelId, {
+          activeEpoch: definition.keyEpoch,
+          nextSequence: prior.nextSequence,
+          pendingHeader: prior.pendingHeader,
+        });
+      }
+      try {
+        const stored = await this.#backend.put(publicPut(
+          sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE,
+          epochStateSerialize(state), record === undefined ? { ifAbsent: true } : { ifRevision: record.revision },
+        ));
+        return this.#decodeV2StateRecord(stored);
+      } catch (error) {
+        if (error instanceof StorageConflictError) continue;
+        throw storageError(error);
+      }
+    }
+    fail("concurrent_update");
+  }
+
+  async state(): Promise<EpochState> {
+    const record = await this.#stateRecord();
+    if (record === undefined) fail("not_initialized");
+    return this.#decodeV2StateRecord(record);
+  }
+
+  async prepareRotation(
+    definition: ChannelDefinition,
+    targetRoster: readonly ReceiverIdentity[],
+    rotation: RotationPlan,
+  ): Promise<PreparationOutcome> {
+    await this.#requireDefinition(definition, false);
+    const state = await this.state();
+    if (state.pendingHeader !== undefined) fail("pending_append");
+    if (state.activeEpoch === MAX_U64) fail("epoch_exhausted");
+    const expected = state.activeEpoch + 1n;
+    if (rotation.newEpoch !== expected) fail("unexpected_epoch");
+    const prepared = prepareRotationCandidate(definition, state.activeEpoch, targetRoster, rotation);
+    let selection: CustodySelection;
+    try { selection = await custodyCall(() => this.#custody.prepareIfAbsent(prepared)); }
+    finally { prepared.destroy(); }
+    if (selection === "conflict") fail("conflicting_preparation");
+    await this.#replayPreparation(definition, expected);
+    return selection === "selected" ? "prepared" : "idempotent";
+  }
+
+  async recoverPreparation(
+    definition: ChannelDefinition,
+    newEpoch: bigint,
+  ): Promise<PreparationOutcome> {
+    await this.#requireDefinition(definition, false);
+    const active = (await this.state()).activeEpoch;
+    if (newEpoch < active) fail("decreasing_epoch");
+    if (newEpoch !== active) {
+      if (active === MAX_U64) fail("epoch_exhausted");
+      if (newEpoch !== active + 1n) fail("unexpected_epoch");
+    }
+    await this.#replayPreparation(definition, newEpoch);
+    return "idempotent";
+  }
+
+  async activatePreparedEpoch(
+    definition: ChannelDefinition,
+    newEpoch: bigint,
+  ): Promise<ActivationOutcome> {
+    await this.#requireDefinition(definition, false);
+    const prepared = await custodyCall(() => this.#custody.loadPreparation(this.#channelId, newEpoch));
+    if (prepared === undefined) fail("preparation_missing");
+    for (let attempt = 0; attempt < MAX_EPOCH_CAS_ATTEMPTS; attempt += 1) {
+      await this.#requireDefinition(definition, false);
+      const record = await this.#stateRecord();
+      if (record === undefined) fail("not_initialized");
+      const state = this.#decodeV2StateRecord(record);
+      if (state.activeEpoch === newEpoch) {
+        await this.#validateAndReplay(definition, prepared);
+        await this.#requireHandle(newEpoch);
+        return "idempotent";
+      }
+      if (state.activeEpoch > newEpoch) fail("decreasing_epoch");
+      if (state.activeEpoch === MAX_U64) fail("epoch_exhausted");
+      if (
+        state.activeEpoch + 1n !== newEpoch || prepared.baseEpoch !== state.activeEpoch ||
+        prepared.newEpoch !== newEpoch
+      ) fail("unexpected_epoch");
+      await this.#validateAndReplay(definition, prepared);
+      await this.#requireHandle(newEpoch);
+      if (state.pendingHeader !== undefined) fail("pending_append");
+      const updated = state.withActiveEpoch(this.#channelId, newEpoch);
+      try {
+        const stored = await this.#backend.put(publicPut(
+          sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE,
+          epochStateSerialize(updated), { ifRevision: record.revision },
+        ));
+        if (!this.#decodeV2StateRecord(stored).equals(updated)) fail("corrupt_record");
+        return "activated";
+      } catch (error) {
+        if (error instanceof StorageConflictError) continue;
+        if (error instanceof EpochActivationError) throw error;
+        throw storageError(error);
+      }
+    }
+    fail("concurrent_update");
+  }
+
+  /** Reserve a publish using only the epoch authoritative in D18S v2. */
+  async reservePublishUsingActiveEpoch(
+    definition: ChannelDefinition,
+    request: ActiveEpochAppendRequest,
+    plaintext: Uint8Array,
+  ): Promise<EpochReservation> {
+    await this.#requireDefinition(definition, false);
+    if (!bytesEqual(request.originatorId, definition.originator.agentId)) fail("invalid_plan");
+    for (let attempt = 0; attempt < MAX_EPOCH_CAS_ATTEMPTS; attempt += 1) {
+      const record = await this.#stateRecord();
+      if (record === undefined) fail("not_initialized");
+      const state = this.#decodeV2StateRecord(record);
+      if (request.keyEpoch !== undefined && request.keyEpoch !== state.activeEpoch) fail("unactivated_epoch");
+      const handle = await this.#requireHandle(state.activeEpoch);
+      if (state.pendingHeader !== undefined) fail("pending_append");
+      if (state.nextSequence === MAX_U64) fail("crypto_error");
+      let header: MessageHeader;
+      try {
+        header = new MessageHeader({
+          messageId: request.messageId,
+          timestampNs: request.timestampNs,
+          originatorId: request.originatorId,
+          channelId: this.#channelId,
+          sequence: state.nextSequence,
+          keyEpoch: state.activeEpoch,
+          contentType: request.contentType,
+          plaintextHash: sha256(plaintext),
+        });
+      } catch { fail("crypto_error"); }
+      const updated = state.withPending(this.#channelId, state.nextSequence + 1n, header);
+      try {
+        await this.#backend.put(publicPut(
+          sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE,
+          epochStateSerialize(updated), { ifRevision: record.revision },
+        ));
+        return new EpochReservation(header, handle);
+      } catch (error) {
+        if (error instanceof StorageConflictError) continue;
+        throw storageError(error);
+      }
+    }
+    fail("concurrent_update");
+  }
+
+  /** Encrypt, idempotently persist, and clear one exact reservation. */
+  async commitReserved(
+    definition: ChannelDefinition,
+    reservation: EpochReservation,
+    plaintext: Uint8Array,
+    signingKey: OriginatorSigningKey,
+  ): Promise<D18Message> {
+    await this.#requireDefinition(definition, false);
+    const header = reservation.header;
+    if (
+      !bytesEqual(header.channelId, this.#channelId) ||
+      header.keyEpoch !== reservation.keyHandle.epoch ||
+      !bytesEqual(reservation.keyHandle.channelId, this.#channelId) ||
+      !bytesEqual(signingKey.publicKey, definition.originator.publicKey) ||
+      !bytesEqual(sha256(plaintext), header.plaintextHash)
+    ) fail("invalid_plan");
+    const state = await this.state();
+    if (state.pendingHeader === undefined) {
+      const key = messageRecordKey(this.#channelId, header.sequence);
+      const stored = await backendCall(() => this.#backend.get(CHANNEL_STORAGE_NAMESPACE, key));
+      if (stored === undefined) fail("corrupt_record");
+      this.#requireEnvelope(stored, key, CHANNEL_MESSAGE_CONTENT_TYPE);
+      let message: D18Message;
+      try { message = messageDeserialize(stored.body); } catch { fail("corrupt_record"); }
+      if (!messageMatchesHeader(message, header)) fail("corrupt_record");
+      const expected = await this.#encryptWithHandle(reservation.keyHandle, header, plaintext, signingKey);
+      if (!bytesEqual(messageSerialize(expected), stored.body)) fail("corrupt_record");
+      return message;
+    }
+    if (!state.pendingHeader.equals(header)) fail("invalid_plan");
+    const message = await this.#encryptWithHandle(reservation.keyHandle, header, plaintext, signingKey);
+    await this.#putImmutable(
+      messageRecordKey(this.#channelId, header.sequence), CHANNEL_MESSAGE_CONTENT_TYPE,
+      messageSerialize(message), "corrupt_record",
+    );
+    await this.#clearPending(header);
+    return message;
+  }
+
+  async abandonPending(): Promise<MessageHeader | undefined> {
+    for (let attempt = 0; attempt < MAX_EPOCH_CAS_ATTEMPTS; attempt += 1) {
+      const record = await this.#stateRecord();
+      if (record === undefined) fail("not_initialized");
+      const state = this.#decodeV2StateRecord(record);
+      if (state.pendingHeader === undefined) return undefined;
+      const updated = state.withPending(this.#channelId, state.nextSequence);
+      try {
+        await this.#backend.put(publicPut(
+          sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE,
+          epochStateSerialize(updated), { ifRevision: record.revision },
+        ));
+        return state.pendingHeader;
+      } catch (error) {
+        if (error instanceof StorageConflictError) continue;
+        throw storageError(error);
+      }
+    }
+    fail("concurrent_update");
+  }
+
+  async activationPlan(newEpoch: bigint): Promise<ActivationPlan | undefined> {
+    const key = activationPlanRecordKey(this.#channelId, newEpoch);
+    const record = await backendCall(() => this.#backend.get(CHANNEL_STORAGE_NAMESPACE, key));
+    if (record === undefined) return undefined;
+    this.#requireEnvelope(record, key, ACTIVATION_PLAN_CONTENT_TYPE);
+    let plan: ActivationPlan;
+    try { plan = activationPlanDeserialize(record.body); } catch { fail("corrupt_record"); }
+    if (!bytesEqual(plan.channelId, this.#channelId) || plan.newEpoch !== newEpoch) fail("corrupt_record");
+    return plan;
+  }
+
+  async applyDestruction(definition: ChannelDefinition): Promise<void> {
+    await this.#requireDefinition(definition, true);
+    await custodyCall(() => this.#custody.destroyChannel(this.#channelId));
+  }
+
+  async #ensureInitialKey(epoch: bigint, currentCmk?: ChannelMasterKey): Promise<void> {
+    if (await custodyCall(() => this.#custody.resolveHandle(this.#channelId, epoch)) !== undefined) return;
+    if (currentCmk === undefined) fail("active_key_missing");
+    await this.#importInitialKey(epoch, currentCmk);
+  }
+
+  async #importInitialKey(epoch: bigint, currentCmk: ChannelMasterKey): Promise<void> {
+    let selection: CustodySelection;
+    try { selection = await custodyCall(() => this.#custody.importActiveIfAbsent(this.#channelId, epoch, currentCmk)); }
+    finally { currentCmk.destroy(); }
+    if (selection === "conflict") fail("conflicting_active_key");
+  }
+
+  async #replayPreparation(definition: ChannelDefinition, newEpoch: bigint): Promise<void> {
+    const prepared = await custodyCall(() => this.#custody.loadPreparation(this.#channelId, newEpoch));
+    if (prepared === undefined) fail("preparation_missing");
+    await this.#validateAndReplay(definition, prepared);
+  }
+
+  async #validateAndReplay(definition: ChannelDefinition, prepared: PublicPreparation): Promise<void> {
+    const plan = validatePublicPreparation(definition, prepared);
+    await this.#putImmutable(
+      activationPlanRecordKey(this.#channelId, plan.newEpoch), ACTIVATION_PLAN_CONTENT_TYPE,
+      prepared.planBytes, "conflicting_plan",
+    );
+    for (const bytes of prepared.grants) {
+      let grant: PortableKeyGrant;
+      try { grant = grantDeserialize(bytes); } catch { fail("crypto_error"); }
+      await this.#putImmutable(
+        keyGrantRecordKey(this.#channelId, grant.keyEpoch, grant.receiverId),
+        CHANNEL_GRANT_CONTENT_TYPE, bytes, "conflicting_grant",
+      );
+    }
+    const stored = await this.activationPlan(plan.newEpoch);
+    if (stored === undefined || !stored.equals(plan)) fail("corrupt_record");
+    for (const bytes of prepared.grants) {
+      const grant = cryptoCall(() => grantDeserialize(bytes));
+      const key = keyGrantRecordKey(this.#channelId, grant.keyEpoch, grant.receiverId);
+      const record = await backendCall(() => this.#backend.get(CHANNEL_STORAGE_NAMESPACE, key));
+      if (record === undefined) fail("corrupt_record");
+      this.#requireEnvelope(record, key, CHANNEL_GRANT_CONTENT_TYPE);
+      if (!bytesEqual(record.body, bytes)) fail("corrupt_record");
+    }
+  }
+
+  async #encryptWithHandle(
+    handle: EpochKeyHandle,
+    header: MessageHeader,
+    plaintext: Uint8Array,
+    signingKey: OriginatorSigningKey,
+  ): Promise<D18Message> {
+    return custodyCall(() => this.#custody.withKey(handle, (cmk) => {
+      const bytes = cmk.bytes;
+      try {
+        return cryptoCall(() => messageCreateWithSigner(
+          {
+            messageId: header.messageId, timestampNs: header.timestampNs,
+            originatorId: header.originatorId, channelId: header.channelId,
+            sequence: header.sequence, keyEpoch: header.keyEpoch, contentType: header.contentType,
+          },
+          plaintext,
+          (message) => signingKey.sign(message),
+          bytes,
+        ));
+      } finally { bytes.fill(0); }
+    }));
+  }
+
+  async #requireHandle(epoch: bigint): Promise<EpochKeyHandle> {
+    const handle = await custodyCall(() => this.#custody.resolveHandle(this.#channelId, epoch));
+    if (handle === undefined) fail("active_key_missing");
+    return handle;
+  }
+
+  async #clearPending(expected: MessageHeader): Promise<void> {
+    for (let attempt = 0; attempt < MAX_EPOCH_CAS_ATTEMPTS; attempt += 1) {
+      const record = await this.#stateRecord();
+      if (record === undefined) fail("not_initialized");
+      const state = this.#decodeV2StateRecord(record);
+      if (state.pendingHeader === undefined) return;
+      if (!state.pendingHeader.equals(expected)) fail("invalid_plan");
+      const updated = state.withPending(this.#channelId, state.nextSequence);
+      try {
+        await this.#backend.put(publicPut(
+          sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE,
+          epochStateSerialize(updated), { ifRevision: record.revision },
+        ));
+        return;
+      } catch (error) {
+        if (error instanceof StorageConflictError) continue;
+        throw storageError(error);
+      }
+    }
+    fail("concurrent_update");
+  }
+
+  async #requireDefinition(expected: ChannelDefinition, requireDestroyed: boolean): Promise<void> {
+    if (!bytesEqual(expected.channelId, this.#channelId)) fail("invalid_plan");
+    let actual: ChannelDefinition | undefined;
+    try { actual = await new ChannelDefinitionStore(this.#backend).load(this.#channelId); }
+    catch (error) {
+      if (error instanceof ChannelProfileError && error.code === "channel_destroyed") fail("channel_destroyed");
+      if (error instanceof ChannelProfileError) fail("corrupt_record");
+      throw storageError(error);
+    }
+    if (actual === undefined) fail("not_initialized");
+    if (!actual.equals(expected)) fail("invalid_plan");
+    if (!requireDestroyed && actual.lifecycle === "destroyed") fail("channel_destroyed");
+    if (requireDestroyed && actual.lifecycle !== "destroyed") fail("invalid_plan");
+  }
+
+  async #stateRecord(): Promise<StorageRecord | undefined> {
+    return backendCall(() => this.#backend.get(
+      CHANNEL_STORAGE_NAMESPACE, sequenceStateRecordKey(this.#channelId),
+    ));
+  }
+
+  #decodeV2StateRecord(record: StorageRecord): EpochState {
+    this.#requireEnvelope(record, sequenceStateRecordKey(this.#channelId), EPOCH_STATE_CONTENT_TYPE);
+    try { return epochStateDeserialize(record.body, this.#channelId); }
+    catch { fail("corrupt_record"); }
+  }
+
+  #requireEnvelope(record: StorageRecord, key: string, contentType: string): void {
+    if (
+      record.namespace !== CHANNEL_STORAGE_NAMESPACE || record.key !== key ||
+      record.contentType !== contentType || Object.keys(record.metadata).length !== 0
+    ) fail("corrupt_record");
+  }
+
+  async #putImmutable(
+    key: string,
+    contentType: string,
+    body: Uint8Array,
+    conflictCode: EpochActivationErrorCode,
+  ): Promise<void> {
+    try {
+      const record = await this.#backend.put(publicPut(key, contentType, body, { ifAbsent: true }));
+      this.#requireEnvelope(record, key, contentType);
+      if (!bytesEqual(record.body, body)) fail("corrupt_record");
+    } catch (error) {
+      if (!(error instanceof StorageConflictError)) {
+        if (error instanceof EpochActivationError) throw error;
+        throw storageError(error);
+      }
+      const record = await backendCall(() => this.#backend.get(CHANNEL_STORAGE_NAMESPACE, key));
+      if (record === undefined) fail("corrupt_record");
+      this.#requireEnvelope(record, key, contentType);
+      if (!bytesEqual(record.body, body)) fail(conflictCode);
+    }
+  }
+}
+
+/** Pure candidate construction used by fixture and crash-boundary tests. */
+export function prepareRotationCandidate(
+  definition: ChannelDefinition,
+  baseEpoch: bigint,
+  targetRoster: readonly ReceiverIdentity[],
+  rotation: RotationPlan,
+): PreparedEpoch {
+  try {
+    if (
+      targetRoster.length < 1 || targetRoster.length > MAX_PLAN_RECEIVERS ||
+      targetRoster.length !== rotation.grants.length
+    ) fail("invalid_plan");
+    const roster = targetRoster.map((receiver) => ({
+      agentId: receiver.agentId.slice(), publicKey: receiver.publicKey.slice(),
+    })).sort((left, right) => compareBytes(left.agentId, right.agentId));
+    for (let index = 1; index < roster.length; index += 1) {
+      if (bytesEqual(roster[index - 1]!.agentId, roster[index]!.agentId)) fail("invalid_plan");
+    }
+    for (let index = 0; index < roster.length; index += 1) {
+      const receiver = roster[index]!;
+      const grant = rotation.grants[index]!;
+      if (!bytesEqual(receiver.agentId, grant.receiverId) || grant.keyEpoch !== rotation.newEpoch) {
+        fail("invalid_plan");
+      }
+      cryptoCall(() => verifyGrantSignature(
+        grant, definition.originator.agentId, receiver.agentId,
+        definition.channelId, definition.originator.publicKey,
+      ));
+    }
+    if (baseEpoch === MAX_U64) fail("epoch_exhausted");
+    if (rotation.newEpoch !== baseEpoch + 1n) fail("unexpected_epoch");
+    const grantBytes = rotation.grants.map((grant) => cryptoCall(() => grantSerialize(grant)));
+    const entries = rotation.grants.map((grant, index) => new ActivationPlanEntry(
+      sha256(grant.receiverId), sha256(grantBytes[index]!),
+    ));
+    const plan = new ActivationPlan(definition.channelId, baseEpoch, rotation.newEpoch, entries);
+    const publicPreparation = new PublicPreparation(
+      definition.channelId, baseEpoch, rotation.newEpoch,
+      activationPlanSerialize(plan), grantBytes,
+    );
+    const cmk = rotation.newCmk;
+    try { return new PreparedEpoch(publicPreparation, cmk); }
+    finally { cmk.destroy(); }
+  } finally {
+    rotation.destroy();
+  }
+}
+
+function validatePublicPreparation(
+  definition: ChannelDefinition,
+  prepared: PublicPreparation,
+): ActivationPlan {
+  if (
+    !bytesEqual(prepared.channelId, definition.channelId) || prepared.baseEpoch === MAX_U64 ||
+    prepared.newEpoch !== prepared.baseEpoch + 1n || prepared.grants.length < 1 ||
+    prepared.grants.length > MAX_PLAN_RECEIVERS
+  ) fail("invalid_plan");
+  let plan: ActivationPlan;
+  try { plan = activationPlanDeserialize(prepared.planBytes); } catch { fail("corrupt_record"); }
+  if (
+    !bytesEqual(plan.channelId, prepared.channelId) || plan.baseEpoch !== prepared.baseEpoch ||
+    plan.newEpoch !== prepared.newEpoch || plan.receivers.length !== prepared.grants.length
+  ) fail("invalid_plan");
+  let priorReceiver: Uint8Array | undefined;
+  const entries: ActivationPlanEntry[] = [];
+  for (const bytes of prepared.grants) {
+    const grant = cryptoCall(() => grantDeserialize(bytes));
+    if (
+      !bytesEqual(grant.channelId, prepared.channelId) || grant.keyEpoch !== prepared.newEpoch ||
+      (priorReceiver !== undefined && compareBytes(priorReceiver, grant.receiverId) >= 0)
+    ) fail("invalid_plan");
+    cryptoCall(() => verifyGrantSignature(
+      grant, definition.originator.agentId, grant.receiverId,
+      definition.channelId, definition.originator.publicKey,
+    ));
+    priorReceiver = grant.receiverId;
+    entries.push(new ActivationPlanEntry(sha256(grant.receiverId), sha256(bytes)));
+  }
+  const expected = new ActivationPlan(
+    prepared.channelId, prepared.baseEpoch, prepared.newEpoch, entries,
+  );
+  if (!plan.equals(expected)) fail("invalid_plan");
+  return plan;
+}
+
+function publicPut(
+  key: string,
+  contentType: string,
+  body: Uint8Array,
+  condition: { readonly ifAbsent: true } | { readonly ifRevision: string },
+) {
+  return {
+    namespace: CHANNEL_STORAGE_NAMESPACE, key, contentType,
+    metadata: Object.freeze({}), body: body.slice(), ...condition,
+  };
+}
+
+function messageMatchesHeader(message: D18Message, header: MessageHeader): boolean {
+  return bytesEqual(message.messageId, header.messageId) && message.timestampNs === header.timestampNs &&
+    bytesEqual(message.originatorId, header.originatorId) && bytesEqual(message.channelId, header.channelId) &&
+    message.sequence === header.sequence && message.keyEpoch === header.keyEpoch &&
+    message.contentType === header.contentType && bytesEqual(message.plaintextHash, header.plaintextHash);
+}
+
+async function backendCall<T>(operation: () => Promise<T>): Promise<T> {
+  try { return await operation(); } catch (error) { throw storageError(error); }
+}
+function storageError(error: unknown): EpochActivationError {
+  if (error instanceof EpochActivationError) return error;
+  return new EpochActivationError("storage_error");
+}
+async function custodyCall<T>(operation: () => Promise<T>): Promise<T> {
+  try { return await operation(); }
+  catch (error) {
+    if (error instanceof EpochActivationError) throw error;
+    fail("custody_error");
+  }
+}
+function cryptoCall<T>(operation: () => T): T {
+  try { return operation(); }
+  catch (error) {
+    if (error instanceof EpochActivationError) throw error;
+    fail("crypto_error");
+  }
+}
+function compareBytes(left: Uint8Array, right: Uint8Array): number {
+  for (let index = 0; index < Math.min(left.length, right.length); index += 1) {
+    if (left[index] !== right[index]) return left[index]! - right[index]!;
+  }
+  return left.length - right.length;
+}
+function fail(code: EpochActivationErrorCode): never { throw new EpochActivationError(code); }
+
+export { InMemoryKeyCustody };

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/wire.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/wire.ts
@@ -1,0 +1,258 @@
+/** Exact D18S v2 state and D18T v1 activation-plan codecs. */
+
+import {
+  MAX_PENDING_HEADER_BYTES,
+  MAX_U64,
+  MessageHeader,
+  bytesEqual,
+  messageHeaderDeserialize,
+  messageHeaderSerialize,
+  validateUuidV7,
+} from "@coding-adventures/chief-of-staff-channel-store";
+
+export const EPOCH_STATE_CONTENT_TYPE =
+  "application/vnd.coding-adventures.chief-channel-state-v2";
+export const ACTIVATION_PLAN_CONTENT_TYPE =
+  "application/vnd.coding-adventures.chief-channel-epoch-activation-v1";
+export const MAX_PLAN_RECEIVERS = 1024;
+
+export class EpochWireError extends Error {
+  readonly code = "corrupt_record" as const;
+  constructor() { super("corrupt_record"); this.name = "EpochWireError"; }
+}
+
+export interface EpochStateParts {
+  readonly activeEpoch: bigint;
+  readonly nextSequence: bigint;
+  readonly pendingHeader?: MessageHeader;
+}
+
+export class EpochState {
+  readonly activeEpoch: bigint;
+  readonly nextSequence: bigint;
+  readonly #pendingHeader?: MessageHeader;
+
+  constructor(channelId: Uint8Array, parts: EpochStateParts) {
+    requireU64(parts.activeEpoch);
+    requireU64(parts.nextSequence);
+    if (parts.pendingHeader !== undefined) {
+      const header = parts.pendingHeader;
+      if (
+        !bytesEqual(header.channelId, channelId) ||
+        header.sequence === MAX_U64 ||
+        header.sequence + 1n !== parts.nextSequence ||
+        header.keyEpoch !== parts.activeEpoch
+      ) fail();
+    }
+    this.activeEpoch = parts.activeEpoch;
+    this.nextSequence = parts.nextSequence;
+    this.#pendingHeader = parts.pendingHeader;
+    Object.freeze(this);
+  }
+
+  get pendingHeader(): MessageHeader | undefined { return this.#pendingHeader; }
+
+  withActiveEpoch(channelId: Uint8Array, activeEpoch: bigint): EpochState {
+    return new EpochState(channelId, {
+      activeEpoch, nextSequence: this.nextSequence, pendingHeader: this.#pendingHeader,
+    });
+  }
+
+  withPending(
+    channelId: Uint8Array,
+    nextSequence: bigint,
+    pendingHeader?: MessageHeader,
+  ): EpochState {
+    return new EpochState(channelId, { activeEpoch: this.activeEpoch, nextSequence, pendingHeader });
+  }
+
+  equals(other: EpochState): boolean {
+    return this.activeEpoch === other.activeEpoch &&
+      this.nextSequence === other.nextSequence &&
+      ((this.#pendingHeader === undefined && other.#pendingHeader === undefined) ||
+        (this.#pendingHeader !== undefined && other.#pendingHeader !== undefined &&
+          this.#pendingHeader.equals(other.#pendingHeader)));
+  }
+}
+
+export class ActivationPlanEntry {
+  readonly #receiverIdHash: Uint8Array;
+  readonly #grantHash: Uint8Array;
+
+  constructor(receiverIdHash: Uint8Array, grantHash: Uint8Array) {
+    requireLength(receiverIdHash, 32);
+    requireLength(grantHash, 32);
+    this.#receiverIdHash = receiverIdHash.slice();
+    this.#grantHash = grantHash.slice();
+    Object.freeze(this);
+  }
+
+  get receiverIdHash(): Uint8Array { return this.#receiverIdHash.slice(); }
+  get grantHash(): Uint8Array { return this.#grantHash.slice(); }
+}
+
+export class ActivationPlan {
+  readonly #channelId: Uint8Array;
+  readonly baseEpoch: bigint;
+  readonly newEpoch: bigint;
+  readonly #receivers: readonly ActivationPlanEntry[];
+
+  constructor(
+    channelId: Uint8Array,
+    baseEpoch: bigint,
+    newEpoch: bigint,
+    receivers: readonly ActivationPlanEntry[],
+  ) {
+    try { validateUuidV7(channelId); } catch { fail(); }
+    requireU64(baseEpoch);
+    requireU64(newEpoch);
+    if (baseEpoch === MAX_U64 || newEpoch !== baseEpoch + 1n) fail();
+    if (receivers.length < 1 || receivers.length > MAX_PLAN_RECEIVERS) fail();
+    const ordered = [...receivers].sort((left, right) => compare(left.receiverIdHash, right.receiverIdHash));
+    for (let index = 1; index < ordered.length; index += 1) {
+      const prior = ordered[index - 1]!;
+      const current = ordered[index]!;
+      if (bytesEqual(prior.receiverIdHash, current.receiverIdHash) ||
+          bytesEqual(prior.grantHash, current.grantHash)) fail();
+    }
+    for (let left = 0; left < ordered.length; left += 1) {
+      for (let right = left + 1; right < ordered.length; right += 1) {
+        if (bytesEqual(ordered[left]!.grantHash, ordered[right]!.grantHash)) fail();
+      }
+    }
+    this.#channelId = channelId.slice();
+    this.baseEpoch = baseEpoch;
+    this.newEpoch = newEpoch;
+    this.#receivers = Object.freeze(ordered);
+    Object.freeze(this);
+  }
+
+  get channelId(): Uint8Array { return this.#channelId.slice(); }
+  get receivers(): readonly ActivationPlanEntry[] { return this.#receivers; }
+
+  equals(other: ActivationPlan): boolean {
+    return bytesEqual(activationPlanSerialize(this), activationPlanSerialize(other));
+  }
+}
+
+export function epochStateSerialize(state: EpochState): Uint8Array {
+  const writer = new Writer();
+  writer.ascii("D18S").u8(2).u64(state.activeEpoch).u64(state.nextSequence);
+  if (state.pendingHeader === undefined) return writer.u8(0).finish();
+  const header = messageHeaderSerialize(state.pendingHeader);
+  if (header.length > MAX_PENDING_HEADER_BYTES) fail();
+  return writer.u8(1).u32(header.length).bytes(header).finish();
+}
+
+export function epochStateDeserialize(bytes: Uint8Array, channelId: Uint8Array): EpochState {
+  try {
+    const reader = new Reader(bytes);
+    reader.magic("D18S");
+    if (reader.u8() !== 2) fail();
+    const activeEpoch = reader.u64();
+    const nextSequence = reader.u64();
+    const flag = reader.u8();
+    let pendingHeader: MessageHeader | undefined;
+    if (flag === 1) {
+      const length = reader.u32();
+      if (length > MAX_PENDING_HEADER_BYTES) fail();
+      try { pendingHeader = messageHeaderDeserialize(reader.bytes(length)); } catch { fail(); }
+    } else if (flag !== 0) fail();
+    reader.finish();
+    return new EpochState(channelId, { activeEpoch, nextSequence, pendingHeader });
+  } catch (error) {
+    if (error instanceof EpochWireError) throw error;
+    fail();
+  }
+}
+
+export function activationPlanSerialize(plan: ActivationPlan): Uint8Array {
+  const writer = new Writer();
+  writer.ascii("D18T").u8(1).bytes(plan.channelId)
+    .u64(plan.baseEpoch).u64(plan.newEpoch).u32(plan.receivers.length);
+  for (const receiver of plan.receivers) {
+    writer.bytes(receiver.receiverIdHash).bytes(receiver.grantHash);
+  }
+  return writer.finish();
+}
+
+export function activationPlanDeserialize(bytes: Uint8Array): ActivationPlan {
+  try {
+    const reader = new Reader(bytes);
+    reader.magic("D18T");
+    if (reader.u8() !== 1) fail();
+    const channelId = reader.bytes(16);
+    const baseEpoch = reader.u64();
+    const newEpoch = reader.u64();
+    const count = reader.u32();
+    if (count < 1 || count > MAX_PLAN_RECEIVERS) fail();
+    const receivers: ActivationPlanEntry[] = [];
+    for (let index = 0; index < count; index += 1) {
+      receivers.push(new ActivationPlanEntry(reader.bytes(32), reader.bytes(32)));
+    }
+    reader.finish();
+    for (let index = 1; index < receivers.length; index += 1) {
+      if (compare(receivers[index - 1]!.receiverIdHash, receivers[index]!.receiverIdHash) >= 0) fail();
+    }
+    const plan = new ActivationPlan(channelId, baseEpoch, newEpoch, receivers);
+    return plan;
+  } catch (error) {
+    if (error instanceof EpochWireError) throw error;
+    fail();
+  }
+}
+
+export function activationPlanRecordKey(channelId: Uint8Array, newEpoch: bigint): string {
+  requireLength(channelId, 16);
+  requireU64(newEpoch);
+  return `${hex(channelId)}/epochs/${newEpoch.toString().padStart(20, "0")}/activation`;
+}
+
+class Writer {
+  readonly #parts: Uint8Array[] = [];
+  ascii(value: string): this { return this.bytes(new TextEncoder().encode(value)); }
+  u8(value: number): this { this.#parts.push(Uint8Array.of(value)); return this; }
+  u32(value: number): this {
+    if (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff) fail();
+    const bytes = new Uint8Array(4); new DataView(bytes.buffer).setUint32(0, value); return this.bytes(bytes);
+  }
+  u64(value: bigint): this {
+    requireU64(value); const bytes = new Uint8Array(8); new DataView(bytes.buffer).setBigUint64(0, value); return this.bytes(bytes);
+  }
+  bytes(value: Uint8Array): this { this.#parts.push(value.slice()); return this; }
+  finish(): Uint8Array {
+    const length = this.#parts.reduce((sum, part) => sum + part.length, 0);
+    const output = new Uint8Array(length); let offset = 0;
+    for (const part of this.#parts) { output.set(part, offset); offset += part.length; }
+    return output;
+  }
+}
+
+class Reader {
+  #offset = 0;
+  constructor(readonly source: Uint8Array) {}
+  bytes(length: number): Uint8Array {
+    if (length < 0 || this.#offset + length > this.source.length) fail();
+    const result = this.source.slice(this.#offset, this.#offset + length); this.#offset += length; return result;
+  }
+  magic(value: string): void { if (!bytesEqual(this.bytes(4), new TextEncoder().encode(value))) fail(); }
+  u8(): number { return this.bytes(1)[0]!; }
+  u32(): number { const bytes = this.bytes(4); return new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0); }
+  u64(): bigint { const bytes = this.bytes(8); return new DataView(bytes.buffer, bytes.byteOffset, 8).getBigUint64(0); }
+  finish(): void { if (this.#offset !== this.source.length) fail(); }
+}
+
+function requireLength(value: Uint8Array, length: number): void {
+  if (!(value instanceof Uint8Array) || value.length !== length) fail();
+}
+function requireU64(value: bigint): void { if (value < 0n || value > MAX_U64) fail(); }
+function compare(left: Uint8Array, right: Uint8Array): number {
+  for (let index = 0; index < Math.min(left.length, right.length); index += 1) {
+    if (left[index] !== right[index]) return left[index]! - right[index]!;
+  }
+  return left.length - right.length;
+}
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+function fail(): never { throw new EpochWireError(); }

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/fixtures.test.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/fixtures.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  ChannelMasterKey,
+  OriginatorSigningKey,
+  ReceiverKeyPair,
+  RotationReceiver,
+  planRotation,
+} from "@coding-adventures/chief-of-staff-channel-crypto";
+import {
+  ChannelDefinition,
+  channelStateDeserialize,
+} from "@coding-adventures/chief-of-staff-channel-store";
+import {
+  EPOCH_ACTIVATION_ERROR_CODES,
+  EPOCH_STATE_CONTENT_TYPE,
+  ACTIVATION_PLAN_CONTENT_TYPE,
+  activationPlanDeserialize,
+  activationPlanRecordKey,
+  epochStateDeserialize,
+  epochStateSerialize,
+  epochActivationSecretErasureCapability,
+  prepareRotationCandidate,
+} from "../src/index.js";
+
+interface Manifest {
+  fixture_format: string;
+  spec: string;
+  warning: string;
+  constants: Record<string, string>;
+  test_only_secrets: Record<string, string>;
+  state_migrations: Array<{
+    name: string; d18s_v1_b64: string; d18s_v2_b64: string;
+    active_epoch: string; next_sequence: string;
+  }>;
+  activation_case: {
+    plan_record_key: string; plan_content_type: string; plan_b64: string;
+    grant_b64: string[]; receiver_a_new_grant: null;
+    receiver_a_retains_epochs: string[]; receiver_b_retains_epochs: string[];
+  };
+  crash_replay_traces: Array<{ name: string }>;
+  race_traces: Array<{ name: string }>;
+  stable_error_codes: string[];
+  negative_scenarios: Array<{ name: string }>;
+  secret_erasure_capability: string;
+}
+
+const manifest = JSON.parse(readFileSync(
+  new URL("../../../../fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json", import.meta.url),
+  "utf8",
+)) as Manifest;
+const channelId = fromHex("018f47a09b6c7def923456789abcdef0");
+
+describe("D18T canonical shared fixtures", () => {
+  it("locks constants, scenarios, stable errors, and the secret boundary", () => {
+    expect(manifest.fixture_format).toBe("D18T-durable-epoch-activation-fixtures-v1");
+    expect(manifest.spec).toBe("code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md");
+    expect(manifest.warning).toContain("Never log");
+    expect(manifest.constants).toEqual({
+      state_magic_ascii: "D18S", state_version: "2",
+      plan_magic_ascii: "D18T", plan_version: "1",
+      state_content_type: EPOCH_STATE_CONTENT_TYPE,
+      plan_content_type: ACTIVATION_PLAN_CONTENT_TYPE,
+      max_cas_attempts: "16",
+    });
+    expect([...EPOCH_ACTIVATION_ERROR_CODES]).toEqual(manifest.stable_error_codes);
+    expect(manifest.crash_replay_traces.map(({ name }) => name)).toEqual([
+      "after-custody-selection", "after-plan-write", "after-first-grant",
+      "after-all-grants", "after-activation-cas",
+    ]);
+    expect(manifest.race_traces).toHaveLength(4);
+    expect(manifest.negative_scenarios).toHaveLength(6);
+    expect(manifest.secret_erasure_capability).toBe("guaranteed");
+    expect(epochActivationSecretErasureCapability()).toBe("best_effort");
+    const text = JSON.stringify(manifest);
+    for (const secret of Object.values(manifest.test_only_secrets)) {
+      expect(text.split(secret)).toHaveLength(2);
+    }
+  });
+
+  it("migrates exact D18S v1 vectors by adding only the active epoch", () => {
+    expect(manifest.state_migrations.map(({ name }) => name)).toEqual(["no-pending", "pending-d18h"]);
+    for (const vector of manifest.state_migrations) {
+      const v1 = channelStateDeserialize(fromBase64(vector.d18s_v1_b64), channelId);
+      const bytes = fromBase64(vector.d18s_v2_b64);
+      const v2 = epochStateDeserialize(bytes, channelId);
+      expect(v2.activeEpoch).toBe(BigInt(vector.active_epoch));
+      expect(v2.nextSequence).toBe(v1.nextSequence);
+      expect(v2.nextSequence).toBe(BigInt(vector.next_sequence));
+      if (v1.pendingHeader === undefined) expect(v2.pendingHeader).toBeUndefined();
+      else expect(v2.pendingHeader?.equals(v1.pendingHeader)).toBe(true);
+      expect(epochStateSerialize(v2)).toEqual(bytes);
+    }
+  });
+
+  it("consumes the Rust-authored activation plan and revocation history directly", () => {
+    const activation = manifest.activation_case;
+    const bytes = fromBase64(activation.plan_b64);
+    const plan = activationPlanDeserialize(bytes);
+    expect(plan.channelId).toEqual(channelId);
+    expect(plan.baseEpoch).toBe(0n);
+    expect(plan.newEpoch).toBe(1n);
+    expect(plan.receivers).toHaveLength(1);
+    expect(activationPlanRecordKey(channelId, 1n)).toBe(activation.plan_record_key);
+    expect(activation.plan_content_type).toBe(ACTIVATION_PLAN_CONTENT_TYPE);
+    expect(activation.grant_b64).toHaveLength(1);
+    expect(activation.receiver_a_new_grant).toBeNull();
+    expect(activation.receiver_a_retains_epochs).toEqual(["0"]);
+    expect(activation.receiver_b_retains_epochs).toEqual(["0", "1"]);
+  });
+
+  it("reproduces the Rust-authored D18T plan and D18G grant byte-for-byte", () => {
+    const signer = OriginatorSigningKey.fromSeed(fromHex(manifest.test_only_secrets.originator_signing_seed_hex!));
+    const receiverAKey = ReceiverKeyPair.fromPrivateKey(fromHex(manifest.test_only_secrets.receiver_a_private_key_hex!));
+    const receiverBKey = ReceiverKeyPair.fromPrivateKey(fromHex(manifest.test_only_secrets.receiver_b_private_key_hex!));
+    const receiverA = { agentId: utf8("receiver-a"), publicKey: receiverAKey.publicKey };
+    const receiverB = { agentId: utf8("receiver-b"), publicKey: receiverBKey.publicKey };
+    const definition = new ChannelDefinition({
+      channelId,
+      originator: { agentId: utf8("originator"), publicKey: signer.publicKey },
+      receivers: [receiverA, receiverB],
+      createdAtNs: 1_725_000_000_000_000_000n,
+      keyEpoch: 0n,
+    });
+    const rotation = planRotation(
+      utf8("originator"), channelId, 0n,
+      ChannelMasterKey.fromBytes(fromHex(manifest.test_only_secrets.next_cmk_hex!)),
+      [RotationReceiver.withMaterial(
+        receiverB.agentId,
+        receiverB.publicKey,
+        fromHex(manifest.test_only_secrets.ephemeral_private_key_hex!),
+        fromHex(manifest.test_only_secrets.wrapping_nonce_hex!),
+      )],
+      signer,
+    );
+    const prepared = prepareRotationCandidate(definition, 0n, [receiverB], rotation);
+    expect(prepared.publicPreparation.planBytes).toEqual(fromBase64(manifest.activation_case.plan_b64));
+    expect(prepared.publicPreparation.grants).toEqual(
+      manifest.activation_case.grant_b64.map(fromBase64),
+    );
+    prepared.destroy();
+    signer.destroy(); receiverAKey.destroy(); receiverBKey.destroy();
+  });
+
+  it("rejects malformed state and non-canonical plan records", () => {
+    const state = fromBase64(manifest.state_migrations[0]!.d18s_v2_b64);
+    expect(() => epochStateDeserialize(state.slice(0, -1), channelId)).toThrowError("corrupt_record");
+    const badVersion = state.slice(); badVersion[4] = 3;
+    expect(() => epochStateDeserialize(badVersion, channelId)).toThrowError("corrupt_record");
+
+    const plan = fromBase64(manifest.activation_case.plan_b64);
+    const trailing = new Uint8Array(plan.length + 1); trailing.set(plan);
+    expect(() => activationPlanDeserialize(trailing)).toThrowError("corrupt_record");
+    const wrongOrder = new Uint8Array(41 + 128);
+    wrongOrder.set(plan.slice(0, 41));
+    new DataView(wrongOrder.buffer).setUint32(37, 2);
+    wrongOrder.set(new Uint8Array(32).fill(2), 41);
+    wrongOrder.set(new Uint8Array(32).fill(4), 73);
+    wrongOrder.set(new Uint8Array(32).fill(1), 105);
+    wrongOrder.set(new Uint8Array(32).fill(3), 137);
+    expect(() => activationPlanDeserialize(wrongOrder)).toThrowError("corrupt_record");
+  });
+});
+
+function fromHex(value: string): Uint8Array {
+  return Uint8Array.from(value.match(/../g) ?? [], (pair) => Number.parseInt(pair, 16));
+}
+function fromBase64(value: string): Uint8Array { return Uint8Array.from(Buffer.from(value, "base64")); }
+function utf8(value: string): Uint8Array { return new TextEncoder().encode(value); }

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/orchestration.test.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/orchestration.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+import {
+  ChannelMasterKey,
+  OriginatorSigningKey,
+  ReceiverKeyPair,
+  RotationReceiver,
+  grantDeserialize,
+  messageVerify,
+  planRotation,
+} from "@coding-adventures/chief-of-staff-channel-crypto";
+import {
+  CHANNEL_GRANT_CONTENT_TYPE,
+  CHANNEL_STORAGE_NAMESPACE,
+  ChannelDefinition,
+  ChannelDefinitionStore,
+  ChannelStore,
+  MemoryChannelStorage,
+  StorageConflictError,
+  type ChannelStorageBackend,
+  type ReceiverIdentity,
+  type StorageListOptions,
+  type StoragePage,
+  type StoragePut,
+  type StorageRecord,
+  keyGrantRecordKey,
+  sequenceStateRecordKey,
+} from "@coding-adventures/chief-of-staff-channel-store";
+import {
+  ACTIVATION_PLAN_CONTENT_TYPE,
+  EPOCH_STATE_CONTENT_TYPE,
+  EpochActivationError,
+  EpochActivationStore,
+  InMemoryKeyCustody,
+  activationPlanRecordKey,
+  prepareRotationCandidate,
+} from "../src/index.js";
+
+const CURRENT_CMK = new Uint8Array(32).fill(0x21);
+const NEXT_CMK = new Uint8Array(32).fill(0x31);
+
+class Fixture {
+  readonly backend = new MemoryChannelStorage();
+  readonly custody = new InMemoryKeyCustody();
+  readonly signer = OriginatorSigningKey.fromSeed(new Uint8Array(32).fill(0x11));
+  readonly receiverAKey = ReceiverKeyPair.fromPrivateKey(new Uint8Array(32).fill(0x41));
+  readonly receiverBKey = ReceiverKeyPair.fromPrivateKey(new Uint8Array(32).fill(0x42));
+  readonly receiverA: ReceiverIdentity = {
+    agentId: utf8("receiver-a"), publicKey: this.receiverAKey.publicKey,
+  };
+  readonly receiverB: ReceiverIdentity = {
+    agentId: utf8("receiver-b"), publicKey: this.receiverBKey.publicKey,
+  };
+  readonly definition = new ChannelDefinition({
+    channelId: channelId(),
+    originator: { agentId: utf8("originator"), publicKey: this.signer.publicKey },
+    receivers: [this.receiverA, this.receiverB],
+    createdAtNs: 1_725_000_000_000_000_000n,
+    keyEpoch: 0n,
+  });
+
+  async initialize(): Promise<this> {
+    await new ChannelDefinitionStore(this.backend).create(this.definition);
+    return this;
+  }
+  async store(): Promise<EpochActivationStore> {
+    return EpochActivationStore.openForTesting(this.backend, this.custody, channelId());
+  }
+  rotation(cmk = NEXT_CMK, material = 0x51) {
+    return planRotation(
+      utf8("originator"), channelId(), 0n, ChannelMasterKey.fromBytes(cmk),
+      [RotationReceiver.withMaterial(
+        this.receiverB.agentId, this.receiverB.publicKey,
+        new Uint8Array(32).fill(material), new Uint8Array(24).fill(material + 0x10),
+      )],
+      this.signer,
+    );
+  }
+  twoReceiverRotation() {
+    return planRotation(
+      utf8("originator"), channelId(), 0n, ChannelMasterKey.fromBytes(NEXT_CMK),
+      [
+        RotationReceiver.withMaterial(this.receiverB.agentId, this.receiverB.publicKey, new Uint8Array(32).fill(0x52), new Uint8Array(24).fill(0x62)),
+        RotationReceiver.withMaterial(this.receiverA.agentId, this.receiverA.publicKey, new Uint8Array(32).fill(0x51), new Uint8Array(24).fill(0x61)),
+      ],
+      this.signer,
+    );
+  }
+}
+
+describe("D18T orchestration", () => {
+  it("creates a new D18T-aware channel only after custody owns its initial CMK", async () => {
+    const fixture = new Fixture();
+    const store = await fixture.store();
+    const state = await store.createEpochChannel(
+      fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK),
+    );
+    expect(state.activeEpoch).toBe(0n);
+    expect(state.nextSequence).toBe(0n);
+    expect(state.pendingHeader).toBeUndefined();
+    expect(fixture.custody.retainedKeyCount).toBe(1);
+    const record = await fixture.backend.get(
+      CHANNEL_STORAGE_NAMESPACE, sequenceStateRecordKey(channelId()),
+    );
+    expect(record?.contentType).toBe(EPOCH_STATE_CONTENT_TYPE);
+    expect((await store.createEpochChannel(
+      fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK),
+    )).activeEpoch).toBe(0n);
+    await expect(store.createEpochChannel(
+      fixture.definition, ChannelMasterKey.fromBytes(new Uint8Array(32).fill(0x99)),
+    )).rejects.toMatchObject({ code: "conflicting_active_key" });
+  });
+
+  it("migrates a legacy pending state without changing its D18H", async () => {
+    const fixture = await new Fixture().initialize();
+    const legacy = new ChannelStore(fixture.backend, channelId());
+    const pending = await legacy.reserveAppend({
+      messageId: messageId(1), timestampNs: 11n, originatorId: utf8("originator"),
+      keyEpoch: 0n, contentType: "text/plain",
+    }, utf8("already reserved"));
+    const store = await fixture.store();
+    const state = await store.migrateEpochState(
+      fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK),
+    );
+    expect(state.activeEpoch).toBe(0n);
+    expect(state.nextSequence).toBe(1n);
+    expect(state.pendingHeader?.equals(pending)).toBe(true);
+    expect((await store.migrateEpochState(fixture.definition)).equals(state)).toBe(true);
+  });
+
+  it("selects, replays, activates, and publishes with the authoritative epoch idempotently", async () => {
+    const fixture = await new Fixture().initialize();
+    const store = await fixture.store();
+    await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    expect(await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation())).toBe("prepared");
+    expect(await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation())).toBe("idempotent");
+    expect(await store.activatePreparedEpoch(fixture.definition, 1n)).toBe("activated");
+    expect(await store.activatePreparedEpoch(fixture.definition, 1n)).toBe("idempotent");
+    const reservation = await store.reservePublishUsingActiveEpoch(fixture.definition, {
+      messageId: messageId(2), timestampNs: 12n, originatorId: utf8("originator"),
+      contentType: "text/plain", keyEpoch: 1n,
+    }, utf8("epoch one"));
+    expect(reservation.header.keyEpoch).toBe(1n);
+    expect(reservation.keyHandle.toString()).toBe("EpochKeyHandle([REDACTED])");
+    const message = await store.commitReserved(
+      fixture.definition, reservation, utf8("epoch one"), fixture.signer,
+    );
+    expect(messageVerify(message, fixture.signer.publicKey, NEXT_CMK)).toEqual(utf8("epoch one"));
+    expect((await store.commitReserved(fixture.definition, reservation, utf8("epoch one"), fixture.signer)).sequence).toBe(0n);
+    expect((await store.state()).pendingHeader).toBeUndefined();
+    await expect(store.reservePublishUsingActiveEpoch(fixture.definition, {
+      messageId: messageId(3), timestampNs: 13n, originatorId: utf8("originator"),
+      contentType: "text/plain", keyEpoch: 0n,
+    }, utf8("old"))).rejects.toMatchObject({ code: "unactivated_epoch" });
+  });
+
+  it("serializes publication and activation through one shared state CAS", async () => {
+    const fixture = await new Fixture().initialize();
+    const store = await fixture.store();
+    await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation());
+    const reservation = await store.reservePublishUsingActiveEpoch(fixture.definition, {
+      messageId: messageId(4), timestampNs: 14n, originatorId: utf8("originator"), contentType: "text/plain",
+    }, utf8("epoch zero first"));
+    expect(reservation.header.keyEpoch).toBe(0n);
+    await expect(store.activatePreparedEpoch(fixture.definition, 1n)).rejects.toMatchObject({ code: "pending_append" });
+    await store.commitReserved(fixture.definition, reservation, utf8("epoch zero first"), fixture.signer);
+    expect(await store.activatePreparedEpoch(fixture.definition, 1n)).toBe("activated");
+
+    const abandoned = await store.reservePublishUsingActiveEpoch(fixture.definition, {
+      messageId: messageId(5), timestampNs: 15n, originatorId: utf8("originator"), contentType: "text/plain",
+    }, utf8("abandon"));
+    expect((await store.abandonPending())?.equals(abandoned.header)).toBe(true);
+    expect(await store.abandonPending()).toBeUndefined();
+  });
+
+  it("replays every public-record crash boundary from custody's selected bundle", async () => {
+    for (let recordsWritten = 0; recordsWritten <= 3; recordsWritten += 1) {
+      const fixture = await new Fixture().initialize();
+      const store = await fixture.store();
+      await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+      const prepared = prepareRotationCandidate(
+        fixture.definition, 0n, [fixture.receiverA, fixture.receiverB], fixture.twoReceiverRotation(),
+      );
+      const publicPreparation = prepared.publicPreparation.clone();
+      expect(await fixture.custody.prepareIfAbsent(prepared)).toBe("selected");
+      prepared.destroy();
+      if (recordsWritten >= 1) {
+        await fixture.backend.put({
+          namespace: CHANNEL_STORAGE_NAMESPACE,
+          key: activationPlanRecordKey(channelId(), 1n),
+          contentType: ACTIVATION_PLAN_CONTENT_TYPE, metadata: {},
+          body: publicPreparation.planBytes, ifAbsent: true,
+        });
+      }
+      for (const bytes of publicPreparation.grants.slice(0, Math.max(0, recordsWritten - 1))) {
+        const grant = grantDeserialize(bytes);
+        await fixture.backend.put({
+          namespace: CHANNEL_STORAGE_NAMESPACE,
+          key: keyGrantRecordKey(channelId(), grant.keyEpoch, grant.receiverId),
+          contentType: CHANNEL_GRANT_CONTENT_TYPE, metadata: {}, body: bytes, ifAbsent: true,
+        });
+      }
+      expect(await (await fixture.store()).recoverPreparation(fixture.definition, 1n)).toBe("idempotent");
+      expect(await (await fixture.store()).activatePreparedEpoch(fixture.definition, 1n)).toBe("activated");
+    }
+  });
+
+  it("selects exactly one candidate and rejects invalid rosters before custody", async () => {
+    const fixture = await new Fixture().initialize();
+    const store = await fixture.store();
+    await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation());
+    await expect(store.prepareRotation(
+      fixture.definition, [fixture.receiverB], fixture.rotation(new Uint8Array(32).fill(0x32), 0x52),
+    )).rejects.toMatchObject({ code: "conflicting_preparation" });
+
+    const invalid = await new Fixture().initialize();
+    const invalidStore = await invalid.store();
+    await invalidStore.migrateEpochState(invalid.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await expect(invalidStore.prepareRotation(invalid.definition, [invalid.receiverA], invalid.rotation()))
+      .rejects.toMatchObject({ code: "invalid_plan" });
+  });
+
+  it("rejects non-durable production custody and erases secrets on logical destruction", async () => {
+    const fixture = await new Fixture().initialize();
+    await expect(EpochActivationStore.open(fixture.backend, fixture.custody, channelId()))
+      .rejects.toMatchObject({ code: "custody_error" });
+    const store = await fixture.store();
+    await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation());
+    expect(fixture.custody.retainedKeyCount).toBe(2);
+    const destroyed = await new ChannelDefinitionStore(fixture.backend).destroy(channelId());
+    await store.applyDestruction(destroyed);
+    expect(fixture.custody.retainedKeyCount).toBe(0);
+    expect((await store.state()).activeEpoch).toBe(0n);
+    await expect(store.activatePreparedEpoch(destroyed, 1n)).rejects.toMatchObject({ code: "channel_destroyed" });
+  });
+
+  it("fails closed for missing custody, corrupt public records, and epoch order", async () => {
+    const missing = await new Fixture().initialize();
+    const missingStore = await missing.store();
+    await missingStore.migrateEpochState(missing.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await expect(missingStore.activatePreparedEpoch(missing.definition, 1n))
+      .rejects.toMatchObject({ code: "preparation_missing" });
+    await expect(missingStore.migrateEpochState(missing.definition))
+      .resolves.toMatchObject({ activeEpoch: 0n });
+
+    const corrupt = await new Fixture().initialize();
+    const corruptStore = await corrupt.store();
+    await corruptStore.migrateEpochState(corrupt.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    const prepared = prepareRotationCandidate(corrupt.definition, 0n, [corrupt.receiverB], corrupt.rotation());
+    const publicPreparation = prepared.publicPreparation.clone();
+    await corrupt.custody.prepareIfAbsent(prepared); prepared.destroy();
+    await corrupt.backend.put({
+      namespace: CHANNEL_STORAGE_NAMESPACE, key: activationPlanRecordKey(channelId(), 1n),
+      contentType: "application/octet-stream", metadata: {}, body: publicPreparation.planBytes,
+      ifAbsent: true,
+    });
+    await expect(corruptStore.recoverPreparation(corrupt.definition, 1n))
+      .rejects.toMatchObject({ code: "corrupt_record" });
+
+    const advanced = await new Fixture().initialize();
+    const advancedStore = await advanced.store();
+    await advancedStore.migrateEpochState(advanced.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await advancedStore.prepareRotation(advanced.definition, [advanced.receiverB], advanced.rotation());
+    await advancedStore.activatePreparedEpoch(advanced.definition, 1n);
+    await expect(advancedStore.recoverPreparation(advanced.definition, 0n))
+      .rejects.toMatchObject({ code: "decreasing_epoch" });
+  });
+
+  it("returns concurrent_update after exactly sixteen activation CAS conflicts", async () => {
+    const backend = new StateCasConflictBackend();
+    const fixture = new Fixture();
+    await new ChannelDefinitionStore(backend).create(fixture.definition);
+    const custody = new InMemoryKeyCustody();
+    const store = await EpochActivationStore.openForTesting(backend, custody, channelId());
+    await store.migrateEpochState(fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await store.prepareRotation(fixture.definition, [fixture.receiverB], fixture.rotation());
+    backend.rejectStateCas = true;
+    await expect(store.activatePreparedEpoch(fixture.definition, 1n))
+      .rejects.toMatchObject({ code: "concurrent_update" });
+    expect(backend.rejected).toBe(16);
+    expect((await store.state()).activeEpoch).toBe(0n);
+  });
+
+  it("reports epoch exhaustion before accepting an irrelevant candidate", async () => {
+    const fixture = new Fixture();
+    const definition = new ChannelDefinition({
+      channelId: channelId(), originator: fixture.definition.originator,
+      receivers: [fixture.receiverB], createdAtNs: 1n, keyEpoch: (1n << 64n) - 1n,
+    });
+    await new ChannelDefinitionStore(fixture.backend).create(definition);
+    const store = await fixture.store();
+    await store.migrateEpochState(definition, ChannelMasterKey.fromBytes(CURRENT_CMK));
+    await expect(store.prepareRotation(definition, [fixture.receiverB], fixture.rotation()))
+      .rejects.toMatchObject({ code: "epoch_exhausted" });
+  });
+});
+
+class StateCasConflictBackend implements ChannelStorageBackend {
+  readonly inner = new MemoryChannelStorage();
+  rejectStateCas = false;
+  rejected = 0;
+  initialize(): Promise<void> { return this.inner.initialize(); }
+  get(namespace: string, key: string): Promise<StorageRecord | undefined> { return this.inner.get(namespace, key); }
+  async put(input: StoragePut): Promise<StorageRecord> {
+    if (this.rejectStateCas && input.key === sequenceStateRecordKey(channelId()) && input.ifRevision !== undefined) {
+      this.rejected += 1; throw new StorageConflictError();
+    }
+    return this.inner.put(input);
+  }
+  list(namespace: string, options: StorageListOptions): Promise<StoragePage> { return this.inner.list(namespace, options); }
+}
+
+function channelId(): Uint8Array { return fromHex("018f47a09b6c7def923456789abcdef0"); }
+function messageId(byte: number): Uint8Array {
+  const bytes = new Uint8Array(16).fill(byte); bytes[6] = 0x70 | (byte & 0x0f); bytes[8] = 0x80 | (byte & 0x3f); return bytes;
+}
+function utf8(value: string): Uint8Array { return new TextEncoder().encode(value); }
+function fromHex(value: string): Uint8Array {
+  return Uint8Array.from(value.match(/../g) ?? [], (pair) => Number.parseInt(pair, 16));
+}
+
+void EpochActivationError;

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/tsconfig.json
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/vitest.config.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/code/scripts/tests/test_typescript_tsconfig_portability.py
+++ b/code/scripts/tests/test_typescript_tsconfig_portability.py
@@ -407,12 +407,13 @@ console.log(prose, nested);
         # +1: path-raster, the scanline rasterizer P2D08 specifies.
         # +1: chief-of-staff-channel-crypto, the portable D18F message profile.
         # +1: chief-of-staff-channel-store, the durable D18P profile.
-        self.assertEqual(summary.total_projects, 463)
+        # +1: chief-of-staff-channel-epoch-activation, the D18T coordinator.
+        self.assertEqual(summary.total_projects, 464)
         self.assertEqual(summary.shared_projects, 287)
         self.assertEqual(summary.inherited_root_dir, 129)
         self.assertEqual(summary.inherited_out_dir, 132)
-        self.assertEqual(summary.standalone_emit_projects, 146)
-        self.assertEqual(summary.isolated_standalone_projects, 146)
+        self.assertEqual(summary.standalone_emit_projects, 147)
+        self.assertEqual(summary.isolated_standalone_projects, 147)
         self.assertEqual(summary.unbounded_root_projects, 0)
         self.assertEqual(summary.outside_root_inputs, 0)
         # 94: +1 for script-ductus. Nothing the package SHIPS touches a Node
@@ -435,7 +436,8 @@ console.log(prose, nested);
         # +1: path-raster, the scanline rasterizer P2D08 specifies.
         # +1: chief-of-staff-channel-crypto locks its standalone compiler.
         # +1: chief-of-staff-channel-store locks its standalone compiler.
-        self.assertEqual(summary.locked_compilers, 454)
+        # +1: chief-of-staff-channel-epoch-activation locks its compiler.
+        self.assertEqual(summary.locked_compilers, 455)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #11783

## Summary

- add the scaffolded TypeScript D18T package with exact D18S v2 and D18T v1 codecs
- compose D18P storage, D18Q rotation plans, and injected atomic originator-key custody into one crash-safe coordinator
- cover custody-first creation and migration, prepare/replay/recovery, activation, current-epoch publication, abandonment, and destruction
- add receiver-key-free D18G signature verification and a non-exportable D18F signer boundary
- seal RotationPlan construction behind the trusted D18Q planner
- consume and reproduce the canonical Rust-authored D18T fixture bytes directly

## Validation

- chief-of-staff-channel-crypto BUILD: 18 tests, 94.40% line coverage
- chief-of-staff-channel-epoch-activation BUILD: 15 tests, 92.23% line coverage
- TypeScript checks: tsc --noEmit for both touched packages
- affected-package planner: 13 built, 442 skipped, 0 failed
- npm pack --dry-run: publishable 7-file package, no tests, coverage, or node_modules
- security review: redacted secret surfaces, constant-time CMK comparison, bounded CAS, durable-custody enforcement, sealed trusted-plan construction
