### PR TITLE
feat(semantic-ir-to-c): SIR21 T3b-2 Slice 2 — div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.38.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive only — no frontend emits these names yet, bare `"/"`/`"tdiv"`/
+`"utdiv"` keep working unchanged. All three dispatch sites (`variadic_helper`,
+the binary-arity table, and the value-referenced-builtin `_sir_builtin_dispatch`
+in `runtime.rs`) gained entries for the four new canonical division op names,
+per `code/specs/SIR21-type-system-and-integer-semantics.md` §E3:
+
+- `div_floor` → `_sir_divide` (the SAME helper `/` already uses — a rename,
+  zero new logic; floors ints toward −∞, true-divides floats).
+- `div_trunc`/`udiv_trunc` → `_sir_itdiv`/`_sir_utdiv` (the SAME helpers
+  `tdiv`/`utdiv` already use — also a rename; `tdiv`/`utdiv` themselves stay
+  working for now, removed in a later cleanup slice once every frontend
+  emitting them has migrated).
+- `div_true` → new `_sir_true_div(SirValue a, SirValue b)`: always coerces
+  both operands to `double` and divides, regardless of operand tag (models
+  Python's `/`). Fails loudly (`fprintf` + `exit(1)`) on a zero divisor,
+  matching every other division builtin in this file — deliberately NOT
+  matching the older `_sir_divide_v`'s float path, which silently produces
+  IEEE `inf`/`nan` on `x / 0.0`, since Python's `ZeroDivisionError` fires
+  unconditionally, not just on the integer path.
+
+New `tests/compile_and_run_division_ops.rs`: real `cc`/`clang`/`gcc`
+compile-and-execute proof for all four ops (mirrors
+`compile_and_run_floats.rs`'s pattern) — §E3's own worked example, the
+floor-vs-truncate divergence on negative operands, `div_floor`/`div_trunc`
+emitting the byte-identical helper call `/`/`tdiv`/`utdiv` already did, and
+`div_true`'s zero-divisor failure specifically (no existing test covered
+this path at all before this PR).
+
 ## 0.37.0 — SIR28 §7: remove dead bare `print`/`puts` handling
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1926,6 +1926,11 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
         "-" => "_sir_minus",
         "*" => "_sir_times",
         "/" => "_sir_divide",
+        // SIR21 T3b-2: `div_floor` is `/` under its canonical name (same
+        // floor-int/true-divide-float helper, zero behaviour change) --
+        // bare `/` stays too, as Twig's permanent fallback (see the SIR21
+        // spec's §E3).
+        "div_floor" => "_sir_divide",
         // Ruby unary minus (`-x`) lowers to `BuiltinCall("neg", [x])`. It was
         // UNIMPLEMENTED here, so any negative literal made the C backend report
         // an unsupported builtin and skip. Unary minus IS single-argument
@@ -2573,6 +2578,15 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         "tmod" => ("_sir_itmod", 2),
         "utdiv" => ("_sir_utdiv", 2),
         "utmod" => ("_sir_utmod", 2),
+        // SIR21 T3b-2: div_trunc/udiv_trunc are tdiv/utdiv under their new
+        // canonical names (same helpers, zero behaviour change -- see this
+        // crate's CHANGELOG for why T3b-2 folds the synonym families
+        // together). div_true is genuinely new: always coerce to float,
+        // never branch on operand tag (see `_sir_true_div`'s own doc
+        // comment in runtime.rs for its zero-divisor handling).
+        "div_trunc" => ("_sir_itdiv", 2),
+        "udiv_trunc" => ("_sir_utdiv", 2),
+        "div_true" => ("_sir_true_div", 2),
         // Milestone 9 numeric conversions: `to_f` (int → double) and `to_i`
         // (double → int, truncating toward zero, matching C's `(int)double`).
         "to_f" => ("_sir_to_f", 1),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -449,6 +449,22 @@ SirValue _sir_utmod(SirValue a, SirValue b) {
     return _sir_int((int64_t)((uint64_t)a.as.i % (uint64_t)b.as.i));
 }
 
+/* SIR21 T3b-2: true (float) division -- always coerces both operands to
+ * double and divides, regardless of operand tag (unlike `_sir_divide_v`,
+ * which floors when both operands happen to be Int -- that's `div_floor`'s
+ * job, this is `div_true`'s). Fails loudly on a zero divisor, matching
+ * every other division builtin in this file (`_sir_ifloordiv`/`_sir_itdiv`/
+ * `_sir_utdiv`) rather than the OLDER `_sir_divide_v`'s float path, which
+ * silently produces IEEE inf/nan on `x / 0.0` -- `div_true` models
+ * Python's `/`, and Python's `ZeroDivisionError` fires unconditionally,
+ * not just when both operands happen to be integers, so IEEE inf/nan is
+ * never a silently-produced result here. */
+SirValue _sir_true_div(SirValue a, SirValue b) {
+    double bn = _sir_as_num(b);
+    if (bn == 0.0) { fprintf(stderr, "sir: divided by 0\n"); exit(1); }
+    return _sir_float(_sir_as_num(a) / bn);
+}
+
 SirValue _sir_divide_v(SirValue *xs, int n) {
     int i;
     if (n <= 0) return _sir_int(1);
@@ -3896,6 +3912,15 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, "tmod") == 0)     return _sir_itmod(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "utdiv") == 0)    return _sir_utdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "utmod") == 0)    return _sir_utmod(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    /* SIR21 T3b-2: div_floor is `_sir_divide_v` under a new name (identical
+       floor-int/true-divide-float dispatch, zero new logic). div_trunc/
+       udiv_trunc are `tdiv`/`utdiv` under new names -- see this file's own
+       CHANGELOG for why T3b-2 folds the two synonym families into one.
+       div_true is genuinely new (see `_sir_true_div`'s own doc comment). */
+    if (strcmp(name, "div_floor") == 0)  return _sir_divide_v(args, argc);
+    if (strcmp(name, "div_trunc") == 0)  return _sir_itdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "udiv_trunc") == 0) return _sir_utdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "div_true") == 0)   return _sir_true_div(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "cons") == 0)     return _sir_cons(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "car") == 0)      return _sir_car(_sir_arg(args, argc, 0));
     if (strcmp(name, "cdr") == 0)      return _sir_cdr(_sir_arg(args, argc, 0));

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_division_ops.rs
@@ -1,0 +1,289 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the C backend — hand-build modules calling each op
+//! directly (bypassing the frontend, since no frontend emits these names
+//! yet), emit C, compile with a real gcc/clang-style compiler, run, assert
+//! stdout. Skips gracefully when no `cc` is present, mirroring
+//! `compile_and_run_floats.rs`'s identical pattern.
+//!
+//! `div_floor`/`div_trunc`/`udiv_trunc` are renames of this backend's
+//! existing `_sir_divide`/`_sir_itdiv`/`_sir_utdiv` (verified here by
+//! checking they compute the SAME values those already-tested helpers do
+//! — zero new logic, so these are regression tests, not new-behavior
+//! tests). `div_true` is genuinely new (see `runtime.rs`'s `_sir_true_div`
+//! doc comment) and gets the most coverage here, including its
+//! zero-divisor behavior, which has no precedent to regress against.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn compile_and_link(module: &Module) -> Option<(PathBuf, String)> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_div_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm")
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    Some((exe, artifact.source))
+}
+
+/// Run and require success — for the ordinary (non-zero-divisor) cases.
+fn run(module: &Module) -> Option<String> {
+    let (exe, _src) = compile_and_link(module)?;
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+/// Run and require FAILURE with the "divided by 0" message — for the
+/// zero-divisor cases, which are expected to `exit(1)`, not print a result.
+fn run_expect_zero_div_failure(module: &Module) -> Option<()> {
+    let (exe, _src) = compile_and_link(module)?;
+    let r = Command::new(&exe).output().expect("run");
+    assert!(
+        !r.status.success(),
+        "expected a zero-divisor failure (nonzero exit), got success with stdout:\n{}",
+        String::from_utf8_lossy(&r.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        stderr.contains("divided by 0"),
+        "expected 'divided by 0' on stderr, got:\n{stderr}"
+    );
+    Some(())
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    bc(name, vec![a, b])
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
+        ),
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+// ── §E3's own worked example, verbatim ──────────────────────────────────
+
+#[test]
+fn e3_worked_example() {
+    // puts(div_floor(7, 2))    // 3   — Ruby's `/`
+    // puts(div_trunc(-7, 2))   // -3  — C's `/`
+    // puts(div_true(7, 2))     // 3.5 — Python's `/`
+    match run(&div_module(vec![
+        puts(bin("div_floor", ilit(7), ilit(2))),
+        puts(bin("div_trunc", ilit(-7), ilit(2))),
+        puts(bin("div_true", ilit(7), ilit(2))),
+    ])) {
+        Some(out) => assert_eq!(out, "3\n-3\n3.5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// ── div_floor: a rename of `_sir_divide` — same floor/true-divide split ──
+
+#[test]
+fn div_floor_floors_toward_negative_infinity_on_integers() {
+    match run(&div_module(vec![
+        puts(bin("div_floor", ilit(7), ilit(2))),   // 3
+        puts(bin("div_floor", ilit(-7), ilit(2))),  // -4 (floors, not truncates)
+        puts(bin("div_floor", ilit(7), ilit(-2))),  // -4
+        puts(bin("div_floor", ilit(-7), ilit(-2))), // 3
+    ])) {
+        Some(out) => assert_eq!(out, "3\n-4\n-4\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn div_floor_emits_the_same_helper_as_bare_slash() {
+    // Zero behaviour change: both names must emit the identical call.
+    let src = semantic_ir_to_c::compile(&div_module(vec![
+        puts(bin("/", ilit(7), ilit(2))),
+        puts(bin("div_floor", ilit(7), ilit(2))),
+    ]))
+    .expect("compile")
+    .source;
+    let slash_call = "_sir_divide(2, _sir_int(7LL), _sir_int(2LL))";
+    assert_eq!(
+        src.matches(slash_call).count(),
+        2,
+        "both `/` and `div_floor` must emit the identical `_sir_divide` call:\n{src}"
+    );
+}
+
+// ── div_trunc/udiv_trunc: renames of tdiv/utdiv ──────────────────────────
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    match run(&div_module(vec![
+        puts(bin("div_trunc", ilit(7), ilit(2))),   // 3
+        puts(bin("div_trunc", ilit(-7), ilit(2))),  // -3 (truncates, not floors)
+        puts(bin("div_trunc", ilit(7), ilit(-2))),  // -3
+        puts(bin("div_trunc", ilit(-7), ilit(-2))), // 3
+    ])) {
+        Some(out) => assert_eq!(out, "3\n-3\n-3\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    // No unsigned literal constructor in this hand-built harness, so this
+    // exercises udiv_trunc's ordinary (non-high-bit) path -- the emitted
+    // helper is identical to div_trunc's signed twin except for the C-level
+    // uint64_t cast, which only matters once the top bit is set (covered by
+    // `_sir_utdiv`'s own existing unit tests in runtime.rs, unchanged here).
+    match run(&div_module(vec![puts(bin("udiv_trunc", ilit(7), ilit(2)))])) {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn div_trunc_udiv_trunc_emit_the_same_helpers_as_tdiv_utdiv() {
+    let src = semantic_ir_to_c::compile(&div_module(vec![
+        puts(bin("tdiv", ilit(7), ilit(2))),
+        puts(bin("div_trunc", ilit(7), ilit(2))),
+        puts(bin("utdiv", ilit(7), ilit(2))),
+        puts(bin("udiv_trunc", ilit(7), ilit(2))),
+    ]))
+    .expect("compile")
+    .source;
+    assert_eq!(
+        src.matches("_sir_itdiv(_sir_int(7LL), _sir_int(2LL))").count(),
+        2,
+        "tdiv and div_trunc must emit the identical _sir_itdiv call:\n{src}"
+    );
+    assert_eq!(
+        src.matches("_sir_utdiv(_sir_int(7LL), _sir_int(2LL))").count(),
+        2,
+        "utdiv and udiv_trunc must emit the identical _sir_utdiv call:\n{src}"
+    );
+}
+
+// ── div_true: genuinely new — always coerces to float, never floors ─────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    match run(&div_module(vec![
+        puts(bin("div_true", ilit(7), ilit(2))),   // 3.5, not 3
+        puts(bin("div_true", ilit(-7), ilit(2))),  // -3.5, not -4
+        puts(bin("div_true", ilit(6), ilit(3))),   // 2.0 (exact, still a float)
+    ])) {
+        Some(out) => assert_eq!(out, "3.5\n-3.5\n2.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn div_floor_and_div_trunc_zero_divisor_fails_loudly() {
+    match run_expect_zero_div_failure(&div_module(vec![puts(bin("div_floor", ilit(7), ilit(0)))])) {
+        Some(()) => {}
+        None => eprintln!("skip: no cc"),
+    }
+    match run_expect_zero_div_failure(&div_module(vec![puts(bin("div_trunc", ilit(7), ilit(0)))])) {
+        Some(()) => {}
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn div_true_zero_divisor_fails_loudly_not_silent_ieee_infinity() {
+    // Unlike raw IEEE double division (which would silently yield `inf`),
+    // div_true models Python's `/`, which raises ZeroDivisionError
+    // unconditionally -- see `_sir_true_div`'s own doc comment in
+    // runtime.rs for why this deliberately does NOT match the OLDER
+    // `_sir_divide_v`'s silent-infinity float path.
+    match run_expect_zero_div_failure(&div_module(vec![puts(bin("div_true", ilit(7), ilit(0)))])) {
+        Some(()) => {}
+        None => eprintln!("skip: no cc"),
+    }
+}


### PR DESCRIPTION
## Summary

First of 7 backend PRs implementing SIR21 T3b-2's division-op split for the C backend (see [#11872](https://github.com/adhithyan15/coding-adventures/pull/11872), Slice 1, for the full design/spec). Additive only — no frontend emits these names yet, bare `"/"`/`"tdiv"`/`"utdiv"` keep working unchanged.

- **`div_floor`** → `_sir_divide` (same helper `/` already uses — a rename, zero new logic).
- **`div_trunc`/`udiv_trunc`** → `_sir_itdiv`/`_sir_utdiv` (same helpers `tdiv`/`utdiv` already use — also a rename; those stay working until the cleanup slice).
- **`div_true`** → new `_sir_true_div`: always coerces to `double` and divides regardless of operand tag (models Python's `/`), fails loudly on a zero divisor matching every other division builtin in this file — deliberately *not* matching the older `_sir_divide_v`'s float path, which silently produces IEEE `inf`/`nan` on `x / 0.0`.

New `tests/compile_and_run_division_ops.rs`: real `cc`/`clang`/`gcc` compile-and-execute proof (9 tests) — §E3's own worked example, floor-vs-truncate divergence on negative operands, `div_floor`/`div_trunc` emitting the byte-identical helper call the old names already did, and `div_true`'s zero-divisor failure specifically (previously untested).

## Test plan
- [x] `cargo test -p semantic-ir-to-c` — full suite green, including the new 9-test real-compile-and-run file
- [x] `cargo clippy -p semantic-ir-to-c --all-targets -- -D warnings` — clean
- [x] `/security-review` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)