### PR TITLE
feat(chief-of-staff-channel-crypto): export VerifyGrantSignature for Go D18Q parity

### DIFF
--- a/code/packages/go/chief-of-staff-channel-crypto/CHANGELOG.md
+++ b/code/packages/go/chief-of-staff-channel-crypto/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Add `VerifyGrantSignature`, which checks every public `D18G` binding and the
+  originator's Ed25519 signature without a receiver private key. Go previously
+  reached these checks only through `OpenChannelKeyGrant`, which needs a
+  `ReceiverKeyPair` in order to unwrap — so an originator, holding no receiver
+  secrets, had no way to verify the grants it had just sealed. D18T plan
+  validation requires exactly that, which is why Rust, Python, and TypeScript
+  already export the equivalent. Brings Go to parity with them.
+- Refactor `OpenChannelKeyGrant` onto a shared `verifyGrantBindings` path so the
+  receiver-key-free and unwrapping entry points cannot drift on binding order or
+  stable error codes. No behavior change: every pre-existing opening fixture
+  still produces its declared code, now asserted against both entry points.
 - Add immutable-by-convention D18Q `D18G` v1 grants using repository X25519,
   HKDF-SHA256, XChaCha20-Poly1305, and Ed25519 primitives.
 - Add managed keys, atomic monotonic receiver epoch state, deterministic

--- a/code/packages/go/chief-of-staff-channel-crypto/README.md
+++ b/code/packages/go/chief-of-staff-channel-crypto/README.md
@@ -46,6 +46,27 @@ outcome, err := receiverEpochs.InstallGrant(grant)
 epochKey, err := receiverEpochs.Key(fields.KeyEpoch())
 ```
 
+### Verifying a grant you cannot open
+
+Opening a grant needs the receiver's private key, because unwrapping performs an
+X25519 agreement. An originator holds no receiver secrets, so it cannot open the
+grants it seals — yet D18T requires it to verify the originator signature on
+every receiver's grant before a rotation candidate may be offered to key
+custody. `VerifyGrantSignature` is that weaker, receiver-key-free check:
+
+```go
+err := channelcrypto.VerifyGrantSignature(
+    grant, expectedOriginatorID, expectedReceiverID, channelID, originatorPublicKey,
+)
+```
+
+It proves the originator signed this exact `(originator, receiver, channel,
+epoch, ephemeral key, nonce, wrapped CMK)` tuple. It proves nothing about
+whether the wrapped CMK decrypts — only unwrapping can establish that, so a
+caller verifying grants it cannot open must not treat success as proof the
+receiver will be able to use the grant. Both entry points share one verification
+path, so they always agree on binding order and stable error codes.
+
 `PlanRotation` creates a complete receiver-sorted prospective plan and emits no
 grant for a revoked receiver. D18Q failures are `KeyGrantProfileError` values
 with stable codes. `GrantSecretErasureCapability()` honestly reports

--- a/code/packages/go/chief-of-staff-channel-crypto/grant.go
+++ b/code/packages/go/chief-of-staff-channel-crypto/grant.go
@@ -531,31 +531,79 @@ func SealChannelKeyWithMaterial(fields KeyGrantFields, cmk *ChannelMasterKey, re
 	return newPortableKeyGrant(fields.originatorID, fields.receiverID, fields.channelID[:], fields.keyEpoch, ephemeralPublic[:], nonce[:], wrapped, signature)
 }
 
-// OpenChannelKeyGrant verifies bindings in normative order before unwrapping a CMK.
-func OpenChannelKeyGrant(grant PortableKeyGrant, expectedOriginatorID, expectedReceiverID, expectedChannelID []byte, receiverKeyPair *ReceiverKeyPair, originatorPublicKey []byte) (*ChannelMasterKey, error) {
+// VerifyGrantSignature checks every public D18G binding and the originator's
+// Ed25519 signature without needing the receiver's private key.
+//
+// # Why this exists separately from OpenChannelKeyGrant
+//
+// Opening a grant answers "may I, the receiver, unwrap this CMK?" — it needs a
+// receiver secret because unwrapping performs an X25519 agreement. But some
+// callers need a strictly weaker answer: "is this grant authentic?" The D18T
+// durable epoch-activation profile is the motivating case. Before a rotation
+// candidate may be offered to key custody, D18T must verify the originator
+// signature on *every* receiver's grant — and the originator holds no receiver
+// private keys, so it cannot open any of them.
+//
+//	OpenChannelKeyGrant       authenticity + unwrap    needs receiver secret
+//	VerifyGrantSignature      authenticity only        needs only public keys
+//
+// Both share one verification path, so the two can never drift: the checks
+// below are exactly the checks OpenChannelKeyGrant performs before it reaches
+// for the receiver key pair.
+//
+// # What "verified" does and does not mean
+//
+// A successful return proves the originator named by originatorPublicKey signed
+// this exact (originator, receiver, channel, epoch, ephemeral key, nonce,
+// wrapped CMK) tuple. It says nothing about whether the wrapped CMK decrypts to
+// anything sensible — that is the receiver's business, and only unwrapping can
+// establish it. Callers verifying grants they cannot open MUST NOT treat this
+// as proof that the receiver will be able to use the grant.
+//
+// Bindings are compared in constant time and in the order D18Q fixes, so a
+// caller can rely on the returned code identifying the *first* mismatched
+// field rather than an arbitrary one.
+func VerifyGrantSignature(grant PortableKeyGrant, expectedOriginatorID, expectedReceiverID, expectedChannelID, originatorPublicKey []byte) error {
+	_, err := verifyGrantBindings(grant, expectedOriginatorID, expectedReceiverID, expectedChannelID, originatorPublicKey)
+	return err
+}
+
+// verifyGrantBindings is the shared authenticity path. It returns the validated
+// 32-byte originator public key so that OpenChannelKeyGrant does not have to
+// re-derive it before unwrapping.
+func verifyGrantBindings(grant PortableKeyGrant, expectedOriginatorID, expectedReceiverID, expectedChannelID, originatorPublicKey []byte) ([32]byte, error) {
+	var empty [32]byte
 	if err := validatePortableKeyGrant(grant); err != nil {
-		return nil, err
+		return empty, err
 	}
 	channel, err := grantArray16(expectedChannelID)
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 	publicKey, err := grantArray32(originatorPublicKey)
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 	if !constantTimeEqual(grant.originatorID, expectedOriginatorID) {
-		return nil, grantFail(KeyGrantErrUnexpectedOriginator)
+		return empty, grantFail(KeyGrantErrUnexpectedOriginator)
 	}
 	if !constantTimeEqual(grant.receiverID, expectedReceiverID) {
-		return nil, grantFail(KeyGrantErrUnexpectedReceiver)
+		return empty, grantFail(KeyGrantErrUnexpectedReceiver)
 	}
 	if subtle.ConstantTimeCompare(grant.channelID[:], channel[:]) != 1 {
-		return nil, grantFail(KeyGrantErrUnexpectedChannel)
+		return empty, grantFail(KeyGrantErrUnexpectedChannel)
 	}
 	signatureInput := grantSignatureInput(grant.originatorID, grant.receiverID, grant.channelID[:], grant.keyEpoch, grant.ephemeralPublicKey[:], grant.wrappingNonce[:], grant.wrappedCMK[:])
 	if !ed25519.Verify(signatureInput, grant.originatorSignature, publicKey) {
-		return nil, grantFail(KeyGrantErrInvalidSignature)
+		return empty, grantFail(KeyGrantErrInvalidSignature)
+	}
+	return publicKey, nil
+}
+
+// OpenChannelKeyGrant verifies bindings in normative order before unwrapping a CMK.
+func OpenChannelKeyGrant(grant PortableKeyGrant, expectedOriginatorID, expectedReceiverID, expectedChannelID []byte, receiverKeyPair *ReceiverKeyPair, originatorPublicKey []byte) (*ChannelMasterKey, error) {
+	if _, err := verifyGrantBindings(grant, expectedOriginatorID, expectedReceiverID, expectedChannelID, originatorPublicKey); err != nil {
+		return nil, err
 	}
 	shared, err := receiverKeyPair.agree(grant.ephemeralPublicKey[:])
 	if err != nil {

--- a/code/packages/go/chief-of-staff-channel-crypto/grant_verify_test.go
+++ b/code/packages/go/chief-of-staff-channel-crypto/grant_verify_test.go
@@ -1,0 +1,174 @@
+package channelcrypto
+
+import "testing"
+
+// preUnwrapOpeningCodes are the D18Q failures that VerifyGrantSignature can
+// reach, because they are decided before a receiver secret is ever needed.
+//
+// Every other opening failure -- invalid_key_agreement and the whole
+// authentication_failed family -- lives strictly *after* signature
+// verification, in the X25519 agreement or the AEAD open. Those cases are
+// therefore expected to VERIFY SUCCESSFULLY here. That is the sharpest
+// statement these tests make: the receiver-key-free entry point stops at
+// exactly the boundary where the receiver key becomes necessary, no earlier
+// and no later.
+var preUnwrapOpeningCodes = map[string]bool{
+	"unexpected_originator": true,
+	"unexpected_receiver":   true,
+	"unexpected_channel":    true,
+	"invalid_signature":     true,
+}
+
+func TestVerifyGrantSignatureAcceptsEveryPositiveFixtureUsingOnlyPublicInputs(t *testing.T) {
+	fixtures := loadGrantFixtures(t)
+	if len(fixtures.manifest.PositiveCases) == 0 {
+		t.Fatal("expected at least one positive D18Q fixture")
+	}
+	for _, testCase := range fixtures.manifest.PositiveCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			grant, err := GrantDeserialize(decodeGrantB64(t, testCase.D18GB64))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Note what is absent: receiver_private_key_hex is never read.
+			// An originator holds no receiver secrets, and D18T requires it to
+			// verify every receiver's grant regardless.
+			if err := VerifyGrantSignature(
+				grant,
+				decodeGrantB64(t, testCase.OriginatorIDB64),
+				decodeGrantB64(t, testCase.ReceiverIDB64),
+				decodeHex(t, testCase.ChannelIDHex),
+				fixtures.publicKey,
+			); err != nil {
+				t.Fatalf("expected the canonical grant to verify, got %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifyGrantSignatureStopsExactlyAtTheReceiverKeyBoundary(t *testing.T) {
+	fixtures := loadGrantFixtures(t)
+	seenPreUnwrap, seenPostUnwrap := 0, 0
+	for _, testCase := range fixtures.manifest.OpeningNegativeCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			grant, err := GrantDeserialize(decodeGrantB64(t, testCase.D18GB64))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = VerifyGrantSignature(
+				grant,
+				decodeGrantB64(t, testCase.ExpectedOriginatorIDB64),
+				decodeGrantB64(t, testCase.ExpectedReceiverIDB64),
+				decodeHex(t, testCase.ExpectedChannelIDHex),
+				fixtures.publicKey,
+			)
+			if preUnwrapOpeningCodes[testCase.ExpectedError] {
+				seenPreUnwrap++
+				// Same grant, same expectation, same stable code as
+				// OpenChannelKeyGrant would have produced.
+				requireGrantCode(t, err, testCase.ExpectedError)
+				return
+			}
+			seenPostUnwrap++
+			if err != nil {
+				t.Fatalf("%q fails only during unwrapping, so signature verification must succeed; got %v", testCase.ExpectedError, err)
+			}
+		})
+	}
+	// Guard against a manifest that silently loses one side of the split and
+	// leaves half this test vacuous.
+	if seenPreUnwrap == 0 || seenPostUnwrap == 0 {
+		t.Fatalf("expected the manifest to exercise both sides of the boundary, saw %d pre-unwrap and %d post-unwrap", seenPreUnwrap, seenPostUnwrap)
+	}
+}
+
+func TestVerifyGrantSignatureAndOpenChannelKeyGrantAgreeOnEveryOpeningFixture(t *testing.T) {
+	fixtures := loadGrantFixtures(t)
+	for _, testCase := range fixtures.manifest.OpeningNegativeCases {
+		if !preUnwrapOpeningCodes[testCase.ExpectedError] {
+			continue
+		}
+		t.Run(testCase.Name, func(t *testing.T) {
+			grant, err := GrantDeserialize(decodeGrantB64(t, testCase.D18GB64))
+			if err != nil {
+				t.Fatal(err)
+			}
+			receiver, err := ReceiverKeyPairFromPrivateKey(decodeHex(t, testCase.ReceiverPrivateKeyHex))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer receiver.Destroy()
+			originator := decodeGrantB64(t, testCase.ExpectedOriginatorIDB64)
+			receiverID := decodeGrantB64(t, testCase.ExpectedReceiverIDB64)
+			channel := decodeHex(t, testCase.ExpectedChannelIDHex)
+
+			verifyErr := VerifyGrantSignature(grant, originator, receiverID, channel, fixtures.publicKey)
+			_, openErr := OpenChannelKeyGrant(grant, originator, receiverID, channel, receiver, fixtures.publicKey)
+
+			// Both paths share verifyGrantBindings, so they can never disagree
+			// on a pre-unwrap failure. This test is what makes that structural
+			// claim observable rather than merely asserted in a comment.
+			requireGrantCode(t, verifyErr, testCase.ExpectedError)
+			requireGrantCode(t, openErr, testCase.ExpectedError)
+		})
+	}
+}
+
+func TestVerifyGrantSignatureRejectsMalformedPublicInputs(t *testing.T) {
+	fixtures := loadGrantFixtures(t)
+	positive := fixtures.manifest.PositiveCases[0]
+	grant, err := GrantDeserialize(decodeGrantB64(t, positive.D18GB64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	originator := decodeGrantB64(t, positive.OriginatorIDB64)
+	receiverID := decodeGrantB64(t, positive.ReceiverIDB64)
+	channel := decodeHex(t, positive.ChannelIDHex)
+
+	for _, testCase := range []struct {
+		name      string
+		channel   []byte
+		publicKey []byte
+	}{
+		{"short-channel-id", channel[:15], fixtures.publicKey},
+		{"long-channel-id", append(append([]byte{}, channel...), 0), fixtures.publicKey},
+		{"empty-channel-id", []byte{}, fixtures.publicKey},
+		{"short-public-key", channel, fixtures.publicKey[:31]},
+		{"long-public-key", channel, append(append([]byte{}, fixtures.publicKey...), 0)},
+		{"empty-public-key", channel, []byte{}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := VerifyGrantSignature(grant, originator, receiverID, testCase.channel, testCase.publicKey); err == nil {
+				t.Fatal("expected malformed public inputs to fail closed")
+			}
+		})
+	}
+}
+
+func TestVerifyGrantSignatureRejectsAnotherOriginatorsPublicKey(t *testing.T) {
+	fixtures := loadGrantFixtures(t)
+	positive := fixtures.manifest.PositiveCases[0]
+	grant, err := GrantDeserialize(decodeGrantB64(t, positive.D18GB64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A well-formed key belonging to somebody else must not verify. Without
+	// this, a caller could be fooled by any 32 valid bytes.
+	other, err := OriginatorSigningKeyFromSeed(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer other.Destroy()
+	otherPublic, err := other.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = VerifyGrantSignature(
+		grant,
+		decodeGrantB64(t, positive.OriginatorIDB64),
+		decodeGrantB64(t, positive.ReceiverIDB64),
+		decodeHex(t, positive.ChannelIDHex),
+		otherPublic,
+	)
+	requireGrantCode(t, err, string(KeyGrantErrInvalidSignature))
+}


### PR DESCRIPTION
## Why

D18T plan validation ([spec](../blob/main/code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md), step 6) requires verifying the originator's Ed25519 signature on every receiver's D18G grant using only the channel definition's public key — explicitly *"without requiring a receiver private key"*. An originator holds no receiver secrets, so it cannot open the grants it just sealed.

**Go could not do this.** The verification logic existed only inside `OpenChannelKeyGrant`, which takes a `*ReceiverKeyPair` because it goes on to perform an X25519 agreement and unwrap the CMK.

| Language | `verify_grant_signature` | D18T adapter shipped |
|---|---|---|
| Rust | ✅ `grant_profile.rs` | ✅ #11793 |
| TypeScript | ✅ `grant-profile.ts` | ✅ #11799 |
| Python | ✅ `grant_profile.py` | ✅ #11803 |
| **Go** | ❌ | ⬜ #11785 |
| **Ruby** | ❌ | ⬜ #11786 |
| **Elixir** | ❌ | ⬜ #11787 |

That correlation is not a coincidence — it is the reason the D18T chain stalled exactly at Go. Ruby and Elixir will hit the same wall.

## What this changes

- **`VerifyGrantSignature(grant, originatorID, receiverID, channelID, publicKey) error`** — validation, constant-time binding comparison in D18Q's normative order, and Ed25519 signature verification. No receiver secret involved.
- **`OpenChannelKeyGrant` refactored onto a shared `verifyGrantBindings` path** rather than duplicating the checks, so the two entry points cannot drift on binding order or stable error codes.

**No behavior change to `OpenChannelKeyGrant`.** Every pre-existing opening fixture still yields its declared stable code, now asserted against *both* entry points simultaneously.

## How the tests pin the boundary

The existing D18Q manifest's 14 `opening_negative_cases` split cleanly:

- **5 fail before any receiver key is needed** — `unexpected_originator`, `unexpected_receiver`, `unexpected_channel`, `invalid_signature` ×2
- **9 fail only during agreement or AEAD open** — `invalid_key_agreement`, the `authentication_failed` family

`VerifyGrantSignature` must reproduce the first group's codes exactly **and must succeed on the second**. That pins the split at precisely the boundary where the receiver key becomes necessary — neither earlier nor later. A guard fails the test if the manifest ever stops exercising both sides.

Also covered: malformed channel-id/public-key lengths fail closed, and a well-formed public key belonging to a *different* originator yields `invalid_signature` rather than being accepted as any 32 valid bytes.

## Scope limit, stated in the docs

Success proves the originator signed this exact tuple. It proves **nothing** about whether the wrapped CMK decrypts — only unwrapping can establish that. A caller verifying grants it cannot open must not read it as proof the receiver will be able to use the grant. Both the godoc and the README say so explicitly.

`VerifyGrantSignature` deliberately takes no expected `key_epoch`: D18T separates the epoch match (step 5) from the signature check (step 6), and the reference Rust consumer performs the epoch comparison itself. This matches Rust/Python/TypeScript exactly.

## Verification

- Package front door `go test ./... -v -cover` passes at **81.2%** coverage (27 new subtests across 5 tests, all confirmed running under `-v`)
- `gofmt` clean, `go vet` clean
- Sole downstream consumer `go/chief-of-staff-channel-store` builds, vets, and tests clean
- Security review passed first round with no findings — including explicit confirmation that the refactor is line-for-line behavior-preserving, that no secret material can reach the new return path, and that constant-time properties are unchanged

Prerequisite for #11785. Part of #11734, #141, and #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)