### PR TITLE
feat(semantic-ir-to-go): SIR21 T3b-2 Slice 2 — div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.39.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive only — no frontend emits these names yet, bare `"/"` keeps working
+unchanged. Both dispatch sites (the single unified emit-name table and
+`_sir_call_builtin_by_name` in `runtime.rs`) gained entries for the four new
+canonical division op names, per
+`code/specs/SIR21-type-system-and-integer-semantics.md` §E3:
+
+- `div_floor` → `_sir_divide` (the SAME helper `/` already uses — a rename,
+  zero new logic).
+- `div_trunc` → new `_sir_trunc_div`: Go's native int64 `/` already
+  truncates toward zero, so this is a thin wrapper (unlike `_sir_divide`'s
+  int path, which explicitly adjusts for floor semantics).
+- `udiv_trunc` → new `_sir_utrunc_div`: `div_trunc`'s unsigned twin —
+  reinterprets the `int64` bit pattern as `uint64` before dividing (this
+  backend has no typed-unsigned frontend reaching it yet, but the helper is
+  implemented faithfully, mirroring `semantic-ir-to-c`'s existing
+  `_sir_itdiv`/`_sir_utdiv` split, the first backend to need this
+  distinction).
+- `div_true` → new `_sir_true_div`: always coerces both operands to
+  `float64` and divides, regardless of operand tag. Raises
+  `ZeroDivisionError` unconditionally, matching `_sir_divide`'s own
+  float-path convention (Python's `/` behaves the same way) — IEEE `+Inf`
+  is never a silently-produced result here.
+
+New `tests/compile_and_run_division_ops.rs`: real `go run` compile-and-execute
+proof for all four ops (6 tests, mirrors `compile_and_run_floats.rs`'s
+pattern) — §E3's own worked example, the floor-vs-truncate divergence on
+negative operands, and the zero-divisor panic path (Go's uncaught-panic
+default behaviour: nonzero exit + `SirError.Error()`'s formatted message on
+stderr) for every one of the four ops — no existing test covered this path
+before this PR.
+
 ## 0.38.0 — SIR28 §7: remove dead bare `print`/`puts` handling
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1373,6 +1373,16 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "-" => "_sir_minus",
         "*" => "_sir_times",
         "/" => "_sir_divide",
+        // SIR21 T3b-2: div_floor is `/` under its canonical name (same
+        // helper, zero behaviour change) -- bare `/` stays too, as Twig's
+        // permanent fallback (see the SIR21 spec's §E3). div_trunc/
+        // udiv_trunc/div_true are genuinely new (see `_sir_trunc_div`/
+        // `_sir_utrunc_div`/`_sir_true_div`'s own doc comments in
+        // runtime.rs).
+        "div_floor" => "_sir_divide",
+        "div_trunc" => "_sir_trunc_div",
+        "udiv_trunc" => "_sir_utrunc_div",
+        "div_true" => "_sir_true_div",
         "=" => "_sir_eq",
         "case_eq" => "_sir_case_eq",
         "<" => "_sir_lt",

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -603,6 +603,61 @@ func _sir_divide(args []Value) Value {
 	return acc
 }
 
+// SIR21 T3b-2: truncating division (`div_trunc`) — Go's native int64 `/`
+// already truncates toward zero, so this is a thin wrapper (the same
+// "no adjustment needed on this backend" observation `semantic-ir-to-c`'s
+// `_sir_itdiv` makes for C's own native `/`). Raises `ZeroDivisionError`,
+// matching `_sir_divide`'s own convention.
+func _sir_trunc_div(args []Value) Value {
+	if len(args) < 2 {
+		return int64(0)
+	}
+	a := _sir_as_int(args[0])
+	b := _sir_as_int(args[1])
+	if b == 0 {
+		panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+	}
+	return a / b
+}
+
+// SIR21 T3b-2: unsigned truncating division (`udiv_trunc`) — `div_trunc`'s
+// unsigned twin. Values are stored as `int64`, so a `uint64` ≥ 2^63 misreads
+// as negative unless reinterpreted before dividing — mirrors
+// `semantic-ir-to-c`'s existing `_sir_utdiv`, the first backend to need this
+// split (this backend has no typed-unsigned frontend reaching it yet, but
+// the helper is implemented faithfully rather than left as a stub, matching
+// `div_trunc`'s sibling treatment).
+func _sir_utrunc_div(args []Value) Value {
+	if len(args) < 2 {
+		return int64(0)
+	}
+	a := uint64(_sir_as_int(args[0]))
+	b := uint64(_sir_as_int(args[1]))
+	if b == 0 {
+		panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+	}
+	return int64(a / b)
+}
+
+// SIR21 T3b-2: true (float) division (`div_true`) — always coerces both
+// operands to float64 and divides, regardless of operand tag (unlike
+// `_sir_divide`, which floors when both operands happen to be int64 —
+// that's `div_floor`'s job, this is `div_true`'s). Raises
+// `ZeroDivisionError` unconditionally, matching `_sir_divide`'s own
+// float-path convention (models Python's `/`) — IEEE `+Inf` is never a
+// silently-produced result here.
+func _sir_true_div(args []Value) Value {
+	if len(args) < 2 {
+		return float64(0)
+	}
+	a := _sir_as_float(args[0])
+	b := _sir_as_float(args[1])
+	if b == 0 {
+		panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+	}
+	return a / b
+}
+
 func _sir_eq(args []Value) Value {
 	if len(args) < 2 {
 		return true
@@ -1344,6 +1399,14 @@ func _sir_call_builtin_by_name(name string, args []Value) Value {
 		return _sir_times(args)
 	case "/":
 		return _sir_divide(args)
+	case "div_floor":
+		return _sir_divide(args)
+	case "div_trunc":
+		return _sir_trunc_div(args)
+	case "udiv_trunc":
+		return _sir_utrunc_div(args)
+	case "div_true":
+		return _sir_true_div(args)
 	case "neg":
 		return _sir_neg(args)
 	case "=", "==":

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_division_ops.rs
@@ -1,0 +1,229 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the Go backend — hand-builds a module calling each op
+//! directly (bypassing the frontend, since no frontend emits these names
+//! yet), emits Go, runs it with `go run`, checks stdout/exit status.
+//! Mirrors `compile_and_run_floats.rs`'s identical pattern; gates on `go`
+//! being on `PATH` and skips (does not fail) if absent.
+//!
+//! `div_floor`/`div_trunc` are renames of this backend's existing
+//! `_sir_divide` (int path) — verified here by checking they compute the
+//! SAME values that already-tested helper does. `udiv_trunc`/`div_true`
+//! are genuinely new (see `runtime.rs`'s doc comments for each), and get
+//! the most coverage here, including the zero-divisor panic path, which
+//! Go's uncaught-panic default behaviour turns into a nonzero exit +
+//! `SirError.Error()`'s formatted message on stderr.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile, write to a unique temp file, `go run` it. Returns `None` if
+/// `go` is unavailable (caller should skip, not fail).
+fn run_raw(module: &Module, tag: &str) -> Option<std::process::Output> {
+    if !go_available() {
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_div_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    Some(out)
+}
+
+fn run(module: &Module, tag: &str) -> Option<String> {
+    let out = run_raw(module, tag)?;
+    assert!(
+        out.status.success(),
+        "emitted Go failed to compile/run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+fn run_expect_zero_div_panic(module: &Module, tag: &str) -> Option<()> {
+    let out = run_raw(module, tag)?;
+    assert!(
+        !out.status.success(),
+        "expected a zero-divisor panic (nonzero exit), got success with stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ZeroDivisionError: divided by 0"),
+        "expected 'ZeroDivisionError: divided by 0' on stderr, got:\n{stderr}"
+    );
+    Some(())
+}
+
+// ── §E3's own worked example, verbatim ──────────────────────────────────
+
+#[test]
+fn e3_worked_example() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_floor", ilit(7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+            print_stmt(bin("div_true", ilit(7), ilit(2))),
+        ]),
+        "e3",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-3", "3.5"]),
+        None => eprintln!("skip: no go"),
+    }
+}
+
+// ── div_floor: a rename of `_sir_divide`'s int path ──────────────────────
+
+#[test]
+fn div_floor_floors_toward_negative_infinity() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_floor", ilit(7), ilit(2))),
+            print_stmt(bin("div_floor", ilit(-7), ilit(2))),
+            print_stmt(bin("div_floor", ilit(7), ilit(-2))),
+            print_stmt(bin("div_floor", ilit(-7), ilit(-2))),
+        ]),
+        "floor",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-4", "-4", "3"]),
+        None => eprintln!("skip: no go"),
+    }
+}
+
+// ── div_trunc/udiv_trunc: truncate toward zero ───────────────────────────
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_trunc", ilit(7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(7), ilit(-2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(-2))),
+        ]),
+        "trunc",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-3", "-3", "3"]),
+        None => eprintln!("skip: no go"),
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    match run(
+        &div_module(vec![print_stmt(bin("udiv_trunc", ilit(7), ilit(2)))]),
+        "udiv",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3"]),
+        None => eprintln!("skip: no go"),
+    }
+}
+
+// ── div_true: genuinely new — always true-divides ────────────────────────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_true", ilit(7), ilit(2))),
+            print_stmt(bin("div_true", ilit(-7), ilit(2))),
+            print_stmt(bin("div_true", ilit(6), ilit(3))),
+        ]),
+        "true",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3.5", "-3.5", "2.0"]),
+        None => eprintln!("skip: no go"),
+    }
+}
+
+#[test]
+fn zero_divisor_panics_with_zero_division_error_for_every_op() {
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        match run_expect_zero_div_panic(
+            &div_module(vec![print_stmt(bin(op, ilit(7), ilit(0)))]),
+            op,
+        ) {
+            Some(()) => {}
+            None => {
+                eprintln!("skip: no go");
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second of 7 backend PRs implementing SIR21 T3b-2's division-op split (see [#11872](https://github.com/adhithyan15/coding-adventures/pull/11872) for the full design/spec). Additive only — no frontend emits these names yet, bare `"/"` keeps working unchanged.

- **`div_floor`** → `_sir_divide` (same helper `/` already uses — a rename, zero new logic).
- **`div_trunc`** → new `_sir_trunc_div`: Go's native `int64` `/` already truncates toward zero, so this is a thin wrapper (unlike `_sir_divide`'s int path, which explicitly adjusts for floor semantics).
- **`udiv_trunc`** → new `_sir_utrunc_div`: `div_trunc`'s unsigned twin, reinterprets the `int64` bit pattern as `uint64` before dividing (mirrors `semantic-ir-to-c`'s existing `_sir_itdiv`/`_sir_utdiv` split).
- **`div_true`** → new `_sir_true_div`: always coerces to `float64` and divides regardless of operand tag, raises `ZeroDivisionError` unconditionally matching `_sir_divide`'s own float-path convention.

New `tests/compile_and_run_division_ops.rs`: real `go run` compile-and-execute proof for all four ops (6 tests) — §E3's own worked example, floor-vs-truncate divergence on negative operands, and the zero-divisor panic path for every op (previously untested).

## Test plan
- [x] `cargo test -p semantic-ir-to-go` — full suite green, including the new real `go run` execution tests
- [x] `cargo clippy -p semantic-ir-to-go --all-targets -- -D warnings` — clean
- [x] `/security-review` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)