### PR TITLE
fix(wasm-runtime): instantiate() requires a validated module (task #100)

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — wasm-conformance
 
+## 0.1.28 — 2026-08-16 — instantiate() call sites updated for ValidatedModule (task #100)
+
+### Changed
+
+- `wasm-runtime::WasmRuntime::instantiate()` now takes `&ValidatedModule`
+  instead of `&WasmModule` (see `wasm-runtime`'s own CHANGELOG). This
+  harness already called `validate()` before `instantiate()` -- it just
+  discarded the `ValidatedModule` and re-passed `&validated.module`, so
+  the fix is a one-line change per call site (`&validated` instead of
+  `&validated.module`). No behavioral change; full baseline regen
+  confirms byte-identical results.
+
 ## 0.1.27 — 2026-08-16 — vendor table_get.wast/table_set.wast; baseline regen (task #96)
 
 ### Changed

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/src/lib.rs
+++ b/code/packages/rust/wasm-conformance/src/lib.rs
@@ -280,7 +280,7 @@ impl Executor {
                     Err(e) => DirectiveOutcome::Fail(format!("module failed structural validation: {e}")),
                     Ok(validated) => {
                         let host = RegistryHost { registry: Rc::clone(&self.registry) };
-                        match WasmRuntime::with_host(Box::new(host)).instantiate(&validated.module) {
+                        match WasmRuntime::with_host(Box::new(host)).instantiate(&validated) {
                             Ok(instance) => {
                                 let instance = Rc::new(RefCell::new(instance));
                                 self.registry.borrow_mut().insert(None, Rc::clone(&instance));
@@ -489,7 +489,7 @@ impl Executor {
                 Err(_) => DirectiveOutcome::Pass,
                 Ok(validated) => {
                     let host = RegistryHost { registry: Rc::clone(&self.registry) };
-                    match WasmRuntime::with_host(Box::new(host)).instantiate(&validated.module) {
+                    match WasmRuntime::with_host(Box::new(host)).instantiate(&validated) {
                         Ok(_) => DirectiveOutcome::Fail("module linked successfully; expected unlinkable".to_string()),
                         Err(_) => DirectiveOutcome::Pass,
                     }

--- a/code/packages/rust/wasm-runtime/CHANGELOG.md
+++ b/code/packages/rust/wasm-runtime/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.6.3] — 2026-08-16 (task #100 — instantiate() requires a validated module)
+
+### Changed (breaking)
+
+- `WasmRuntime::instantiate()` now takes `&ValidatedModule` instead of
+  `&WasmModule`. This crate's own `ValidatedModule` doc comment always
+  documented the intent that "downstream code (the runtime) can accept
+  `ValidatedModule` instead of `WasmModule` to ensure validation is
+  never accidentally skipped", but `instantiate()` never actually
+  enforced it: it took a plain `&WasmModule` and never called
+  `validate()` itself, so every `validate()` check -- including the
+  memory/table allocation caps added for task #96's security review --
+  was silently bypassable by any caller who called `instantiate()`
+  directly instead of going through `WasmRuntime::validate()` first.
+  Callers now call `validate()` (or `load_and_run()`, fixed to actually
+  thread its own `validate()` result through instead of discarding it
+  and re-passing the raw module) and pass the resulting
+  `ValidatedModule` -- the guarantee is now a compile-time fact instead
+  of a caller convention.
+- Confined blast radius: outside this crate's own test suite, only
+  `wasm-conformance`'s harness calls `instantiate()`, and it already
+  called `validate()` first (it just threw away the `ValidatedModule`
+  and re-passed `&validated.module` -- trivially updated to pass
+  `&validated` instead). No other crate in the workspace calls
+  `instantiate()` directly.
+
+### Security
+
+- Found via `/security-review` as a follow-up to task #96's memory/
+  table allocation caps: those caps (and every other `validate()`
+  check) were bypassable by any embedder calling `instantiate()`
+  directly. Closed by making `ValidatedModule` the only way to reach
+  `instantiate()` at all.
+
 ## [0.6.2] — 2026-08-15 (W16, task #85 — multi-memory first slice)
 
 ### Changed (breaking)

--- a/code/packages/rust/wasm-runtime/CHANGELOG.md
+++ b/code/packages/rust/wasm-runtime/CHANGELOG.md
@@ -35,6 +35,15 @@ All notable changes to this package will be documented in this file.
   check) were bypassable by any embedder calling `instantiate()`
   directly. Closed by making `ValidatedModule` the only way to reach
   `instantiate()` at all.
+- A second `/security-review` round on this same diff found that
+  `instantiate(&ValidatedModule)` alone wasn't the compile-time
+  guarantee it claimed to be: `ValidatedModule.module` was still a
+  public field in `wasm-validator`, so any crate could construct one
+  directly with a struct literal, skipping `validate()` entirely. See
+  `wasm-validator`'s own CHANGELOG (0.2.9) for that companion fix --
+  this crate's `instantiate()` needed no further change, since it
+  already only reads through the (now-private) field via `wasm_
+  validator`'s public accessor.
 
 ## [0.6.2] — 2026-08-15 (W16, task #85 — multi-memory first slice)
 

--- a/code/packages/rust/wasm-runtime/Cargo.toml
+++ b/code/packages/rust/wasm-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-runtime"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-runtime"
 

--- a/code/packages/rust/wasm-runtime/src/lib.rs
+++ b/code/packages/rust/wasm-runtime/src/lib.rs
@@ -1208,7 +1208,7 @@ impl WasmRuntime {
     /// convention: call `WasmRuntime::validate()` first, matching the
     /// pattern `wasm-conformance`'s harness already used.
     pub fn instantiate(&self, validated: &ValidatedModule) -> Result<WasmInstance, TrapError> {
-        let module = &validated.module;
+        let module = validated.module();
         let mut func_types: Vec<FuncType> = Vec::new();
         let mut func_bodies: Vec<Option<FunctionBody>> = Vec::new();
         let mut host_functions: Vec<Option<Box<dyn HostFunction>>> = Vec::new();

--- a/code/packages/rust/wasm-runtime/src/lib.rs
+++ b/code/packages/rust/wasm-runtime/src/lib.rs
@@ -1193,7 +1193,22 @@ impl WasmRuntime {
     /// an unresolved memory/table/global silently fabricated a default
     /// value from the *declared* type instead of erroring. See
     /// `code/specs/W10-wasm-real-linking-and-unlinkable.md`.
-    pub fn instantiate(&self, module: &WasmModule) -> Result<WasmInstance, TrapError> {
+    ///
+    /// Takes a [`ValidatedModule`], not a raw [`WasmModule`] (task #100,
+    /// security review follow-up to task #96): this crate's own
+    /// `ValidatedModule` doc comment always documented the INTENT that
+    /// "downstream code (the runtime) can accept `ValidatedModule` instead
+    /// of `WasmModule` to ensure validation is never accidentally
+    /// skipped", but `instantiate` never actually enforced it -- it took a
+    /// plain `&WasmModule` and never called `validate()` itself, so every
+    /// `validate()` check (including the memory/table allocation caps
+    /// added for task #96) was silently bypassable by any caller who
+    /// called `instantiate()` directly. Requiring `&ValidatedModule` here
+    /// makes that guarantee a compile-time fact instead of a caller
+    /// convention: call `WasmRuntime::validate()` first, matching the
+    /// pattern `wasm-conformance`'s harness already used.
+    pub fn instantiate(&self, validated: &ValidatedModule) -> Result<WasmInstance, TrapError> {
+        let module = &validated.module;
         let mut func_types: Vec<FuncType> = Vec::new();
         let mut func_bodies: Vec<Option<FunctionBody>> = Vec::new();
         let mut host_functions: Vec<Option<Box<dyn HostFunction>>> = Vec::new();
@@ -1657,8 +1672,8 @@ impl WasmRuntime {
         args: &[i64],
     ) -> Result<Vec<i64>, String> {
         let module = self.load(wasm_bytes)?;
-        self.validate(&module).map_err(|e| format!("{}", e))?;
-        let mut instance = self.instantiate(&module).map_err(|e| format!("{}", e))?;
+        let validated = self.validate(&module).map_err(|e| format!("{}", e))?;
+        let mut instance = self.instantiate(&validated).map_err(|e| format!("{}", e))?;
         self.call(&mut instance, entry, args)
             .map_err(|e| format!("{}", e))
     }
@@ -1906,7 +1921,8 @@ mod tests {
         // arity wiring touches).
         let module = runtime.load(&wasm).expect("cons module must parse");
         assert_eq!(module.struct_types.len(), 1, "the $LispyPair struct is parsed");
-        let mut instance = runtime.instantiate(&module).expect("must instantiate");
+        let validated = runtime.validate(&module).unwrap();
+        let mut instance = runtime.instantiate(&validated).expect("must instantiate");
         let result = runtime
             .call(&mut instance, "main", &[])
             .expect("cons module must run");
@@ -1957,7 +1973,8 @@ mod tests {
 
         let module = runtime.load(&wasm).unwrap();
         let _validated = runtime.validate(&module).unwrap();
-        let mut instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let mut instance = runtime.instantiate(&validated).unwrap();
         let result = runtime.call(&mut instance, "square", &[7]).unwrap();
         assert_eq!(result, vec![49]);
     }
@@ -2025,7 +2042,8 @@ mod tests {
         let wasm = build_square_wasm();
         let runtime = WasmRuntime::new();
         let module = runtime.load(&wasm).unwrap();
-        let instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let instance = runtime.instantiate(&validated).unwrap();
 
         // Check that exports were populated
         assert!(!instance.exports.is_empty());
@@ -2154,7 +2172,8 @@ mod tests {
         };
 
         let runtime = WasmRuntime::new();
-        let mut instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let mut instance = runtime.instantiate(&validated).unwrap();
         let result = runtime.call(&mut instance, "get_global", &[]).unwrap();
         assert_eq!(result, vec![100]);
     }
@@ -2194,7 +2213,8 @@ mod tests {
         };
 
         let runtime = WasmRuntime::new();
-        let mut instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let mut instance = runtime.instantiate(&validated).unwrap();
         let result = runtime.call(&mut instance, "read", &[]).unwrap();
         assert_eq!(result, vec![42]);
     }
@@ -2290,7 +2310,8 @@ mod tests {
             ..Default::default()
         };
 
-        let mut instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let mut instance = runtime.instantiate(&validated).unwrap();
         let result = runtime.call(&mut instance, "call_double", &[5]).unwrap();
         assert_eq!(result, vec![10]);
     }
@@ -2356,7 +2377,8 @@ mod tests {
             "no_such_function",
             FuncType { params: vec![ValueType::I32], results: vec![ValueType::I32] },
         );
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("unknown import"), "{err}");
     }
 
@@ -2370,8 +2392,34 @@ mod tests {
             "double",
             FuncType { params: vec![ValueType::I64], results: vec![ValueType::I32] },
         );
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("incompatible import type"), "{err}");
+    }
+
+    /// Task #100 (security review follow-up to task #96): `instantiate()`
+    /// used to take a bare `&WasmModule`, so a caller who skipped
+    /// `validate()` could reach `Table::new`'s eager allocation with an
+    /// unvalidated, over-cap table size -- silently bypassing every
+    /// `validate()` check, including the memory/table allocation caps.
+    /// Now `instantiate()` requires a `&ValidatedModule`, so this is a
+    /// compile-time fact, not a caller convention: the only way to get a
+    /// `ValidatedModule` for this module is through `validate()`, and
+    /// `validate()` itself rejects it before `instantiate()` ever runs.
+    #[test]
+    fn instantiate_is_unreachable_for_a_module_that_fails_validation() {
+        let runtime = WasmRuntime::new();
+        let module = WasmModule {
+            tables: vec![TableType {
+                element_type: 0x70,
+                limits: Limits { min: wasm_execution::MAX_TABLE_ELEMENTS + 1, max: None },
+            }],
+            ..Default::default()
+        };
+        let err = runtime.validate(&module).unwrap_err();
+        assert!(matches!(err, ValidationError::Other(_)), "{err:?}");
+        // There is no `ValidatedModule` to hand `instantiate()` here --
+        // that absence, not a runtime check, is what protects it.
     }
 
     #[test]
@@ -2381,7 +2429,8 @@ mod tests {
         // actual import to resolve.
         let runtime = WasmRuntime::new();
         let module = WasmModule::default();
-        assert!(runtime.instantiate(&module).is_ok());
+        let validated = runtime.validate(&module).unwrap();
+        assert!(runtime.instantiate(&validated).is_ok());
     }
 
     #[test]
@@ -2396,7 +2445,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("unknown import"), "{err}");
     }
 
@@ -2414,7 +2464,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("incompatible import type"), "{err}");
     }
 
@@ -2430,7 +2481,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let instance = runtime.instantiate(&validated).unwrap();
         assert!(!instance.memories.is_empty());
     }
 
@@ -2446,7 +2498,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("unknown import"), "{err}");
     }
 
@@ -2462,7 +2515,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("incompatible import type"), "{err}");
     }
 
@@ -2478,7 +2532,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let instance = runtime.instantiate(&validated).unwrap();
         assert_eq!(instance.tables.len(), 1);
     }
 
@@ -2494,7 +2549,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("unknown import"), "{err}");
     }
 
@@ -2512,7 +2568,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = runtime.instantiate(&module).err().unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let err = runtime.instantiate(&validated).err().unwrap();
         assert!(err.to_string().contains("incompatible import type"), "{err}");
     }
 
@@ -2528,7 +2585,8 @@ mod tests {
             }],
             ..Default::default()
         };
-        let instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let instance = runtime.instantiate(&validated).unwrap();
         assert_eq!(instance.globals, vec![WasmValue::I32(42)]);
     }
 
@@ -2537,7 +2595,8 @@ mod tests {
         let wasm = build_square_wasm();
         let runtime = WasmRuntime::new();
         let module = runtime.load(&wasm).unwrap();
-        let instance = runtime.instantiate(&module).unwrap();
+        let validated = runtime.validate(&module).unwrap();
+        let instance = runtime.instantiate(&validated).unwrap();
 
         // No memory in square module
         assert!(instance.memories.is_empty());

--- a/code/packages/rust/wasm-runtime/tests/call_typed.rs
+++ b/code/packages/rust/wasm-runtime/tests/call_typed.rs
@@ -16,7 +16,8 @@ fn instantiate(wat: &str) -> (WasmRuntime, wasm_runtime::WasmInstance) {
     let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
     let runtime = WasmRuntime::new();
     runtime.validate(&module).expect("module should validate");
-    let instance = runtime.instantiate(&module).expect("module should instantiate");
+    let validated = runtime.validate(&module).unwrap();
+    let instance = runtime.instantiate(&validated).expect("module should instantiate");
     (runtime, instance)
 }
 

--- a/code/packages/rust/wasm-runtime/tests/v128_persistent_storage.rs
+++ b/code/packages/rust/wasm-runtime/tests/v128_persistent_storage.rs
@@ -58,7 +58,8 @@ fn v128_global_initialized_via_v128_const_instantiates_and_reads_back_exact_byte
     };
 
     let runtime = WasmRuntime::new();
-    let mut instance = runtime.instantiate(&module).expect("module with v128.const global initializer must instantiate");
+    let validated = runtime.validate(&module).unwrap();
+    let mut instance = runtime.instantiate(&validated).expect("module with v128.const global initializer must instantiate");
 
     let (results, v128_bytes) = runtime
         .call_typed_with_v128(&mut instance, "get_g", &[])
@@ -133,7 +134,8 @@ fn v128_value_allocated_in_one_call_is_visible_in_a_later_separate_call() {
     };
 
     let runtime = WasmRuntime::new();
-    let mut instance = runtime.instantiate(&module).unwrap();
+    let validated = runtime.validate(&module).unwrap();
+    let mut instance = runtime.instantiate(&validated).unwrap();
 
     let expected: [u8; 16] = v128_const_bytes(new_lanes).try_into().unwrap();
 

--- a/code/packages/rust/wasm-runtime/tests/wasm07_regression.rs
+++ b/code/packages/rust/wasm-runtime/tests/wasm07_regression.rs
@@ -23,7 +23,8 @@ fn instantiate(wat: &str) -> (WasmRuntime, wasm_runtime::WasmInstance) {
     let module = wasm_wast_parser::parse_module(wat).expect("module should parse");
     let runtime = WasmRuntime::new();
     runtime.validate(&module).expect("module should validate");
-    let instance = runtime.instantiate(&module).expect("module should instantiate");
+    let validated = runtime.validate(&module).unwrap();
+    let instance = runtime.instantiate(&validated).expect("module should instantiate");
     (runtime, instance)
 }
 

--- a/code/packages/rust/wasm-validator/CHANGELOG.md
+++ b/code/packages/rust/wasm-validator/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.9] - 2026-08-16 (task #100 — ValidatedModule.module made private)
+
+### Changed (breaking)
+
+- `ValidatedModule.module` is no longer a public field -- access it via
+  the new `ValidatedModule::module()` accessor instead.
+
+### Security
+
+- Found via `/security-review` on `wasm-runtime`'s task #100 fix (making
+  `instantiate()` require `&ValidatedModule` instead of `&WasmModule`,
+  so its validation checks can't be skipped): that fix offered no real
+  protection while `ValidatedModule.module` was a public field, since
+  any crate depending on `wasm-validator` could construct
+  `ValidatedModule { module: attacker_controlled }` directly with a
+  struct literal, skipping `validate()` (and its memory/table allocation
+  caps) entirely. Privatizing the field makes `validate()` succeeding
+  the only way to obtain a `ValidatedModule` at all.
+
 ## [0.2.8] - 2026-08-16 (task #96 — multi-table)
 
 ### Changed (breaking)

--- a/code/packages/rust/wasm-validator/Cargo.toml
+++ b/code/packages/rust/wasm-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-validator"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "WebAssembly 1.0 wasm-validator"
 

--- a/code/packages/rust/wasm-validator/src/lib.rs
+++ b/code/packages/rust/wasm-validator/src/lib.rs
@@ -102,10 +102,37 @@ impl std::error::Error for ValidationError {}
 /// type system guarantees that `validate()` was called and succeeded.
 /// Downstream code (the runtime) can accept `ValidatedModule` instead of
 /// `WasmModule` to ensure validation is never accidentally skipped.
+///
+/// The wrapped module is deliberately private (task #100, security
+/// review): an earlier version exposed it as `pub module: WasmModule`,
+/// which meant any crate depending on `wasm-validator` could construct
+/// `ValidatedModule { module: attacker_controlled }` directly with a
+/// struct literal, skipping `validate()` entirely and defeating the very
+/// guarantee this type exists to provide (e.g. `wasm-runtime::
+/// instantiate()` requiring `&ValidatedModule` -- see its own doc
+/// comment -- offered no real protection while this field was public).
+/// [`ValidatedModule::module`] is the only way to reach the wrapped
+/// value now; the only way to construct a `ValidatedModule` at all is
+/// [`validate`] succeeding. This is enforced by the compiler, not a
+/// convention -- the struct literal that used to be the bypass is now a
+/// compile error:
+///
+/// ```compile_fail
+/// use wasm_types::WasmModule;
+/// use wasm_validator::ValidatedModule;
+///
+/// let bypass = ValidatedModule { module: WasmModule::default() };
+/// ```
 #[derive(Debug, Clone)]
 pub struct ValidatedModule {
-    /// The underlying parsed module.
-    pub module: WasmModule,
+    module: WasmModule,
+}
+
+impl ValidatedModule {
+    /// The underlying parsed module, proven to have passed [`validate`].
+    pub fn module(&self) -> &WasmModule {
+        &self.module
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to task #96's security review (which added memory/table allocation caps in `wasm-validator`). This PR closes the gap that made those caps — and every other `validate()` check — bypassable in the first place.

- `WasmRuntime::instantiate()` took a plain `&WasmModule` and never called `validate()` internally, so any caller who called `instantiate()` directly (skipping `WasmRuntime::validate()`) got zero protection from the memory/table caps or any other structural check. This crate's own `ValidatedModule` doc comment always documented the *intent* that `instantiate()` should require a validated module — it just was never actually enforced.
- `instantiate()` now takes `&ValidatedModule` instead of `&WasmModule`. Also fixes `load_and_run()`, a convenience wrapper that already called `validate()` but discarded the result and re-passed the raw module to `instantiate()` — the exact bug hiding in the crate's own code.
- **Found via a second `/security-review` round on this same diff**: the fix above wasn't actually a compile-time guarantee, because `ValidatedModule.module` (in `wasm-validator`) was a **public field** — any crate could construct `ValidatedModule { module: attacker_controlled }` directly with a struct literal, skipping `validate()` entirely. Fixed by making the field private with a `ValidatedModule::module()` accessor. A new `#[compile_fail]` doctest proves the bypass literal no longer compiles; TEMP-REVERT-CHECK confirmed it's load-bearing.

Blast radius confirmed narrow before making the change: outside `wasm-runtime`'s own test suite (~30 call sites updated), only `wasm-conformance`'s harness calls `instantiate()`, and it already validated first (one-line fix per call site). No other crate in the workspace — including every WASM compiler crate (`twig-to-wasm`, `nib-wasm-compiler`, `brainfuck-wasm-compiler`, `ir-to-wasm-compiler`, `iir-to-wasm`, `lang-aot`) — calls `instantiate()` directly.

## Test plan

- [x] Every hand-built test module in `wasm-runtime`'s own suite already passed `validate()` — 0 newly-broken tests
- [x] `cargo test -p wasm-validator -p wasm-runtime -p wasm-conformance -p twig-to-wasm -p nib-wasm-compiler -p brainfuck-wasm-compiler -p ir-to-wasm-compiler -p iir-to-wasm` — all green
- [x] `cargo clippy --all-targets` across touched crates — clean
- [x] Full baseline regen — byte-identical conformance results (pure API-contract change, no interpreter behavior change)
- [x] One pre-existing, unrelated failure (`lang-aot`'s closures WASM lowering) confirmed present on a clean `origin/main` checkout before this diff — not touched by this work
- [x] New regression test (`instantiate_is_unreachable_for_a_module_that_fails_validation`) + new `compile_fail` doctest on `ValidatedModule`, both TEMP-REVERT-CHECK verified load-bearing
- [x] `/security-review` — PASSED after 3 rounds (HIGH+MEDIUM in prior PR → HIGH found → HIGH found and fixed → PASSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)