### PR TITLE
fix(wasm-execution): bounds-check call_indirect's table-sourced func_index

### DIFF
--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.12] - 2026-08-15 (security fix — pre-existing `call_indirect` panic)
+
+### Fixed
+
+- `call_indirect` (0x11)'s type-check block indexed `ctx.func_types[func_index]`
+  directly, where `func_index` comes from `table.get(elem_index)` -- DATA, not
+  a static part of the bytecode a validator necessarily already checked (this
+  crate's own tests, and real embedders that skip `wasm-validator`, can drive
+  this engine directly). A crafted or corrupt table entry pointing past
+  `func_types.len()` panicked instead of trapping cleanly, whenever the
+  embedder had set a type section via `set_type_section` (the common case --
+  `wasm-runtime` always does). This is the exact bug class WASM16's own
+  security review fixed in the new `return_call_indirect` (0x13) handler
+  (0.6.11); that review explicitly flagged this pre-existing, untouched
+  occurrence in `call_indirect` as a follow-up rather than in-scope for that
+  PR. Fixed with the same `.get().ok_or_else(...)` pattern. New regression
+  test (`test_call_indirect_through_a_table_entry_referencing_an_undefined_
+  function_is_a_clean_error_not_a_panic`), verified via TEMP-REVERT-CHECK to
+  reproduce the exact real panic (`index out of bounds: the len is 1 but the
+  index is 99`) with the fix reverted.
+
 ## [0.6.11] - 2026-08-15 (WASM16 — real tail calls, genuinely constant Rust-stack space)
 
 ### Added

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -3641,8 +3641,21 @@ fn register_control(vm: &mut GenericVM) {
         // embedder never set it, there's nothing to check against; skip
         // rather than fail closed on missing type info the caller never
         // promised to provide.
+        //
+        // Security review (WASM16, follow-up): `func_index` comes from
+        // `table.get(elem_index)` -- DATA, not a static part of the
+        // bytecode a validator necessarily already checked (this crate's
+        // own tests construct engines that skip `wasm-validator`
+        // entirely). A direct `ctx.func_types[func_index]` index here
+        // panicked on an out-of-range table entry whenever a type section
+        // was set (the common case); `.get()` makes it a clean trap
+        // instead, matching `return_call_indirect` (0x13)'s identical fix.
         if let Some(expected) = ctx.types.get(type_idx) {
-            let actual = &ctx.func_types[func_index as usize];
+            let actual = ctx.func_types.get(func_index as usize).ok_or_else(|| {
+                VMError::GenericError(
+                    "indirect call: table entry references an undefined function".into(),
+                )
+            })?;
             if expected.params != actual.params || expected.results != actual.results {
                 return Err(VMError::GenericError("indirect call type mismatch".into()));
             }
@@ -3697,11 +3710,10 @@ fn register_control(vm: &mut GenericVM) {
         // part of the bytecode a validator necessarily already checked
         // (this crate's own tests construct engines that skip
         // `wasm-validator` entirely, e.g. `wasm16_tail_calls.rs`'s
-        // `engine_from_wat`). `.get()` here, not `call_indirect`'s own
-        // adjacent `&ctx.func_types[func_index as usize]` (unchanged,
-        // pre-existing, only reached when a type section is set) --
-        // this call site is unconditional, so it must never panic on an
-        // out-of-range table entry.
+        // `engine_from_wat`). `.get()` here -- this call site is
+        // unconditional, so it must never panic on an out-of-range table
+        // entry. `call_indirect` (0x11) has the identical `.get()` fix on
+        // its own equivalent lookup.
         let func_type = ctx
             .func_types
             .get(func_index)
@@ -5475,6 +5487,34 @@ mod tests {
             func_bodies: vec![Some(body)],
             host_functions: vec![None],
         });
+        assert!(engine.call_function(0, &[]).is_err());
+    }
+
+    #[test]
+    fn test_call_indirect_through_a_table_entry_referencing_an_undefined_function_is_a_clean_error_not_a_panic() {
+        // Same bug class as `return_call_indirect`'s regression test above,
+        // on `call_indirect` (0x11) itself. The vulnerable branch only
+        // runs when `ctx.types.get(type_idx)` is `Some` (a type section is
+        // set -- the common real-world case, e.g. via `wasm-runtime`), so
+        // this test must call `set_type_section` to actually exercise it,
+        // unlike `return_call_indirect`'s fix which is unconditional. A
+        // hand-built engine with a corrupt table entry used to panic on
+        // the direct `ctx.func_types[func_index]` index inside that block.
+        let code = vec![0x41, 0x00, 0x11, 0x00, 0x00, 0x0B]; // i32.const 0; call_indirect type=0 table=0; end
+        let func_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+        let body = FunctionBody { locals: vec![], code };
+        let mut table = Table::new(1, None);
+        table.set(0, Some(99)).unwrap(); // function index 99 doesn't exist -- only index 0 (this function itself) does
+        let mut engine = WasmExecutionEngine::new(WasmEngineConfig {
+            memory: None,
+            tables: vec![table],
+            globals: vec![],
+            global_types: vec![],
+            func_types: vec![func_type.clone()],
+            func_bodies: vec![Some(body)],
+            host_functions: vec![None],
+        });
+        engine.set_type_section(vec![func_type]);
         assert!(engine.call_function(0, &[]).is_err());
     }
 


### PR DESCRIPTION
## Summary
- `call_indirect` (0x11)'s type-check block indexed `ctx.func_types[func_index]` directly, where `func_index` comes from `table.get(elem_index)` -- module/table-DATA, not something a validator necessarily already checked. A corrupt/out-of-range table entry panicked instead of trapping cleanly, whenever a type section was set (the common case -- `wasm-runtime` always sets one).
- Same bug class WASM16's security review already fixed in the adjacent `return_call_indirect` (0x13) handler (#11820) -- that review explicitly flagged this pre-existing, out-of-scope occurrence in `call_indirect` as a follow-up.
- Fixed with the same `.get().ok_or_else(...)` pattern, returning a clean `VMError` instead of panicking.

## Test plan
- [x] New regression test `test_call_indirect_through_a_table_entry_referencing_an_undefined_function_is_a_clean_error_not_a_panic`
- [x] TEMP-REVERT-CHECK: reverting the fix reproduces the exact panic (`index out of bounds: the len is 1 but the index is 99`)
- [x] `cargo test -p wasm-execution -p wasm-runtime -p wasm-conformance` all green, including the golden-baseline conformance test (zero drift)
- [x] `cargo clippy -p wasm-execution --all-targets -- -D warnings` clean
- [x] `/security-review` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)