### PR TITLE
fix(twig-aot): bind the post-link chmod to the file, not its path

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Changelog — `twig-aot`
 
 
+
+## 0.54.0 - 2026-08-15 - chmod binds to the file, not to its path
+
+Both post-link `chmod 0755` sites did `std::fs::metadata(path)` then
+`std::fs::set_permissions(path, ..)` — **two** path resolutions, both following
+symlinks. In an attacker-writable output directory that is a
+replace-with-symlink race: swap the path between the two calls and an unrelated
+file gets mode 0755 (CWE-367). A reviewer reproduced it: the victim went to
+0755 under the old code.
+
+Both now go through one `set_executable` helper. Three properties make it safe,
+and security review caught each of the first two attempts getting one wrong:
+
+* **`File::set_permissions` is `fchmod`** on the open descriptor (std's
+  `sys/fs/unix.rs`), so a swap AFTER the open cannot redirect it.
+* **`O_NOFOLLOW` closes the window BEFORE the open too**, via
+  `OpenOptionsExt::custom_flags` — which is in std. An earlier version of this
+  entry claimed closing that window "needs a `libc` dependency this crate
+  deliberately does not have". **That was simply wrong**, and it was being used
+  to justify leaving a live race unfixed. A planted symlink now fails `ELOOP`.
+* **The file is opened READ-only.** `fchmod` needs no write access, and
+  `chmod(2)` requires ownership while `open(O_WRONLY)` requires the write BIT —
+  independent things. Under a `umask` that clears owner-write (e.g. `0222`) the
+  linker succeeds and leaves the output `0555`; the first fix then returned
+  `EACCES` on a file the old code chmod'd fine, turning a working link into a
+  hard failure.
+
+Plus an explicit regular-file check: `O_NOFOLLOW` blocks symlinks but not
+directories, and on Linux `O_RDONLY` on a directory succeeds.
+
+Surfaced by the security review on PR #11264 and deferred there on purpose,
+since it changes the linker path and did not belong in a BUILD-file fix.
+
 ## 0.53.0 - 2026-08-14 - source_map moves with the instructions
 
 `source_map` is a POSITIONAL side table — `source_map[i]` describes

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.49.0 (E4-dyn): runtime `str_cmp` lowers to `call_builtin str_cmp`, routing procedure results and branch-selected locals to the shared -1/0/1 C helper. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -791,7 +791,6 @@ pub fn link_macos_arm64_executable(
     out_path: &Path,
 ) -> Result<(), AotError> {
     use std::io::Write as _;
-    use std::os::unix::fs::PermissionsExt;
 
     let mut tmp_obj = tempfile::Builder::new()
         .prefix(&format!("twig-aot-{stem}-"))
@@ -801,10 +800,64 @@ pub fn link_macos_arm64_executable(
     invoke_ld(tmp_obj.path(), out_path)?;
     drop(tmp_obj);
 
-    let mut perms = std::fs::metadata(out_path)?.permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(out_path, perms)?;
+    set_executable(out_path)?;
     Ok(())
+}
+
+/// Mark a just-linked output executable, binding the change to the FILE we
+/// opened rather than to its path.
+///
+/// The previous form was `metadata(path)` then `set_permissions(path, ..)` —
+/// **two** path resolutions, both following symlinks. In an attacker-writable
+/// output directory that is a replace-with-symlink race: swap the path between
+/// the two calls and an unrelated file gets mode 0755 (CWE-367).
+///
+/// Three things make this safe, and each was got wrong on the first attempt:
+///
+/// * **`File::set_permissions` is `fchmod`** on the open descriptor (see std's
+///   `sys/fs/unix.rs`), so a swap AFTER the open cannot redirect it.
+/// * **`O_NOFOLLOW` closes the window BEFORE the open too.** This needs no
+///   `libc` dependency — `OpenOptionsExt::custom_flags` is in std and takes raw
+///   `open(2)` flags. An earlier version of this comment claimed otherwise and
+///   left the window open on that false premise. A planted symlink now fails
+///   `ELOOP` instead of being followed.
+/// * **Open READ-only.** `fchmod` needs no write access, and `chmod(2)` requires
+///   ownership while `open(O_WRONLY)` requires the write BIT — independent
+///   things. Under a `umask` that clears owner-write (e.g. `0222`, used by some
+///   hardened build daemons) the linker succeeds and leaves the output `0555`;
+///   a write-open then fails `EACCES` on a file the old code chmod'd fine.
+///
+/// `O_NOFOLLOW` blocks symlinks but not directories, and on Linux `O_RDONLY` on
+/// a directory succeeds — hence the explicit regular-file check.
+#[cfg(unix)]
+fn set_executable(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    // Raw `open(2)` flag values are per-target, and a wrong bit would silently
+    // mean some other flag. This crate ships aarch64-apple and x86_64-linux, so
+    // those are the two that must be right; anything else degrades to the
+    // previous (post-open-only) protection rather than guessing.
+    #[cfg(target_vendor = "apple")]
+    const O_NOFOLLOW: i32 = 0x0100;
+    #[cfg(target_os = "linux")]
+    const O_NOFOLLOW: i32 = 0o400000;
+    #[cfg(not(any(target_vendor = "apple", target_os = "linux")))]
+    const O_NOFOLLOW: i32 = 0;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NOFOLLOW)
+        .open(path)?;
+    let meta = file.metadata()?; // fstat — bound to the descriptor
+    if !meta.file_type().is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "twig-aot: linker output is not a regular file",
+        ));
+    }
+    let mut perms = meta.permissions();
+    perms.set_mode(0o755);
+    file.set_permissions(perms)
 }
 
 /// Run Apple's system linker on `object_path`, producing `out_path`.
@@ -1696,7 +1749,6 @@ pub fn link_linux_x86_64_executable(
     out: &Path,
 ) -> Result<(), AotError> {
     use std::io::Write as _;
-    use std::os::unix::fs::PermissionsExt;
 
     if RUNTIME_LINUX_X86_64.len() <= 4 {
         return Err(AotError::Linker {
@@ -1753,9 +1805,7 @@ pub fn link_linux_x86_64_executable(
         });
     }
 
-    let mut perms = std::fs::metadata(out)?.permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(out, perms)?;
+    set_executable(out)?;
     Ok(())
 }
 


### PR DESCRIPTION
Both post-link `chmod 0755` sites did `metadata(path)` then `set_permissions(path, ..)` — **two** path resolutions, both following symlinks. In an attacker-writable output directory that's a replace-with-symlink race (**CWE-367**). A reviewer reproduced it: the victim file went to `0755` under the old code.

Both now go through one `set_executable` helper.

## Three properties make it safe — review caught each of my first two attempts getting one wrong

| property | why |
|---|---|
| **`File::set_permissions` is `fchmod`** on the open descriptor (std's `sys/fs/unix.rs`) | a swap *after* the open can't redirect it |
| **`O_NOFOLLOW`** via `OpenOptionsExt::custom_flags` | closes the window *before* the open too — a planted symlink now fails `ELOOP` |
| **Opened READ-only** | `fchmod` needs no write access |

The second one is worth calling out. My first version claimed closing that window *"needs a `libc` dependency this crate deliberately does not have"* and left the race live on that basis. **The claim was false** — `custom_flags` is in std. The residual I documented as unavoidable was avoidable.

The third was a genuine regression I introduced: `chmod(2)` requires **ownership**, `open(O_WRONLY)` requires the **write bit** — independent things. Under a `umask` clearing owner-write (e.g. `0222`, used by some hardened build daemons) the linker succeeds and leaves the output `0555`, and my write-open version returned `EACCES` where the old code worked — turning a successful link into a hard failure.

Plus a regular-file check: `O_NOFOLLOW` blocks symlinks but not directories, and on Linux `O_RDONLY` on a directory succeeds.

## Also: a dead import that would have broken Linux CI

Removes the now-unused `use PermissionsExt` in the **Linux** linker function — the twin of the one removed on the macOS side. Unused there once `set_mode` goes, it would have failed the ubuntu `-D warnings` build while being **invisible on this macOS host**, because the whole function is `cfg`'d out here.

## Verification

61 lib tests, clippy `-D warnings` clean, BUILD clean run through `sh -c` per line. `macos_arm64_smoke` — which links and runs real executables — is **13 passed / 3 failed, identical to `origin/main`**, confirmed by swapping main's `lib.rs` back in. Those 3 are the known precise-GC failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)