### PR TITLE
feat(wasm): v128 persistent storage across an instance's lifetime (W15, task #79)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog — wasm-conformance
 
+## 0.1.23 — 2026-08-15 — v128 global reads resolved; baseline regen (W15, task #79)
+
+### Fixed
+
+- `run_action`'s `Action::Get` arm (a bare `(get "name")` action reading
+  an exported global directly, not via a function call) used to always
+  return `None` for a `WasmValue::V128` global's resolved bytes -- at
+  the time that code was written (SIMD PR1b-3), there was no way to
+  resolve a v128 handle outside of an active call's `ctx.v128_heap`.
+  Now that `WasmInstance.v128_heap` is a persistent, directly-readable
+  field (`wasm-runtime` 0.6.1, W15), a `Get` action resolves the handle
+  against it exactly like a call's result does. No vendored corpus file
+  currently exercises `(get ...)` against a v128 global, so this has no
+  baseline-visible effect today, but closes the gap for real ahead of a
+  future corpus file that does.
+
+### Changed
+
+- Baseline regen following `wasm-execution` 0.9.2 / `wasm-runtime` 0.6.1
+  (W15, task #79 -- v128 persistent storage). `simd_const.wast`'s
+  `module` tally moves from 308/309 (1 trap) to 309/309 (the module
+  whose `(global (mut v128) (v128.const ...))` initializer previously
+  failed to instantiate now builds); `assert_return` moves from 235/240
+  (5 fails) to 235/240 (4 fails, `not_yet_supported` +1) -- one
+  previously-collateral failure now correctly grades
+  `NotYetSupported("a v128 invoke ARGUMENT is not yet supported...")`,
+  a real, SEPARATE, already-documented gap (v128.const literals aren't
+  yet supported as `invoke` arguments -- logged as task #86, NOT fixed
+  by this PR). The remaining 4 fails are a direct, expected downstream
+  consequence of that same NotYetSupported case (globals a skipped
+  "set" call never actually set), not a new or masked bug. Zero
+  regressions anywhere else in the 61-file vendored corpus (full
+  before/after diff of every file's per-kind tally).
+
 ## 0.1.22 — 2026-08-15 — assert_malformed also validates; baseline regen (tasks #82-84)
 
 ### Fixed

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/src/lib.rs
+++ b/code/packages/rust/wasm-conformance/src/lib.rs
@@ -534,17 +534,25 @@ impl Executor {
                     .iter()
                     .find(|(n, kind, _)| n == name && *kind == ExternalKind::Global)
                     .and_then(|(_, _, idx)| instance.globals.get(*idx as usize).copied())
-                    // A global read is not a call -- there's no engine `ctx`/
-                    // `v128_heap` involved at all, so a `WasmValue::V128`
-                    // global's handle can't be resolved here either way.
-                    // No vendored fixture currently reads a v128-typed
-                    // global, so this doesn't silently mis-grade anything
-                    // today; a real v128 global read would need its own
-                    // follow-up (globals persist in `instance.globals`
-                    // across calls, but the `v128_heap` slot a stored handle
-                    // pointed to does NOT survive past the call that wrote
-                    // it -- a separate, deeper gap from this PR's scope).
-                    .map(|v| (vec![v], vec![None]))
+                    // A global read is not a call -- there's no engine
+                    // `ctx` involved at all -- but UNLIKE at the time this
+                    // comment was first written (SIMD PR1b-3), a
+                    // `WasmValue::V128` global's handle CAN now be
+                    // resolved here: `code/specs/
+                    // W15-wasm-v128-persistent-storage.md` moved
+                    // `v128_heap` onto the persistent `WasmInstance`
+                    // itself, so the same `Vec` a call's `ctx.v128_heap`
+                    // clones from/restores to is directly readable here
+                    // too, no engine required.
+                    .map(|v| {
+                        let bytes = match v {
+                            WasmValue::V128(handle) => {
+                                instance.v128_heap.get(handle as usize).copied().map(V128Bytes)
+                            }
+                            _ => None,
+                        };
+                        (vec![v], vec![bytes])
+                    })
                     .ok_or_else(|| ActionError::Trap(format!("no global export named {name:?}")))
             }
         }

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -2883,9 +2883,9 @@
       },
       "assert_return": {
         "pass": 235,
-        "fail": 5,
+        "fail": 4,
         "trap": 0,
-        "not_yet_supported": 25
+        "not_yet_supported": 26
       },
       "assert_trap": {
         "pass": 0,
@@ -2900,9 +2900,9 @@
         "not_yet_supported": 0
       },
       "module": {
-        "pass": 308,
+        "pass": 309,
         "fail": 0,
-        "trap": 1,
+        "trap": 0,
         "not_yet_supported": 3
       },
       "register": {
@@ -3444,9 +3444,9 @@
     },
     "assert_return": {
       "pass": 15515,
-      "fail": 5,
+      "fail": 4,
       "trap": 0,
-      "not_yet_supported": 509
+      "not_yet_supported": 510
     },
     "assert_trap": {
       "pass": 478,
@@ -3461,9 +3461,9 @@
       "not_yet_supported": 0
     },
     "module": {
-      "pass": 932,
+      "pass": 933,
       "fail": 1,
-      "trap": 1,
+      "trap": 0,
       "not_yet_supported": 32
     },
     "register": {

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -28,11 +28,20 @@ All notable changes to this package will be documented in this file.
   companion `wasm-runtime` 0.6.1 release) now round-trips correctly
   instead of the handle going stale the moment one call ends.
 - `WasmEngineState` gains a `v128_heap` field, written back from
-  `WasmExecutionEngine::into_state()` -- AFTER, not alongside, the
-  existing per-result `V128Bytes` resolution loop in
-  `call_function_impl` (that loop still needs a live borrow of
-  `ctx.v128_heap`; moving it out earlier would have been a
-  use-after-move compile error).
+  `WasmExecutionEngine::into_state()`. `call_function_impl` clones
+  `ctx.v128_heap` into `self.v128_heap` UNCONDITIONALLY, alongside
+  `self.globals`/`self.host_functions`, before the trap-check that can
+  return early -- a clone rather than a move because the per-result
+  `V128Bytes` resolution loop later in the same function still needs a
+  live borrow of `ctx.v128_heap`. Security review (round 1) caught an
+  earlier version of this that wrote back only AFTER that resolution
+  loop, which is reachable only on the success path: a call that pushed
+  a new `v128.const` entry and then trapped silently lost that heap
+  growth -- the exact class of bug `wasm-runtime::call_engine`'s own
+  doc comment already warns about for memory/tables. New regression
+  test (`v128_heap_growth_survives_a_call_that_traps`,
+  TEMP-REVERT-CHECK confirmed load-bearing) proves heap growth from
+  before a trap is retained.
 
 See `code/specs/W15-wasm-v128-persistent-storage.md` for the full design
 and motivating corpus evidence.

--- a/code/packages/rust/wasm-execution/CHANGELOG.md
+++ b/code/packages/rust/wasm-execution/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.9.2] - 2026-08-15 (W15, task #79 — v128 persistent storage)
+
+### Fixed (breaking)
+
+- `evaluate_const_expr`'s signature grows a third parameter,
+  `v128_heap: &mut Vec<[u8; 16]>`, and gains a `0xFD`/`v128.const` match
+  arm. Previously any `v128.const` inside a constant expression (a
+  global initializer, data-segment offset, or element-segment offset)
+  hit the catch-all `"illegal opcode 0x{opcode:02X} in constant
+  expression"` -- real, spec-legal WAT like
+  `(global (mut v128) (v128.const ...))` failed to instantiate
+  outright. Confirmed against the real, pinned-commit `simd_const.wast`
+  corpus.
+- `WasmExecutionContext::v128_heap` is no longer unconditionally reseeded
+  to `vec![[0u8; 16]]` on every `call_function`/`call_function_with_v128`
+  invocation -- it now clones from a new `WasmExecutionEngine` field
+  (also `v128_heap`, defaulting to the same reserved-zero-entry `Vec`),
+  set via a new optional setter, `set_v128_heap` (same pattern as the
+  existing `set_struct_field_counts`/`set_type_section`, chosen
+  specifically so the ~50 existing `WasmEngineConfig`-construction unit
+  tests that don't care about v128 at all don't need updating). Any v128
+  value a caller wants to persist across separate calls on the same
+  engine (e.g. `wasm-runtime`'s `WasmInstance.v128_heap`, see the
+  companion `wasm-runtime` 0.6.1 release) now round-trips correctly
+  instead of the handle going stale the moment one call ends.
+- `WasmEngineState` gains a `v128_heap` field, written back from
+  `WasmExecutionEngine::into_state()` -- AFTER, not alongside, the
+  existing per-result `V128Bytes` resolution loop in
+  `call_function_impl` (that loop still needs a live borrow of
+  `ctx.v128_heap`; moving it out earlier would have been a
+  use-after-move compile error).
+
+See `code/specs/W15-wasm-v128-persistent-storage.md` for the full design
+and motivating corpus evidence.
+
 ## [0.9.1] - 2026-08-15 (task #81 — v128/funcref/externref single-value blocktypes)
 
 ### Fixed

--- a/code/packages/rust/wasm-execution/Cargo.toml
+++ b/code/packages/rust/wasm-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-execution"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-execution"
 

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -5093,6 +5093,19 @@ impl WasmExecutionEngine {
         // the dedicated thread could fail to produce a normal result.
         self.globals = ctx.globals;
         self.host_functions = ctx.host_functions;
+        // Cloned here (NOT moved), unconditionally alongside globals/
+        // host_functions above -- security review (task #79): a version
+        // of this that only wrote back AFTER the `outcome` trap-check
+        // below (see `final_result_count`) silently lost any `v128.const`
+        // growth from a call that trapped, the exact class of bug
+        // `wasm-runtime::call_engine`'s own doc comment already warns
+        // about for memory/tables ("skip this restoration on any trap ...
+        // masking whatever the test was actually checking"). Cloning
+        // (rather than moving) here is required because the per-result
+        // `V128Bytes` resolution loop below still needs to BORROW
+        // `ctx.v128_heap` after this point -- moving it out now would be
+        // a use-after-move compile error.
+        self.v128_heap = ctx.v128_heap.clone();
         // gc_heap itself is not persisted (see its own doc comment above);
         // the counters are, so a caller can inspect this call's GC activity
         // via gc_live_object_count()/gc_profile() (W04).
@@ -5126,14 +5139,6 @@ impl WasmExecutionEngine {
         }
         results.reverse();
         v128_bytes.reverse();
-
-        // Write back LAST, after every read of `ctx.v128_heap` above (the
-        // per-result V128Bytes resolution) is done with it -- this moves
-        // it out of `ctx`, unlike the borrow those reads use. See
-        // code/specs/W15-wasm-v128-persistent-storage.md: unlike gc_heap,
-        // this DOES need to persist past the call, onto `self` and from
-        // there into `into_state()`/the owning `WasmInstance`.
-        self.v128_heap = ctx.v128_heap;
 
         Ok((results, v128_bytes))
     }
@@ -6960,6 +6965,35 @@ mod tests {
         let (results, v128_bytes) = engine.call_function_with_v128(0, &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(v128_bytes[0], Some(V128Bytes(v128_const_bytes([11, 22, 33, 44]).try_into().unwrap())));
+    }
+
+    /// Security review regression (task #79): `self.v128_heap` must be
+    /// written back from `ctx.v128_heap` UNCONDITIONALLY, not only on a
+    /// successful call -- a call that pushes a new `v128.const` entry and
+    /// then traps must not silently lose that heap growth. Before this
+    /// fix, the write-back sat after the `outcome` trap-check (`?` on a
+    /// `TrapError` returns early, skipping it entirely), the exact class
+    /// of bug `wasm-runtime::call_engine`'s own doc comment already warns
+    /// about for memory/tables. Verified via `into_state()` after a
+    /// trapped call, since `WasmExecutionEngine` doesn't expose
+    /// `v128_heap` any other way.
+    #[test]
+    fn v128_heap_growth_survives_a_call_that_traps() {
+        let mut code = vec![0xFD, 0x0C]; // v128.const -- pushes handle 1
+        code.extend(v128_const_bytes([1, 2, 3, 4]));
+        code.push(0x1A); // drop (discard the v128 -- we only care about heap growth)
+        code.push(0x00); // unreachable -- traps
+        code.push(0x0B); // end (unreachable code, never executed)
+        let mut engine = simd_engine(code);
+        let result = engine.call_function(0, &[]);
+        assert!(result.is_err(), "unreachable must trap");
+        let state = engine.into_state();
+        assert_eq!(
+            state.v128_heap.len(),
+            2,
+            "the v128.const pushed before the trap must still be in the restored heap, not discarded"
+        );
+        assert_eq!(&state.v128_heap[1][..], v128_const_bytes([1, 2, 3, 4]).as_slice());
     }
 
     #[test]

--- a/code/packages/rust/wasm-execution/src/lib.rs
+++ b/code/packages/rust/wasm-execution/src/lib.rs
@@ -800,8 +800,18 @@ pub trait HostInterface {
 /// data segment offsets, and element segment offsets).
 ///
 /// Allowed opcodes: i32.const (0x41), i64.const (0x42), f32.const (0x43),
-/// f64.const (0x44), global.get (0x23), end (0x0B).
-pub fn evaluate_const_expr(expr: &[u8], globals: &[WasmValue]) -> Result<WasmValue, TrapError> {
+/// f64.const (0x44), global.get (0x23), v128.const (0xFD 0x0C), end (0x0B).
+///
+/// `v128_heap` is the instance's own persistent v128 heap (see
+/// `code/specs/W15-wasm-v128-persistent-storage.md`) -- a `v128.const` here
+/// allocates directly into it, so the resulting handle stays valid for the
+/// instance's entire lifetime, not just this one evaluation. Every other
+/// arm ignores it.
+pub fn evaluate_const_expr(
+    expr: &[u8],
+    globals: &[WasmValue],
+    v128_heap: &mut Vec<[u8; 16]>,
+) -> Result<WasmValue, TrapError> {
     let mut result: Option<WasmValue> = None;
     let mut pos: usize = 0;
 
@@ -856,6 +866,38 @@ pub fn evaluate_const_expr(expr: &[u8], globals: &[WasmValue]) -> Result<WasmVal
                     )));
                 }
                 result = Some(globals[idx as usize]);
+            }
+            // v128.const (SIMD, 0xFD-prefixed) -- the sub-opcode is a
+            // LEB128 u32 (verified against the real binary encoding, see
+            // `decode_leb_u32`'s own call site in `decode_immediates`),
+            // `0x0C` is the only SIMD sub-opcode legal in a constant
+            // expression, and its own operand is 16 RAW bytes (not
+            // LEB128) -- the literal lane bytes themselves. Any other
+            // `0xFD`-prefixed sub-opcode here is itself illegal and falls
+            // through to the catch-all below.
+            0xFD => {
+                let (sub_opcode, consumed) = decode_leb_u32(expr, pos);
+                pos += consumed;
+                if sub_opcode != 0x0C {
+                    return Err(TrapError::new(format!(
+                        "illegal SIMD sub-opcode 0x{:02X} in constant expression",
+                        sub_opcode
+                    )));
+                }
+                if pos + 16 > expr.len() {
+                    return Err(TrapError::new("v128.const: not enough bytes"));
+                }
+                if v128_heap.len() >= MAX_V128_HEAP_LEN {
+                    return Err(TrapError::new(
+                        "v128 heap limit exceeded (too many SIMD values created)",
+                    ));
+                }
+                let mut bytes = [0u8; 16];
+                bytes.copy_from_slice(&expr[pos..pos + 16]);
+                pos += 16;
+                let handle = v128_heap.len() as u32;
+                v128_heap.push(bytes);
+                result = Some(WasmValue::V128(handle));
             }
             // end
             0x0B => {
@@ -4499,6 +4541,15 @@ pub struct WasmEngineState {
     pub tables: Vec<Table>,
     pub globals: Vec<WasmValue>,
     pub host_functions: Vec<Option<Box<dyn HostFunction>>>,
+    /// The instance's persistent v128 heap after this call (see
+    /// `code/specs/W15-wasm-v128-persistent-storage.md`) -- set via
+    /// [`WasmExecutionEngine::set_v128_heap`] before the call (mirroring
+    /// `struct_field_counts`/`type_section`'s optional-setter pattern
+    /// rather than a mandatory `WasmEngineConfig` field, so the ~50
+    /// existing test construction sites that don't care about v128 don't
+    /// all need updating), written back here so the caller can restore it
+    /// onto the owning `WasmInstance`.
+    pub v128_heap: Vec<[u8; 16]>,
 }
 
 /// The WASM execution engine — interprets validated WASM modules.
@@ -4537,6 +4588,14 @@ pub struct WasmExecutionEngine {
     /// [`Self::gc_live_object_count`] / [`Self::gc_profile`] without needing
     /// access to the ephemeral `WasmExecutionContext` itself.
     last_gc_state: gc::GcState,
+    /// The instance's persistent v128 heap (see `code/specs/
+    /// W15-wasm-v128-persistent-storage.md`) -- defaults to just the
+    /// reserved all-zero entry (index 0), matching every `v128_heap`
+    /// elsewhere in this crate; set for real via [`Self::set_v128_heap`]
+    /// (same optional-setter pattern as `struct_field_counts`/
+    /// `type_section`) when the embedder has a persistent instance to
+    /// thread it from.
+    v128_heap: Vec<[u8; 16]>,
 }
 
 impl WasmExecutionEngine {
@@ -4558,6 +4617,7 @@ impl WasmExecutionEngine {
             struct_field_counts: Vec::new(),
             type_section: Vec::new(),
             last_gc_state: gc::GcState::default(),
+            v128_heap: vec![[0u8; 16]],
         }
     }
 
@@ -4588,6 +4648,21 @@ impl WasmExecutionEngine {
         self
     }
 
+    /// Register the instance's persistent v128 heap (see `code/specs/
+    /// W15-wasm-v128-persistent-storage.md`) -- same optional-setter
+    /// pattern as [`Self::set_struct_field_counts`]/[`Self::set_type_section`]
+    /// for the identical reason: a mandatory `WasmEngineConfig` field would
+    /// force every existing construction site (including the many
+    /// v128-agnostic hand-built modules in this crate's own unit tests) to
+    /// supply it. Left unset, the engine keeps its `new()`-time default
+    /// (just the reserved all-zero entry at index 0), which is correct for
+    /// any module that never sets a v128 global -- there's nothing to
+    /// persist. Returns `&mut self` for chaining.
+    pub fn set_v128_heap(&mut self, heap: Vec<[u8; 16]>) -> &mut Self {
+        self.v128_heap = heap;
+        self
+    }
+
     /// Live `gc_heap` object count as of the most recently completed
     /// [`Self::call_function`] (W04). `gc_heap` itself resets every call, so
     /// this reflects only that one call's allocation/collection activity,
@@ -4611,6 +4686,7 @@ impl WasmExecutionEngine {
             tables: self.tables.into_iter().map(|table| *table).collect(),
             globals: self.globals,
             host_functions: self.host_functions,
+            v128_heap: self.v128_heap,
         }
     }
 
@@ -4723,9 +4799,13 @@ impl WasmExecutionEngine {
             // back-edges and calls, so a long call no longer grows it
             // without bound.
             gc_heap: Vec::new(),
-            // Index 0 reserved as the all-zero vector -- see `v128_heap`'s
-            // own doc comment.
-            v128_heap: vec![[0u8; 16]],
+            // Cloned from `self.v128_heap`, NOT reseeded to
+            // `vec![[0u8; 16]]` -- see `code/specs/
+            // W15-wasm-v128-persistent-storage.md`. Reseeding here was
+            // the original bug this spec fixes: any v128 handle a global
+            // held across calls became garbage once the heap it indexed
+            // into was thrown away and rebuilt from scratch every call.
+            v128_heap: self.v128_heap.clone(),
             struct_field_counts: self.struct_field_counts.clone(),
             gc_state: gc::GcState::default(),
             call_depth: 0,
@@ -5047,6 +5127,14 @@ impl WasmExecutionEngine {
         results.reverse();
         v128_bytes.reverse();
 
+        // Write back LAST, after every read of `ctx.v128_heap` above (the
+        // per-result V128Bytes resolution) is done with it -- this moves
+        // it out of `ctx`, unlike the borrow those reads use. See
+        // code/specs/W15-wasm-v128-persistent-storage.md: unlike gc_heap,
+        // this DOES need to persist past the call, onto `self` and from
+        // there into `into_state()`/the owning `WasmInstance`.
+        self.v128_heap = ctx.v128_heap;
+
         Ok((results, v128_bytes))
     }
 
@@ -5200,7 +5288,7 @@ mod tests {
     fn test_evaluate_const_expr_i32() {
         // i32.const 42; end
         let expr = vec![0x41, 0x2A, 0x0B];
-        let result = evaluate_const_expr(&expr, &[]).unwrap();
+        let result = evaluate_const_expr(&expr, &[], &mut Vec::new()).unwrap();
         assert_eq!(result, WasmValue::I32(42));
     }
 
@@ -5209,7 +5297,7 @@ mod tests {
         // global.get 0; end
         let expr = vec![0x23, 0x00, 0x0B];
         let globals = vec![WasmValue::I32(100)];
-        let result = evaluate_const_expr(&expr, &globals).unwrap();
+        let result = evaluate_const_expr(&expr, &globals, &mut Vec::new()).unwrap();
         assert_eq!(result, WasmValue::I32(100));
     }
 
@@ -6673,7 +6761,7 @@ mod tests {
     fn test_const_expr_i64() {
         // i64.const 42; end (42 in signed LEB128 = 0x2A)
         let expr = vec![0x42, 0x2A, 0x0B];
-        let result = evaluate_const_expr(&expr, &[]).unwrap();
+        let result = evaluate_const_expr(&expr, &[], &mut Vec::new()).unwrap();
         assert_eq!(result, WasmValue::I64(42));
     }
 
@@ -6682,7 +6770,7 @@ mod tests {
         let val: f32 = 3.14;
         let bytes = val.to_le_bytes();
         let expr = vec![0x43, bytes[0], bytes[1], bytes[2], bytes[3], 0x0B];
-        let result = evaluate_const_expr(&expr, &[]).unwrap();
+        let result = evaluate_const_expr(&expr, &[], &mut Vec::new()).unwrap();
         assert_eq!(result, WasmValue::F32(3.14));
     }
 
@@ -6693,45 +6781,45 @@ mod tests {
         let mut expr = vec![0x44];
         expr.extend_from_slice(&bytes);
         expr.push(0x0B);
-        let result = evaluate_const_expr(&expr, &[]).unwrap();
+        let result = evaluate_const_expr(&expr, &[], &mut Vec::new()).unwrap();
         assert_eq!(result, WasmValue::F64(2.718281828));
     }
 
     #[test]
     fn test_const_expr_global_get_oob() {
         let expr = vec![0x23, 0x05, 0x0B]; // global.get 5
-        assert!(evaluate_const_expr(&expr, &[]).is_err());
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err());
     }
 
     #[test]
     fn test_const_expr_empty() {
         // Just end opcode
         let expr = vec![0x0B];
-        assert!(evaluate_const_expr(&expr, &[]).is_err()); // "empty constant expression"
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err()); // "empty constant expression"
     }
 
     #[test]
     fn test_const_expr_illegal_opcode() {
         let expr = vec![0x6A, 0x0B]; // i32.add is not allowed in const expr
-        assert!(evaluate_const_expr(&expr, &[]).is_err());
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err());
     }
 
     #[test]
     fn test_const_expr_missing_end() {
         let expr = vec![0x41, 0x2A]; // i32.const 42 without end
-        assert!(evaluate_const_expr(&expr, &[]).is_err());
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err());
     }
 
     #[test]
     fn test_const_expr_f32_truncated() {
         let expr = vec![0x43, 0x00, 0x00]; // f32.const but only 2 bytes
-        assert!(evaluate_const_expr(&expr, &[]).is_err());
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err());
     }
 
     #[test]
     fn test_const_expr_f64_truncated() {
         let expr = vec![0x44, 0x00, 0x00, 0x00]; // f64.const but only 3 bytes
-        assert!(evaluate_const_expr(&expr, &[]).is_err());
+        assert!(evaluate_const_expr(&expr, &[], &mut Vec::new()).is_err());
     }
 
     // ══════════════════════════════════════════════════════════════════════

--- a/code/packages/rust/wasm-runtime/CHANGELOG.md
+++ b/code/packages/rust/wasm-runtime/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.1] — 2026-08-15 (W15, task #79 — v128 persistent storage)
+
+### Fixed (breaking)
+
+- `WasmInstance` gains a `pub v128_heap: Vec<[u8; 16]>` field -- the
+  instance's own persistent v128 (SIMD) value storage, replacing the old
+  per-call-only `wasm_execution::WasmExecutionContext::v128_heap`. A
+  v128-typed global's `WasmValue::V128(handle)` used to go stale the
+  moment one `call`/`call_typed` invocation ended (the heap it indexed
+  into was thrown away and rebuilt fresh every call); it now survives
+  across separate invocations on the same instance, exactly like
+  `globals`/`memory`/`tables` already do. `instantiate()` builds this
+  field up directly (starting from the reserved all-zero entry) as it
+  evaluates global/data/element initializers, so a `v128.const` inside
+  one of those (previously a hard instantiation failure -- see the
+  companion `wasm-execution` 0.9.2 release) now allocates straight into
+  the instance's own long-lived heap.
+- `build_engine`/`call_engine`/`call_engine_with_v128` thread
+  `v128_heap` through the exact clone/restore shape `globals` already
+  uses (`build_engine` calls the new
+  `WasmExecutionEngine::set_v128_heap`; both `call_engine` variants
+  restore `instance.v128_heap = state.v128_heap` after the call,
+  unconditionally, matching the existing regardless-of-trap discipline
+  documented on `call_engine` itself).
+- This is a breaking change to `WasmInstance`'s public field list -- the
+  one hand-built test construction site in this crate's own integration
+  tests was updated in the same PR; per this repo's stated preference
+  (break compatibility freely, no back-compat shims), no deprecated
+  alias or default was added.
+
+See `code/specs/W15-wasm-v128-persistent-storage.md` for the full design
+and motivating corpus evidence.
+
 ## [0.6.0] — 2026-08-15 (SIMD PR1b-1 — call_typed_with_v128, real v128 results end to end)
 
 ### Added

--- a/code/packages/rust/wasm-runtime/Cargo.toml
+++ b/code/packages/rust/wasm-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-runtime"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-runtime"
 

--- a/code/packages/rust/wasm-runtime/src/lib.rs
+++ b/code/packages/rust/wasm-runtime/src/lib.rs
@@ -1100,6 +1100,16 @@ pub struct WasmInstance {
     pub host_functions: Vec<Option<Box<dyn HostFunction>>>,
     /// Export map: name -> (kind, index).
     pub exports: Vec<(String, ExternalKind, u32)>,
+    /// Persistent v128 (SIMD) value storage for this instance's whole
+    /// lifetime -- see `code/specs/W15-wasm-v128-persistent-storage.md`.
+    /// `WasmValue::V128(handle)` is an index into this `Vec`; without it
+    /// living here, a v128-typed global's handle would go stale the
+    /// moment one call ends (the old bug this field fixes). Index 0 is
+    /// permanently reserved as the all-zero entry, matching
+    /// `wasm_execution::WasmExecutionContext::v128_heap`'s own
+    /// convention. `build_engine`/`call_engine`/`call_engine_with_v128`
+    /// clone/restore it exactly like `globals`.
+    pub v128_heap: Vec<[u8; 16]>,
 }
 
 /// Build a link-error `TrapError` for a failed import (WASM05/W10) --
@@ -1276,17 +1286,26 @@ impl WasmRuntime {
             tables.push(Table::new(table_type.limits.min, table_type.limits.max));
         }
 
+        // The instance's persistent v128 heap (see `code/specs/
+        // W15-wasm-v128-persistent-storage.md`) -- built up here, during
+        // instantiation, so a `v128.const` in a global/data/elem
+        // initializer allocates directly into the SAME `Vec` this
+        // instance will keep for its whole lifetime, not a throwaway one.
+        // Index 0 reserved as the all-zero entry, matching
+        // `wasm_execution::WasmExecutionContext::v128_heap`'s convention.
+        let mut v128_heap: Vec<[u8; 16]> = vec![[0u8; 16]];
+
         // Initialize globals.
         for global in &module.globals {
             global_types.push(global.global_type.clone());
-            let value = evaluate_const_expr(&global.init_expr, &globals)?;
+            let value = evaluate_const_expr(&global.init_expr, &globals, &mut v128_heap)?;
             globals.push(value);
         }
 
         // Apply data segments.
         if let Some(ref mut mem) = memory {
             for seg in &module.data {
-                let offset = evaluate_const_expr(&seg.offset_expr, &globals)?;
+                let offset = evaluate_const_expr(&seg.offset_expr, &globals, &mut v128_heap)?;
                 let offset_num = offset.as_i32().map_err(|e| TrapError::new(e.message))? as usize;
                 mem.write_bytes(offset_num, &seg.data)?;
             }
@@ -1295,7 +1314,7 @@ impl WasmRuntime {
         // Apply element segments.
         for elem in &module.elements {
             if let Some(table) = tables.get_mut(elem.table_index as usize) {
-                let offset = evaluate_const_expr(&elem.offset_expr, &globals)?;
+                let offset = evaluate_const_expr(&elem.offset_expr, &globals, &mut v128_heap)?;
                 let offset_num = offset.as_i32().map_err(|e| TrapError::new(e.message))? as u32;
                 for (j, &func_idx) in elem.function_indices.iter().enumerate() {
                     table.set(offset_num + j as u32, Some(func_idx))?;
@@ -1320,6 +1339,7 @@ impl WasmRuntime {
             func_bodies,
             host_functions,
             exports,
+            v128_heap,
         };
 
         Ok(instance)
@@ -1505,6 +1525,14 @@ impl WasmRuntime {
         // site actually declared instead of skipping the check.
         engine.set_type_section(instance.module.types.clone());
 
+        // Thread the instance's persistent v128 heap into the engine (see
+        // `code/specs/W15-wasm-v128-persistent-storage.md`) -- same
+        // optional-setter pattern as `set_type_section`/
+        // `set_struct_field_counts` above, so a v128-typed global's
+        // handle stays valid across this call instead of indexing into a
+        // throwaway per-call heap.
+        engine.set_v128_heap(instance.v128_heap.clone());
+
         // Register the module's WasmGC struct field counts (LANG77 / McCarthy
         // L3b-3a-3c-2) so the engine knows how many fields each `struct.new`
         // allocates — without this, a `struct.new` traps with "no field count
@@ -1582,6 +1610,7 @@ impl WasmRuntime {
         instance.tables = state.tables;
         instance.globals = state.globals;
         instance.host_functions = state.host_functions;
+        instance.v128_heap = state.v128_heap;
 
         result
     }
@@ -1605,6 +1634,7 @@ impl WasmRuntime {
         instance.tables = state.tables;
         instance.globals = state.globals;
         instance.host_functions = state.host_functions;
+        instance.v128_heap = state.v128_heap;
 
         result
     }

--- a/code/packages/rust/wasm-runtime/tests/call_typed_with_v128.rs
+++ b/code/packages/rust/wasm-runtime/tests/call_typed_with_v128.rs
@@ -35,6 +35,7 @@ fn instance_with_v128_const(lanes: [i32; 4]) -> wasm_runtime::WasmInstance {
         func_bodies: vec![Some(FunctionBody { locals: vec![], code })],
         host_functions,
         exports: vec![("make_v128".to_string(), ExternalKind::Function, 0)],
+        v128_heap: vec![[0u8; 16]],
     }
 }
 

--- a/code/packages/rust/wasm-runtime/tests/v128_persistent_storage.rs
+++ b/code/packages/rust/wasm-runtime/tests/v128_persistent_storage.rs
@@ -1,0 +1,153 @@
+//! # v128 persistent storage across an instance's lifetime (W15, task #79)
+//!
+//! Direct regression tests for the two real bugs `code/specs/
+//! W15-wasm-v128-persistent-storage.md` fixes: a v128-typed global's
+//! handle used to go stale between separate `call_typed` invocations
+//! (`ctx.v128_heap` was rebuilt fresh every call), and `v128.const` inside
+//! a global initializer used to fail instantiation outright
+//! (`evaluate_const_expr` had no heap to allocate into).
+
+use wasm_execution::{V128Bytes, WasmValue};
+use wasm_runtime::WasmRuntime;
+use wasm_types::{
+    ExternalKind, Export, FuncType, FunctionBody, Global, GlobalType, ValueType, WasmModule,
+};
+
+/// A v128 literal's 16 raw little-endian bytes for four i32 lanes.
+fn v128_const_bytes(lanes: [i32; 4]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(16);
+    for lane in lanes {
+        bytes.extend_from_slice(&lane.to_le_bytes());
+    }
+    bytes
+}
+
+/// Real corpus case (task #78/#79): a module declaring
+/// `(global (mut v128) (v128.const ...))` used to fail to instantiate at
+/// all -- `evaluate_const_expr` had no `0xFD` arm and no heap to allocate
+/// a `v128.const` literal into. Confirms instantiation now succeeds AND
+/// the global's initial value round-trips exactly through a getter
+/// function.
+#[test]
+fn v128_global_initialized_via_v128_const_instantiates_and_reads_back_exact_bytes() {
+    let lanes = [11, 22, 33, 44];
+    let mut init_expr = vec![0xFD, 0x0C]; // v128.const
+    init_expr.extend(v128_const_bytes(lanes));
+    init_expr.push(0x0B); // end
+
+    let mut get_code = vec![0x23, 0x00]; // global.get 0
+    get_code.push(0x0B); // end
+
+    let module = WasmModule {
+        types: vec![FuncType { params: vec![], results: vec![ValueType::V128] }],
+        struct_types: vec![],
+        imports: vec![],
+        functions: vec![0],
+        tables: vec![],
+        memories: vec![],
+        globals: vec![Global {
+            global_type: GlobalType { value_type: ValueType::V128, mutable: true },
+            init_expr,
+        }],
+        exports: vec![Export { name: "get_g".to_string(), kind: ExternalKind::Function, index: 0 }],
+        start: None,
+        elements: vec![],
+        code: vec![FunctionBody { locals: vec![], code: get_code }],
+        data: vec![],
+        customs: vec![],
+    };
+
+    let runtime = WasmRuntime::new();
+    let mut instance = runtime.instantiate(&module).expect("module with v128.const global initializer must instantiate");
+
+    let (results, v128_bytes) = runtime
+        .call_typed_with_v128(&mut instance, "get_g", &[])
+        .expect("reading back the v128 global must succeed");
+
+    assert_eq!(results.len(), 1);
+    assert!(matches!(results[0], WasmValue::V128(_)));
+    let expected: [u8; 16] = v128_const_bytes(lanes).try_into().unwrap();
+    assert_eq!(v128_bytes[0], Some(V128Bytes(expected)));
+}
+
+/// The direct regression case for the storage-layer bug itself. Crucially,
+/// this must involve a v128 value ALLOCATED DURING one call and read back
+/// during a SEPARATE, later call -- a getter that only reads a value
+/// already present in the instance's post-`instantiate()` heap does NOT
+/// exercise the bug, because that heap entry was already correct from
+/// instantiation and never needed restoring. Here, `set_and_get` (call 1)
+/// pushes a brand-new `v128.const` entry into the per-call heap and
+/// stores its handle into the global; `get_g` (call 2, a SEPARATE
+/// `call_typed_with_v128` invocation) must see that same new entry.
+/// Before this fix, call 1's newly-pushed entry was thrown away the
+/// moment its `ctx.v128_heap` was dropped (never written back to
+/// `instance.v128_heap`), so call 2's fresh heap clone wouldn't contain
+/// it -- trapping with "v128 operand: heap handle out of range" (or, if
+/// the index happened to coincidentally exist from an unrelated earlier
+/// allocation, silently returning the WRONG bytes).
+#[test]
+fn v128_value_allocated_in_one_call_is_visible_in_a_later_separate_call() {
+    let init_lanes = [0, 0, 0, 0];
+    let new_lanes = [100, 200, 300, 400];
+
+    let mut init_expr = vec![0xFD, 0x0C];
+    init_expr.extend(v128_const_bytes(init_lanes));
+    init_expr.push(0x0B);
+
+    // set_and_get: v128.const <new_lanes>; global.set 0; global.get 0; end
+    let mut set_and_get_code = vec![0xFD, 0x0C];
+    set_and_get_code.extend(v128_const_bytes(new_lanes));
+    set_and_get_code.push(0x24); // global.set
+    set_and_get_code.push(0x00);
+    set_and_get_code.push(0x23); // global.get
+    set_and_get_code.push(0x00);
+    set_and_get_code.push(0x0B); // end
+
+    // get_g: global.get 0; end
+    let get_g_code = vec![0x23, 0x00, 0x0B];
+
+    let func_type = FuncType { params: vec![], results: vec![ValueType::V128] };
+    let module = WasmModule {
+        types: vec![func_type.clone(), func_type],
+        struct_types: vec![],
+        imports: vec![],
+        functions: vec![0, 1],
+        tables: vec![],
+        memories: vec![],
+        globals: vec![Global {
+            global_type: GlobalType { value_type: ValueType::V128, mutable: true },
+            init_expr,
+        }],
+        exports: vec![
+            Export { name: "set_and_get".to_string(), kind: ExternalKind::Function, index: 0 },
+            Export { name: "get_g".to_string(), kind: ExternalKind::Function, index: 1 },
+        ],
+        start: None,
+        elements: vec![],
+        code: vec![
+            FunctionBody { locals: vec![], code: set_and_get_code },
+            FunctionBody { locals: vec![], code: get_g_code },
+        ],
+        data: vec![],
+        customs: vec![],
+    };
+
+    let runtime = WasmRuntime::new();
+    let mut instance = runtime.instantiate(&module).unwrap();
+
+    let expected: [u8; 16] = v128_const_bytes(new_lanes).try_into().unwrap();
+
+    // Call 1: allocates the new v128 entry and stores its handle into the global.
+    let (_, v128_bytes1) = runtime
+        .call_typed_with_v128(&mut instance, "set_and_get", &[])
+        .expect("set_and_get must succeed");
+    assert_eq!(v128_bytes1[0], Some(V128Bytes(expected)), "set_and_get's own return must already be correct");
+
+    // Call 2: a SEPARATE invocation, reading the global's value back --
+    // must see the exact bytes allocated during call 1, not trap and not
+    // read a stale/wrong value.
+    let (_, v128_bytes2) = runtime
+        .call_typed_with_v128(&mut instance, "get_g", &[])
+        .expect("get_g must succeed and see the value call 1 allocated, not trap on a stale handle");
+    assert_eq!(v128_bytes2[0], Some(V128Bytes(expected)), "the value allocated in call 1 must survive into call 2");
+}


### PR DESCRIPTION
## Summary
Implements `code/specs/W15-wasm-v128-persistent-storage.md`. `v128` values were handles into `WasmExecutionContext::v128_heap`, a per-call `Vec` that reset on every `call_function` invocation:
- A v128-typed global's handle survived across calls (it rides the existing `globals` round-trip) but the heap slot it pointed into did not, so dereferencing it trapped.
- `evaluate_const_expr` had no heap parameter at all, so `v128.const` in a global initializer failed instantiation outright.

`WasmInstance` now owns a persistent `v128_heap`, threaded through the same clone/restore shape `globals` already uses across `build_engine`/`call_engine`/`call_engine_with_v128`, via a new optional `WasmExecutionEngine::set_v128_heap` setter (mirrors `set_struct_field_counts`/`set_type_section`, avoiding a mandatory `WasmEngineConfig` field that would have broken ~50 existing test construction sites). `evaluate_const_expr` takes a `&mut Vec<[u8;16]>` and gains a `0xFD`/`v128.const` arm; `instantiate()` threads the instance's own heap through its three call sites.

Also fixes `wasm-conformance`'s `Action::Get` (bare global read) to resolve a v128 handle against the now-persistent instance heap, which was blocked on exactly this storage gap.

## Verification
- [x] `cargo test -p wasm-execution -p wasm-runtime -p wasm-conformance` — 226/38/2 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean across all three crates
- [x] Two direct regression tests confirm a v128 value allocated in one call is visible in a separate, later call on the same instance (TEMP-REVERT-CHECK confirmed load-bearing)
- [x] `wasm-conformance` baseline regenerated: `simd_const.wast`'s `module` tally 308/309 (1 trap) → 309/309, zero regressions across the 61-file vendored corpus
- [x] `/security-review` — round 1 found the `v128_heap` write-back only ran on the success path (lost heap growth from a call that trapped); fixed to restore unconditionally, matching `wasm-runtime::call_engine`'s own established trap-safety discipline, with a new TEMP-REVERT-CHECK-verified regression test. Round 2 passed clean (one LOW/INFO note about per-call clone cost at a fully-grown heap, not blocking).

4 remaining `simd_const.wast` fails are a separate, pre-existing, already-documented gap (`v128.const` not yet supported as an `invoke` argument — logged as task #86), not fixed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)