### PR TITLE
feat(hl-c221): the literal-markup gate — and an authoring comment found in a shipped book

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -13,6 +13,56 @@ record of what was *learned*; it is no longer the record of what is *next*, beca
 a hand-ordered list goes stale silently and in the flattering direction. The
 prioritization sections below are kept as history and are dated accordingly.
 
+## HL-C221 — the literal-markup gate is BUILT, and what it cost to justify
+
+HL-C217 specified it and logged it. HL-C219 then reintroduced the defect **one PR
+after fixing it** — two lessons in the very next tranche carried `&nbsp;` again,
+from a template that still had it, caught by hand only because somebody went
+looking. That is the whole argument: **a mistake that survives its own fix by one
+iteration will not be fixed by remembering harder.**
+
+Built as `literal-markup.ts`, blocking, 11 tests. `npm test` now fails on any
+HTML entity or bare HTML tag that would reach a reader.
+
+**Three design choices worth keeping:**
+
+1. **Two layers, two patterns.** The source scan finds `&nbsp;` in a `.md` and
+   names the file an author edits. The rendered scan finds `\&nbsp;` in the
+   generated `.tex` — a *different pattern*, because the escaper has been over it,
+   which is precisely why grepping the books for `&nbsp;` found nothing for three
+   releases.
+2. **Exemptions are load-bearing.** `<!-- hl-knowledge -->` IS the corpus's
+   directive syntax; code fences and inline spans are how a lesson (or this
+   backlog entry) *quotes* markup rather than emitting it. Without those three
+   exemptions the gate flags every lesson in the corpus and is switched off within
+   a day. Exempt spans are blanked, not deleted, so line numbers survive.
+3. **Blocking from commit one.** The corpus is clean at both layers today — 0
+   findings across 2,885 lessons and every generated book — so there is no
+   inherited debt for authors to route around. HL05's "report-only first" rule
+   exists for gates that start red; this one starts green.
+
+**Self-tested against a real planted defect, not fixtures.** `&nbsp;` was added to
+a committed Spanish lesson; the gate failed naming `ES-C01-hola:68 &nbsp;`; the
+file was restored and the gate went green. A fixture-only proof would not have
+shown that the corpus assertion is wired to the corpus.
+
+**The corpus assertion names its findings rather than counting them**, and a
+companion test plants one line into the real lesson set to pin that the same
+measurement still fires — so a clean run cannot be vacuous.
+
+### The class this belongs to, which is bigger than one gate
+
+Every other check in this package asks whether the output is **safe** or
+**reproducible**. `check:books` confirmed the byte-identical `\&nbsp;` on every
+run for three releases, faithfully reproducing the mistake. **Nothing asked
+whether the output was MEANINGFUL.**
+
+Other members of the same class, not yet covered and worth their own rows: a
+Markdown link whose text and target disagree, a `[YOU SAY: …]` stage direction
+with an empty payload, a table with a header and no rows, a cross-reference to a
+lesson that exists but teaches something else. All render perfectly and all say
+the wrong thing.
+
 ## HL-C220 — three Russian words were written with Latin letters, and the ъ ones are NOT the same class
 
 Surfaced by the security review of HL-C219 as an informational note, then swept

--- a/code/learning/human-languages/spanish/book/chapters/ch07-thank-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch07-thank-you.tex
@@ -101,8 +101,6 @@ Here's the thing English splits and Spanish doesn't. English has \textbf{\textqu
   \item as the \textbf{answer}. Someone asks you something — anything at all — and this one syllable declines it. You do not need to understand the question to answer it, which is exactly why this word comes early.
   \item and later, as the word that turns a sentence around — but that needs a sentence first, so it waits until you have one. For now: \emph{\textbf{no}} is how you decline, refuse, and disagree, which is most of what a beginner needs it for.
 \end{itemize}
-
-<!-- the negator sense is taught in ES-C06-hablo-espanol, the first lesson where the learner has a verb to put it in front of. Named by lesson id, never by chapter number: an earlier version of this comment gave a number, went stale across three renumbers, was \textquotedblleft{}fixed\textquotedblright{} with a fresh number, and went stale again two PRs later. Chapter numbers move; lesson ids do not. -->
 \end{culture}
 
 \subsection*{Your turn}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Added - the literal-markup gate (HL-C217, HL-C221)
+
+- Add `literal-markup.ts`: authoring markup that survives escaping into reader-facing text — HTML entities, numeric entities, and a closed list of bare HTML tags.
+- Checks **both layers**. The lesson source is where an author can act; the generated `.tex` is what the reader actually gets, and catches markup arriving from a template rather than a lesson.
+- The rendered pattern is separate from the source one on purpose: the escaper turns `&` into `\&`, so grepping the book for `&nbsp;` finds nothing. That is exactly how the defect stayed invisible through three merged releases.
+- Exempts the corpus's own `<!-- hl-knowledge -->` / `<!-- hl-activity -->` directives, fenced code blocks and inline code spans — a gate that flags every lesson, or every backlog entry describing the defect, gets switched off within a day. Exempt spans are blanked rather than deleted so reported line numbers stay true.
+- **Blocking from the first commit**, not report-only: the corpus is clean at both layers today (0 findings across 2,885 lessons and every generated book), so there is no inherited debt to route around.
+- Self-tested against a real planted defect, not just fixtures: `&nbsp;` added to a committed Spanish lesson, gate failed naming `ES-C01-hola:68 &nbsp;`, file restored, gate green.
+- The corpus assertion names its findings rather than counting them, and a companion test pins that the same measurement over the same corpus plus one planted line still fires — so a clean run cannot be vacuous.
+
+### Fixed - an authoring comment was typesetting into the shipped Spanish book (HL-C221)
+
+- `renderMarkdown` passed any non-directive `<!-- ... -->` straight into the book as body text. One had been printing inside a coloured culture box in `spanish/book/chapters/ch07-thank-you.tex` — a note from an author to future authors, in the reader's PDF.
+- `parse.ts` strips the `hl-knowledge` and `hl-activity` directives because it consumes them; everything else arrived at the renderer untouched. Comments are now stripped whole-string, so a multi-line one goes as a unit.
+- Found by the security review of the gate above, which observed that applying **Markdown** comment semantics to **LaTeX** output made the gate blind in exactly the place it exists to watch.
+
+### Fixed - four findings from the gate's own security review (HL-C221)
+
+- **Polynomial ReDoS.** `<\s*\/?\s*` split N whitespace characters between two `\s*` in O(N²) ways: measured **2,634 ms at N=64,000**, and reachable from ordinary Markdown because a long inline code span is blanked *into spaces*. Regrouping the slash gives **0 ms** at the same input. Timing harness self-tested against `/(a+)+b/` first.
+- **Exemptions no longer apply to the rendered layer.** In LaTeX `<!--` is not a comment and a backtick is an open quote; blanking on them hid 7,852 characters of the real corpus and let `\&nbsp;` be smuggled past inside a comment.
+- **`<!--` and `-->` are now themselves rendered-layer findings**, since either one reaching a `.tex` means an authoring comment reached the reader.
+- **Control characters are stripped from rendered findings.** `[^>]*` admits ESC, CR and BEL and the finding goes straight to a terminal; a finding must not be able to repaint the report that reports it.
+
+
+
 ### Fixed - a lesson id is validated at parse (HL-C211)
 
 - `lessonId` is interpolated RAW into `\label{lesson:<id>}` and into the `% canonical-lessons:` header of every generated `.tex` — the sibling of the `chapters.json` label hole closed in HL-C209, and found by the security review of the very next tranche.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **Polynomial ReDoS.** `<\s*\/?\s*` split N whitespace characters between two `\s*` in O(N²) ways: measured **2,634 ms at N=64,000**, and reachable from ordinary Markdown because a long inline code span is blanked *into spaces*. Regrouping the slash gives **0 ms** at the same input. Timing harness self-tested against `/(a+)+b/` first.
 - **Exemptions no longer apply to the rendered layer.** In LaTeX `<!--` is not a comment and a backtick is an open quote; blanking on them hid 7,852 characters of the real corpus and let `\&nbsp;` be smuggled past inside a comment.
 - **`<!--` and `-->` are now themselves rendered-layer findings**, since either one reaching a `.tex` means an authoring comment reached the reader.
+- **`stripHtmlComments` replaces the comment regex with a linear scan**, fixing three CodeQL high alerts at once: `js/polynomial-redos` (`<!--[\s\S]*?-->` rescanned to EOF from every unterminated opener — 76 ms at 32 KB, now 1 ms), `js/bad-tag-filter` (HTML also closes a comment with `--!>`, so one closed that way survived the strip), and `js/incomplete-multi-character-sanitization` (a single pass over a malformed comment could leave fragments that re-form). Consuming the whole span from `<!--` to its terminator means nothing can re-form; an unterminated comment runs to end-of-text, as a browser treats one.
 - **Control characters are stripped from rendered findings.** `[^>]*` admits ESC, CR and BEL and the finding goes straight to a terminal; a finding must not be able to repaint the report that reports it.
 
 

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -6,6 +6,7 @@ import type {
   ChapterCapability,
   CompiledLessonActivity,
 } from "./types.js";
+import { stripHtmlComments } from "./literal-markup.js";
 import type { ParsedLesson } from "./parse.js";
 import type { ChapterModality } from "./modality.js";
 
@@ -898,7 +899,7 @@ function renderMarkdown(
   // consumes them; everything else arrived here untouched. Stripping is done on
   // the whole string rather than per line so a comment spanning several lines --
   // which the live instance did -- goes as one unit.
-  markdown = markdown.replace(/<!--[\s\S]*?-->/g, "");
+  markdown = stripHtmlComments(markdown, "remove");
   const output: string[] = [];
   const paragraph: string[] = [];
   const quote: string[] = [];

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -889,6 +889,16 @@ function renderMarkdown(
   options?: InlineRenderOptionsInput,
   tableLayout: "grid" | "records" = "grid",
 ): string {
+  // An HTML comment is BY DEFINITION not reader-facing, and this renderer used
+  // to pass any non-directive one straight into the book as body text. One had
+  // been typesetting into the shipped Spanish PDF -- a note from an author to
+  // future authors, printed inside a coloured culture box for the reader.
+  //
+  // `parse.ts` strips the `hl-knowledge` and `hl-activity` directives because it
+  // consumes them; everything else arrived here untouched. Stripping is done on
+  // the whole string rather than per line so a comment spanning several lines --
+  // which the live instance did -- goes as one unit.
+  markdown = markdown.replace(/<!--[\s\S]*?-->/g, "");
   const output: string[] = [];
   const paragraph: string[] = [];
   const quote: string[] = [];

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -304,6 +304,12 @@ export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";
 export { runCompletionPlan } from "./plan-cli.js";
 export {
+  measureLiteralMarkup,
+  renderLiteralMarkup,
+  type LiteralMarkupFinding,
+  type LiteralMarkupReport,
+} from "./literal-markup.js";
+export {
   buildCompletionPlan,
   renderCompletionPlan,
   CERTIFIABLE_LEVELS,

--- a/code/packages/typescript/human-language-data/src/literal-markup.ts
+++ b/code/packages/typescript/human-language-data/src/literal-markup.ts
@@ -70,7 +70,10 @@ const SOURCE_MARKUP =
  * looks like HTML at all, and grepping the `.tex` for `&nbsp;` finds nothing.
  * That is precisely how it stayed invisible.
  */
-const RENDERED_MARKUP = /\\&(?:nbsp|amp|lt|gt|quot|apos|\#\d+|\#x[0-9A-Fa-f]+);|<!--|-->/g;
+// `--!>` closes an HTML comment as surely as `-->` does; CodeQL's js/bad-tag-filter
+// flags a filter that knows only one of them, and it is right — an authoring
+// comment ending `--!>` would have reached the reader unseen.
+const RENDERED_MARKUP = /\\&(?:nbsp|amp|lt|gt|quot|apos|\#\d+|\#x[0-9A-Fa-f]+);|<!--|--!?>/g;
 
 export interface LiteralMarkupFinding {
   /** Lesson id for a source finding, or the file path for a rendered one. */
@@ -107,10 +110,53 @@ export interface LiteralMarkupReport {
  * Replacing with spaces rather than deleting keeps every offset and newline, so
  * a reported line number still points at the right line.
  */
+/**
+ * Remove or blank every HTML comment, by a linear scan rather than a regex.
+ *
+ * `/<!--[\s\S]*?-->/g` looks obvious and has three defects, all of which CodeQL
+ * flagged and all of which are real:
+ *
+ *  - **It rescans to EOF from every unterminated `<!--`.** Quadratic: measured
+ *    0.48ms at 2KB of repeated `<!--` and 76ms at 32KB, a clean 4x per doubling.
+ *  - **It only knows `-->`.** HTML also ends a comment with `--!>`, so a comment
+ *    closed that way would survive the strip and reach the reader.
+ *  - **One pass can leave a fragment behind**, which is the incomplete-multi-
+ *    character-sanitization class: strip a well-formed comment out of a malformed
+ *    one and the leftovers can re-form.
+ *
+ * A scan fixes all three at once and is easier to read than the regex was.
+ * Consuming the WHOLE span from `<!--` to its terminator means nothing can
+ * re-form, and an unterminated comment runs to end-of-text, which is what a
+ * browser does with one.
+ */
+export function stripHtmlComments(text: string, mode: "remove" | "blank"): string {
+  let out = "";
+  let cursor = 0;
+  for (;;) {
+    const start = text.indexOf("<!--", cursor);
+    if (start === -1) {
+      out += text.slice(cursor);
+      return out;
+    }
+    out += text.slice(cursor, start);
+    const plain = text.indexOf("-->", start + 4);
+    const bang = text.indexOf("--!>", start + 4);
+    let end: number;
+    if (plain === -1 && bang === -1) end = text.length;
+    else if (bang === -1) end = plain + 3;
+    else if (plain === -1) end = bang + 4;
+    else end = plain < bang ? plain + 3 : bang + 4;
+    const span = text.slice(start, end);
+    // Blanking rather than deleting preserves offsets and newlines, so a
+    // reported line number still points at the right line.
+    out += mode === "blank" ? span.replace(/[^\n]/g, " ") : "";
+    cursor = end;
+  }
+}
+
 function blankExemptSpans(text: string): string {
   const blank = (match: string) => match.replace(/[^\n]/g, " ");
-  return text
-    .replace(/<!--[\s\S]*?-->/g, blank)
+  return stripHtmlComments(text, "blank")
     .replace(/```[\s\S]*?```/g, blank)
     .replace(/`[^`\n]*`/g, blank);
 }

--- a/code/packages/typescript/human-language-data/src/literal-markup.ts
+++ b/code/packages/typescript/human-language-data/src/literal-markup.ts
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------------
+// literal-markup.ts — authoring markup that reaches the reader as text.
+//
+// WHY THIS MODULE EXISTS
+//
+// Eight lessons across four tracks wrote `&nbsp;` to space out a display line.
+// `&nbsp;` is HTML. These lessons are Markdown, rendered to LaTeX, and the LaTeX
+// escaper does exactly its job on the ampersand:
+//
+//     \gu{હા} \&nbsp;\&nbsp; \gu{ના}
+//
+// A reader of the PDF sees the characters `&nbsp;` on the page. Three of the four
+// tracks were already merged, so it was live in three published books.
+//
+// EVERY EXISTING GATE MISSED IT, and the reason is the interesting part. It is
+// not a schema error, not an untaught glyph, not a LaTeX injection, not a font
+// gap, not a ramp violation. It is *correctly escaped text that should never have
+// been text*. `check:books` even confirms the byte-identical `\&nbsp;` on every
+// run, because the generator is faithfully reproducing the mistake.
+//
+// The whole suite checks that output is SAFE and REPRODUCIBLE. Nothing checked
+// that it was MEANINGFUL.
+//
+// WHY IT IS A GATE RATHER THAN A REPORT
+//
+// The defect recurred ONE PR after being fixed — two lessons in the very next
+// tranche had it again, from a template that still carried it. A mistake that
+// survives its own fix by one iteration is not going to be fixed by remembering
+// harder. The corpus is clean today (0 hits at both layers), so this can block
+// from the first commit rather than start as inherited debt.
+//
+// BOTH LAYERS ARE CHECKED, and they catch different things:
+//
+//   - the LESSON SOURCE is where an author can act. `&nbsp;` in a `.md` names
+//     the file to edit.
+//   - the GENERATED .tex is what the reader actually gets. It catches markup
+//     that arrives from a template or a generator change rather than from a
+//     lesson, which the source scan cannot see.
+//
+// See BACKLOG HL-C217.
+// ---------------------------------------------------------------------------
+import type { ParsedLesson } from "./parse.js";
+
+/**
+ * HTML entities and bare HTML tags in Markdown meant for a LaTeX renderer.
+ *
+ * `&#\d+;` and `&#x…;` are included because a numeric entity is the same mistake
+ * wearing a different hat, and an author who reaches for `&#160;` is even less
+ * likely to check the rendered page than one who writes `&nbsp;`.
+ *
+ * The tag list is deliberately short and closed. Matching `<[a-z]+>` generally
+ * would flag `<PAUSE 2s>`-style stage directions, arrows in prose, and every
+ * `a < b` in a grammar explanation — a gate that cries wolf gets suppressed, and
+ * then it catches nothing.
+ */
+// `<\s*\/?\s*` looks harmless and is quadratic: with the `\/?` matching empty,
+// N whitespace characters can be split between the two `\s*` in O(N^2) ways, all
+// of them tried before the tag list fails. Measured 2.6ms at N=2000 and 2,480ms
+// at N=64,000, a clean 4x per doubling — and reachable from ordinary Markdown,
+// because `blankExemptSpans` rewrites a long inline code span INTO spaces.
+// Grouping the slash with its own `\s*` removes the ambiguity: 0.12ms at N=64,000.
+const SOURCE_MARKUP =
+  /&(?:nbsp|amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);|<\s*(?:\/\s*)?(?:br|p|div|span|hr|table|tr|td|th|ul|ol|li|strong|em)\b[^>]*>/gi;
+
+/**
+ * The same mistake after the LaTeX escaper has been over it.
+ *
+ * The escaper turns `&` into `\&`, which is why this is a separate pattern
+ * rather than the same one: by the time it reaches the book the text no longer
+ * looks like HTML at all, and grepping the `.tex` for `&nbsp;` finds nothing.
+ * That is precisely how it stayed invisible.
+ */
+const RENDERED_MARKUP = /\\&(?:nbsp|amp|lt|gt|quot|apos|\#\d+|\#x[0-9A-Fa-f]+);|<!--|-->/g;
+
+export interface LiteralMarkupFinding {
+  /** Lesson id for a source finding, or the file path for a rendered one. */
+  where: string;
+  language: string;
+  /** 1-indexed line within the lesson body or the file. */
+  line: number;
+  /** The offending text, verbatim. */
+  markup: string;
+  layer: "source" | "rendered";
+}
+
+export interface LiteralMarkupReport {
+  findings: LiteralMarkupFinding[];
+  summary: {
+    lessonsScanned: number;
+    sourceFindings: number;
+    renderedFindings: number;
+  };
+}
+
+/**
+ * Blank out the spans where this markup is legitimate, preserving line numbers.
+ *
+ * Three exemptions, and each one is load-bearing:
+ *
+ *  - **HTML comments.** `<!-- hl-knowledge: … -->` and `<!-- hl-activity: … -->`
+ *    ARE the directive syntax. Flagging them would flag every lesson in the
+ *    corpus.
+ *  - **Fenced code blocks** and **inline code spans.** A lesson explaining an
+ *    entity, or showing a snippet, is quoting rather than emitting — and this
+ *    module's own backlog entry does exactly that.
+ *
+ * Replacing with spaces rather than deleting keeps every offset and newline, so
+ * a reported line number still points at the right line.
+ */
+function blankExemptSpans(text: string): string {
+  const blank = (match: string) => match.replace(/[^\n]/g, " ");
+  return text
+    .replace(/<!--[\s\S]*?-->/g, blank)
+    .replace(/```[\s\S]*?```/g, blank)
+    .replace(/`[^`\n]*`/g, blank);
+}
+
+function scan(text: string, pattern: RegExp, exempt: boolean): { line: number; markup: string }[] {
+  const out: { line: number; markup: string }[] = [];
+  // The exemptions are MARKDOWN semantics and must only be applied to Markdown.
+  // In LaTeX none of the three is a comment: `%` is. Applying them to generated
+  // output made the gate blind in exactly the place it exists to watch — an
+  // authoring comment that reaches the reader is invisible to a scanner that
+  // treats `<!-- -->` as a comment, and `\&nbsp;` smuggled inside one scored
+  // zero findings while the same string outside scored one. Backticks are the
+  // same mistake: in LaTeX a backtick is an open quote, and blanking on it hid
+  // 7,852 characters of the real corpus.
+  const lines = (exempt ? blankExemptSpans(text) : text).split("\n");
+  lines.forEach((line, index) => {
+    // A fresh lastIndex per line: these are /g regexes and a shared one would
+    // skip every other match on a line holding two.
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(line)) !== null) {
+      out.push({ line: index + 1, markup: match[0] });
+      if (match.index === pattern.lastIndex) pattern.lastIndex += 1;
+    }
+  });
+  return out;
+}
+
+/** Scan lesson sources. */
+export function measureLiteralMarkup(
+  lessons: readonly ParsedLesson[],
+  renderedFiles: readonly { path: string; language: string; text: string }[] = [],
+): LiteralMarkupReport {
+  const findings: LiteralMarkupFinding[] = [];
+
+  for (const lesson of lessons) {
+    for (const hit of scan(lesson.body, SOURCE_MARKUP, true)) {
+      findings.push({
+        where: lesson.realization.lessonId,
+        language: lesson.language,
+        line: hit.line,
+        markup: hit.markup,
+        layer: "source",
+      });
+    }
+  }
+
+  for (const file of renderedFiles) {
+    for (const hit of scan(file.text, RENDERED_MARKUP, false)) {
+      findings.push({
+        where: file.path,
+        language: file.language,
+        line: hit.line,
+        markup: hit.markup,
+        layer: "rendered",
+      });
+    }
+  }
+
+  findings.sort(
+    (a, b) => a.language.localeCompare(b.language) || a.where.localeCompare(b.where) || a.line - b.line,
+  );
+
+  return {
+    findings,
+    summary: {
+      lessonsScanned: lessons.length,
+      sourceFindings: findings.filter((f) => f.layer === "source").length,
+      renderedFindings: findings.filter((f) => f.layer === "rendered").length,
+    },
+  };
+}
+
+/** Render for a terminal. */
+export function renderLiteralMarkup(report: LiteralMarkupReport): string[] {
+  const { sourceFindings, renderedFindings, lessonsScanned } = report.summary;
+  if (sourceFindings + renderedFindings === 0) {
+    return [`literal markup: none in ${lessonsScanned} lessons or any generated book`];
+  }
+  const lines = [
+    `literal markup: ${sourceFindings} in lesson sources, ${renderedFindings} in generated books ` +
+      `-- authoring markup that reaches the reader as text`,
+  ];
+  for (const finding of report.findings.slice(0, 25)) {
+    // `[^>]*` admits ESC, CR and BEL, and this string goes straight to a
+    // terminal. A finding must not be able to repaint the report that reports it.
+    const safe = finding.markup.replace(/[\u0000-\u001f\u007f]/g, "?");
+    lines.push(`  ${finding.layer.padEnd(8)} ${finding.where}:${finding.line}  ${safe}`);
+  }
+  if (report.findings.length > 25) lines.push(`  ... and ${report.findings.length - 25} more`);
+  return lines;
+}

--- a/code/packages/typescript/human-language-data/src/report-cli.ts
+++ b/code/packages/typescript/human-language-data/src/report-cli.ts
@@ -16,6 +16,7 @@ import { cellCoverage, renderCellCoverage } from "./grammar-cells.js";
 import { buildRootLedger, renderRootLedger } from "./root-ledger.js";
 import { measureInfoDump, renderInfoDump } from "./info-dump.js";
 import { measureMetalanguage, renderMetalanguage } from "./metalanguage.js";
+import { measureLiteralMarkup, renderLiteralMarkup } from "./literal-markup.js";
 
 interface ReportOptions {
   root?: string;
@@ -96,8 +97,15 @@ export function runCurriculumGapReport(args = process.argv.slice(2)): number {
   // singular present indicative" has spent six technical terms on one form.
   const metalanguage = measureMetalanguage(lessons, loadMetalanguage(options.root));
 
+  // HL-C217. Authoring markup that survived escaping into reader-facing text --
+  // the one class the rest of this suite cannot see, because the output is both
+  // safe and reproducible and simply says the wrong thing. Source layer only
+  // here; the rendered layer is checked in the test suite, which already has the
+  // generator's output in hand and does not need the report to rebuild it.
+  const literalMarkup = measureLiteralMarkup(lessons);
+
   const json = `${JSON.stringify(
-    { ...report, strands, grammarCells: cells, rootLedger: rootLedger.summary, infoDump: infoDump.summary, metalanguage: metalanguage.summary },
+    { ...report, strands, grammarCells: cells, rootLedger: rootLedger.summary, infoDump: infoDump.summary, metalanguage: metalanguage.summary, literalMarkup: literalMarkup.summary },
     null,
     2,
   )}\n`;
@@ -112,6 +120,7 @@ export function runCurriculumGapReport(args = process.argv.slice(2)): number {
     renderInfoDump(infoDump).join("\n"),
     "",
     renderMetalanguage(metalanguage).join("\n"),
+    renderLiteralMarkup(literalMarkup).join("\n"),
     "",
   ].join("\n");
   process.stdout.write(options.format === "json" ? json : text);

--- a/code/packages/typescript/human-language-data/tests/literal-markup.test.ts
+++ b/code/packages/typescript/human-language-data/tests/literal-markup.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { measureLiteralMarkup, renderLiteralMarkup } from "../src/literal-markup.js";
+import { parseLesson } from "../src/parse.js";
+import { loadEverything } from "../src/loader.js";
+import { generatedBookOutputs } from "../src/book-cli.js";
+
+const lesson = (body: string) =>
+  parseLesson(
+    [
+      "---",
+      "schema_version: 2",
+      "id: ES-C01-hola",
+      "chapter: 1",
+      "type: word",
+      "headword: hola",
+      "gloss: hello",
+      "concept_tag: GREETING-HELLO",
+      "---",
+      "",
+      body,
+    ].join("\n"),
+    "spanish",
+  );
+
+describe("literal markup", () => {
+  it("catches the exact defect that shipped to three books", () => {
+    const report = measureLiteralMarkup([lesson("> **હા** &nbsp;&nbsp; **ના**")]);
+    expect(report.summary.sourceFindings).toBe(2);
+    expect(report.findings[0]!.markup).toBe("&nbsp;");
+    expect(report.findings[0]!.where).toBe("ES-C01-hola");
+  });
+
+  it("catches the same mistake after the LaTeX escaper has been over it", () => {
+    // By the time it reaches the book it no longer looks like HTML, which is
+    // exactly how it stayed invisible: grepping the .tex for `&nbsp;` finds
+    // nothing, because the escaper turned the ampersand into `\&`.
+    const report = measureLiteralMarkup(
+      [],
+      [{ path: "gujarati/book/chapters/ch13.tex", language: "gujarati", text: "\\gu{હા} \\&nbsp; \\gu{ના}" }],
+    );
+    expect(report.summary.renderedFindings).toBe(1);
+    expect(report.findings[0]!.layer).toBe("rendered");
+  });
+
+  it("catches numeric entities, which are the same mistake in a different hat", () => {
+    const report = measureLiteralMarkup([lesson("a &#160; b &#xA0; c")]);
+    expect(report.summary.sourceFindings).toBe(2);
+  });
+
+  it("catches bare HTML tags", () => {
+    const report = measureLiteralMarkup([lesson("one<br>two<br />three")]);
+    expect(report.summary.sourceFindings).toBe(2);
+  });
+
+  it("does NOT flag the directive comments, which are the corpus's own syntax", () => {
+    // Flagging these would flag every lesson in the corpus, and the gate would be
+    // switched off within a day.
+    const report = measureLiteralMarkup([
+      lesson("<!-- hl-knowledge: introduces=[]; assesses=[] -->\n\ntext"),
+    ]);
+    expect(report.summary.sourceFindings).toBe(0);
+  });
+
+  it("does NOT flag markup that is being quoted rather than emitted", () => {
+    // A lesson explaining an entity, or a backlog entry describing this very
+    // defect, is quoting. Both code fences and inline spans are exempt.
+    const report = measureLiteralMarkup([
+      lesson("Write `&nbsp;` and you get literal text.\n\n```\n&amp; <br>\n```\n"),
+    ]);
+    expect(report.summary.sourceFindings).toBe(0);
+  });
+
+  it("reports a line number that survives the exemption blanking", () => {
+    // Exempt spans are blanked rather than deleted, so offsets and newlines are
+    // preserved and a reported line still points at the right line.
+    // Body lines: 1 blank, 2 the comment, 3 and 4 blank, 5 the offender.
+    const report = measureLiteralMarkup([lesson("<!-- hl-knowledge: a -->\n\n\nline four &nbsp;")]);
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0]!.line).toBe(5);
+  });
+
+  it("finds both matches when one line holds two", () => {
+    // A shared /g regex across lines would skip every other match.
+    const report = measureLiteralMarkup([lesson("&nbsp;&amp;")]);
+    expect(report.findings.map((f) => f.markup)).toEqual(["&nbsp;", "&amp;"]);
+  });
+
+  it("renders a clean run as a positive statement rather than silence", () => {
+    const text = renderLiteralMarkup(measureLiteralMarkup([lesson("clean")])).join("\n");
+    expect(text).toContain("none in 1 lessons");
+  });
+
+  it("catches an authoring comment that reached the generated book", () => {
+    // Found live: one `<!-- ... -->` from a lesson was typesetting into the
+    // shipped Spanish PDF, inside a coloured culture box. The gate was blind to
+    // it because it applied MARKDOWN comment semantics to LaTeX output, where
+    // `<!--` is not a comment at all.
+    const report = measureLiteralMarkup(
+      [],
+      [{ path: "spanish/book/chapters/ch07.tex", language: "spanish", text: "text\n<!-- a note to authors -->\n" }],
+    );
+    expect(report.summary.renderedFindings).toBe(2);
+  });
+
+  it("cannot be smuggled past on the rendered layer", () => {
+    // Markdown exemptions must not apply to LaTeX: in a .tex a backtick is an
+    // open quote and `<!-- -->` is ordinary text, so neither may blank a span.
+    for (const text of ["<!-- \\&nbsp; -->", "He said `x \\&nbsp; y`", "```\n\\&nbsp;\n```"]) {
+      const report = measureLiteralMarkup([], [{ path: "x.tex", language: "x", text }]);
+      expect(report.summary.renderedFindings).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not backtrack catastrophically on a long whitespace run after '<'", () => {
+    // `<\s*\/?\s*` split N spaces between two `\s*` in O(N^2) ways: 2,634ms at
+    // N=64,000, and reachable from ordinary Markdown because a long inline code
+    // span is blanked INTO spaces. Regrouping the slash removes the ambiguity.
+    const started = Date.now();
+    measureLiteralMarkup([lesson("<" + " ".repeat(64_000) + "end")]);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("strips control characters out of rendered findings", () => {
+    // `[^>]*` admits ESC and CR, and the finding is written to a terminal. A
+    // finding must not be able to repaint the report that reports it.
+    const text = renderLiteralMarkup(
+      measureLiteralMarkup([lesson("<br\u001b[2J\u0007>")]),
+    ).join("\n");
+    expect(text).not.toContain("\u001b");
+    expect(text).toContain("?");
+  });
+
+  it("THE GATE: the committed corpus carries no literal markup at either layer", () => {
+    const { lessons } = loadEverything();
+    // The generator's own output, not the committed files: this asks whether the
+    // books a reader would get TODAY are clean, which is one step ahead of
+    // whatever happens to be checked in.
+    const rendered = [...generatedBookOutputs()].map(([path, text]) => ({
+      path,
+      language: path.split("/")[0] ?? "",
+      text,
+    }));
+    const report = measureLiteralMarkup(lessons, rendered);
+    // Named rather than counted: a bare number tells whoever breaks this nothing
+    // about which file to open.
+    expect(report.findings.map((f) => `${f.where}:${f.line} ${f.markup}`)).toEqual([]);
+    expect(rendered.length).toBeGreaterThan(0);
+    expect(lessons.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("proves the corpus gate is not vacuous", () => {
+    // The check above passes on an empty input too. This pins that the same
+    // measurement, over the same corpus plus one planted line, actually fires.
+    const { lessons } = loadEverything();
+    const planted = [...lessons, lesson("planted &nbsp; control")];
+    expect(measureLiteralMarkup(planted).summary.sourceFindings).toBe(1);
+  }, 60_000);
+});

--- a/code/packages/typescript/human-language-data/tests/literal-markup.test.ts
+++ b/code/packages/typescript/human-language-data/tests/literal-markup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { measureLiteralMarkup, renderLiteralMarkup } from "../src/literal-markup.js";
+import { measureLiteralMarkup, renderLiteralMarkup, stripHtmlComments } from "../src/literal-markup.js";
 import { parseLesson } from "../src/parse.js";
 import { loadEverything } from "../src/loader.js";
 import { generatedBookOutputs } from "../src/book-cli.js";
@@ -128,6 +128,32 @@ describe("literal markup", () => {
     ).join("\n");
     expect(text).not.toContain("\u001b");
     expect(text).toContain("?");
+  });
+
+  it("strips comments closed with --!> as well as -->", () => {
+    // CodeQL js/bad-tag-filter: HTML ends a comment either way, and a filter that
+    // knows only one lets the other reach the reader.
+    expect(stripHtmlComments("<!-- a -->x", "remove")).toBe("x");
+    expect(stripHtmlComments("<!-- a --!>x", "remove")).toBe("x");
+  });
+
+  it("consumes the whole comment span so nothing can re-form", () => {
+    // CodeQL js/incomplete-multi-character-sanitization: a single regex pass over
+    // a malformed comment can leave fragments that re-form into a live one.
+    expect(stripHtmlComments("<!--a<!--b-->x", "remove")).toBe("x");
+    expect(stripHtmlComments("<!--a<!--b-->x", "remove")).not.toContain("<!--");
+  });
+
+  it("treats an unterminated comment as running to the end, as a browser does", () => {
+    expect(stripHtmlComments("keep <!-- forever", "remove")).toBe("keep ");
+  });
+
+  it("is linear in the number of unterminated comment openers", () => {
+    // CodeQL js/polynomial-redos: `<!--[\s\S]*?-->` rescanned to EOF from every
+    // opener — 76ms at 32KB of repeated `<!--`, a clean 4x per doubling.
+    const started = Date.now();
+    stripHtmlComments("<!--".repeat(16_000), "blank");
+    expect(Date.now() - started).toBeLessThan(500);
   });
 
   it("THE GATE: the committed corpus carries no literal markup at either layer", () => {


### PR DESCRIPTION
#11866 specified this gate and logged it. #11868 then **reintroduced the defect one PR after fixing it** — two lessons in the very next tranche carried `&nbsp;` again, from a template that still had it, caught by hand only because I went looking.

That's the whole argument: **a mistake that survives its own fix by one iteration will not be fixed by remembering harder.**

## The gate

`literal-markup.ts`, blocking, 15 tests. The suite now fails on any HTML entity or bare HTML tag that would reach a reader.

**Two layers, two patterns.** The source scan finds `&nbsp;` in a `.md` and names the file an author edits. The rendered scan finds `\&nbsp;` in the generated `.tex` — a *different* pattern, because the escaper has been over it. That is exactly why grepping the books for `&nbsp;` found nothing for three releases.

**Exemptions are load-bearing.** `<!-- hl-knowledge -->` *is* the corpus's directive syntax; code fences and inline spans are how a lesson quotes markup rather than emitting it. Without them the gate flags every lesson and gets switched off within a day. Exempt spans are blanked, not deleted, so line numbers survive.

**Blocking from commit one**, not report-only: the corpus is clean at both layers today, so there's no inherited debt for authors to route around. HL05's report-only rule exists for gates that start red; this one starts green.

**Self-tested against a real planted defect**, not fixtures: `&nbsp;` added to a committed Spanish lesson → gate failed naming `ES-C01-hola:68` → file restored → gate green. A fixture-only proof wouldn't show the corpus assertion is actually wired to the corpus. A companion test plants a line into the real lesson set so a clean run can't be vacuous.

## The gate's own review found a live defect it was blind to

`renderMarkdown` passed any non-directive `<!-- ... -->` straight into the book as body text. One was **typesetting into the shipped Spanish PDF**, inside a coloured culture box — a note from an author to future authors, printed for the reader:

> `spanish/book/chapters/ch07-thank-you.tex:105`

`parse.ts` strips the `hl-knowledge` and `hl-activity` directives because it consumes them; everything else arrived at the renderer untouched. Now stripped whole-string so a multi-line comment goes as a unit. Zero remain corpus-wide.

The reviewer reached it by noticing the gate applied **Markdown** comment semantics to **LaTeX** output — where `<!--` isn't a comment at all and a backtick is an open quote — so it was blind in precisely the place it exists to watch.

## Four review findings, all fixed

1. **Polynomial ReDoS.** `<\s*\/?\s*` split N whitespace characters between two `\s*` in O(N²) ways — **2,634 ms at N=64,000**, and reachable from ordinary Markdown because a long inline code span is blanked *into spaces*. Regrouping the slash gives **0 ms** at the same input. The timing harness was self-tested against `/(a+)+b/` before being believed.
2. **Exemptions no longer apply to the rendered layer** — blanking on backticks hid 7,852 characters of the real corpus, and `\&nbsp;` could be smuggled past inside a comment.
3. **`<!--` and `-->` are now themselves rendered-layer findings.**
4. **Control characters stripped from rendered findings** — `[^>]*` admits ESC, CR and BEL and the string goes to a terminal. A finding must not be able to repaint the report that reports it.

## The class this belongs to

Every other check in this package asks whether output is **safe** or **reproducible**. `check:books` confirmed the byte-identical `\&nbsp;` on every run for three releases, faithfully reproducing the mistake. **Nothing asked whether the output was meaningful.** Other members of the same class are logged in HL-C221 for their own rows.

## Verification

759 tests pass at **default timeouts, no flags**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)