### PR TITLE
feat(wasm-execution): WASM10 -- call_function on a dedicated thread, raised MAX_CALL_DEPTH

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — wasm-conformance
 
+## 0.1.16 — 2026-08-15 — baseline regen: call.wast even/odd now pass (WASM10)
+
+### Changed
+
+- Baseline regen following `wasm-execution` 0.7.0 (WASM10 — `call_function`
+  now runs on a dedicated thread with a re-bisected, much higher
+  `MAX_CALL_DEPTH`): `call.wast`'s `assert_return` moves from `pass: 67,
+  fail: 2` to `pass: 69, fail: 0` — the `even(100)`/`odd(200)` mutual-
+  recursion cases that previously needed more than the old 80-depth
+  ceiling now complete. Confirmed via a full baseline diff that this is
+  the ONLY file affected; zero regressions elsewhere.
+
 ## 0.1.15 — 2026-08-15 — real assert_unlinkable grading via registry-backed HostInterface (WASM05)
 
 ### Added

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -362,8 +362,8 @@
         "not_yet_supported": 0
       },
       "assert_return": {
-        "pass": 67,
-        "fail": 2,
+        "pass": 69,
+        "fail": 0,
         "trap": 0,
         "not_yet_supported": 0
       },
@@ -2715,8 +2715,8 @@
       "not_yet_supported": 375
     },
     "assert_return": {
-      "pass": 14016,
-      "fail": 2,
+      "pass": 14018,
+      "fail": 0,
       "trap": 0,
       "not_yet_supported": 3
     },

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.7.0] - 2026-08-15 (WASM10 — dedicated-thread `call_function`, raised `MAX_CALL_DEPTH`)
+
+### Changed
+
+- `call_function` (the top-level, public entry point) now spawns one
+  dedicated OS thread per call, via `Builder::stack_size(DEDICATED_STACK_SIZE)
+  .spawn_scoped(...)`, and runs its entire recursive decode/dispatch loop —
+  including every nested `call`/`call_indirect` through `call_function_inner`
+  — on that thread, joining synchronously before returning. `MAX_CALL_DEPTH`'s
+  safety margin no longer depends on whatever stack the CALLER happens to
+  provide; the calling thread only spawns and blocks in `.join()`, doing
+  none of the recursive work itself. See `code/specs/
+  W12-wasm-dedicated-thread-call-depth.md` for the full design and the
+  reasoning for rejecting a `Send`-bound change to `HostFunction`/
+  `HostInterface` in favor of this approach.
+- New private `AssertSend<T>` newtype (with an explicit, in-code safety
+  argument) crosses the thread boundary for the call-local raw memory/table
+  pointers and `Box<dyn HostFunction>` entries — this is the mechanism that
+  avoids the breaking trait change. One real gotcha hit and fixed during
+  implementation: Rust 2021's disjoint-closure-capture analysis reaches
+  straight through a `let AssertSend(inner) = x;` destructure at the top of
+  a spawned closure, capturing `x`'s non-`Send` INNER fields individually
+  rather than `x` itself -- silently defeating the wrapper (the closure then
+  fails to compile, requiring `Send` on the raw pointers directly, the exact
+  error this type exists to avoid). Fixed by adding `AssertSend::into_inner`,
+  a method call (not a field-projection/destructure), which forces
+  whole-value capture of the wrapper instead.
+- `MAX_CALL_DEPTH` re-bisected directly against the new `DEDICATED_STACK_SIZE`
+  (8 MiB) rather than scaled by assumption from the old 512-KiB-based value:
+  a real bounded countdown-recursion WASM module, run at increasing depths
+  through `call_function` (so through the real dedicated-thread path), one
+  depth per subprocess (a stack overflow aborts the whole process). Measured,
+  reproducible (3 repeats, identical result) debug-build floor: safe at
+  depth 1820, overflows at depth 1830. Applying the same ~33%-margin-below-
+  the-safe-floor convention the original 80 used: raised from **80 to
+  1200**.
+- `call.wast`'s `even(100)`/`odd(200)` mutual-recursion cases -- previously
+  the only 2 `assert_return` failures in that file, a known, honestly-
+  documented trade-off since the original `MAX_CALL_DEPTH` guard shipped --
+  now both pass. `wasm-conformance` baseline regen: `call.wast`
+  `assert_return` moves from `pass: 67, fail: 2` to `pass: 69, fail: 0`;
+  confirmed via a full baseline diff that this is the ONLY file affected,
+  zero regressions elsewhere.
+- New `tests/wasm10_dedicated_thread.rs`: the exact `call.wast` even/odd
+  shape as a standalone regression guard; a caller-thread-with-a-256-KiB-
+  stack test proving `call_function` now completes ~1000 levels of
+  recursion that would overflow a Rust stack that size directly, since the
+  heavy work runs elsewhere (verified this is load-bearing via
+  TEMP-REVERT-CHECK: temporarily shrinking `DEDICATED_STACK_SIZE` to 64 KiB
+  reproduced the exact same crash the dedicated thread exists to prevent);
+  an unbounded-recursion-still-traps-cleanly test at the new ceiling.
+  `tests/call_depth_guard.rs`'s existing
+  `depth_guard_trips_before_overflow_on_the_documented_minimum_stack` test
+  doc comment updated to reflect its changed meaning under WASM10 (it now
+  proves the caller-stack decoupling, not the original caller-stack-size
+  claim, which no longer applies).
+
+### Non-goals (unchanged from the spec)
+
+- `HostFunction`/`HostInterface` — no `Send` bound added, no signature
+  change; `wasm-conformance`'s real `Rc<RefCell<..>>`-based cross-module
+  linking (WASM05) is untouched.
+- Real concurrent/multi-threaded WASM execution — this dedicated thread is
+  purely an implementation detail for stack-size control; `call_function`
+  remains synchronous and single-result from the outside, identical to
+  before.
+- Thread pooling/reuse for performance — explicitly deferred; the known
+  trade-off (per-call OS thread spawn overhead, most visible in
+  `wasm-conformance`'s full baseline run) is accepted for this first slice.
+
 ## [0.6.12] - 2026-08-15 (security fix — pre-existing `call_indirect` panic)
 
 ### Fixed

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -115,6 +115,48 @@ All notable changes to this package will be documented in this file.
   full 100-deep chain completes instead of trapping) with the guard
   disabled.
 
+### Fixed — round 2: 1 more finding from re-reviewing the fixes above
+
+- **A thread-spawn failure could ALSO skip the state write-back.** The
+  first version of the panic-safety fix above still moved `ctx` BY VALUE
+  into the closure passed to `Builder::spawn_scoped`. If spawning the
+  dedicated thread itself failed (a real possibility under OS thread/
+  resource exhaustion — this feature can spawn up to
+  `MAX_DEDICATED_THREAD_DEPTH` nested 8 MiB-stack threads per call chain,
+  on top of one thread per concurrent top-level call from a multi-
+  threaded host), the closure — and `ctx`, and `self.host_functions`
+  moved into it — was dropped without ever running, and the `.expect(...)`
+  on the failed `spawn_scoped` call panicked immediately, unwinding
+  straight out of `call_function` BEFORE the `let AssertSend((ctx, ...))
+  = ...` binding (and the restoration after it) was ever reached — the
+  same WASM07 bug class, reintroduced via a THIRD trigger the first round
+  of fixes didn't cover. Fixed by keeping `ctx` OWNED in `call_function`'s
+  own (spawning) stack frame for the entire call — only a raw pointer to
+  it (`ctx_ptr`, given the exact same `AssertSend`/safety treatment
+  `vm_ptr` already had) crosses into the spawned closure, so `ctx` is
+  provably still there to restore from regardless of whether the thread
+  spawns, panics, or completes normally. Restructured the three possible
+  outcomes (success / panic / spawn failure) into a small local
+  `DedicatedThreadFailure` enum so the mandatory restoration runs exactly
+  once, unconditionally, before any of the three is handled. This
+  invariant is now also compiler-enforced, not just test-enforced: since
+  `ctx` is never moved into the closure, any future regression that tried
+  to move it there again would fail to compile (`self.host_functions =
+  ctx.host_functions;` after the `thread::scope(...)` call requires `ctx`
+  to still be a valid, non-moved binding).
+- Fixing the above surfaced a real, independent bug in the FIRST draft of
+  this restructuring (caught by the full test suite, not by the security
+  review): `ctx` inside the spawned closure became `&mut
+  WasmExecutionContext` (a reference, via `ctx_ptr`) instead of an owned
+  value, so every existing `&mut ctx` call site (e.g. `vm.
+  execute_with_context(&code, &mut ctx)`) silently built a `&mut &mut
+  WasmExecutionContext` instead of `&mut WasmExecutionContext` — type-
+  checks fine, but breaks the opcode dispatcher's downcast at runtime
+  ("context must be WasmExecutionContext"), which 128 of 213 unit tests
+  caught immediately. Fixed by relying on Rust's implicit reborrow
+  (passing `ctx` directly, not `&mut ctx`, since `ctx` is already a `&mut`
+  reference) at the one call site that needed it.
+
 ## [0.6.12] - 2026-08-15 (security fix — pre-existing `call_indirect` panic)
 
 ### Fixed

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -72,6 +72,49 @@ All notable changes to this package will be documented in this file.
   trade-off (per-call OS thread spawn overhead, most visible in
   `wasm-conformance`'s full baseline run) is accepted for this first slice.
 
+### Fixed — 2 findings from this PR's own `/security-review`, before shipping
+
+- **Panic during the dedicated thread skipped the mandatory state
+  write-back.** A panic reached through `Box<dyn HostFunction>::call`
+  (e.g. `wasm-conformance`'s real `CrossModuleFunction` hitting its own
+  documented `RefCell` double-borrow panic on a circular cross-module
+  import) used to `resume_unwind` BEFORE `self.host_functions`/
+  `self.globals` were restored from `ctx` — the exact bug class WASM07's
+  security review already fixed once for TRAPS, reintroduced here for
+  PANICS (`self.host_functions`, emptied via `mem::take` for the
+  panicking call, would stay empty for every LATER, unrelated call on the
+  same engine). Fixed by wrapping the dedicated thread's loop in
+  `std::panic::catch_unwind(AssertUnwindSafe(...))` and restoring engine
+  state UNCONDITIONALLY before ever propagating the caught panic via
+  `resume_unwind`. New regression test
+  (`a_panic_inside_the_dedicated_thread_restores_engine_state_before_propagating`),
+  verified via TEMP-REVERT-CHECK to reproduce the exact bug (a later call
+  to an unrelated, previously-working host-imported function fails with
+  `"no body for function 1"`) when the restore is reordered back to after
+  the panic check.
+- **Unbounded OS-thread nesting via cross-module host calls.** Every
+  top-level `call_function` now spawns a dedicated 8 MiB-stack thread —
+  including calls reached through `HostFunction::call` re-entering a
+  DIFFERENT engine's own `call_function` (exactly `wasm-conformance`'s
+  real cross-module linking, WASM05). `MAX_CALL_DEPTH`/`ctx.call_depth`
+  resets to 0 per top-level call and does not see across this boundary at
+  all, so an ordinary, non-circular chain of N linked module instances
+  would spawn N nested OS threads with no bound — a materially larger,
+  more exhaustible resource than the old unbounded-Rust-stack-recursion
+  version of this same reentrancy pattern. Fixed with a new
+  `MAX_DEDICATED_THREAD_DEPTH` (64) guard, tracked via a `thread_local!`
+  counter explicitly propagated parent-thread → child-thread at each
+  `call_function` invocation (deliberately NOT a single process-global
+  counter, which would incorrectly conflate unrelated, genuinely-
+  concurrent top-level call chains from separate caller threads). New
+  regression tests: a white-box pair in `lib.rs` proving the guard trips
+  exactly at the max and not below it, and a black-box
+  `a_long_but_finite_cross_module_chain_traps_cleanly_before_exhausting_os_threads`
+  integration test (a real 100-engine `Rc<RefCell<..>>` chain), verified
+  via TEMP-REVERT-CHECK to reproduce the unbounded-spawn behavior (the
+  full 100-deep chain completes instead of trapping) with the guard
+  disabled.
+
 ## [0.6.12] - 2026-08-15 (security fix — pre-existing `call_indirect` panic)
 
 ### Fixed

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.6.12"
+version = "0.7.0"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -4334,7 +4334,7 @@ impl WasmExecutionEngine {
             .collect();
         let host_functions = std::mem::take(&mut self.host_functions);
 
-        let ctx = WasmExecutionContext {
+        let mut ctx = WasmExecutionContext {
             memory: memory_ptr,
             tables: table_ptrs,
             globals: self.globals.clone(),
@@ -4371,19 +4371,43 @@ impl WasmExecutionEngine {
         // `call_function_inner`) runs on a dedicated OS thread with an
         // explicit `DEDICATED_STACK_SIZE`, decoupling `MAX_CALL_DEPTH`
         // from whatever stack the CALLER of `call_function` happens to
-        // have. `vm_ptr` (raw, since `GenericVM` must stay reachable both
-        // here and from inside the spawned closure) and `ctx` (which owns
-        // the raw memory/table pointers and host-function trait objects)
-        // cross the thread boundary via `AssertSend` -- see its own doc
-        // comment for the full safety argument.
+        // have. Security review (WASM10, round 2): `ctx` stays OWNED
+        // here, in this (spawning) stack frame -- only a raw pointer to
+        // it (`ctx_ptr`, alongside `vm_ptr`) crosses the thread boundary,
+        // the same treatment `vm_ptr` already gets. This is deliberate:
+        // an earlier version moved `ctx` BY VALUE into the spawned
+        // closure, which meant a `Builder::spawn_scoped` failure (a real
+        // possibility under OS thread/resource exhaustion -- this
+        // feature can spawn up to `MAX_DEDICATED_THREAD_DEPTH` nested
+        // threads per call chain) would drop the closure -- and `ctx`
+        // along with it -- before `self.host_functions` (moved out via
+        // `mem::take` above) was ever restored, permanently corrupting
+        // engine state for later, unrelated calls (the exact WASM07 bug
+        // class, via a THIRD trigger beyond the trap/panic cases already
+        // fixed). Keeping `ctx` owned here means it's always available to
+        // restore from, regardless of whether the thread spawns, panics,
+        // or completes normally. See `AssertSend`'s own doc comment for
+        // the full cross-thread-access safety argument (identical to
+        // `vm_ptr`'s).
         let vm_ptr: *mut GenericVM = &mut self.vm;
-        let payload = AssertSend((vm_ptr, ctx, func_index, args.to_vec(), dedicated_thread_depth));
+        let ctx_ptr: *mut WasmExecutionContext = &mut ctx;
+        let payload = AssertSend((vm_ptr, ctx_ptr, func_index, args.to_vec(), dedicated_thread_depth));
 
-        let AssertSend((ctx, panic_result)) = std::thread::scope(|scope| {
-            let handle = std::thread::Builder::new()
-                .stack_size(DEDICATED_STACK_SIZE)
-                .spawn_scoped(scope, move || {
-                    let (vm_ptr, mut ctx, func_index, initial_args, parent_depth) = payload.into_inner();
+        /// The three ways the dedicated thread can fail to produce a
+        /// normal `VMResult<usize>` -- kept distinct from `VMError`
+        /// (an ordinary WASM-level trap, handled via `Ok(Err(..))`
+        /// below) because a spawn failure and a panic both need
+        /// `ctx`'s state restored before propagating, but must be
+        /// propagated differently (a spawn failure becomes a clean
+        /// `TrapError`; a panic must keep unwinding via `resume_unwind`).
+        enum DedicatedThreadFailure {
+            SpawnFailed(std::io::Error),
+            Panicked(Box<dyn std::any::Any + Send>),
+        }
+
+        let outcome: Result<VMResult<usize>, DedicatedThreadFailure> = std::thread::scope(|scope| {
+            match std::thread::Builder::new().stack_size(DEDICATED_STACK_SIZE).spawn_scoped(scope, move || {
+                    let (vm_ptr, ctx_ptr, func_index, initial_args, parent_depth) = payload.into_inner();
                     // Propagate this THREAD's own nesting depth before
                     // doing anything else -- see `DEDICATED_THREAD_DEPTH`'s
                     // own doc comment. A fresh OS thread starts with a
@@ -4392,10 +4416,13 @@ impl WasmExecutionEngine {
                     DEDICATED_THREAD_DEPTH.with(|d| d.set(parent_depth + 1));
                     // SAFETY: see `AssertSend`'s doc comment -- for the
                     // whole lifetime of this closure, the spawning thread
-                    // is blocked in `.join()` below and touches nothing
-                    // reachable through `vm_ptr`/`ctx`, so this is the
-                    // only thread ever dereferencing `vm_ptr` at a time.
+                    // is blocked in `.join()` below (or, if spawning
+                    // itself failed, this closure never ran at all) and
+                    // touches nothing reachable through `vm_ptr`/
+                    // `ctx_ptr`, so this is the only thread ever
+                    // dereferencing them at a time.
                     let vm = unsafe { &mut *vm_ptr };
+                    let ctx = unsafe { &mut *ctx_ptr };
 
                     // WASM10 (security review): the loop below can call
                     // arbitrary embedder-supplied `Box<dyn HostFunction>`
@@ -4543,7 +4570,12 @@ impl WasmExecutionEngine {
 
                                 vm.pc = 0;
                                 vm.halted = false;
-                                if let Err(e) = vm.execute_with_context(&code, &mut ctx) {
+                                // `ctx` is already `&mut WasmExecutionContext` here (obtained
+                                // via `ctx_ptr`) -- pass it directly, relying on Rust's
+                                // implicit reborrow, NOT `&mut ctx` (which would build a
+                                // `&mut &mut WasmExecutionContext` and break
+                                // `execute_with_context`'s downcast).
+                                if let Err(e) = vm.execute_with_context(&code, ctx) {
                                     break Err(e);
                                 }
 
@@ -4559,28 +4591,42 @@ impl WasmExecutionEngine {
                             exec_result
                         }));
 
-                    AssertSend((ctx, panic_result))
-                })
-                .expect("failed to spawn WASM10 dedicated execution thread");
-
-            match handle.join() {
-                Ok(v) => v,
-                // Defensive fallback only: `catch_unwind` above already
-                // catches every panic reachable from ordinary WASM
-                // execution or host-function calls, so this thread
-                // should always return normally. Propagate exactly as if
-                // it had happened on the calling thread directly, same
-                // as before -- this thread boundary is an implementation
-                // detail, not a fault-isolation layer.
-                Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+                    panic_result
+                }) {
+                Ok(handle) => match handle.join() {
+                    // `panic_result` is itself `std::thread::Result<
+                    // VMResult<usize>>` -- flatten its `Err` (a caught
+                    // panic, from the `catch_unwind` inside the closure)
+                    // into `DedicatedThreadFailure::Panicked` too, so
+                    // both this and the `join()`-level `Err` arm below
+                    // are handled uniformly by the caller.
+                    Ok(panic_result) => panic_result.map_err(DedicatedThreadFailure::Panicked),
+                    // Defensive fallback only: `catch_unwind` above
+                    // already catches every panic reachable from
+                    // ordinary WASM execution or host-function calls, so
+                    // this thread should always return normally via the
+                    // `Ok` arm above. This arm exists only for a panic
+                    // reached OUTSIDE that `catch_unwind` (e.g. in
+                    // `payload.into_inner()` or the raw-pointer derefs
+                    // immediately above it) -- effectively unreachable
+                    // in practice, but handled the same way as a caught
+                    // panic below rather than silently ignored.
+                    Err(join_panic_payload) => Err(DedicatedThreadFailure::Panicked(join_panic_payload)),
+                },
+                Err(spawn_err) => Err(DedicatedThreadFailure::SpawnFailed(spawn_err)),
             }
         });
 
-        // Update globals back UNCONDITIONALLY, before propagating a trap
-        // OR a panic (WASM07 security review, extended by WASM10's own
-        // security review to cover the panic case too): `self.
-        // host_functions` was moved out via `mem::take` above, so the
-        // ONLY way it's ever seen again is `ctx.host_functions` here.
+        // Update engine state back UNCONDITIONALLY, before propagating
+        // ANY failure -- a trap, a panic, OR a thread-spawn failure
+        // (WASM07 security review, extended twice over by WASM10's own
+        // security review: once to cover the panic case, and again to
+        // cover the spawn-failure case, which an earlier version of this
+        // fix still missed -- `ctx` moving BY VALUE into the spawned
+        // closure meant a `spawn_scoped` failure dropped it, along with
+        // `self.host_functions`, before this restoration ever ran).
+        // `self.host_functions` was moved out via `mem::take` above, so
+        // the ONLY way it's ever seen again is `ctx.host_functions` here.
         // Propagating a failure before this line permanently leaves
         // `self.host_functions` empty for every LATER, unrelated call on
         // this engine. `wasm-runtime`'s real embedding path wires WASI
@@ -4588,7 +4634,11 @@ impl WasmExecutionEngine {
         // exactly this field, so this was a real, reachable bug, not a
         // theoretical one: `wasm-runtime`'s own `call_engine` had the
         // identical bug for `instance.memory`/`instance.tables` (fixed in
-        // this same PR, WASM07) one layer further out.
+        // this same PR, WASM07) one layer further out. Keeping `ctx`
+        // OWNED by this (spawning) stack frame the whole time -- see the
+        // comment where `ctx_ptr` is built above -- is what makes this
+        // restoration reachable regardless of which of the three ways
+        // the dedicated thread could fail to produce a normal result.
         self.globals = ctx.globals;
         self.host_functions = ctx.host_functions;
         // gc_heap itself is not persisted (see its own doc comment above);
@@ -4596,9 +4646,12 @@ impl WasmExecutionEngine {
         // via gc_live_object_count()/gc_profile() (W04).
         self.last_gc_state = ctx.gc_state;
 
-        let final_result_count = match panic_result {
+        let final_result_count = match outcome {
             Ok(exec_result) => exec_result.map_err(|e| TrapError::new(format!("{}", e)))?,
-            Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+            Err(DedicatedThreadFailure::SpawnFailed(spawn_err)) => {
+                return Err(TrapError::new(format!("failed to spawn dedicated execution thread: {spawn_err}")));
+            }
+            Err(DedicatedThreadFailure::Panicked(panic_payload)) => std::panic::resume_unwind(panic_payload),
         };
 
         // Collect return values.

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1462,6 +1462,44 @@ const MAX_CALL_DEPTH: usize = 1200;
 /// again the same way, not just recomputed by ratio.
 const DEDICATED_STACK_SIZE: usize = 8 * 1024 * 1024;
 
+/// Caps how many WASM10 dedicated threads may be nested inside one
+/// another via cross-module host calls (e.g. `wasm-conformance`'s
+/// `CrossModuleFunction`, which re-enters a DIFFERENT engine's own
+/// `call_function` from inside a host-function call reached through
+/// `HostFunction::call`). Each nested `call_function` invocation spawns
+/// its OWN dedicated thread and `DEDICATED_STACK_SIZE` stack — unlike
+/// ordinary same-instance recursion (bounded by `MAX_CALL_DEPTH`/
+/// `ctx.call_depth`, which resets to 0 per top-level call and therefore
+/// does NOT see across this boundary at all). Security review (WASM10):
+/// without a separate bound, an ordinary, non-circular chain of N linked
+/// module instances calling into each other spawns N nested OS threads,
+/// each reserving `DEDICATED_STACK_SIZE` — a materially larger and more
+/// exhaustible resource than the old unbounded-Rust-stack-recursion
+/// version of this same reentrancy pattern. `64` bounds worst-case
+/// address-space use to `64 * DEDICATED_STACK_SIZE` (512 MiB at the
+/// current stack size) while comfortably covering legitimate multi-
+/// module linking chains.
+const MAX_DEDICATED_THREAD_DEPTH: usize = 64;
+
+thread_local! {
+    /// How many WASM10 dedicated threads deep the CURRENT thread is
+    /// nested, relative to the original (non-WASM-spawned) caller — see
+    /// `MAX_DEDICATED_THREAD_DEPTH`'s own doc comment. Deliberately a
+    /// `thread_local!`, NOT a single process-global counter: thread-
+    /// locals do not inherit across `std::thread::spawn`/`spawn_scoped`
+    /// on their own, so each `call_function` invocation explicitly reads
+    /// its OWN thread's current depth, passes `depth + 1` into the
+    /// spawned closure's payload, and that closure sets its own (fresh)
+    /// thread's local value at the top before doing anything else. A
+    /// global counter would incorrectly conflate two unrelated,
+    /// genuinely-concurrent top-level `call_function` chains (e.g. a
+    /// multi-threaded host serving independent requests), tripping a
+    /// false trap on one because of unrelated depth building up
+    /// elsewhere — this per-thread, explicitly-propagated design avoids
+    /// that.
+    static DEDICATED_THREAD_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// Crosses `call_function`'s internal dedicated-thread boundary (WASM10)
 /// for data this crate cannot make genuinely `Send` without a breaking
 /// change to public API: `WasmExecutionContext`'s raw `*mut
@@ -4270,6 +4308,21 @@ impl WasmExecutionEngine {
             return host_func.call(args, self.memory.as_deref_mut());
         }
 
+        // WASM10 (security review): about to spawn a dedicated OS thread
+        // for this call. If a `HostFunction::call` reached from inside
+        // that thread re-enters a DIFFERENT engine's own `call_function`
+        // (as `wasm-conformance`'s real cross-module linking does), THAT
+        // nested call spawns its OWN dedicated thread, nested inside this
+        // one -- unlike same-instance recursion, this isn't bounded by
+        // `MAX_CALL_DEPTH`/`ctx.call_depth` at all (that resets to 0 per
+        // top-level call). Reject before spawning rather than let an
+        // ordinary, non-circular multi-module chain exhaust OS threads.
+        // See `MAX_DEDICATED_THREAD_DEPTH`'s own doc comment.
+        let dedicated_thread_depth = DEDICATED_THREAD_DEPTH.with(|d| d.get());
+        if dedicated_thread_depth >= MAX_DEDICATED_THREAD_DEPTH {
+            return Err(TrapError::new("cross-module call nesting exhausted".to_string()));
+        }
+
         // Build raw pointers for the context -- shared VM-level state,
         // computed once regardless of how many WASM16 tail-call
         // transitions follow below.
@@ -4324,13 +4377,19 @@ impl WasmExecutionEngine {
         // cross the thread boundary via `AssertSend` -- see its own doc
         // comment for the full safety argument.
         let vm_ptr: *mut GenericVM = &mut self.vm;
-        let payload = AssertSend((vm_ptr, ctx, func_index, args.to_vec()));
+        let payload = AssertSend((vm_ptr, ctx, func_index, args.to_vec(), dedicated_thread_depth));
 
-        let AssertSend((ctx, exec_result, final_result_count)) = std::thread::scope(|scope| {
+        let AssertSend((ctx, panic_result)) = std::thread::scope(|scope| {
             let handle = std::thread::Builder::new()
                 .stack_size(DEDICATED_STACK_SIZE)
                 .spawn_scoped(scope, move || {
-                    let (vm_ptr, mut ctx, func_index, initial_args) = payload.into_inner();
+                    let (vm_ptr, mut ctx, func_index, initial_args, parent_depth) = payload.into_inner();
+                    // Propagate this THREAD's own nesting depth before
+                    // doing anything else -- see `DEDICATED_THREAD_DEPTH`'s
+                    // own doc comment. A fresh OS thread starts with a
+                    // fresh (zeroed) thread-local, so this must be set
+                    // explicitly from the parent's depth, not inherited.
+                    DEDICATED_THREAD_DEPTH.with(|d| d.set(parent_depth + 1));
                     // SAFETY: see `AssertSend`'s doc comment -- for the
                     // whole lifetime of this closure, the spawning thread
                     // is blocked in `.join()` below and touches nothing
@@ -4338,168 +4397,198 @@ impl WasmExecutionEngine {
                     // only thread ever dereferencing `vm_ptr` at a time.
                     let vm = unsafe { &mut *vm_ptr };
 
-                    let mut current_func_index = func_index;
-                    let mut pending_args: Option<Vec<WasmValue>> = Some(initial_args);
-                    let mut final_result_count = 0usize;
+                    // WASM10 (security review): the loop below can call
+                    // arbitrary embedder-supplied `Box<dyn HostFunction>`
+                    // code, including (via `wasm-conformance`'s real
+                    // `CrossModuleFunction`) a re-entrant call into a
+                    // DIFFERENT engine's own `call_function`, which might
+                    // panic. `catch_unwind` here, rather than letting the
+                    // panic unwind straight out of this thread past
+                    // `handle.join()` below, lets the calling thread
+                    // restore `self.globals`/`self.host_functions` from
+                    // `ctx` BEFORE the panic is re-raised -- the same
+                    // "restore engine state before propagating ANY
+                    // failure" rule the WASM07 security review already
+                    // established for traps, extended here to panics
+                    // (a bare `resume_unwind` before that restoration
+                    // would permanently leave `self.host_functions` empty
+                    // -- moved out via `mem::take` above -- for every
+                    // LATER, unrelated call on this same engine).
+                    // `AssertUnwindSafe` is sound here specifically
+                    // because a caught panic means this call is being
+                    // abandoned regardless (about to be re-raised) --
+                    // `ctx`'s post-panic contents are only ever used for
+                    // that restoration, never assumed logically
+                    // consistent for anything else.
+                    let panic_result: std::thread::Result<VMResult<usize>> =
+                        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            let mut current_func_index = func_index;
+                            let mut pending_args: Option<Vec<WasmValue>> = Some(initial_args);
 
-                    // WASM16: this top-level entry point has its own
-                    // separate instruction-decode-and-dispatch path (it
-                    // doesn't go through `call_function_inner`, which
-                    // only handles NESTED calls) — so a
-                    // `return_call`/`return_call_indirect` chain that
-                    // starts at the very top level needs the SAME "swap
-                    // the current frame instead of recursing" handling
-                    // duplicated here. See `call_function_inner`'s
-                    // matching loop and
-                    // `WasmExecutionContext::pending_tail_call`'s own
-                    // doc comment.
-                    let exec_result: VMResult<()> = loop {
-                        let func_type = match ctx
-                            .func_types
-                            .get(current_func_index)
-                            .ok_or_else(|| VMError::GenericError(format!("undefined function {current_func_index}")))
-                        {
-                            Ok(t) => t.clone(),
-                            Err(e) => break Err(e),
-                        };
-                        let current_args = pending_args.take().expect("pending_args is always Some at the top of each loop iteration");
+                            // WASM16: this top-level entry point has its own
+                            // separate instruction-decode-and-dispatch path (it
+                            // doesn't go through `call_function_inner`, which
+                            // only handles NESTED calls) — so a
+                            // `return_call`/`return_call_indirect` chain that
+                            // starts at the very top level needs the SAME "swap
+                            // the current frame instead of recursing" handling
+                            // duplicated here. See `call_function_inner`'s
+                            // matching loop and
+                            // `WasmExecutionContext::pending_tail_call`'s own
+                            // doc comment.
+                            //
+                            // The `Ok` variant carries the result arity
+                            // alongside `()` (as `usize`) so it can be read
+                            // back out after `catch_unwind` returns without
+                            // needing a separate `&mut final_result_count`
+                            // capture into this closure.
+                            let exec_result: VMResult<usize> = loop {
+                                let func_type = match ctx
+                                    .func_types
+                                    .get(current_func_index)
+                                    .ok_or_else(|| VMError::GenericError(format!("undefined function {current_func_index}")))
+                                {
+                                    Ok(t) => t.clone(),
+                                    Err(e) => break Err(e),
+                                };
+                                let current_args = pending_args.take().expect("pending_args is always Some at the top of each loop iteration");
 
-                        // A tail call landing on a host import is still a leaf call
-                        // (no further WASM frames) -- call it, push its results
-                        // exactly like `call_function_inner`'s own host branch
-                        // does, and stop. `final_result_count` lets the shared
-                        // "collect return values" step below pop them back off
-                        // uniformly, whether this loop ran zero, one, or many
-                        // tail-call transitions before landing here.
-                        if let Some(Some(host_func)) = ctx.host_functions.get(current_func_index) {
-                            match host_func.call(&current_args, ctx.memory.map(|ptr| unsafe { &mut *ptr })) {
-                                Ok(results) => {
-                                    for r in results {
-                                        push_wasm(vm, r);
+                                // A tail call landing on a host import is still a leaf call
+                                // (no further WASM frames) -- call it, push its results
+                                // exactly like `call_function_inner`'s own host branch
+                                // does, and stop.
+                                if let Some(Some(host_func)) = ctx.host_functions.get(current_func_index) {
+                                    match host_func.call(&current_args, ctx.memory.map(|ptr| unsafe { &mut *ptr })) {
+                                        Ok(results) => {
+                                            for r in results {
+                                                push_wasm(vm, r);
+                                            }
+                                            break Ok(func_type.results.len());
+                                        }
+                                        Err(e) => break Err(VMError::from(e)),
                                     }
-                                    final_result_count = func_type.results.len();
-                                    break Ok(());
                                 }
-                                Err(e) => break Err(VMError::from(e)),
-                            }
-                        }
 
-                        // Module-defined function.
-                        let body = match ctx
-                            .func_bodies
-                            .get(current_func_index)
-                            .and_then(|b| b.as_ref())
-                            .ok_or_else(|| VMError::GenericError(format!("no body for function {current_func_index}")))
-                        {
-                            Ok(b) => b.clone(),
-                            Err(e) => break Err(e),
-                        };
+                                // Module-defined function.
+                                let body = match ctx
+                                    .func_bodies
+                                    .get(current_func_index)
+                                    .and_then(|b| b.as_ref())
+                                    .ok_or_else(|| VMError::GenericError(format!("no body for function {current_func_index}")))
+                                {
+                                    Ok(b) => b.clone(),
+                                    Err(e) => break Err(e),
+                                };
 
-                        // Decode the function body.
-                        let decoded = decode_function_body(&body);
-                        ctx.control_flow_map = build_control_flow_map(&decoded);
+                                // Decode the function body.
+                                let decoded = decode_function_body(&body);
+                                ctx.control_flow_map = build_control_flow_map(&decoded);
 
-                        // Convert to VM instructions, building this function's
-                        // side-tables (br_table targets + WasmGC ops) in lockstep.
-                        // Each complex instruction stores its index into the
-                        // relevant Vec as its Operand::Index. Nested calls save/
-                        // restore these on the saved-frame stack so callee and
-                        // caller don't collide; a tail-call transition here simply
-                        // overwrites them, matching the fact that no new logical
-                        // call frame is being pushed.
-                        let mut br_table_targets: Vec<Vec<u32>> = Vec::new();
-                        let mut gc_ops: Vec<GcOp> = Vec::new();
-                        let mut vm_instructions: Vec<Instruction> = Vec::new();
-                        for d in &decoded {
-                            let operand = convert_operand(&d.operand, &mut br_table_targets, &mut gc_ops);
-                            vm_instructions.push(Instruction {
-                                opcode: d.opcode,
-                                operand,
-                            });
-                        }
-                        ctx.br_table_targets = br_table_targets;
-                        ctx.gc_ops = gc_ops;
+                                // Convert to VM instructions, building this function's
+                                // side-tables (br_table targets + WasmGC ops) in lockstep.
+                                // Each complex instruction stores its index into the
+                                // relevant Vec as its Operand::Index. Nested calls save/
+                                // restore these on the saved-frame stack so callee and
+                                // caller don't collide; a tail-call transition here simply
+                                // overwrites them, matching the fact that no new logical
+                                // call frame is being pushed.
+                                let mut br_table_targets: Vec<Vec<u32>> = Vec::new();
+                                let mut gc_ops: Vec<GcOp> = Vec::new();
+                                let mut vm_instructions: Vec<Instruction> = Vec::new();
+                                for d in &decoded {
+                                    let operand = convert_operand(&d.operand, &mut br_table_targets, &mut gc_ops);
+                                    vm_instructions.push(Instruction {
+                                        opcode: d.opcode,
+                                        operand,
+                                    });
+                                }
+                                ctx.br_table_targets = br_table_targets;
+                                ctx.gc_ops = gc_ops;
 
-                        // Initialize locals.
-                        let mut typed_locals: Vec<WasmValue> = current_args;
-                        for t in &body.locals {
-                            typed_locals.push(WasmValue::default_for(*t));
-                        }
-                        ctx.typed_locals = typed_locals;
+                                // Initialize locals.
+                                let mut typed_locals: Vec<WasmValue> = current_args;
+                                for t in &body.locals {
+                                    typed_locals.push(WasmValue::default_for(*t));
+                                }
+                                ctx.typed_locals = typed_locals;
 
-                        // See `call_function_inner`'s matching comment: a WASM
-                        // function body is itself an implicit outer `block` whose
-                        // label is the function's own end, so `br`/`br_if`/
-                        // `br_table` at a depth that walks out of every *explicit*
-                        // block (including a bare top-level `(br 0)`, which is
-                        // ordinary, spec-legal WASM meaning "return") needs a label
-                        // on `label_stack` to resolve against. `stack_height: 0` is
-                        // correct on every iteration, not just the first: the
-                        // validator requires a `return_call`/`return_call_indirect`
-                        // site to leave the operand stack at exactly this
-                        // function's entry height once the callee's args are
-                        // popped (the same "stack-polymorphic, like `return`" rule
-                        // that lets `return_call` type-check at all), so control
-                        // never reaches a later iteration with anything extra left
-                        // on `vm`'s stack.
-                        ctx.label_stack = vec![Label {
-                            arity: func_type.results.len(),
-                            param_arity: func_type.params.len(),
-                            target_pc: vm_instructions.len(),
-                            stack_height: 0,
-                            is_loop: false,
-                        }];
+                                // See `call_function_inner`'s matching comment: a WASM
+                                // function body is itself an implicit outer `block` whose
+                                // label is the function's own end, so `br`/`br_if`/
+                                // `br_table` at a depth that walks out of every *explicit*
+                                // block (including a bare top-level `(br 0)`, which is
+                                // ordinary, spec-legal WASM meaning "return") needs a label
+                                // on `label_stack` to resolve against. `stack_height: 0` is
+                                // correct on every iteration, not just the first: the
+                                // validator requires a `return_call`/`return_call_indirect`
+                                // site to leave the operand stack at exactly this
+                                // function's entry height once the callee's args are
+                                // popped (the same "stack-polymorphic, like `return`" rule
+                                // that lets `return_call` type-check at all), so control
+                                // never reaches a later iteration with anything extra left
+                                // on `vm`'s stack.
+                                ctx.label_stack = vec![Label {
+                                    arity: func_type.results.len(),
+                                    param_arity: func_type.params.len(),
+                                    target_pc: vm_instructions.len(),
+                                    stack_height: 0,
+                                    is_loop: false,
+                                }];
 
-                        let code = CodeObject {
-                            instructions: vm_instructions,
-                            constants: vec![],
-                            names: vec![],
-                        };
+                                let code = CodeObject {
+                                    instructions: vm_instructions,
+                                    constants: vec![],
+                                    names: vec![],
+                                };
 
-                        vm.pc = 0;
-                        vm.halted = false;
-                        if let Err(e) = vm.execute_with_context(&code, &mut ctx) {
-                            break Err(e);
-                        }
+                                vm.pc = 0;
+                                vm.halted = false;
+                                if let Err(e) = vm.execute_with_context(&code, &mut ctx) {
+                                    break Err(e);
+                                }
 
-                        if let Some((next_func_index, next_args)) = ctx.pending_tail_call.take() {
-                            current_func_index = next_func_index;
-                            pending_args = Some(next_args);
-                            continue;
-                        }
+                                if let Some((next_func_index, next_args)) = ctx.pending_tail_call.take() {
+                                    current_func_index = next_func_index;
+                                    pending_args = Some(next_args);
+                                    continue;
+                                }
 
-                        final_result_count = func_type.results.len();
-                        break Ok(());
-                    };
+                                break Ok(func_type.results.len());
+                            };
 
-                    AssertSend((ctx, exec_result, final_result_count))
+                            exec_result
+                        }));
+
+                    AssertSend((ctx, panic_result))
                 })
                 .expect("failed to spawn WASM10 dedicated execution thread");
 
             match handle.join() {
                 Ok(v) => v,
-                // Propagate a panic from the dedicated thread exactly as
-                // if it had happened on the calling thread directly --
-                // this thread boundary is an implementation detail, not
-                // a fault-isolation layer.
+                // Defensive fallback only: `catch_unwind` above already
+                // catches every panic reachable from ordinary WASM
+                // execution or host-function calls, so this thread
+                // should always return normally. Propagate exactly as if
+                // it had happened on the calling thread directly, same
+                // as before -- this thread boundary is an implementation
+                // detail, not a fault-isolation layer.
                 Err(panic_payload) => std::panic::resume_unwind(panic_payload),
             }
         });
 
         // Update globals back UNCONDITIONALLY, before propagating a trap
-        // (WASM07 security review): `self.host_functions` was moved out via
-        // `mem::take` above, so on a trapped call the ONLY way it's ever
-        // seen again is `ctx.host_functions` here. Propagating the error
-        // via `?` before this line (the original shape) permanently left
-        // `self.host_functions` empty after the FIRST trap on this engine
-        // — every later call, however unrelated, would then fail with "no
-        // body for function N" for what used to be a host-imported
-        // function. `wasm-runtime`'s real embedding path wires WASI
+        // OR a panic (WASM07 security review, extended by WASM10's own
+        // security review to cover the panic case too): `self.
+        // host_functions` was moved out via `mem::take` above, so the
+        // ONLY way it's ever seen again is `ctx.host_functions` here.
+        // Propagating a failure before this line permanently leaves
+        // `self.host_functions` empty for every LATER, unrelated call on
+        // this engine. `wasm-runtime`'s real embedding path wires WASI
         // imports (fd_write, random_get, clock_time_get, ...) through
         // exactly this field, so this was a real, reachable bug, not a
         // theoretical one: `wasm-runtime`'s own `call_engine` had the
         // identical bug for `instance.memory`/`instance.tables` (fixed in
-        // this same PR) one layer further out.
+        // this same PR, WASM07) one layer further out.
         self.globals = ctx.globals;
         self.host_functions = ctx.host_functions;
         // gc_heap itself is not persisted (see its own doc comment above);
@@ -4507,7 +4596,10 @@ impl WasmExecutionEngine {
         // via gc_live_object_count()/gc_profile() (W04).
         self.last_gc_state = ctx.gc_state;
 
-        exec_result.map_err(|e| TrapError::new(format!("{}", e)))?;
+        let final_result_count = match panic_result {
+            Ok(exec_result) => exec_result.map_err(|e| TrapError::new(format!("{}", e)))?,
+            Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+        };
 
         // Collect return values.
         let mut results = Vec::new();
@@ -5631,6 +5723,59 @@ mod tests {
         });
         engine.set_type_section(vec![func_type]);
         assert!(engine.call_function(0, &[]).is_err());
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // WASM10: dedicated-thread call_function, cross-module nesting guard
+    // ══════════════════════════════════════════════════════════════════════
+
+    /// Security review (WASM10): white-box test of `MAX_DEDICATED_THREAD_
+    /// DEPTH`'s guard itself -- directly sets this thread's own depth
+    /// counter to the maximum (simulating what it would read if a real
+    /// chain of that many cross-module `HostFunction` re-entries into
+    /// `call_function` got this far -- see `wasm10_dedicated_thread.rs`'s
+    /// own integration test for the end-to-end propagation proof) and
+    /// confirms `call_function` rejects cleanly -- crucially, WITHOUT
+    /// spawning another OS thread at all -- rather than only catching the
+    /// problem after actually exhausting real threads.
+    #[test]
+    fn dedicated_thread_depth_guard_traps_without_spawning_when_already_at_max() {
+        DEDICATED_THREAD_DEPTH.with(|d| d.set(MAX_DEDICATED_THREAD_DEPTH));
+        let func_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+        let body = FunctionBody { locals: vec![], code: vec![0x41, 0x2a, 0x0B] }; // i32.const 42; end
+        let mut engine = WasmExecutionEngine::new(WasmEngineConfig {
+            memory: None,
+            tables: vec![],
+            globals: vec![],
+            global_types: vec![],
+            func_types: vec![func_type],
+            func_bodies: vec![Some(body)],
+            host_functions: vec![None],
+        });
+        let result = engine.call_function(0, &[]);
+        DEDICATED_THREAD_DEPTH.with(|d| d.set(0)); // don't leak into other tests on this thread
+        assert!(result.is_err(), "call_function must reject once already at MAX_DEDICATED_THREAD_DEPTH");
+        assert!(result.unwrap_err().to_string().contains("cross-module call nesting exhausted"));
+    }
+
+    /// Companion: confirms the guard does NOT false-trip on ordinary,
+    /// shallow calls -- depth 0 (the default for any thread that never
+    /// nested through a nested `call_function`) must succeed normally.
+    #[test]
+    fn dedicated_thread_depth_guard_does_not_trip_at_the_default_depth() {
+        DEDICATED_THREAD_DEPTH.with(|d| d.set(0));
+        let func_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+        let body = FunctionBody { locals: vec![], code: vec![0x41, 0x2a, 0x0B] }; // i32.const 42; end
+        let mut engine = WasmExecutionEngine::new(WasmEngineConfig {
+            memory: None,
+            tables: vec![],
+            globals: vec![],
+            global_types: vec![],
+            func_types: vec![func_type],
+            func_bodies: vec![Some(body)],
+            host_functions: vec![None],
+        });
+        assert_eq!(engine.call_function(0, &[]).unwrap(), vec![WasmValue::I32(42)]);
     }
 
     // ══════════════════════════════════════════════════════════════════════

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1430,7 +1430,80 @@ pub struct WasmExecutionContext {
 /// leaving the unguarded host-crash risk in place while that larger,
 /// separate architectural change (blocked on this crate's `*mut
 /// LinearMemory`/`*mut Table` raw pointers not being `Send`) is pending.
-const MAX_CALL_DEPTH: usize = 80;
+///
+/// **WASM10 update**: the blocker above is resolved (see
+/// [`DEDICATED_STACK_SIZE`] and `call_function`'s own doc comment) —
+/// `call_function` now always runs its decode/dispatch loop on a
+/// dedicated thread with an explicit, generous stack, so this ceiling no
+/// longer depends on what stack the CALLER happens to provide. Re-bisected
+/// directly against that new stack size (see `code/specs/
+/// W12-wasm-dedicated-thread-call-depth.md` for the full methodology) —
+/// a bounded, terminating countdown-recursion WASM module, run at
+/// increasing depths
+/// via `call_function` (so through the real `DEDICATED_STACK_SIZE`
+/// dedicated thread, not a simulation of one), each depth its own
+/// subprocess (a stack overflow aborts the whole process, so bisection
+/// can't share one). Measured, real, reproducible (3 repeats, identical
+/// result each time) debug-build floor: **safe at depth 1820, overflows
+/// at depth 1830** on an 8 MiB stack. Applying the same ~33%-margin-below-
+/// the-safe-floor convention the original 80 used (`120 * 0.67 ≈ 80`):
+/// `1820 * 0.67 ≈ 1214`, rounded down to a clean **1200**. This clears
+/// `call.wast`'s `even(100)`/`odd(200)` cases (previously the only 2
+/// `assert_return` failures in that file, now both pass) with over 10x
+/// margin to spare, not just barely.
+const MAX_CALL_DEPTH: usize = 1200;
+
+/// The stack size `call_function` gives its internally-spawned dedicated
+/// execution thread (WASM10). 8 MiB — 16x the 512 KiB floor the original
+/// (caller-stack-dependent) `MAX_CALL_DEPTH` was bisected against — chosen
+/// as a generous, round starting point, then [`MAX_CALL_DEPTH`] was
+/// re-measured directly against THIS value rather than assumed via linear
+/// scaling. If this ever changes, `MAX_CALL_DEPTH` must be re-bisected
+/// again the same way, not just recomputed by ratio.
+const DEDICATED_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// Crosses `call_function`'s internal dedicated-thread boundary (WASM10)
+/// for data this crate cannot make genuinely `Send` without a breaking
+/// change to public API: `WasmExecutionContext`'s raw `*mut
+/// LinearMemory`/`*mut Table` pointers, and its `Box<dyn HostFunction>`
+/// entries (`HostFunction`/`HostInterface` deliberately do NOT require
+/// `Send` — see `code/specs/W12-wasm-dedicated-thread-call-depth.md` for
+/// why: adding it would force a breaking `Rc<RefCell<..>>` ->
+/// `Arc<Mutex<..>>` rewrite of `wasm-conformance`'s real cross-module
+/// linking, WASM05, for no benefit to this goal).
+///
+/// SAFETY (must hold at every call site that constructs one): the wrapped
+/// value is moved into a thread spawned via `Builder::spawn_scoped`, and
+/// the spawning thread calls `.join()` on the returned handle immediately,
+/// with no other work happening on the spawning thread in between. So the
+/// wrapped data is accessed from exactly one thread at a time — the
+/// spawned thread, for the whole duration of the call, then nothing, since
+/// the spawning thread is blocked in `.join()` for the spawned thread's
+/// entire lifetime. This is never true "shared across threads" access,
+/// only "which one OS thread's stack this synchronous call happens to run
+/// on" — the same "logically sequential, never actually concurrent"
+/// shape `wasm-conformance`'s own `RefCell`-based cross-module registry
+/// already relies on (different mechanism, same argument), made explicit
+/// here because `unsafe impl Send` needs its own standalone justification.
+struct AssertSend<T>(T);
+// SAFETY: see `AssertSend`'s own doc comment above.
+unsafe impl<T> Send for AssertSend<T> {}
+
+impl<T> AssertSend<T> {
+    /// Unwraps back to `T`. Deliberately a *method call*, not a `let
+    /// AssertSend(inner) = x;` destructure or `.0` field access, at every
+    /// call site inside a spawned closure: Rust's 2021 disjoint-capture
+    /// analysis reaches straight through direct field-projection syntax,
+    /// capturing `x`'s INNER (non-`Send`) fields individually rather than
+    /// `x` itself — silently defeating this wrapper's whole purpose (the
+    /// closure would then require `Send` on the unwrapped raw pointers
+    /// directly, the exact compile error this type exists to avoid). A
+    /// method call with a by-value `self` is not a field-projection path,
+    /// so it forces whole-value capture of the wrapper instead.
+    fn into_inner(self) -> T {
+        self.0
+    }
+}
 
 /// One decoded WasmGC instruction's immediates — see [`DecodedOperand::Gc`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -4158,19 +4231,19 @@ impl WasmExecutionEngine {
 
     /// Call a WASM function by index.
     ///
-    /// **Caller stack requirement**: nested WASM `call`/`call_indirect`
-    /// recurse through the calling thread's real Rust stack, one level per
-    /// nested call, up to [`MAX_CALL_DEPTH`] (currently 80) before this
-    /// returns a "call stack exhausted" trap. That ceiling was measured
-    /// assuming the calling thread has **at least 512 KiB** of stack space
-    /// available at the point this is called — Rust's own default spawned-
-    /// thread stack (2 MiB) and the main thread's default on every major OS
-    /// both clear this comfortably. If you invoke this on a thread you've
-    /// deliberately given a smaller stack than that (a constrained worker-
-    /// thread pool, an embedded target, a reactor/executor with small
-    /// per-task stacks), this guard cannot promise a clean trap instead of
-    /// a host-process abort — give the calling thread at least 512 KiB, or
-    /// treat a smaller stack as unsupported for now.
+    /// **WASM10**: nested WASM `call`/`call_indirect` recurse through a
+    /// Rust call stack one level per nested call, up to [`MAX_CALL_DEPTH`]
+    /// before this returns a "call stack exhausted" trap — but that
+    /// recursion now runs entirely on a dedicated OS thread this call
+    /// spawns internally with an explicit [`DEDICATED_STACK_SIZE`], not on
+    /// whatever stack the CALLER of `call_function` happens to have. The
+    /// calling thread only spawns and immediately `.join()`s; it does none
+    /// of the recursive work itself. This means, unlike before WASM10,
+    /// there is no caller-stack-size requirement at all — `call_function`
+    /// is safe to invoke from a thread with a small or unusual stack (a
+    /// constrained worker-thread pool, a reactor/executor with small
+    /// per-task stacks) without that affecting how deep WASM recursion can
+    /// safely go.
     pub fn call_function(
         &mut self,
         func_index: usize,
@@ -4208,7 +4281,7 @@ impl WasmExecutionEngine {
             .collect();
         let host_functions = std::mem::take(&mut self.host_functions);
 
-        let mut ctx = WasmExecutionContext {
+        let ctx = WasmExecutionContext {
             memory: memory_ptr,
             tables: table_ptrs,
             globals: self.globals.clone(),
@@ -4240,136 +4313,178 @@ impl WasmExecutionEngine {
         self.vm.reset();
         register_all_handlers(&mut self.vm);
 
-        let mut current_func_index = func_index;
-        let mut pending_args: Option<Vec<WasmValue>> = Some(args.to_vec());
-        let mut final_result_count = 0usize;
+        // WASM10: everything below that actually recurses (this loop,
+        // plus every NESTED `call`/`call_indirect` it triggers through
+        // `call_function_inner`) runs on a dedicated OS thread with an
+        // explicit `DEDICATED_STACK_SIZE`, decoupling `MAX_CALL_DEPTH`
+        // from whatever stack the CALLER of `call_function` happens to
+        // have. `vm_ptr` (raw, since `GenericVM` must stay reachable both
+        // here and from inside the spawned closure) and `ctx` (which owns
+        // the raw memory/table pointers and host-function trait objects)
+        // cross the thread boundary via `AssertSend` -- see its own doc
+        // comment for the full safety argument.
+        let vm_ptr: *mut GenericVM = &mut self.vm;
+        let payload = AssertSend((vm_ptr, ctx, func_index, args.to_vec()));
 
-        // WASM16: this top-level entry point has its own separate
-        // instruction-decode-and-dispatch path (it doesn't go through
-        // `call_function_inner`, which only handles NESTED calls) — so
-        // a `return_call`/`return_call_indirect` chain that starts at
-        // the very top level needs the SAME "swap the current frame
-        // instead of recursing" handling duplicated here. See
-        // `call_function_inner`'s matching loop and
-        // `WasmExecutionContext::pending_tail_call`'s own doc comment.
-        let exec_result: VMResult<()> = loop {
-            let func_type = match ctx
-                .func_types
-                .get(current_func_index)
-                .ok_or_else(|| VMError::GenericError(format!("undefined function {current_func_index}")))
-            {
-                Ok(t) => t.clone(),
-                Err(e) => break Err(e),
-            };
-            let current_args = pending_args.take().expect("pending_args is always Some at the top of each loop iteration");
+        let AssertSend((ctx, exec_result, final_result_count)) = std::thread::scope(|scope| {
+            let handle = std::thread::Builder::new()
+                .stack_size(DEDICATED_STACK_SIZE)
+                .spawn_scoped(scope, move || {
+                    let (vm_ptr, mut ctx, func_index, initial_args) = payload.into_inner();
+                    // SAFETY: see `AssertSend`'s doc comment -- for the
+                    // whole lifetime of this closure, the spawning thread
+                    // is blocked in `.join()` below and touches nothing
+                    // reachable through `vm_ptr`/`ctx`, so this is the
+                    // only thread ever dereferencing `vm_ptr` at a time.
+                    let vm = unsafe { &mut *vm_ptr };
 
-            // A tail call landing on a host import is still a leaf call
-            // (no further WASM frames) -- call it, push its results
-            // exactly like `call_function_inner`'s own host branch
-            // does, and stop. `final_result_count` lets the shared
-            // "collect return values" step below pop them back off
-            // uniformly, whether this loop ran zero, one, or many
-            // tail-call transitions before landing here.
-            if let Some(Some(host_func)) = ctx.host_functions.get(current_func_index) {
-                match host_func.call(&current_args, ctx.memory.map(|ptr| unsafe { &mut *ptr })) {
-                    Ok(results) => {
-                        for r in results {
-                            push_wasm(&mut self.vm, r);
+                    let mut current_func_index = func_index;
+                    let mut pending_args: Option<Vec<WasmValue>> = Some(initial_args);
+                    let mut final_result_count = 0usize;
+
+                    // WASM16: this top-level entry point has its own
+                    // separate instruction-decode-and-dispatch path (it
+                    // doesn't go through `call_function_inner`, which
+                    // only handles NESTED calls) — so a
+                    // `return_call`/`return_call_indirect` chain that
+                    // starts at the very top level needs the SAME "swap
+                    // the current frame instead of recursing" handling
+                    // duplicated here. See `call_function_inner`'s
+                    // matching loop and
+                    // `WasmExecutionContext::pending_tail_call`'s own
+                    // doc comment.
+                    let exec_result: VMResult<()> = loop {
+                        let func_type = match ctx
+                            .func_types
+                            .get(current_func_index)
+                            .ok_or_else(|| VMError::GenericError(format!("undefined function {current_func_index}")))
+                        {
+                            Ok(t) => t.clone(),
+                            Err(e) => break Err(e),
+                        };
+                        let current_args = pending_args.take().expect("pending_args is always Some at the top of each loop iteration");
+
+                        // A tail call landing on a host import is still a leaf call
+                        // (no further WASM frames) -- call it, push its results
+                        // exactly like `call_function_inner`'s own host branch
+                        // does, and stop. `final_result_count` lets the shared
+                        // "collect return values" step below pop them back off
+                        // uniformly, whether this loop ran zero, one, or many
+                        // tail-call transitions before landing here.
+                        if let Some(Some(host_func)) = ctx.host_functions.get(current_func_index) {
+                            match host_func.call(&current_args, ctx.memory.map(|ptr| unsafe { &mut *ptr })) {
+                                Ok(results) => {
+                                    for r in results {
+                                        push_wasm(vm, r);
+                                    }
+                                    final_result_count = func_type.results.len();
+                                    break Ok(());
+                                }
+                                Err(e) => break Err(VMError::from(e)),
+                            }
                         }
+
+                        // Module-defined function.
+                        let body = match ctx
+                            .func_bodies
+                            .get(current_func_index)
+                            .and_then(|b| b.as_ref())
+                            .ok_or_else(|| VMError::GenericError(format!("no body for function {current_func_index}")))
+                        {
+                            Ok(b) => b.clone(),
+                            Err(e) => break Err(e),
+                        };
+
+                        // Decode the function body.
+                        let decoded = decode_function_body(&body);
+                        ctx.control_flow_map = build_control_flow_map(&decoded);
+
+                        // Convert to VM instructions, building this function's
+                        // side-tables (br_table targets + WasmGC ops) in lockstep.
+                        // Each complex instruction stores its index into the
+                        // relevant Vec as its Operand::Index. Nested calls save/
+                        // restore these on the saved-frame stack so callee and
+                        // caller don't collide; a tail-call transition here simply
+                        // overwrites them, matching the fact that no new logical
+                        // call frame is being pushed.
+                        let mut br_table_targets: Vec<Vec<u32>> = Vec::new();
+                        let mut gc_ops: Vec<GcOp> = Vec::new();
+                        let mut vm_instructions: Vec<Instruction> = Vec::new();
+                        for d in &decoded {
+                            let operand = convert_operand(&d.operand, &mut br_table_targets, &mut gc_ops);
+                            vm_instructions.push(Instruction {
+                                opcode: d.opcode,
+                                operand,
+                            });
+                        }
+                        ctx.br_table_targets = br_table_targets;
+                        ctx.gc_ops = gc_ops;
+
+                        // Initialize locals.
+                        let mut typed_locals: Vec<WasmValue> = current_args;
+                        for t in &body.locals {
+                            typed_locals.push(WasmValue::default_for(*t));
+                        }
+                        ctx.typed_locals = typed_locals;
+
+                        // See `call_function_inner`'s matching comment: a WASM
+                        // function body is itself an implicit outer `block` whose
+                        // label is the function's own end, so `br`/`br_if`/
+                        // `br_table` at a depth that walks out of every *explicit*
+                        // block (including a bare top-level `(br 0)`, which is
+                        // ordinary, spec-legal WASM meaning "return") needs a label
+                        // on `label_stack` to resolve against. `stack_height: 0` is
+                        // correct on every iteration, not just the first: the
+                        // validator requires a `return_call`/`return_call_indirect`
+                        // site to leave the operand stack at exactly this
+                        // function's entry height once the callee's args are
+                        // popped (the same "stack-polymorphic, like `return`" rule
+                        // that lets `return_call` type-check at all), so control
+                        // never reaches a later iteration with anything extra left
+                        // on `vm`'s stack.
+                        ctx.label_stack = vec![Label {
+                            arity: func_type.results.len(),
+                            param_arity: func_type.params.len(),
+                            target_pc: vm_instructions.len(),
+                            stack_height: 0,
+                            is_loop: false,
+                        }];
+
+                        let code = CodeObject {
+                            instructions: vm_instructions,
+                            constants: vec![],
+                            names: vec![],
+                        };
+
+                        vm.pc = 0;
+                        vm.halted = false;
+                        if let Err(e) = vm.execute_with_context(&code, &mut ctx) {
+                            break Err(e);
+                        }
+
+                        if let Some((next_func_index, next_args)) = ctx.pending_tail_call.take() {
+                            current_func_index = next_func_index;
+                            pending_args = Some(next_args);
+                            continue;
+                        }
+
                         final_result_count = func_type.results.len();
                         break Ok(());
-                    }
-                    Err(e) => break Err(VMError::from(e)),
-                }
+                    };
+
+                    AssertSend((ctx, exec_result, final_result_count))
+                })
+                .expect("failed to spawn WASM10 dedicated execution thread");
+
+            match handle.join() {
+                Ok(v) => v,
+                // Propagate a panic from the dedicated thread exactly as
+                // if it had happened on the calling thread directly --
+                // this thread boundary is an implementation detail, not
+                // a fault-isolation layer.
+                Err(panic_payload) => std::panic::resume_unwind(panic_payload),
             }
-
-            // Module-defined function.
-            let body = match ctx
-                .func_bodies
-                .get(current_func_index)
-                .and_then(|b| b.as_ref())
-                .ok_or_else(|| VMError::GenericError(format!("no body for function {current_func_index}")))
-            {
-                Ok(b) => b.clone(),
-                Err(e) => break Err(e),
-            };
-
-            // Decode the function body.
-            let decoded = decode_function_body(&body);
-            ctx.control_flow_map = build_control_flow_map(&decoded);
-
-            // Convert to VM instructions, building this function's
-            // side-tables (br_table targets + WasmGC ops) in lockstep.
-            // Each complex instruction stores its index into the
-            // relevant Vec as its Operand::Index. Nested calls save/
-            // restore these on the saved-frame stack so callee and
-            // caller don't collide; a tail-call transition here simply
-            // overwrites them, matching the fact that no new logical
-            // call frame is being pushed.
-            let mut br_table_targets: Vec<Vec<u32>> = Vec::new();
-            let mut gc_ops: Vec<GcOp> = Vec::new();
-            let mut vm_instructions: Vec<Instruction> = Vec::new();
-            for d in &decoded {
-                let operand = convert_operand(&d.operand, &mut br_table_targets, &mut gc_ops);
-                vm_instructions.push(Instruction {
-                    opcode: d.opcode,
-                    operand,
-                });
-            }
-            ctx.br_table_targets = br_table_targets;
-            ctx.gc_ops = gc_ops;
-
-            // Initialize locals.
-            let mut typed_locals: Vec<WasmValue> = current_args;
-            for t in &body.locals {
-                typed_locals.push(WasmValue::default_for(*t));
-            }
-            ctx.typed_locals = typed_locals;
-
-            // See `call_function_inner`'s matching comment: a WASM
-            // function body is itself an implicit outer `block` whose
-            // label is the function's own end, so `br`/`br_if`/
-            // `br_table` at a depth that walks out of every *explicit*
-            // block (including a bare top-level `(br 0)`, which is
-            // ordinary, spec-legal WASM meaning "return") needs a label
-            // on `label_stack` to resolve against. `stack_height: 0` is
-            // correct on every iteration, not just the first: the
-            // validator requires a `return_call`/`return_call_indirect`
-            // site to leave the operand stack at exactly this
-            // function's entry height once the callee's args are
-            // popped (the same "stack-polymorphic, like `return`" rule
-            // that lets `return_call` type-check at all), so control
-            // never reaches a later iteration with anything extra left
-            // on `self.vm`'s stack.
-            ctx.label_stack = vec![Label {
-                arity: func_type.results.len(),
-                param_arity: func_type.params.len(),
-                target_pc: vm_instructions.len(),
-                stack_height: 0,
-                is_loop: false,
-            }];
-
-            let code = CodeObject {
-                instructions: vm_instructions,
-                constants: vec![],
-                names: vec![],
-            };
-
-            self.vm.pc = 0;
-            self.vm.halted = false;
-            if let Err(e) = self.vm.execute_with_context(&code, &mut ctx) {
-                break Err(e);
-            }
-
-            if let Some((next_func_index, next_args)) = ctx.pending_tail_call.take() {
-                current_func_index = next_func_index;
-                pending_args = Some(next_args);
-                continue;
-            }
-
-            final_result_count = func_type.results.len();
-            break Ok(());
-        };
+        });
 
         // Update globals back UNCONDITIONALLY, before propagating a trap
         // (WASM07 security review): `self.host_functions` was moved out via

--- a/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
+++ b/code/packages/rust/wasm-execution/tests/call_depth_guard.rs
@@ -122,15 +122,20 @@ fn sibling_calls_after_a_trapped_recursive_call_are_unaffected() {
 /// ~1 MiB, because its justification compared against a *different*
 /// crate's measured floor on a *different*, lighter recursive path
 /// instead of measuring `wasm-execution`'s own (heavier) recursion
-/// directly. This test is that direct measurement, committed as a
-/// permanent regression guard: run the exact unbounded-recursion shape on
-/// a thread with the documented minimum stack size (see
-/// `MAX_CALL_DEPTH`'s own doc comment for the full methodology and
-/// margin), with **no** `RUST_MIN_STACK` env var trick — a real
-/// `Builder::stack_size`, so this is testing the actual condition, not a
-/// simulation of one. A clean `Err` (not a `join()` failure from a
-/// crashed thread) proves the guard trips before the native overflow
-/// point at the stack size this crate assumes callers provide.
+/// directly. This test was that direct measurement, and remains a
+/// permanent regression guard, but its meaning changed under WASM10:
+/// `call_function` no longer runs its recursive dispatch loop on
+/// whatever thread calls it — it spawns its OWN dedicated thread with an
+/// explicit `DEDICATED_STACK_SIZE` internally, and that internal thread
+/// is what `MAX_CALL_DEPTH` is actually bisected against now (see its own
+/// doc comment). So this test, still spawning a 512 KiB CALLING thread,
+/// no longer exercises the guard's real stack-size assumption at all —
+/// it instead proves something strictly stronger: `call_function` works
+/// correctly (unbounded recursion still traps cleanly, not a host crash)
+/// even when invoked from a caller thread with far less stack than
+/// `DEDICATED_STACK_SIZE`, because the calling thread does none of the
+/// recursive work itself. Kept as a regression guard for that
+/// decoupling, not for the original caller-stack-size claim.
 #[test]
 fn depth_guard_trips_before_overflow_on_the_documented_minimum_stack() {
     let handle = std::thread::Builder::new()

--- a/code/packages/rust/wasm-execution/tests/wasm10_dedicated_thread.rs
+++ b/code/packages/rust/wasm-execution/tests/wasm10_dedicated_thread.rs
@@ -1,0 +1,115 @@
+//! # WASM10 — `call_function` on a dedicated thread, raised `MAX_CALL_DEPTH`
+//!
+//! `call_function`'s recursive decode/dispatch loop (and every nested
+//! `call`/`call_indirect` it triggers through `call_function_inner`) now
+//! runs on an internally-spawned dedicated OS thread with an explicit,
+//! generous stack (`DEDICATED_STACK_SIZE`), not on whatever stack the
+//! CALLER happens to provide. `MAX_CALL_DEPTH` was re-bisected directly
+//! against that new stack size (see `code/specs/
+//! W12-wasm-dedicated-thread-call-depth.md` and `MAX_CALL_DEPTH`'s own doc
+//! comment for the full measured-not-scaled methodology).
+//!
+//! These tests build real WASM modules via `wasm-wast-parser` and actually
+//! run them, matching this crate's own established practice of proving
+//! behavior rather than inferring it from reading the code.
+
+use wasm_execution::{HostFunction, WasmEngineConfig, WasmExecutionEngine, WasmValue};
+use wasm_types::{FuncType, FunctionBody, WasmModule};
+
+fn engine_from_wat(wat: &str) -> (WasmExecutionEngine, WasmModule) {
+    let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
+    let func_types: Vec<FuncType> = module.functions.iter().map(|&t| module.types[t as usize].clone()).collect();
+    let func_bodies: Vec<Option<FunctionBody>> = module.code.iter().cloned().map(Some).collect();
+    let host_functions: Vec<Option<Box<dyn HostFunction>>> = module.functions.iter().map(|_| None).collect();
+    let engine = WasmExecutionEngine::new(WasmEngineConfig {
+        memory: None,
+        tables: vec![],
+        globals: vec![],
+        global_types: vec![],
+        func_types,
+        func_bodies,
+        host_functions,
+    });
+    (engine, module)
+}
+
+fn export_index(module: &WasmModule, name: &str) -> usize {
+    module
+        .exports
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("no export named {name:?}"))
+        .index as usize
+}
+
+/// The exact acceptance criterion from `code/specs/
+/// W12-wasm-dedicated-thread-call-depth.md`: the real official testsuite's
+/// `call.wast` `even`/`odd` mutual recursion, previously the only 2
+/// `assert_return` failures in that file (needed >80, the pre-WASM10
+/// ceiling) — reproduced here verbatim (same function bodies, same
+/// expected results) as a standalone regression guard independent of the
+/// full `wasm-conformance` baseline regen.
+#[test]
+fn call_wast_even_odd_mutual_recursion_now_completes() {
+    let (mut engine, module) = engine_from_wat(
+        "(module
+           (func $even (export \"even\") (param i64) (result i32)
+             (if (result i32) (i64.eqz (local.get 0))
+               (then (i32.const 44))
+               (else (call $odd (i64.sub (local.get 0) (i64.const 1))))))
+           (func $odd (export \"odd\") (param i64) (result i32)
+             (if (result i32) (i64.eqz (local.get 0))
+               (then (i32.const 99))
+               (else (call $even (i64.sub (local.get 0) (i64.const 1)))))))",
+    );
+    let even_idx = export_index(&module, "even");
+    let odd_idx = export_index(&module, "odd");
+
+    assert_eq!(engine.call_function(even_idx, &[WasmValue::I64(100)]).unwrap(), vec![WasmValue::I32(44)]);
+    assert_eq!(engine.call_function(odd_idx, &[WasmValue::I64(200)]).unwrap(), vec![WasmValue::I32(99)]);
+}
+
+/// The real point of WASM10: `call_function`'s heavy recursive work runs
+/// on its OWN internally-spawned thread now, not the caller's — so a
+/// caller thread with a stack far too small to survive ~1000 levels of
+/// ordinary Rust recursion, but still large enough for the (non-
+/// recursive) setup work `call_function` does before spawning that
+/// dedicated thread, must still complete a deep, comfortably-under-
+/// `MAX_CALL_DEPTH` WASM call without crashing — proving the recursion
+/// genuinely happens elsewhere, not just that this particular depth also
+/// happens to be small enough for a small caller stack.
+#[test]
+fn a_caller_thread_with_a_tiny_stack_still_completes_deep_recursion() {
+    let handle = std::thread::Builder::new()
+        .stack_size(256 * 1024)
+        .spawn(|| {
+            let (mut engine, module) = engine_from_wat(
+                "(module
+                   (func $countdown (export \"countdown\") (param i32) (result i32)
+                     local.get 0
+                     i32.eqz
+                     (if (result i32)
+                       (then (i32.const 0))
+                       (else (call $countdown (i32.sub (local.get 0) (i32.const 1)))))))",
+            );
+            let idx = export_index(&module, "countdown");
+            let result = engine.call_function(idx, &[WasmValue::I32(1000)]).expect("deep-but-bounded recursion should succeed even from a tiny calling thread");
+            assert_eq!(result, vec![WasmValue::I32(0)]);
+        })
+        .expect("failed to spawn a 256 KiB worker thread");
+    handle.join().expect("call_function must not crash a 256 KiB calling thread -- the recursion runs on its own dedicated thread");
+}
+
+/// Unbounded recursion must still trap cleanly at the new, higher
+/// ceiling — `MAX_CALL_DEPTH` is a real guard, not a value WASM10 quietly
+/// removed the point of. Companion to `call_depth_guard.rs`'s own
+/// unbounded-recursion tests, pinned here specifically against the
+/// dedicated-thread path with the WASM10-era depth value.
+#[test]
+fn unbounded_recursion_still_traps_cleanly_at_the_new_ceiling() {
+    let (mut engine, module) = engine_from_wat("(module (func $loop (export \"loop\") (result i32) call $loop))");
+    let idx = export_index(&module, "loop");
+    let result = engine.call_function(idx, &[]);
+    assert!(result.is_err(), "unbounded recursion should still trap, not hang or crash");
+    assert!(result.unwrap_err().to_string().contains("call stack exhausted"));
+}

--- a/code/packages/rust/wasm-execution/tests/wasm10_dedicated_thread.rs
+++ b/code/packages/rust/wasm-execution/tests/wasm10_dedicated_thread.rs
@@ -13,8 +13,11 @@
 //! run them, matching this crate's own established practice of proving
 //! behavior rather than inferring it from reading the code.
 
-use wasm_execution::{HostFunction, WasmEngineConfig, WasmExecutionEngine, WasmValue};
-use wasm_types::{FuncType, FunctionBody, WasmModule};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_execution::{HostFunction, LinearMemory, TrapError, WasmEngineConfig, WasmExecutionEngine, WasmValue};
+use wasm_types::{FuncType, FunctionBody, ValueType, WasmModule};
 
 fn engine_from_wat(wat: &str) -> (WasmExecutionEngine, WasmModule) {
     let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
@@ -112,4 +115,140 @@ fn unbounded_recursion_still_traps_cleanly_at_the_new_ceiling() {
     let result = engine.call_function(idx, &[]);
     assert!(result.is_err(), "unbounded recursion should still trap, not hang or crash");
     assert!(result.unwrap_err().to_string().contains("call stack exhausted"));
+}
+
+/// Security-review regression (Finding 1): a panic reached through
+/// `Box<dyn HostFunction>` while running inside `call_function`'s
+/// dedicated thread -- exactly the shape `wasm-conformance`'s real
+/// `CrossModuleFunction` can hit (its own documented `RefCell`
+/// double-borrow panic on a circular cross-module import) -- used to
+/// skip the mandatory `self.host_functions`/`self.globals` write-back.
+/// That's the same bug class WASM07's security review already fixed once
+/// for TRAPS; this proves it's now also fixed for PANICS: the panic must
+/// still propagate (`call_function` is not a fault-isolation boundary),
+/// but a LATER, unrelated call on the SAME engine must still succeed --
+/// `self.host_functions` (moved out via `mem::take` for the panicking
+/// call) must not have been permanently left empty.
+struct PanickingHostFunction {
+    func_type: FuncType,
+}
+impl HostFunction for PanickingHostFunction {
+    fn func_type(&self) -> &FuncType {
+        &self.func_type
+    }
+    fn call(&self, _args: &[WasmValue], _memory: Option<&mut LinearMemory>) -> Result<Vec<WasmValue>, TrapError> {
+        panic!("PanickingHostFunction always panics -- WASM10 security-review regression test");
+    }
+}
+
+/// A second, well-behaved host function -- the point of this test is that
+/// re-invoking THIS one (via `self.host_functions`' own fast path, which
+/// requires `self.host_functions` to have been correctly restored, not
+/// left empty by `mem::take`) after the panicking call still works. A
+/// self-contained WASM function that never touches `host_functions` at
+/// all (like a bare `i32.const 42`) would pass this test even with the
+/// bug present, so it can't be the thing re-invoked here.
+struct EchoHostFunction {
+    func_type: FuncType,
+}
+impl HostFunction for EchoHostFunction {
+    fn func_type(&self) -> &FuncType {
+        &self.func_type
+    }
+    fn call(&self, _args: &[WasmValue], _memory: Option<&mut LinearMemory>) -> Result<Vec<WasmValue>, TrapError> {
+        Ok(vec![WasmValue::I32(99)])
+    }
+}
+
+#[test]
+fn a_panic_inside_the_dedicated_thread_restores_engine_state_before_propagating() {
+    let boom_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+    let echo_type = boom_type.clone();
+    let panics_type = boom_type.clone();
+    // fn 0: host import "boom" (panics); fn 1: host import "echo" (returns
+    // 99); fn 2: "$panics" (call fn 0; end).
+    let mut engine = WasmExecutionEngine::new(WasmEngineConfig {
+        memory: None,
+        tables: vec![],
+        globals: vec![],
+        global_types: vec![],
+        func_types: vec![boom_type.clone(), echo_type.clone(), panics_type],
+        func_bodies: vec![None, None, Some(FunctionBody { locals: vec![], code: vec![0x10, 0x00, 0x0B] })],
+        host_functions: vec![
+            Some(Box::new(PanickingHostFunction { func_type: boom_type }) as Box<dyn HostFunction>),
+            Some(Box::new(EchoHostFunction { func_type: echo_type }) as Box<dyn HostFunction>),
+            None,
+        ],
+    });
+
+    let before = engine.call_function(1, &[]).expect("the echo host function should succeed before any panic");
+    assert_eq!(before, vec![WasmValue::I32(99)]);
+
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| engine.call_function(2, &[])));
+    assert!(panicked.is_err(), "the panic must still propagate out of call_function");
+
+    let after = engine
+        .call_function(1, &[])
+        .expect("the echo host function must still work after an unrelated panicking call -- host_functions must be restored");
+    assert_eq!(after, vec![WasmValue::I32(99)]);
+}
+
+/// Security-review regression (Finding 2): an ordinary, non-circular,
+/// finite chain of linked module instances -- the SAME shape
+/// `wasm-conformance`'s real cross-module linking (WASM05) supports --
+/// where each instance's host-imported "reenter" function calls into the
+/// NEXT engine's own `call_function`, must trap cleanly at
+/// `MAX_DEDICATED_THREAD_DEPTH` rather than spawning an unbounded number
+/// of OS threads. The chain is deliberately FINITE and terminates on its
+/// own at its base case (proving this isn't inherently-infinite
+/// recursion, which `call.wast`'s "runaway" cases already cover) --
+/// deliberately built deep enough (100 levels) that reaching the end
+/// without the guard firing first would mean the guard doesn't work.
+struct ChainHostFunction {
+    next: Option<Rc<RefCell<WasmExecutionEngine>>>,
+    func_type: FuncType,
+}
+impl HostFunction for ChainHostFunction {
+    fn func_type(&self) -> &FuncType {
+        &self.func_type
+    }
+    fn call(&self, _args: &[WasmValue], _memory: Option<&mut LinearMemory>) -> Result<Vec<WasmValue>, TrapError> {
+        match &self.next {
+            Some(next_engine) => next_engine.borrow_mut().call_function(1, &[]),
+            None => Ok(vec![WasmValue::I32(0)]), // base case: bottom of the chain
+        }
+    }
+}
+
+fn make_chain_link(next: Option<Rc<RefCell<WasmExecutionEngine>>>, loop_type: FuncType) -> Rc<RefCell<WasmExecutionEngine>> {
+    let host_functions: Vec<Option<Box<dyn HostFunction>>> =
+        vec![Some(Box::new(ChainHostFunction { next, func_type: loop_type.clone() }) as Box<dyn HostFunction>), None];
+    Rc::new(RefCell::new(WasmExecutionEngine::new(WasmEngineConfig {
+        memory: None,
+        tables: vec![],
+        globals: vec![],
+        global_types: vec![],
+        func_types: vec![loop_type.clone(), loop_type],
+        // fn 0: host import "reenter"; fn 1: "$loop" (call fn 0; end).
+        func_bodies: vec![None, Some(FunctionBody { locals: vec![], code: vec![0x10, 0x00, 0x0B] })],
+        host_functions,
+    })))
+}
+
+#[test]
+fn a_long_but_finite_cross_module_chain_traps_cleanly_before_exhausting_os_threads() {
+    let loop_type = FuncType { params: vec![], results: vec![ValueType::I32] };
+    const CHAIN_LEN: usize = 100; // comfortably more than the private MAX_DEDICATED_THREAD_DEPTH
+
+    let mut current = make_chain_link(None, loop_type.clone());
+    for _ in 0..CHAIN_LEN - 1 {
+        current = make_chain_link(Some(current), loop_type.clone());
+    }
+
+    let result = current.borrow_mut().call_function(1, &[]);
+    assert!(
+        result.is_err(),
+        "a 100-deep, ordinary (non-circular) cross-module call chain should trap cleanly at the depth guard, not hang, crash, or exhaust OS threads"
+    );
+    assert!(result.unwrap_err().to_string().contains("cross-module call nesting exhausted"));
 }


### PR DESCRIPTION
## Summary
- `call_function` (the top-level, public `wasm-execution` entry point) now spawns one dedicated OS thread per call with an explicit 8 MiB stack (`DEDICATED_STACK_SIZE`), and runs its entire recursive decode/dispatch loop there -- decoupling `MAX_CALL_DEPTH`'s safety margin from whatever stack the CALLER happens to provide.
- Avoids a breaking `Send`-bound change to `HostFunction`/`HostInterface` (which would force `wasm-conformance`'s real `Rc<RefCell<..>>`-based cross-module linking into a correctness-sensitive `Arc<Mutex<..>>` rewrite) via a localized, explicitly-justified `AssertSend<T>` newtype.
- `MAX_CALL_DEPTH` re-bisected directly against the new 8 MiB stack (measured, not scaled): safe at depth 1820, crashes at 1830 in a debug build -- raised from 80 to 1200. `call.wast`'s `even(100)`/`odd(200)` (the only 2 `assert_return` failures in that file since the original guard shipped) now both pass. Full baseline diff confirms this is the ONLY conformance file affected.
- See `code/specs/W12-wasm-dedicated-thread-call-depth.md` for the full design (merged separately, #11823).

## Security review findings, all fixed before push (3 rounds)
1. **Panic during the dedicated thread skipped the mandatory `self.host_functions`/`self.globals` write-back** -- the same bug class a prior WASM07 review fixed for traps, reintroduced here for panics. Fixed with `catch_unwind` + restore-before-`resume_unwind`.
2. **Unbounded OS-thread nesting via cross-module host calls** (`HostFunction::call` re-entering a different engine's own `call_function`, e.g. `wasm-conformance`'s real linking) -- no bound previously existed. Fixed with a new `MAX_DEDICATED_THREAD_DEPTH` (64) guard, tracked via a `thread_local!` counter explicitly propagated parent-thread -> child-thread.
3. **Round 2 self-review**: the round-1 fix still moved `ctx` by value into the spawned closure, so a thread-spawn FAILURE (not just a panic) could also skip the restoration. Fixed by keeping `ctx` owned in `call_function`'s own stack frame the whole time -- only a raw pointer crosses the thread boundary, the same treatment `vm_ptr` already had. This makes the invariant compiler-enforced, not just test-enforced.

All three fixes verified via TEMP-REVERT-CHECK to reproduce the exact pre-fix failure with each fix disabled/reverted.

## Test plan
- [x] `cargo test -p wasm-execution -p wasm-runtime -p wasm-conformance -p lang-aot` all green (only the known, pre-existing, unrelated `closure_identity_returns_captured_value` failure remains, confirmed present on `origin/main`)
- [x] `cargo clippy -p wasm-execution --all-targets -- -D warnings` clean
- [x] `wasm-conformance` golden-baseline test: `call.wast` moves from `pass: 67, fail: 2` to `pass: 69, fail: 0`; zero regressions anywhere else (full baseline diff)
- [x] New tests: `call.wast` even/odd shape, caller-thread-with-256KiB-stack completing 1000-deep recursion, unbounded recursion still traps at the new ceiling, panic-restoration regression, 100-deep finite cross-module chain trapping cleanly at the depth guard, plus 2 white-box depth-guard unit tests
- [x] `/security-review` passed (3 rounds; 2 real findings in round 1/2, both fixed and verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)