### PR TITLE
fix(twig-aot): a compile-time string fact dies when the register is rewritten

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 
 
+
+## 0.55.0 - 2026-08-15 - a compile-time string fact dies when the register is rewritten
+
+Fixes the ALGOL `string procedure` result printing nothing on native AOT, and —
+found by the security review on that fix — an **information disclosure** that
+predates it.
+
+**The reported bug.** ALGOL `s := pick(1)` lowers to `str_const s = ""` (the
+declaration) then `str_concat s = _t3 ++ ""`. `str_concat`'s runtime path
+declined to RECORD a literal for `dest` but never REMOVED the stale one, so
+`print_str s` folded to the empty literal: the program printed nothing while the
+runtime concat ran and its result was discarded.
+
+**The disclosure.** `str_const` guards its insert with `!runtime_str_vars`; the
+`str_concat` fold path and both `str_slice` inserts did not. A branch-selected
+string therefore got a compile-time length whose `const` lives in the OTHER arm,
+so `print_string(s + 8, len)` read an UNINITIALISED register as the length. The
+reviewer measured **4,063,232 bytes of process memory on stdout** — heap
+pointers, stack addresses, allocator magic — from:
+
+```algol
+begin string s; string t; integer n; n := 1;
+  t := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  if n > 0 then s := 'HI' else s := t;
+  print(s) end
+```
+
+All four insert sites now respect `runtime_str_vars`, and a `mov` from a source
+with no known fact erases any fact `dest` held rather than silently keeping it.
+
+One rule, three backends: `iir-to-wasm` (#11214), `iir-to-llvm` before it, and
+now here. **A compile-time fact about a register dies the moment anything writes
+that register** — declining to record is not the same as invalidating.
+
+Two stale-fact leaks remain and are tracked rather than fixed here: the default
+instruction arm (`call`/`call_builtin`/`input`/`field_load` never invalidate)
+and `str_len`/`str_index`/`str_eq` leaving stale `ints` entries. The robust
+repair is to port `iir-to-llvm`'s default-invalidate plus `MANAGES_OWN_STRING_FACTS`
+allowlist, which closes both structurally instead of arm by arm.
+
 ## 0.54.0 - 2026-08-15 - chmod binds to the file, not to its path
 
 Both post-link `chmod 0755` sites did `std::fs::metadata(path)` then

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.49.0 (E4-dyn): runtime `str_cmp` lowers to `call_builtin str_cmp`, routing procedure results and branch-selected locals to the shared -1/0/1 C helper. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -2647,11 +2647,26 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
             if let (Some(dest), Some(Operand::Var(src))) =
                 (instr.dest.as_ref(), instr.srcs.first())
             {
-                if let Some(value) = ints.get(src).copied() {
-                    ints.insert(dest.clone(), value);
+                // A `mov` from a source with NO known fact must ERASE any fact
+                // `dest` already had — copying-when-known but doing nothing
+                // otherwise leaves the old literal in place, and `print_str`
+                // then folds a length the register no longer holds.
+                // `iir-to-llvm` learned this as `forget_literal_string`.
+                match ints.get(src).copied() {
+                    Some(value) => {
+                        ints.insert(dest.clone(), value);
+                    }
+                    None => {
+                        ints.remove(dest);
+                    }
                 }
-                if let Some(string) = strings.get(src).cloned() {
-                    strings.insert(dest.clone(), string);
+                match strings.get(src).cloned() {
+                    Some(string) => {
+                        strings.insert(dest.clone(), string);
+                    }
+                    None => {
+                        strings.remove(dest);
+                    }
                 }
             }
             lowered.push(instr);
@@ -2748,7 +2763,18 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
                         vec![Operand::Var(buf_var)],
                         "i64",
                     ));
-                    strings.insert(dest.clone(), (dest, len_var, lit));
+                    // A branch-selected string must NEVER get a compile-time
+                    // length. `str_const` guards its insert this way; these
+                    // paths did not, so a literal was registered for a register
+                    // whose length const lives in the OTHER arm — and
+                    // `print_string(s+8, len)` then read an UNINITIALISED
+                    // register as the length. Measured: 4 MB of process memory
+                    // (heap pointers, stack addresses) written to stdout.
+                    if runtime_str_vars.contains(&dest) {
+                        strings.remove(&dest);
+                    } else {
+                        strings.insert(dest.clone(), (dest, len_var, lit));
+                    }
                     continue;
                 }
             }
@@ -2757,7 +2783,20 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
             // time literal — or the joined literal isn't printable ASCII. Delegate to
             // `__twig_str_concat(a, b)`, which reads both `[i64 len][bytes]` headers and
             // returns a fresh block handle. `dest` is deliberately NOT recorded in
-            // `strings`, so downstream `print_str`/`str_len` take their runtime
+            // `strings` — but NOT recording it is not enough when `dest` was
+            // already in there. ALGOL's `s := pick(1)` lowers to `str_const s =
+            // ""` (the declaration) and then `str_concat s = _t3 ++ ""`, so a
+            // stale `s -> ""` entry from the declaration survived the
+            // reassignment and `print_str s` folded to the empty literal: the
+            // program printed nothing instead of "HI", with the runtime call
+            // emitted and its result discarded.
+            //
+            // Reassignment must INVALIDATE, not merely decline to record. This
+            // is the same defect `iir-to-wasm` had (#11214) and `iir-to-llvm`
+            // before it — third backend, one rule: a compile-time fact about a
+            // register dies the moment anything else writes that register.
+            strings.remove(&dest);
+            // so downstream `print_str`/`str_len` take their runtime
             // header-reading paths rather than folding a length that isn't known.
             lowered.push(IIRInstr::new(
                 "call_builtin",
@@ -2795,7 +2834,14 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
                 lowered.push(IIRInstr::new("type_assert", None, vec![], "void"));
                 let (bv, lv, lt) = push_aot_string_literal(&mut lowered, &mut next, String::new());
                 lowered.push(IIRInstr::new("mov", Some(dest.clone()), vec![Operand::Var(bv)], "i64"));
-                strings.insert(dest.clone(), (dest, lv, lt));
+                if runtime_str_vars.contains(&dest) {
+                    // Branch-selected: a compile-time length here would point
+                    // at a const emitted in the OTHER arm — uninitialised on
+                    // the taken path. See the str_concat fold path above.
+                    strings.remove(&dest);
+                } else {
+                    strings.insert(dest.clone(), (dest, lv, lt));
+                }
                 continue;
             }
             let slice = literal.as_bytes()[start as usize..end as usize].to_vec();
@@ -2809,7 +2855,14 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
             }
             let (buf_var, len_var, lit) = push_aot_string_literal(&mut lowered, &mut next, literal);
             lowered.push(IIRInstr::new("mov", Some(dest.clone()), vec![Operand::Var(buf_var)], "i64"));
-            strings.insert(dest.clone(), (dest, len_var, lit));
+                if runtime_str_vars.contains(&dest) {
+                    // Branch-selected: a compile-time length here would point
+                    // at a const emitted in the OTHER arm — uninitialised on
+                    // the taken path. See the str_concat fold path above.
+                    strings.remove(&dest);
+                } else {
+                strings.insert(dest.clone(), (dest, len_var, lit));
+                }
             continue;
         }
 


### PR DESCRIPTION
Fixes ALGOL `string procedure` results printing nothing on native AOT — and, found by the security review **on that fix**, an information disclosure that predates it.

## The reported bug

ALGOL `s := pick(1)` lowers to `str_const s = ""` (the declaration) then `str_concat s = _t3 ++ ""`. `str_concat`'s runtime path declined to *record* a literal for `dest` but never *removed* the stale one — so `print_str s` folded to the empty literal. The program printed nothing while the runtime concat ran and its result was discarded.

## The disclosure

`str_const` guards its insert with `!runtime_str_vars`. The `str_concat` **fold** path and both `str_slice` inserts did not. A branch-selected string therefore got a compile-time length whose `const` lives in the **other arm**, so `print_string(s + 8, len)` read an **uninitialised register** as the length.

The reviewer measured **4,063,232 bytes of process memory written to stdout** — heap pointers, stack addresses, allocator magic — from:

```algol
begin string s; string t; integer n; n := 1;
  t := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
  if n > 0 then s := 'HI' else s := t;
  print(s) end
```

All four insert sites now respect `runtime_str_vars`, and a `mov` from a source with no known fact erases any fact `dest` held.

## One rule, three backends

`iir-to-wasm` (#11214), `iir-to-llvm` before it, and now here:

> **A compile-time fact about a register dies the moment anything writes that register.** Declining to record is not the same as invalidating.

## Tracked, not fixed here

Two stale-fact leaks remain: the default instruction arm (`call`/`call_builtin`/`input`/`field_load` never invalidate) and `str_len`/`str_index`/`str_eq` leaving stale `ints` entries. The robust repair is porting `iir-to-llvm`'s default-invalidate + `MANAGES_OWN_STRING_FACTS` allowlist, which closes both structurally rather than arm by arm — too broad for this PR.

## Verification

Matrix **4 → 3** confirmed failures (`NativeAot Algol60` fixed; the 3 remaining are Clr/Jvm, untouched by this change). 61 lib tests, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)