### PR TITLE
feat(hl-c208): the backlog is a function, and its head is script (HL15)

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,9 +5,69 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-12 (second pass), after the CEFR climb reached B2 and
-three measurements changed what the top of this list should be. See
-**Prioritization, 2026-08-12** below for the current order and the numbers behind it.
+**The order no longer lives in this file.** As of HL-C208 the queue is computed
+from the measured deficit — run `npm run plan` in
+`code/packages/typescript/human-language-data`, or see
+[`HL15`](../../specs/HL15-the-completion-plan.md) for why. This file remains the
+record of what was *learned*; it is no longer the record of what is *next*, because
+a hand-ordered list goes stale silently and in the flattering direction. The
+prioritization sections below are kept as history and are dated accordingly.
+
+## HL-C208 — the backlog is now a function; and the head of it is SCRIPT, not vocabulary
+
+The prioritization header on this file was three days stale on the day it was read:
+it ordered work against the frame HL-C183/HL-C184 had already replaced. Nobody was
+careless. That is what happens when the ordering lives in prose that nothing
+recomputes, while every number needed to derive it is computed on every run.
+
+So it is derived now (`completion-plan.ts`, `npm run plan`, spec HL15). Two things
+the first build of it got wrong are worth recording, because both looked right:
+
+**1. A flat sort by family produced a useless queue.** Level rank, then family
+priority, then cost — each key defensible, and the head came out as twenty-two
+consecutive `exam-inventory` items. Every track's research task ahead of every
+track's content, because all 22 tracks sit on the same rung and that family is
+priority 1. No language would have moved until all of them had moved on one axis.
+**Fixed by rotating across tracks**: each language contributes its single most
+important next action before any language contributes a second.
+
+**2. Lookahead outranked the floor.** `pre-A1` is not a CEFR level and no awarding
+body publishes an inventory for it, so a track at pre-A1 generates an inventory item
+for **A1** — the rung above. Family priority then put that ahead of the pre-A1
+content, which is exactly backwards: it is preparation for a climb that has not
+started. An inventory for a level the track has not reached now sorts last within
+that track, and jumps back to first the moment the track stands on that rung.
+
+### What the corrected queue actually says
+
+The head is **not** vocabulary. It is **script**, in fourteen of the first
+twenty-two slots:
+
+```
+459 glyphs shown but never taught, corpus-wide, across 16 non-Latin tracks
+756 lessons ask a reader to decode a glyph nobody taught them
+8 tracks teach NO letters at all
+```
+
+This was already in the report and had never been ordered against anything. It
+outranks the vocabulary grind for a reason that survives argument: it is the only
+family with a terminal state. Tamil has 247 glyphs and then it is done forever;
+vocabulary runs to 16,000 per track. A vocabulary tranche authored into an unclosed
+script is authored onto sand, because the reader cannot decode the word it teaches.
+The owner asked for gentle script introduction on 2026-08-17 independently, which
+agrees with the measurement rather than overriding it.
+
+### The size of the thing, stated plainly
+
+**~10,172 items to C2 across 22 tracks**, of which 89 are enumerable today. 9,995
+are vocabulary tranches, 131 are exam inventories, 46 are script tranches. The other
+four families are not projectable and are reported as `null` rather than as zero,
+because "cannot be projected" and "nothing left to do" are opposite facts.
+
+**1 of 132 exam inventories exists** (Spanish A1). Until a track's inventory is
+written, every number this repository reports for that track at that level is a
+proxy for something nobody is graded on — which is HL-C184's Phase 0 restated, now
+with the item queued per track instead of listed once and forgotten.
 
 ## HL-C207 — Hindi round two landed; Tamil and Malayalam are now the only tracks a round behind
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added - the completion plan is computed, not typed (HL15, HL-C208)
+
+- Add `completion-plan.ts`: the work queue is now a pure function of the measured deficit, built from the level gate, the script-closure report and the external exam inventories rather than from a hand-ordered list in `BACKLOG.md`.
+- Add `plan-cli.ts` and an `npm run plan` target, kept separate from `report` so picking up the next item does not mean reading 100 lines of diagnostics.
+- Add `listExamInventories`, which reads each inventory's own declared `language`/`level` rather than parsing the filename — the file for Spanish is `exam-inventory-es-a1.json`, so a filename-keyed queue would have reported Spanish's A1 target as missing and queued it to be written twice.
+- Order by three mechanical keys: level rank (the floor is universal), family priority, then furthest-behind-first — and ROTATE across tracks so every language moves once before any moves twice.
+- Extend the definition of done with two criteria the four-criterion gate did not carry: external exam-point coverage, and script closure.
+- Measured today: 22 tracks, 89 enumerable items, ~10,172 projected to C2; 459 glyphs shown but never taught corpus-wide; 1 of 132 exam inventories written.
+
+
 ### Changed - the continuity walk is no longer quadratic (HL-C205)
 
 - Index forward-reference candidates by their leading word-run, so each lesson is asked only about words its own text can reach instead of about every word its track teaches.

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -156,6 +156,45 @@ pre-A1, and it is the 44 the gate judges.
 **Zero of 22 tracks have attained even pre-A1.** That gap between the two numbers is
 what let "Spanish reaches A2" stand on fourteen present-tense lessons.
 
+### What to do next — the computed backlog (HL15)
+
+```bash
+npm run plan              # the ordered queue, text
+npm run plan -- --format json --head 5
+npm run plan -- --ceiling A1     # just the first rung
+```
+
+The gate above says what is *wrong*. This says what to *do* about it, and it is a
+pure function of the same measurements rather than a list somebody maintains:
+
+```text
+22 tracks, 0 done; 89 enumerable item(s) today, ~10,172 projected to C2
+
+    1. [pre-A1] script-closure — chinese
+       teach 7 chinese glyph(s) the track shows but never taught
+    2. [pre-A1] script-closure — japanese
+       teach 43 japanese glyph(s) the track shows but never taught
+    3. [pre-A1] vocabulary — latin
+       teaches 23 distinct headwords at or below pre-A1, against 300
+```
+
+Three ordering rules, all mechanical. **The floor is universal** — every pre-A1 item
+outranks every A1 item in any track, because a track that climbs while its floor is
+missing has built a cliff with upper-level lessons on top. **Family priority** then
+decides what a track's next action is: the external exam target first (you cannot
+climb a rung nobody has written down), then script closure, then vocabulary. And the
+queue **rotates across tracks**, furthest-behind first, so every language moves once
+before any language moves twice.
+
+Two corrections are baked in and worth knowing about, because both looked right:
+a flat sort produced a head of 22 consecutive research tasks and no content, and an
+inventory for a rung a track has not reached was outranking the floor it is standing
+on. See `code/specs/HL15-the-completion-plan.md` §4.
+
+Four of the seven families report `null` rather than a number in the projection.
+That means **not projectable** — reinforcement debt at B1 is a function of lessons
+nobody has written — which is a different fact from zero.
+
 ### Continuity — does the course have a memory of itself? (HL09)
 
 The ramp budgets measure how big each **step** is. This measures whether the steps

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -17,6 +17,7 @@
     "generate:progress": "node dist/track-progress-cli.js --write",
     "check:progress": "node dist/track-progress-cli.js --check",
     "report": "node dist/report-cli.js",
+    "plan": "node dist/plan-cli.js",
     "validate": "vitest run tests/integration.test.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/code/packages/typescript/human-language-data/src/completion-plan.ts
+++ b/code/packages/typescript/human-language-data/src/completion-plan.ts
@@ -1,0 +1,487 @@
+// ---------------------------------------------------------------------------
+// completion-plan.ts — the backlog, computed.
+//
+// WHY THIS MODULE EXISTS
+//
+// `BACKLOG.md` carried 148 hand-written entries and a prioritization header that
+// was three days stale the day it was read: it ordered the work against a frame
+// two later findings had already replaced. Nobody was careless. That is simply
+// what happens when the ordering lives in prose that nothing recomputes.
+//
+// Meanwhile every number needed to order the work is computed on every run.
+// `level-gate.ts` says which of four criteria each track fails and by how much.
+// `script-closure.ts` says exactly how many glyphs a track shows its reader and
+// never taught. `exam-inventory.ts` measures against an external published list.
+//
+// So the queue is derived rather than typed:
+//
+//     BACKLOG.md records what was LEARNED.  This module computes what is NEXT.
+//
+// It is the same argument `exam-inventory.ts` makes for probes over annotations,
+// one level up. An annotation goes stale silently and in the flattering
+// direction — and so does a hand-ordered backlog.
+//
+// WHAT IT IS NOT
+//
+// It is not a planner. It makes no estimate of effort in time, invents no
+// dependency graph, and never decides that a deficit is acceptable. It reads
+// measured shortfalls, groups them into tranches of a size that merged PRs have
+// actually sustained, and sorts. Everything interesting is in the sort, and the
+// sort is three mechanical keys with no judgement call at queue-build time.
+//
+// See `code/specs/HL15-the-completion-plan.md`.
+// ---------------------------------------------------------------------------
+import type { CefrLevel } from "./levels.js";
+import { CEFR_LEVELS, levelRank } from "./levels.js";
+import { LEVEL_VOCABULARY, type LevelGateReport } from "./level-gate.js";
+import type { ScriptClosureReport } from "./script-closure.js";
+
+/** The seven families of work. Every item belongs to exactly one. */
+export type WorkKind =
+  | "exam-inventory"
+  | "script-closure"
+  | "vocabulary"
+  | "exam-point"
+  | "reinforcement"
+  | "atom-budget"
+  | "spine-nodes";
+
+/**
+ * Sort key 2 — see HL15 §4.2. Lower goes first.
+ *
+ * The two entries worth defending:
+ *
+ * `exam-inventory` is 1 because until the external list exists, every other
+ * number for that level is a proxy for something nobody is graded on. It is also
+ * the cheapest family in the file: research and JSON, no content authoring.
+ *
+ * `script-closure` is 2 — ahead of the vocabulary grind — because it is the only
+ * family with a TERMINAL state. Tamil has 247 glyphs and then it is finished
+ * forever; vocabulary runs to 16,000 per track. Finite work that unblocks
+ * infinite work goes first, and a vocabulary tranche authored into an unclosed
+ * script is authored onto sand: the reader cannot decode the word it teaches.
+ */
+export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
+  "exam-inventory": 1,
+  "script-closure": 2,
+  vocabulary: 3,
+  "exam-point": 4,
+  reinforcement: 5,
+  "atom-budget": 6,
+  "spine-nodes": 7,
+});
+
+/**
+ * How much outstanding work one PR carries, per family.
+ *
+ * These are EMPIRICAL, not aesthetic. 35 headwords is the size HL-C198's six
+ * merged tranches actually sustained at one PR each — not a round number
+ * somebody liked. They live in one frozen constant so that a future measurement
+ * can move one of them and re-shape the whole queue without anybody editing a
+ * list of work items, which is the entire point of computing the queue.
+ */
+export const TRANCHE_SIZE: Readonly<Record<WorkKind, number>> = Object.freeze({
+  "exam-inventory": 1,
+  "script-closure": 10,
+  vocabulary: 35,
+  "exam-point": 5,
+  reinforcement: 25,
+  "atom-budget": 10,
+  "spine-nodes": 3,
+});
+
+/**
+ * CEFR levels an awarding body actually certifies.
+ *
+ * `pre-A1` is deliberately absent. `core/exam-levels.json` states plainly that
+ * pre-A1 is NOT a CEFR level — it is this curriculum's own label for the ramp
+ * below A1 — so no awarding body publishes an inventory for it, and queueing an
+ * `exam-inventory` item at pre-A1 would be queueing work that cannot be sourced.
+ * pre-A1 is measured against this project's own editorial floor instead, which
+ * `level-gate.ts` already applies.
+ */
+export const CERTIFIABLE_LEVELS: readonly CefrLevel[] = CEFR_LEVELS.filter((level) => level !== "pre-A1");
+
+/** One unit of pickup-able work. */
+export interface WorkItem {
+  /** Stable and derivable — the same corpus produces the same id on every run. */
+  id: string;
+  kind: WorkKind;
+  language: string;
+  /** The level this item serves. Sort key 1. */
+  level: CefrLevel;
+  /** What has to become true, in a sentence naming the measured number. */
+  goal: string;
+  /** Units still outstanding, in this family's own units. */
+  outstanding: number;
+  /** PRs this decomposes into at the family's tranche size. Sort key 3. */
+  tranches: number;
+}
+
+/** Work counted rather than listed, because listing it would be a lie. */
+export interface PlanProjection {
+  kind: WorkKind;
+  /** Items remaining to the ceiling, or `null` where the family is not projectable. */
+  items: number | null;
+  detail: string;
+}
+
+export interface CompletionPlan {
+  ceiling: CefrLevel;
+  /** The next items, fully enumerated and ready to pick up. */
+  head: WorkItem[];
+  /** Everything behind the head, counted per family. */
+  projection: PlanProjection[];
+  summary: {
+    tracks: number;
+    /** Tracks that have attained the ceiling and need nothing further. */
+    tracksDone: number;
+    itemsInHead: number;
+    /** Total enumerable items today, of which `head` is the first slice. */
+    itemsOutstanding: number;
+    /** Head plus projected tail — the honest size of the thing. */
+    projectedTotal: number | null;
+  };
+}
+
+/** A (track, level) pair that already has an external inventory on disk. */
+export interface InventoryPresence {
+  language: string;
+  level: CefrLevel;
+}
+
+export interface CompletionPlanInput {
+  levelGate: LevelGateReport;
+  scriptClosure: ScriptClosureReport;
+  /** Which external inventories exist. Absent ones become `exam-inventory` items. */
+  inventories: readonly InventoryPresence[];
+  /** How far the plan runs. Defaults to C2 — the whole ladder. */
+  ceiling?: CefrLevel;
+  /** How many items to enumerate. Defaults to 25. */
+  headSize?: number;
+}
+
+/** Ceil-divide, with the degenerate case that zero outstanding is zero tranches. */
+function tranchesFor(outstanding: number, kind: WorkKind): number {
+  if (outstanding <= 0) return 0;
+  return Math.ceil(outstanding / TRANCHE_SIZE[kind]);
+}
+
+/**
+ * The lowest certifiable level at or above `from` that has no inventory yet.
+ *
+ * Called with the level a track is IN PROGRESS at, so a track working pre-A1 is
+ * asked for its A1 inventory. That is deliberate: the target for the next rung
+ * has to be written down before the climb reaches it, or the climb is once again
+ * aimed at a number this repository invented. HL-C184's Phase 0 made exactly
+ * this point and it is the reason the item is ordered at the IN-PROGRESS level
+ * rather than at the level it describes.
+ */
+function nextMissingInventory(
+  language: string,
+  from: CefrLevel,
+  ceiling: CefrLevel,
+  have: ReadonlySet<string>,
+): CefrLevel | null {
+  for (const level of CERTIFIABLE_LEVELS) {
+    if (levelRank(level) < levelRank(from)) continue;
+    if (levelRank(level) > levelRank(ceiling)) break;
+    if (!have.has(`${language}/${level}`)) return level;
+  }
+  return null;
+}
+
+/**
+ * Build the ordered queue from measured deficits.
+ *
+ * Pure over report data — it never touches the filesystem — so a test can hand
+ * it a two-track fixture and assert on the ordering without building a corpus.
+ */
+export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan {
+  const ceiling = input.ceiling ?? "C2";
+  const headSize = input.headSize ?? 25;
+  const have = new Set(input.inventories.map((entry) => `${entry.language}/${entry.level}`));
+  const closureByLanguage = new Map(input.scriptClosure.tracks.map((track) => [track.language, track]));
+
+  // Items are collected PER TRACK and interleaved at the end, never pooled and
+  // sorted flat. The first version of this function pooled them, and the queue it
+  // produced was 21 consecutive `exam-inventory` items — every track's research
+  // task, ahead of every track's content. That is a correct reading of family
+  // priority and a useless work queue: no language moves until all of them have
+  // moved on one axis. See `interleave` below.
+  const byTrack = new Map<string, WorkItem[]>();
+  const items: WorkItem[] = [];
+  let tracksDone = 0;
+
+  for (const track of input.levelGate.tracks) {
+    // `inProgressAt` is null exactly when the ladder is complete. A track that
+    // has attained the ceiling needs nothing from this plan.
+    const level = track.inProgressAt;
+    if (level === null || levelRank(level) > levelRank(ceiling)) {
+      tracksDone += 1;
+      continue;
+    }
+    const mine: WorkItem[] = [];
+
+    // 1. The external target for the next certifiable rung, if it is not written.
+    const missing = nextMissingInventory(track.language, level, ceiling, have);
+    if (missing !== null) {
+      mine.push({
+        id: `exam-inventory/${track.language}/${missing}`,
+        kind: "exam-inventory",
+        language: track.language,
+        level,
+        goal:
+          `write the external ${missing} exam inventory for ${track.language}; ` +
+          `until it exists, every ${track.language} number at ${missing} is a proxy`,
+        outstanding: 1,
+        tranches: 1,
+      });
+    }
+
+    // 2. The script. `violations` is the symptom — lessons that ask for an
+    // untaught glyph — but the WORK is teaching the glyphs, so the outstanding
+    // count is `neverTaughtGlyphs`. Counting violations instead would make the
+    // queue shrink by deleting a lesson, which is not progress.
+    const closure = closureByLanguage.get(track.language);
+    if (closure && closure.neverTaughtGlyphs > 0) {
+      mine.push({
+        id: `script-closure/${track.language}`,
+        kind: "script-closure",
+        language: track.language,
+        level,
+        goal:
+          `teach ${closure.neverTaughtGlyphs} ${closure.script} glyph(s) the track shows but never taught ` +
+          `(${closure.violations} lesson(s) currently ask the reader to decode one)`,
+        outstanding: closure.neverTaughtGlyphs,
+        tranches: tranchesFor(closure.neverTaughtGlyphs, "script-closure"),
+      });
+    }
+
+    // 3..7. Whatever the level gate says is short, in its own units. The gate
+    // already scopes each criterion to at-or-below the level, which is the bug
+    // HL09 recorded and this module must not reintroduce by re-deriving them.
+    for (const blocker of track.blockers) {
+      const kind = blocker.criterion as WorkKind;
+      mine.push({
+        id: `${kind}/${track.language}/${level}`,
+        kind,
+        language: track.language,
+        level,
+        goal: blocker.detail,
+        outstanding: blocker.shortfall,
+        tranches: tranchesFor(blocker.shortfall, kind),
+      });
+    }
+
+    // WITHIN one track the order is the spec's first two keys: the lowest rung
+    // first, then family priority. This is the sequence a single language walks.
+    mine.sort(
+      (a, b) => levelRank(a.level) - levelRank(b.level) || effectivePriority(a) - effectivePriority(b),
+    );
+    byTrack.set(track.language, mine);
+    items.push(...mine);
+  }
+
+  return {
+    ceiling,
+    head: interleave(byTrack, input.levelGate).slice(0, headSize),
+    projection: project(input, ceiling, items),
+    summary: {
+      tracks: input.levelGate.tracks.length,
+      tracksDone,
+      itemsInHead: Math.min(headSize, items.length),
+      itemsOutstanding: items.length,
+      projectedTotal: projectedTotal(input, ceiling, items),
+    },
+  };
+}
+
+/**
+ * Family priority, adjusted for whether the item serves the rung the track is
+ * actually standing on.
+ *
+ * `exam-inventory` is family 1 because you cannot climb a rung whose target
+ * nobody has written down. That is true — for the rung you are ON. Every track
+ * in the corpus today sits at pre-A1, which `core/exam-levels.json` states
+ * plainly is NOT a CEFR level and which no awarding body publishes an inventory
+ * for, so the item those tracks generate is for A1: the rung ABOVE. That is
+ * lookahead, and the first build of this module let lookahead outrank the floor
+ * — producing a queue of twenty-two consecutive research PRs while eight tracks
+ * taught no letters at all and one held three words.
+ *
+ * So the demotion: an inventory for a level the track has not reached yet sorts
+ * LAST within that track. It is still queued, still counted in the projection,
+ * and it jumps straight back to family 1 the moment the track's in-progress
+ * level becomes the level the inventory describes. Writing the target down stays
+ * a precondition for the climb; it stops being a precondition for the floor.
+ */
+function effectivePriority(item: WorkItem): number {
+  if (item.kind === "exam-inventory" && !CERTIFIABLE_LEVELS.includes(item.level)) {
+    return KIND_PRIORITY["spine-nodes"] + 1;
+  }
+  return KIND_PRIORITY[item.kind];
+}
+
+/**
+ * Round-robin the per-track queues: every language moves once before any moves twice.
+ *
+ * WHY NOT A FLAT SORT
+ *
+ * The obvious implementation pools every item and sorts by (level, family,
+ * cost). It was written that way first, and against the real corpus it produced
+ * a head of twenty-one consecutive `exam-inventory` items — every track's
+ * research task ahead of every track's content, because all 22 tracks sit at the
+ * same rung and `exam-inventory` is family 1. Each of those items is correctly
+ * placed and the queue as a whole is useless: no language moves at all until all
+ * of them have moved on one axis, and the slowest tracks stay slowest.
+ *
+ * The owner's rule is the other one, and it is a rotation rather than a sort:
+ * *"Please move all languages forward... one loop iteration at a time."* So the
+ * queue takes each track's single most important next action, in track order,
+ * before it comes back for anybody's second. Family priority still decides what
+ * that action IS — it just no longer decides whose turn it is.
+ *
+ * TRACK ORDER IS FURTHEST-BEHIND-FIRST, which is the same rule the hand-run
+ * backlog was already following when it wrote "cheapest first: tamil 84,
+ * malayalam 84" and meant the two LOWEST counts. A track that is further from
+ * its target has more claim on the next slot than one that is nearly there,
+ * because the goal is a reader who can sit an exam in any of these languages —
+ * not a leaderboard.
+ */
+function interleave(byTrack: ReadonlyMap<string, readonly WorkItem[]>, gate: LevelGateReport): WorkItem[] {
+  const shortfall = new Map<string, number>();
+  const rung = new Map<string, number>();
+  for (const track of gate.tracks) {
+    const vocabulary = track.blockers.find((blocker) => blocker.criterion === "vocabulary");
+    shortfall.set(track.language, vocabulary?.shortfall ?? 0);
+    rung.set(track.language, track.inProgressAt === null ? Number.MAX_SAFE_INTEGER : levelRank(track.inProgressAt));
+  }
+
+  const order = [...byTrack.keys()].sort(
+    (a, b) =>
+      // Lowest rung first — the floor is universal (HL15 4.1).
+      (rung.get(a) ?? 0) - (rung.get(b) ?? 0) ||
+      // Then furthest behind on that rung.
+      (shortfall.get(b) ?? 0) - (shortfall.get(a) ?? 0) ||
+      a.localeCompare(b),
+  );
+
+  const out: WorkItem[] = [];
+  const deepest = Math.max(0, ...order.map((language) => byTrack.get(language)?.length ?? 0));
+  for (let slot = 0; slot < deepest; slot += 1) {
+    for (const language of order) {
+      const item = byTrack.get(language)?.[slot];
+      if (item) out.push(item);
+    }
+  }
+  return out;
+}
+
+/**
+ * The tail, counted per family.
+ *
+ * Only two families can honestly be projected to the ceiling. Vocabulary can,
+ * because `LEVEL_VOCABULARY` states the cumulative target at every level and the
+ * corpus states what a track holds today. Inventories can, because there are
+ * exactly 22 tracks times six certifiable levels and that product does not move.
+ *
+ * The other five cannot, and are reported as `null` rather than as a number.
+ * Reinforcement debt at B1 is a function of lessons nobody has written yet;
+ * quoting a figure for it would be inventing one. `null` here means NOT
+ * PROJECTABLE, which is a different fact from zero — the same distinction
+ * `level-gate.ts` had to learn between "not measured" and "attained nothing".
+ */
+function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly WorkItem[]): PlanProjection[] {
+  const target = LEVEL_VOCABULARY[ceiling];
+  let words = 0;
+  let tracksShort = 0;
+  for (const track of input.levelGate.tracks) {
+    const short = Math.max(0, target - track.vocabulary);
+    if (short > 0) tracksShort += 1;
+    words += short;
+  }
+  const vocabularyItems = Math.ceil(words / TRANCHE_SIZE.vocabulary);
+
+  const wanted = input.levelGate.tracks.length * CERTIFIABLE_LEVELS.filter((level) => levelRank(level) <= levelRank(ceiling)).length;
+  const inventoryItems = Math.max(0, wanted - input.inventories.length);
+
+  const glyphs = input.scriptClosure.tracks.reduce((sum, track) => sum + track.neverTaughtGlyphs, 0);
+
+  const counted = (kind: WorkKind) => items.filter((item) => item.kind === kind).length;
+
+  return [
+    {
+      kind: "vocabulary",
+      items: vocabularyItems,
+      detail:
+        `${words.toLocaleString()} headword(s) short of ${target.toLocaleString()} across ` +
+        `${tracksShort} track(s), at ${TRANCHE_SIZE.vocabulary} per tranche`,
+    },
+    {
+      kind: "exam-inventory",
+      items: inventoryItems,
+      detail: `${input.inventories.length} of ${wanted} (track x certifiable level) inventories written`,
+    },
+    {
+      kind: "script-closure",
+      items: Math.ceil(glyphs / TRANCHE_SIZE["script-closure"]),
+      detail: `${glyphs} glyph(s) shown but never taught, corpus-wide; finite and ends`,
+    },
+    {
+      kind: "exam-point",
+      items: null,
+      detail: "not projectable — depends on inventories not yet written",
+    },
+    {
+      kind: "reinforcement",
+      items: null,
+      detail: `not projectable — a function of lessons not yet authored (${counted("reinforcement")} open today)`,
+    },
+    {
+      kind: "atom-budget",
+      items: null,
+      detail: `not projectable — a regression signal, not a deficit (${counted("atom-budget")} open today)`,
+    },
+    {
+      kind: "spine-nodes",
+      items: null,
+      detail: `not projectable — depends on spine growth above B1 (${counted("spine-nodes")} open today)`,
+    },
+  ];
+}
+
+/** Head plus projectable tail, or `null` if nothing can be projected at all. */
+function projectedTotal(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly WorkItem[]): number | null {
+  const projectable = project(input, ceiling, items)
+    .map((entry) => entry.items)
+    .filter((count): count is number => count !== null);
+  if (projectable.length === 0) return null;
+  return projectable.reduce((sum, count) => sum + count, 0);
+}
+
+/** Render the plan for a terminal. */
+export function renderCompletionPlan(plan: CompletionPlan): string[] {
+  const lines: string[] = [];
+  lines.push(`Completion plan (HL15) — ceiling ${plan.ceiling}`);
+  lines.push("=".repeat(`Completion plan (HL15) — ceiling ${plan.ceiling}`.length));
+  lines.push(
+    `${plan.summary.tracks} tracks, ${plan.summary.tracksDone} done; ` +
+      `${plan.summary.itemsOutstanding} enumerable item(s) today, ` +
+      `~${plan.summary.projectedTotal?.toLocaleString() ?? "?"} projected to ${plan.ceiling}`,
+  );
+  lines.push("");
+  lines.push(`Next ${plan.summary.itemsInHead} item(s), in order:`);
+  plan.head.forEach((item, index) => {
+    lines.push(`  ${String(index + 1).padStart(3)}. [${item.level}] ${item.kind} — ${item.language}`);
+    lines.push(`       ${item.goal}`);
+    lines.push(`       ${item.outstanding} outstanding, ${item.tranches} tranche(s)`);
+  });
+  lines.push("");
+  lines.push("Projection to the ceiling, per family:");
+  for (const entry of plan.projection) {
+    const count = entry.items === null ? "     —" : String(entry.items).padStart(6);
+    lines.push(`  ${count}  ${entry.kind.padEnd(15)} ${entry.detail}`);
+  }
+  return lines;
+}

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -302,6 +302,20 @@ export {
 } from "./level-gate.js";
 export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";
+export { runCompletionPlan } from "./plan-cli.js";
+export {
+  buildCompletionPlan,
+  renderCompletionPlan,
+  CERTIFIABLE_LEVELS,
+  KIND_PRIORITY,
+  TRANCHE_SIZE,
+  type CompletionPlan,
+  type CompletionPlanInput,
+  type InventoryPresence,
+  type PlanProjection,
+  type WorkItem,
+  type WorkKind,
+} from "./completion-plan.js";
 export { generatedBookOutputs, runBookGeneration } from "./book-cli.js";
 export {
   FIGURE_CONFIG_PATH,

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -490,3 +490,35 @@ export function loadExamInventory(
   }
   return inventory;
 }
+
+/**
+ * Every external exam inventory that exists on disk, by its own declared fields.
+ *
+ * Deliberately NOT derived from the filename. `loadExamInventory` maps
+ * `spanish` to the code `es`, so the file is `exam-inventory-es-a1.json` while
+ * the track is `spanish` — and a queue keyed on the filename would therefore
+ * report Spanish's A1 inventory as missing and queue somebody to write it again.
+ * The file states `language` and `level` itself; that is the answer.
+ *
+ * A malformed file is SKIPPED rather than thrown on. This function answers
+ * "which targets are written down", and one unparseable file should not stop the
+ * whole plan from being computed — `loadExamInventory` is still the strict door
+ * that anything actually measuring coverage has to come through.
+ */
+export function listExamInventories(root = defaultCurriculumRoot()): { language: string; level: string }[] {
+  const directory = resolve(root, "core");
+  if (!existsSync(directory)) return [];
+  const found: { language: string; level: string }[] = [];
+  for (const file of readdirSync(directory).sort()) {
+    if (!file.startsWith("exam-inventory-") || !file.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(resolve(directory, file), "utf8")) as Partial<ExamInventory>;
+      if (typeof parsed.language === "string" && typeof parsed.level === "string") {
+        found.push({ language: parsed.language, level: parsed.level });
+      }
+    } catch {
+      // Skipped on purpose — see the note above.
+    }
+  }
+  return found;
+}

--- a/code/packages/typescript/human-language-data/src/plan-cli.ts
+++ b/code/packages/typescript/human-language-data/src/plan-cli.ts
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------
+// plan-cli.ts — print the computed work queue.
+//
+// `report-cli` answers "what is the state of the corpus". This answers the only
+// question that follows it: "what do I do next". They are deliberately separate
+// binaries — the report is long and diagnostic, and an agent picking up the next
+// item should not have to read 100 lines of modality tables to find it.
+//
+// See `code/specs/HL15-the-completion-plan.md`.
+// ---------------------------------------------------------------------------
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  defaultCurriculumRoot as defaultRoot,
+  listExamInventories,
+  loadChapterPolicy,
+  loadEverything,
+  loadTrackChapters,
+} from "./loader.js";
+import { policyTableWidth } from "./narration-cli.js";
+import { buildCurriculumGapReport } from "./report.js";
+import { buildCompletionPlan, renderCompletionPlan, type InventoryPresence } from "./completion-plan.js";
+import { CEFR_LEVELS, type CefrLevel } from "./levels.js";
+
+interface PlanOptions {
+  root?: string;
+  format: "json" | "text";
+  ceiling: CefrLevel;
+  headSize: number;
+}
+
+function parseOptions(args: string[]): PlanOptions {
+  const options: PlanOptions = { format: "text", ceiling: "C2", headSize: 25 };
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag !== "--root" && flag !== "--format" && flag !== "--ceiling" && flag !== "--head") {
+      throw new Error(`unknown argument '${flag}'`);
+    }
+    // A missing value and a value that is itself the next FLAG are the same
+    // typo. Without the second check `--root --format json` silently takes
+    // `--format` as the root and dies with an ENOENT stack trace instead of the
+    // clean exit-2 path every other parse error uses.
+    if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    if (flag === "--root") options.root = resolve(value);
+    else if (flag === "--format") {
+      if (value !== "json" && value !== "text") throw new Error("--format must be 'json' or 'text'");
+      options.format = value;
+    } else if (flag === "--ceiling") {
+      const level = CEFR_LEVELS.find((candidate) => candidate === value);
+      if (!level) throw new Error(`--ceiling must be one of ${CEFR_LEVELS.join(", ")}`);
+      options.ceiling = level;
+    } else {
+      // A head size of zero is legal and means "projection only". A negative or
+      // non-numeric one is a typo, and slicing on NaN would silently return an
+      // EMPTY head that looks exactly like "there is no work left".
+      const size = Number(value);
+      if (!Number.isInteger(size) || size < 0) throw new Error("--head must be a non-negative integer");
+      options.headSize = size;
+    }
+    index += 1;
+  }
+  return options;
+}
+
+export function runCompletionPlan(args = process.argv.slice(2)): number {
+  let options: PlanOptions;
+  try {
+    options = parseOptions(args);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
+
+  const { registry, lessons, books, curricula, spine } = loadEverything(options.root);
+  const report = buildCurriculumGapReport({
+    registry,
+    lessons,
+    books,
+    modality: { maxLinearisableTableColumns: policyTableWidth(options.root ?? defaultRoot()) },
+    trackChapters: loadTrackChapters(options.root),
+    chapterPolicy: loadChapterPolicy(options.root),
+    curricula,
+    spine,
+  });
+
+  // `levelGate` is OPTIONAL on `CurriculumGapReport`: it is `undefined` when its
+  // inputs were not supplied, which is a different fact from "every track
+  // passed". Refuse rather than plan against a missing section — an absent gate
+  // yields an EMPTY queue, and an empty queue reads exactly like victory. This
+  // is the same trap `report-cli` fell into when it silently omitted `levels`
+  // from every run for the life of that feature.
+  if (!report.levelGate) {
+    process.stderr.write("plan: the level gate did not run; cannot compute a queue\n");
+    return 2;
+  }
+
+  const inventories = listExamInventories(options.root).flatMap<InventoryPresence>((entry) => {
+    const level = CEFR_LEVELS.find((candidate) => candidate === entry.level);
+    return level ? [{ language: entry.language, level }] : [];
+  });
+
+  const plan = buildCompletionPlan({
+    levelGate: report.levelGate,
+    scriptClosure: report.scriptClosure,
+    inventories,
+    ceiling: options.ceiling,
+    headSize: options.headSize,
+  });
+
+  process.stdout.write(
+    options.format === "json" ? `${JSON.stringify(plan, null, 2)}\n` : `${renderCompletionPlan(plan).join("\n")}\n`,
+  );
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(runCompletionPlan());
+}

--- a/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
+++ b/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCompletionPlan,
+  CERTIFIABLE_LEVELS,
+  renderCompletionPlan,
+  type CompletionPlanInput,
+} from "../src/completion-plan.js";
+import { LEVEL_VOCABULARY, type LevelGateReport } from "../src/level-gate.js";
+import type { ScriptClosureReport, TrackClosure } from "../src/script-closure.js";
+import type { CefrLevel } from "../src/levels.js";
+
+// A two-track fixture is enough to pin every ordering rule, and it keeps these
+// tests off the corpus — which is the point of `buildCompletionPlan` being pure
+// over report data rather than reading the filesystem itself.
+function gate(
+  tracks: {
+    language: string;
+    inProgressAt: CefrLevel | null;
+    vocabulary?: number;
+    blockers?: LevelGateReport["tracks"][number]["blockers"];
+  }[],
+): LevelGateReport {
+  return {
+    vocabularyTargets: LEVEL_VOCABULARY,
+    tracks: tracks.map((track) => ({
+      language: track.language,
+      touches: null,
+      attained: null,
+      inProgressAt: track.inProgressAt,
+      blockers: track.blockers ?? [],
+      vocabulary: track.vocabulary ?? 0,
+    })),
+    summary: {
+      tracksOverstating: 0,
+      tracksWithAnyLevel: 0,
+      attainedByLevel: { "pre-A1": 0, A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 },
+    },
+  };
+}
+
+function closure(tracks: Partial<TrackClosure>[]): ScriptClosureReport {
+  return {
+    tracks: tracks.map((track) => ({
+      language: track.language ?? "x",
+      script: track.script ?? "devanagari",
+      lessonCount: 0,
+      scriptLessons: 0,
+      taughtGlyphs: 0,
+      shownGlyphs: 0,
+      neverTaughtGlyphs: track.neverTaughtGlyphs ?? 0,
+      violations: track.violations ?? 0,
+      exposureOnly: 0,
+      exposureExemptedGlyphs: 0,
+      headwordsWithoutRomanization: 0,
+    })),
+    violations: [],
+    unknownScriptTracks: [],
+    summary: {
+      tracksWithScript: tracks.length,
+      tracksTeachingNothing: 0,
+      violations: 0,
+      exposureOnly: 0,
+      exposureExemptedGlyphs: 0,
+      headwordsWithoutRomanization: 0,
+      tracksWithUnknownScript: 0,
+    },
+  };
+}
+
+const vocabularyBlocker = (short: number) =>
+  [{ criterion: "vocabulary" as const, detail: `teaches ${300 - short} against 300`, shortfall: short }];
+
+function plan(input: Partial<CompletionPlanInput> & Pick<CompletionPlanInput, "levelGate">) {
+  return buildCompletionPlan({
+    scriptClosure: closure([]),
+    inventories: [],
+    ...input,
+  });
+}
+
+describe("completion plan", () => {
+  it("moves every track once before any track moves twice", () => {
+    // Three tracks, each with two items. A flat sort by family would emit all
+    // three script items and only then the vocabulary ones; the rotation must
+    // emit one item per language first. This is the regression the round-robin
+    // exists for.
+    const built = plan({
+      levelGate: gate([
+        { language: "alpha", inProgressAt: "pre-A1", blockers: vocabularyBlocker(100) },
+        { language: "beta", inProgressAt: "pre-A1", blockers: vocabularyBlocker(200) },
+        { language: "gamma", inProgressAt: "pre-A1", blockers: vocabularyBlocker(150) },
+      ]),
+      scriptClosure: closure([
+        { language: "alpha", neverTaughtGlyphs: 10 },
+        { language: "beta", neverTaughtGlyphs: 10 },
+        { language: "gamma", neverTaughtGlyphs: 10 },
+      ]),
+    });
+    expect(built.head.slice(0, 3).map((item) => item.language)).toEqual(["beta", "gamma", "alpha"]);
+    expect(built.head.slice(0, 3).every((item) => item.kind === "script-closure")).toBe(true);
+    expect(built.head.slice(3, 6).map((item) => item.language)).toEqual(["beta", "gamma", "alpha"]);
+  });
+
+  it("orders tracks furthest-behind first", () => {
+    const built = plan({
+      levelGate: gate([
+        { language: "ahead", inProgressAt: "pre-A1", blockers: vocabularyBlocker(20) },
+        { language: "behind", inProgressAt: "pre-A1", blockers: vocabularyBlocker(280) },
+      ]),
+    });
+    expect(built.head.slice(0, 2).map((item) => item.language)).toEqual(["behind", "ahead"]);
+  });
+
+  it("puts a lower rung ahead of a higher one, in any track", () => {
+    const built = plan({
+      levelGate: gate([
+        { language: "climbing", inProgressAt: "A2", blockers: vocabularyBlocker(900) },
+        { language: "floor", inProgressAt: "pre-A1", blockers: vocabularyBlocker(10) },
+      ]),
+    });
+    expect(built.head[0]?.language).toBe("floor");
+  });
+
+  it("demotes an inventory for a rung the track has not reached", () => {
+    // pre-A1 is not certifiable, so this track's inventory item is for A1 —
+    // lookahead. It must sort behind the track's own floor work.
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1", blockers: vocabularyBlocker(250) }]),
+    });
+    expect(built.head.map((item) => item.kind)).toEqual(["vocabulary", "exam-inventory"]);
+  });
+
+  it("promotes the inventory to first once the track stands on that rung", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "A1", blockers: vocabularyBlocker(250) }]),
+    });
+    expect(built.head[0]?.kind).toBe("exam-inventory");
+    expect(built.head[0]?.id).toBe("exam-inventory/alpha/A1");
+  });
+
+  it("rolls past an inventory that already exists to the next unwritten one", () => {
+    // Spanish is the live case: it HAS an A1 inventory, so asking it for A1
+    // again would be busywork. The queue must name the next rung with no target
+    // written down, which is what keeps the climb always aimed at something
+    // external.
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "A1" }]),
+      inventories: [{ language: "alpha", level: "A1" }],
+    });
+    expect(built.head.map((item) => item.id)).toEqual(["exam-inventory/alpha/A2"]);
+  });
+
+  it("asks for no inventory once every level up to the ceiling is written", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "A1" }]),
+      inventories: CERTIFIABLE_LEVELS.map((level) => ({ language: "alpha", level })),
+    });
+    expect(built.head.filter((item) => item.kind === "exam-inventory")).toHaveLength(0);
+  });
+
+  it("counts a finished track as done and queues nothing for it", () => {
+    const built = plan({ levelGate: gate([{ language: "alpha", inProgressAt: null }]) });
+    expect(built.summary.tracksDone).toBe(1);
+    expect(built.head).toHaveLength(0);
+  });
+
+  it("measures script work in glyphs to teach, not in lessons that break", () => {
+    // Deleting the offending lessons would drop `violations` to zero without
+    // teaching anybody a letter. The outstanding count must be the glyphs.
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1" }]),
+      scriptClosure: closure([{ language: "alpha", neverTaughtGlyphs: 24, violations: 300 }]),
+    });
+    const item = built.head.find((entry) => entry.kind === "script-closure");
+    expect(item?.outstanding).toBe(24);
+    expect(item?.tranches).toBe(3);
+  });
+
+  it("respects the ceiling when projecting and when queueing", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "B2" }]),
+      ceiling: "A2",
+    });
+    expect(built.summary.tracksDone).toBe(1);
+    expect(built.ceiling).toBe("A2");
+  });
+
+  it("reports a non-projectable family as null rather than as zero", () => {
+    // "Not projectable" and "nothing left to do" are opposite facts. A zero here
+    // would read as the second.
+    const built = plan({ levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1" }]) });
+    const reinforcement = built.projection.find((entry) => entry.kind === "reinforcement");
+    expect(reinforcement?.items).toBeNull();
+  });
+
+  it("projects vocabulary against the ceiling's cumulative target", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1", vocabulary: 100 }]),
+      ceiling: "A1",
+    });
+    const vocabulary = built.projection.find((entry) => entry.kind === "vocabulary");
+    // 600 at A1, holding 100, at 35 a tranche.
+    expect(vocabulary?.items).toBe(Math.ceil(500 / 35));
+  });
+
+  it("excludes pre-A1 from the certifiable levels", () => {
+    expect(CERTIFIABLE_LEVELS).not.toContain("pre-A1");
+    expect(CERTIFIABLE_LEVELS).toHaveLength(6);
+  });
+
+  it("renders a head and a projection", () => {
+    const text = renderCompletionPlan(
+      plan({ levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1", blockers: vocabularyBlocker(250) }]) }),
+    ).join("\n");
+    expect(text).toContain("Completion plan (HL15)");
+    expect(text).toContain("alpha");
+    expect(text).toContain("Projection to the ceiling");
+  });
+});

--- a/code/specs/HL15-the-completion-plan.md
+++ b/code/specs/HL15-the-completion-plan.md
@@ -1,0 +1,180 @@
+# HL15 — The completion plan: a backlog that is a function, not a file
+
+**Status:** specification, 2026-08-17
+**Supersedes as the ordering authority:** the hand-maintained prioritization
+sections in `code/learning/human-languages/BACKLOG.md`, which stay as the
+narrative record of what was learned and why.
+
+**Goal (owner, restated 2026-08-12 and unchanged since):** *"The goal is not
+whether something touches some level. The goal is can someone pass that level of
+exam with just reading the book and slowly following its gentle ramp."*
+
+**Second goal (owner, 2026-08-17):** *"I want to also introduce the script as
+well for many of these languages in a very gentle way."* This is not a
+sub-clause of the first. A reader who cannot decode the writing system cannot
+sit a reading paper at all, and the script ramp is the one ramp in this project
+that is **finite and ends** — so it is ordered above the vocabulary grind rather
+than behind it. See §4.2.
+
+---
+
+## 1. Why this spec exists
+
+The backlog has 148 hand-written entries and a prioritization header that was
+already three days stale when it was read on 2026-08-17: it ordered work against
+a frame that HL-C183/HL-C184 had replaced. That is not a discipline failure. It
+is what happens when the ordering lives in prose that nothing recomputes.
+
+The corpus, meanwhile, already knows the answer. `level-gate.ts` measures every
+track against four criteria and reports the shortfall in each criterion's own
+units. `script-closure.ts` counts, per track, exactly how many glyphs a reader is
+asked to decode that no lesson taught. `exam-inventory.ts` measures coverage
+against an external, finite published list. Every number needed to order the work
+is computed on every run.
+
+So the backlog should be **derived from those numbers, not typed beside them**:
+
+> **The work queue is a pure function of the measured deficit.**
+> `BACKLOG.md` records what was *learned*. `plan-cli` computes what is *next*.
+
+This is the same argument `exam-inventory.ts` already makes for probes over
+annotations, one level up. An annotation goes stale silently and in the
+flattering direction. So does a hand-ordered backlog.
+
+## 2. What "done" means, per track
+
+A track is **done** when it has *attained* C2 under the HL09 §3.1 gate — all four
+criteria hold at C2 and at every level below it — **and** every exam point on the
+external inventory for each level is covered.
+
+The four criteria are already implemented (`level-gate.ts`); this spec adds the
+fifth requirement and the ordering over all five.
+
+| # | criterion | measured by | source of truth |
+|---|---|---|---|
+| 1 | every spine node at the level is realized | `level-gate.ts` | `core/spine.json` |
+| 2 | cumulative vocabulary target met | `level-gate.ts` | `LEVEL_VOCABULARY` |
+| 3 | no lesson over the new-atom budget | `ramp.ts` | HL14 |
+| 4 | every atom revisited at least twice | `continuity.ts` | HL09 §3.1 |
+| 5 | **every exam point covered** | `exam-inventory.ts` | the awarding body |
+| 6 | **script closure: no untaught glyph is load-bearing** | `script-closure.ts` | HL11 |
+
+Criteria 5 and 6 are the two this spec adds to the definition of done. Criterion 5
+is the only one that comes from outside this repository, which is why it is the
+one that settles the owner's question. Criterion 6 is the one the second goal
+names.
+
+**Nothing here measures a learner.** HL-C182's warning stands and is restated so
+it cannot be lost: a track that satisfies all six is a *corpus* claim. The honest
+test needs a human sitting a past paper, and that item is on the queue (§6).
+
+## 3. The item families
+
+Seven, and every one of them is enumerable from a report the package already
+produces. No work item is ever authored by hand; a *finding* is, and findings go
+in `BACKLOG.md`.
+
+| kind | one item is | outstanding is counted in | tranche |
+|---|---|---|---|
+| `exam-inventory` | write the external point list for one (track, level) | inventories | 1 |
+| `script-closure` | teach the glyphs one track shows but never taught | glyphs | 10 |
+| `vocabulary` | raise one track's headword count at one level | headwords | 35 |
+| `exam-point` | cover one named point from the inventory | points | 5 |
+| `reinforcement` | revisit atoms that appear once and never again | atoms | 25 |
+| `atom-budget` | split lessons that introduce more than the budget | lessons | 10 |
+| `spine-nodes` | realize the level's unrealized spine nodes | nodes | 3 |
+
+Tranche sizes are **empirical, not aesthetic**. 35 headwords is the size
+HL-C198's six merged tranches actually sustained at one PR each; 10 glyphs is a
+chapter's worth of drizzle under HL11. They are recorded in one constant so a
+future measurement can move them, and moving one re-shapes the queue without
+anybody editing a list.
+
+## 4. The ordering
+
+Three keys, applied in order. All three are mechanical; none is a judgement call
+made at queue-build time.
+
+### 4.1 Level rank first — the floor is universal
+
+Every pre-A1 item in every track outranks every A1 item in any track.
+
+This is the gentle ramp expressed as an ordering. A track that climbs to A2 while
+its pre-A1 vocabulary sits at 40% has not built a ramp, it has built a cliff with
+some A2 lessons on top — which is precisely the state HL-C183 found and named. All
+22 tracks are currently `inProgressAt: pre-A1`, so today this key sorts nothing.
+It exists to stop the next climb from starting early, and it will bind the moment
+one track clears the floor.
+
+### 4.2 Kind priority second
+
+```
+1. exam-inventory   you cannot aim at a target you have not written down
+2. script-closure   decoding is a precondition for reading, and it ENDS
+3. vocabulary       the dominant remaining mass
+4. exam-point       named gaps against the external list
+5. reinforcement    retention — what separates a corpus claim from a learner one
+6. atom-budget      a ramp that got steeper is a regression, not a backlog item
+7. spine-nodes      functional coverage, the coarsest of the six
+```
+
+**Why `exam-inventory` is first and cheapest.** Until the list exists, every other
+number for that (track, level) is a proxy for something nobody is graded on. It is
+also finite: 22 tracks × 6 CEFR levels = 132 inventories, of which **one** exists
+(Spanish A1). Research and JSON authoring, no content.
+
+**Why `script-closure` outranks `vocabulary`.** Two reasons, and the second is the
+one that decides it. First, the owner asked for it directly. Second, it is the only
+family with a **terminal state**: Tamil has 247 glyphs and then it is done forever,
+whereas vocabulary runs to 16,000 per track. Finite work that unblocks infinite work
+goes first. A reader who cannot decode a glyph cannot read a word built from it, so
+every vocabulary tranche authored into an unclosed script is authored onto sand.
+
+**Why `atom-budget` is near the bottom despite being cheap.** It is a *regression*
+signal, not a deficit. A lesson over budget means content already landed too steeply.
+HL-C167's rule applies — revert the content, do not re-seat the number — so these
+are handled where they are found rather than queued as fresh work.
+
+### 4.3 Cheapest first, then alphabetical
+
+Within one level and one kind, the track with the fewest outstanding tranches goes
+first, ties broken by language name so the queue is deterministic and two runs on
+one commit agree.
+
+Cheapest-first is also the owner's standing alternation rule expressed
+mechanically: it rotates work onto whichever track is furthest behind its
+siblings, so no track is left to rot, without anybody maintaining a rota.
+
+## 5. The size of the thing
+
+Enumerating every item to C2 would produce roughly **11,000 work items**, and a
+file holding them would be wrong within one merge. So `plan-cli` emits:
+
+- the **head** — the next N items, fully enumerated, ready to pick up; and
+- the **projection** — per family and per track, how many items remain to a
+  chosen ceiling, counted rather than listed.
+
+The projection is what makes the scale honest without pretending the tail is
+planned. At the corpus's measured density the tail is years of work, and §6 of
+HL-C184 already accepted that.
+
+**The enumeration rule is the artifact. The queue head is what you act on.**
+
+## 6. What this plan does not measure, recorded so it is not discovered late
+
+Carried forward from HL-C182 and HL-C184 Phase 3, unchanged:
+
+- **retention over time** — nothing here re-tests a reader a month later;
+- **production under time pressure** — an exam is timed and this corpus is not;
+- **listening at natural speed** — narration exists; natural-speed audio does not;
+- **the papers themselves** — 704 of 704 activities are one shape (`kind: "text"`),
+  and a candidate must clear reading, writing, listening and oral *independently*.
+
+The last one is a genuine gap in this spec's own criterion 5: an inventory covers
+what a candidate must *hold*, not the *shapes* they must perform. Criterion 5 will
+pass on a track that would still fail the paper. That is recorded here as a known
+limit and queued as its own family when the task-shape work (HL-C130) lands, rather
+than left to be rediscovered.
+
+**And the terminal item, which no report can close:** a human sits a real past
+paper. Until that happens, every claim in this file is about a corpus.


### PR DESCRIPTION
## What

The prioritization header on `BACKLOG.md` was three days stale the day it was read — it ordered work against a frame `HL-C183`/`HL-C184` had already replaced. That is what happens when the ordering lives in prose that nothing recomputes, while every number needed to derive it is computed on every run.

So this derives it. `completion-plan.ts` builds the work queue as a pure function of the measured deficit; `plan-cli.ts` prints it (`npm run plan`). `BACKLOG.md` stays as the record of what was **learned** — it is no longer the record of what is **next**.

Spec: [`HL15`](code/specs/HL15-the-completion-plan.md).

## Two things the first build got wrong

Both looked right, and both are recorded in the spec and the backlog so they are not relearned.

1. **A flat sort produced a useless queue.** `(level, family, cost)` — each key defensible — gave a head of **22 consecutive `exam-inventory` items**: every track's research task ahead of every track's content, because all 22 tracks sit on one rung and that family is priority 1. No language would have moved until all of them moved on one axis. Fixed by **rotating across tracks**: every language contributes its single most important next action before any contributes a second.

2. **Lookahead outranked the floor.** `pre-A1` is not a CEFR level and no awarding body publishes an inventory for it, so a pre-A1 track generates an item for **A1** — the rung above. Family priority put that ahead of the track's own pre-A1 content. An inventory for a rung a track has not reached now sorts last within that track, and returns to first the moment the track stands on it.

## What the corrected queue actually says

Not what the backlog assumed. The head is **script**, in 14 of the first 22 slots:

```
459 glyphs shown but never taught, across 16 non-Latin tracks
756 lessons ask a reader to decode a glyph nobody taught them
8 tracks teach NO letters at all
```

Script outranks the vocabulary grind because it is the only family with a **terminal state** — Tamil has 247 glyphs and is then done forever, while vocabulary runs to 16,000 per track. A vocabulary tranche authored into an unclosed script is authored onto sand: the reader cannot decode the word it teaches.

## Size of the thing

**~10,172 items to C2 across 22 tracks**, 89 enumerable today — 9,995 vocabulary tranches, 131 exam inventories, 46 script tranches. **1 of 132 exam inventories exists** (Spanish A1). Four of the seven families report `null` rather than a number, because *not projectable* and *nothing left to do* are opposite facts.

## Also

Extends the definition of done with two criteria the four-criterion gate could not see: coverage against the awarding body's own point list, and script closure.

`listExamInventories` reads each file's own declared `language`/`level` rather than parsing the filename — Spanish's file is `exam-inventory-es-a1.json`, so a filename-keyed queue would have reported its A1 target missing and queued it to be written twice.

## Verification

- 737 tests pass at **default timeouts, no flags** (14 new).
- `tsc` clean.
- Security review passed round one; it self-tested its own probes first and reported that its initial prototype-pollution instrument was broken before it rebuilt it. One cosmetic CLI finding fixed (`--root --format json` consumed a flag as a value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)