### PR TITLE
fix(wasm): v128/funcref/externref single-value blocktype decoding

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — wasm-conformance
 
+## 0.1.20 — 2026-08-15 — baseline regen: blocktype fix (task #81)
+
+### Changed
+
+- Baseline regen following `wasm-execution` 0.9.1 / `wasm-validator`
+  0.2.6 (task #81 -- `v128`/`funcref`/`externref` single-value blocktypes
+  were being misdecoded as bogus negative type indices). `simd_const.wast`
+  moves from `module: 307/309, assert_return: 189/240` to `module:
+  308/309, assert_return: 209/240` -- the module declaring `(block
+  (result v128) ...)`-shaped functions (a SEPARATE module from the
+  still-open v128-global-initializer trap, task #79) now validates and
+  instantiates for real, and the ~20 collateral "no module registered"
+  failures its own callers previously hit are gone. Confirmed via a full
+  JSON diff that this is the ONLY file affected; zero regressions
+  elsewhere.
+
 ## 0.1.19 — 2026-08-15 — vendor simd_const.wast, the first post-MVP-proposal corpus file (task #78)
 
 ### Added

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -2882,8 +2882,8 @@
         "not_yet_supported": 109
       },
       "assert_return": {
-        "pass": 189,
-        "fail": 51,
+        "pass": 209,
+        "fail": 31,
         "trap": 0,
         "not_yet_supported": 25
       },
@@ -2900,8 +2900,8 @@
         "not_yet_supported": 0
       },
       "module": {
-        "pass": 307,
-        "fail": 1,
+        "pass": 308,
+        "fail": 0,
         "trap": 1,
         "not_yet_supported": 3
       },
@@ -3443,8 +3443,8 @@
       "not_yet_supported": 516
     },
     "assert_return": {
-      "pass": 15429,
-      "fail": 91,
+      "pass": 15449,
+      "fail": 71,
       "trap": 0,
       "not_yet_supported": 509
     },
@@ -3461,8 +3461,8 @@
       "not_yet_supported": 0
     },
     "module": {
-      "pass": 931,
-      "fail": 2,
+      "pass": 932,
+      "fail": 1,
       "trap": 1,
       "not_yet_supported": 32
     },

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -25,6 +25,19 @@ All notable changes to this package will be documented in this file.
   byte (not a signed-LEB128 type index), and a real end-to-end `br` out
   of a `(block (result v128) ...)` correctly carries its value across
   the branch.
+- Security review (round 1) found a pre-existing, adjacent issue: the
+  `"blocktype"` operand decoder's `let byte = code[offset];` was an
+  UNCHECKED index, unlike `f32`/`f64` immediately above it (which already
+  guard truncated input with a length check and a safe default). Reachable
+  without going through `wasm-validator::validate()` first --
+  `wasm-runtime::instantiate()`/`call()` don't call it themselves, only
+  the separate `load_and_run()` convenience wrapper does -- so a real
+  embedder could panic the process on a function body truncated right
+  after a `block`/`loop`/`if` opcode. Fixed to `code.get(offset).copied()
+  .unwrap_or(0x40)` (empty blocktype, the same safe-default convention
+  `f32`/`f64` already use on truncation). Verified load-bearing via
+  TEMP-REVERT-CHECK: reverting reproduces the exact predicted panic
+  (`index out of bounds`) on a dedicated regression test, then restored.
 
 ## [0.9.0] - 2026-08-15 (SIMD PR1b-1 — v128 cross-call-boundary materialization)
 

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.9.1] - 2026-08-15 (task #81 — v128/funcref/externref single-value blocktypes)
+
+### Fixed
+
+- `decode_function_body`'s `"blocktype"` operand decoder only special-cased
+  the 4 MVP scalar single-byte blocktypes (`0x40`/`0x7F`/`0x7E`/`0x7D`/
+  `0x7C`) as raw bytes; `v128` (`0x7B`, SIMD) and `funcref`/`externref`
+  (`0x70`/`0x6F`, WASM17) fell through to the signed-LEB128 type-index
+  branch instead, producing a bogus negative "type index" (`0x7B` decodes
+  to signed value -5) for a completely ordinary `(block (result v128)
+  ...)` or similar. Found vendoring the real `simd_const.wast` corpus
+  (task #78) -- confirmed a genuine bug, not a capability gap.
+- `block_arity`'s matching range (`0x7C..=0x7F`) had the identical gap on
+  the runtime side -- a `br` out of a `(block (result v128) ...)` would
+  have silently dropped the branched value (arity `(0, 0)` instead of
+  `(0, 1)`) even once the decoder above is fixed, since this function
+  independently re-derives arity from the same raw byte. Verified
+  load-bearing via TEMP-REVERT-CHECK: reverting just this arm reproduces
+  a `StackUnderflow` trap on a dedicated regression test, then restored.
+- 3 new tests: the decoder now carries `0x7B`/`0x70`/`0x6F` as their raw
+  byte (not a signed-LEB128 type index), and a real end-to-end `br` out
+  of a `(block (result v128) ...)` correctly carries its value across
+  the branch.
+
 ## [0.9.0] - 2026-08-15 (SIMD PR1b-1 — v128 cross-call-boundary materialization)
 
 ### Added

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1250,7 +1250,22 @@ fn decode_immediates(code: &[u8], offset: usize, immediates: &[&str]) -> (Decode
             }
         }
         "blocktype" => {
-            let byte = code[offset];
+            // Security review (task #81's PR): `code[offset]` here was an
+            // unchecked index -- unlike `f32`/`f64` above, which already
+            // guard truncated input with a length check and a safe
+            // default. A module reaching this decoder without first going
+            // through `wasm-validator::validate()` (a real, reachable path:
+            // `wasm-runtime::instantiate()`/`call()` don't call `validate()`
+            // themselves -- only the separate `load_and_run()` convenience
+            // wrapper does) could panic the whole process on a function
+            // body truncated right after a `block`/`loop`/`if` opcode, with
+            // no blocktype byte at all. `0x40` (empty) is a safe, non-
+            // crashing default for the same reason `f32`/`f64` default to
+            // `0.0` on truncation -- the actually-malformed body still gets
+            // caught downstream (by validation, or by a real trap once
+            // execution runs off the end of a too-short instruction
+            // stream), just not via a raw Rust panic here.
+            let byte = code.get(offset).copied().unwrap_or(0x40);
             match byte {
                 // Single-byte value-type blocktypes -- carried as the RAW
                 // byte (not signed-LEB128-decoded), matching `block_arity`'s
@@ -6795,6 +6810,25 @@ mod tests {
             code: vec![0x02, 0x40, 0x0B, 0x0B], // block (empty); end; end
         };
         let decoded = decode_function_body(&body);
+        assert_eq!(decoded[0].opcode, 0x02);
+        match &decoded[0].operand {
+            DecodedOperand::Int(v) => assert_eq!(*v, 0x40),
+            _ => panic!("expected Int operand for blocktype"),
+        }
+    }
+
+    #[test]
+    fn test_decode_block_type_truncated_body_does_not_panic() {
+        // Security review regression: a function body truncated right
+        // after a `block`/`loop`/`if` opcode (no blocktype byte at all)
+        // must not panic via an unchecked `code[offset]` index -- this is
+        // reachable without going through `wasm-validator::validate()`
+        // first (`wasm-runtime::instantiate()`/`call()` don't call it
+        // themselves), so a real embedder could hit this with a crafted
+        // module. Defaults to the same "empty" blocktype (0x40) truncated
+        // f32/f64 immediates already default to on short input.
+        let body = FunctionBody { locals: vec![], code: vec![0x02] }; // block, then nothing
+        let decoded = decode_function_body(&body); // must not panic
         assert_eq!(decoded[0].opcode, 0x02);
         match &decoded[0].operand {
             DecodedOperand::Int(v) => assert_eq!(*v, 0x40),

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -1252,7 +1252,20 @@ fn decode_immediates(code: &[u8], offset: usize, immediates: &[&str]) -> (Decode
         "blocktype" => {
             let byte = code[offset];
             match byte {
-                0x40 | 0x7F | 0x7E | 0x7D | 0x7C => (DecodedOperand::Int(byte as i64), 1),
+                // Single-byte value-type blocktypes -- carried as the RAW
+                // byte (not signed-LEB128-decoded), matching `block_arity`'s
+                // own raw-byte range check below. Originally just the 4 MVP
+                // scalars; `0x7B` (v128, SIMD) and `0x70`/`0x6F` (funcref/
+                // externref, WASM17) were a real, previously-undetected gap
+                // here -- both fell through to the signed-LEB128 type-index
+                // branch below instead, producing a bogus negative "type
+                // index" (e.g. `0x7B` decodes to signed value -5) that a
+                // real module using `(block (result v128) ...)` or
+                // `(block (result funcref) ...)` would then fail structural
+                // validation against (confirmed via the real, pinned-commit
+                // `simd_const.wast` corpus -- see wasm-validator's matching
+                // fix in `decode_blocktype`).
+                0x40 | 0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F => (DecodedOperand::Int(byte as i64), 1),
                 _ => {
                     // Type index (signed LEB128)
                     let (value, consumed) = decode_signed(code, offset).unwrap_or((0, 1));
@@ -1878,7 +1891,13 @@ fn get_table<'a>(ctx: &mut WasmExecutionContext, idx: usize) -> Result<&'a mut T
 fn block_arity(block_type: i64, types: &[FuncType]) -> (usize, usize) {
     match block_type {
         0x40 => (0, 0),                        // empty
-        0x7C..=0x7F => (0, 1),                 // single value type, no params
+        // Single value type, no params -- the 4 MVP scalars (0x7C..=0x7F)
+        // plus v128 (0x7B, SIMD) and funcref/externref (0x70/0x6F, WASM17),
+        // matching the raw-byte blocktype cases `decode_function_body`'s
+        // own "blocktype" operand decoder now carries for all 7 (see that
+        // match's own doc comment for why this was a real, previously-
+        // undetected gap for the 3 non-MVP-scalar types).
+        0x7C..=0x7F | 0x7B | 0x70 | 0x6F => (0, 1),
         n if n >= 0 && (n as usize) < types.len() => {
             let t = &types[n as usize];
             (t.params.len(), t.results.len())
@@ -6781,6 +6800,44 @@ mod tests {
             DecodedOperand::Int(v) => assert_eq!(*v, 0x40),
             _ => panic!("expected Int operand for blocktype"),
         }
+    }
+
+    #[test]
+    fn test_decode_block_type_v128_funcref_externref_are_raw_bytes_not_signed_leb128() {
+        // Real bug (task #81, found vendoring simd_const.wast): these 3
+        // single-byte blocktypes fell through to the signed-LEB128
+        // type-index branch instead of being carried as their raw byte
+        // (like the 4 MVP scalars already were) -- 0x7B/0x70/0x6F decode
+        // to -5/-16/-17 as signed LEB128, which is NOT what `block_arity`
+        // (or wasm-validator's `decode_blocktype`) expects.
+        for byte in [0x7Bu8, 0x70, 0x6F] {
+            let body = FunctionBody { locals: vec![], code: vec![0x02, byte, 0x0B, 0x0B] };
+            let decoded = decode_function_body(&body);
+            match &decoded[0].operand {
+                DecodedOperand::Int(v) => assert_eq!(*v, byte as i64, "blocktype byte {byte:#x}"),
+                _ => panic!("expected Int operand for blocktype {byte:#x}"),
+            }
+        }
+    }
+
+    /// End-to-end proof `block_arity` (not just the decoder) is fixed: a
+    /// `br` OUT OF a `(block (result v128) ...)` must actually carry its
+    /// v128 value across the branch -- before the fix, `block_arity`
+    /// silently returned `(0, 0)` for this blocktype (the `_ => (0, 0)`
+    /// fallback), which would have dropped the branched value instead of
+    /// keeping it on the stack.
+    #[test]
+    fn br_out_of_a_v128_result_block_carries_the_value() {
+        let mut code = vec![0x02, 0x7B]; // block (result v128)
+        code.extend([0xFD, 0x0C]);
+        code.extend(v128_const_bytes([11, 22, 33, 44]));
+        code.extend([0x0C, 0x00]); // br 0
+        code.push(0x0B); // end (block)
+        code.push(0x0B); // end (func)
+        let mut engine = simd_engine_returning_v128(code);
+        let (results, v128_bytes) = engine.call_function_with_v128(0, &[]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(v128_bytes[0], Some(V128Bytes(v128_const_bytes([11, 22, 33, 44]).try_into().unwrap())));
     }
 
     #[test]

--- a/code/packages/rust/wasm-validator/CHANGELOG.md
+++ b/code/packages/rust/wasm-validator/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.6] - 2026-08-15 (task #81 — v128/funcref/externref single-value blocktypes)
+
+### Fixed
+
+- `decode_blocktype` only special-cased the 4 MVP scalar single-byte
+  blocktypes (`i32`/`i64`/`f32`/`f64`) explicitly; `v128` (`0x7B`, SIMD)
+  and `funcref`/`externref` (`0x70`/`0x6F`, WASM17) fell through to the
+  type-index branch, where their raw byte read as signed LEB128 (`0x7B`
+  → -5) always failed with `TypeIndexOutOfBounds` -- even for an
+  ordinary, valid `(block (result v128) ...)`. Found vendoring the real
+  `simd_const.wast` corpus (task #78); see `wasm-execution` 0.9.1's
+  matching fix in `decode_function_body`/`block_arity` (the same
+  representation gap on the runtime side).
+- 1 new test proving all 3 single-value blocktypes now validate
+  correctly.
+
 ## [0.2.5] - 2026-08-15 (SIMD PR1b-2 — type rules for the v128 first slice)
 
 ### Added

--- a/code/packages/rust/wasm-validator/Cargo.toml
+++ b/code/packages/rust/wasm-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-validator"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-validator"
 

--- a/code/packages/rust/wasm-validator/src/type_check.rs
+++ b/code/packages/rust/wasm-validator/src/type_check.rs
@@ -272,6 +272,18 @@ fn decode_blocktype(module: &WasmModule, code: &[u8], offset: usize) -> Result<(
         0x7E => Ok((vec![], vec![ValueType::I64], 1)),
         0x7D => Ok((vec![], vec![ValueType::F32], 1)),
         0x7C => Ok((vec![], vec![ValueType::F64], 1)),
+        // v128 (SIMD) and funcref/externref (WASM17) single-value
+        // blocktypes -- a real, previously-undetected gap: both fell
+        // through to the type-index branch below instead, where their
+        // raw byte read as signed LEB128 (`0x7B`→-5, `0x70`→-16, `0x6F`
+        // →-17) produced a bogus negative "type index" that always
+        // failed with `TypeIndexOutOfBounds`. Confirmed via the real,
+        // pinned-commit `simd_const.wast` corpus (`(block (result v128)
+        // ...)`) -- see `wasm-execution`'s matching fix in
+        // `decode_function_body`'s "blocktype" operand decoder.
+        0x7B => Ok((vec![], vec![ValueType::V128], 1)),
+        0x70 => Ok((vec![], vec![ValueType::Funcref], 1)),
+        0x6F => Ok((vec![], vec![ValueType::Externref], 1)),
         _ => {
             let (idx, size) = decode_signed(code, offset).map_err(|e| ValidationError::Other(format!("bad blocktype immediate: {e}")))?;
             let ty = module

--- a/code/packages/rust/wasm-validator/tests/type_check.rs
+++ b/code/packages/rust/wasm-validator/tests/type_check.rs
@@ -384,6 +384,20 @@ fn valid_v128_local_and_global_round_trip() {
     );
 }
 
+#[test]
+fn valid_block_with_v128_funcref_externref_single_value_blocktype() {
+    // Real bug found vendoring simd_const.wast (task #81): decode_blocktype
+    // only special-cased the 4 MVP scalar single-byte blocktypes
+    // (i32/i64/f32/f64); v128 (SIMD) and funcref/externref (WASM17) fell
+    // through to the type-index branch, where their raw byte read as
+    // signed LEB128 produced a bogus negative "type index" and always
+    // failed with TypeIndexOutOfBounds -- even though a plain `(block
+    // (result v128) ...)` is completely ordinary, valid WASM.
+    assert_valid("(module (func (result v128) (block (result v128) (v128.const i32x4 0 1 2 3))))");
+    assert_valid("(module (func (param funcref) (result funcref) (block (result funcref) (local.get 0))))");
+    assert_valid("(module (func (param externref) (result externref) (block (result externref) (local.get 0))))");
+}
+
 // ── Invalid modules ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Task #81, found vendoring `simd_const.wast` (task #78). Both `wasm-execution::decode_function_body`'s `"blocktype"` operand decoder and `wasm-validator::decode_blocktype` only special-cased the 4 MVP scalar single-byte blocktypes (i32/i64/f32/f64) as raw bytes; `v128` (`0x7B`, SIMD) and `funcref`/`externref` (`0x70`/`0x6F`, WASM17) fell through to the signed-LEB128 type-index branch instead, producing a bogus negative "type index" for a completely ordinary `(block (result v128) ...)` — `0x7B` decodes to signed value -5, always failing `TypeIndexOutOfBounds` at validation, or (if validation were somehow bypassed) silently dropping the branched value at runtime since `wasm-execution`'s `block_arity` had the identical gap on its own raw-byte range check.
- Both sites fixed to explicitly carry all 3 additional single-byte value-type blocktypes the same way as the original 4. Verified `block_arity`'s fix is load-bearing via TEMP-REVERT-CHECK: reverting it reproduces a `StackUnderflow` trap on a dedicated `br`-out-of-a-v128-block regression test.
- **Security review round 1** found an adjacent, pre-existing issue directly next to the touched line: `decode_immediates`'s `"blocktype"` arm did `code[offset]` with no bounds check (unlike `f32`/`f64` immediately above it, which already guard truncated input) — reachable without going through `wasm-validator::validate()` first (`wasm-runtime::instantiate()`/`call()` don't call it themselves), so a real embedder could panic the process on a function body truncated right after a `block`/`loop`/`if` opcode. Fixed to `code.get(offset).copied().unwrap_or(0x40)`, verified load-bearing via TEMP-REVERT-CHECK. **Round 2 passed clean**, confirming the fix is complete and introduces no new issue (traced the "phantom consumed byte" bookkeeping question through `decode_function_body`'s caller loop to confirm it can only cause early, safe loop termination, never an out-of-bounds read).
- **Baseline regen**: `simd_const.wast`'s tallies improve (`module` 308/309, `assert_return` 209/240, up from 307/309, 189/240) with zero regressions elsewhere (confirmed via full JSON diff).
- `wasm-execution` 0.9.0 → 0.9.1, `wasm-validator` 0.2.5 → 0.2.6, `wasm-conformance` 0.1.19 → 0.1.20.

## Test plan

- [x] `cargo test -p wasm-execution -p wasm-validator -p wasm-conformance` — 225 + 75 + 37 tests pass, including 5 new ones (raw-byte blocktype decoding for all 3 new types, end-to-end `br`-carries-v128-value, truncated-body-doesn't-panic, and a validator test for all 3 types)
- [x] TEMP-REVERT-CHECK ×2: `block_arity`'s fix reproduces the exact predicted `StackUnderflow` trap when reverted; the bounds-check fix reproduces the exact predicted `index out of bounds` panic when reverted
- [x] `cargo test -p wasm-runtime -p wasm-wast-parser` — unaffected, all pass
- [x] `cargo clippy -p wasm-execution -p wasm-validator -p wasm-conformance --all-targets -- -D warnings` clean
- [x] Full JSON diff of the regenerated baseline: 0 regressions, exactly the expected `simd_const.wast` improvement
- [x] `/security-review` — 2 rounds, round 1 found 1 real issue (fixed + verified), round 2 PASSED clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)