### PR TITLE
feat(semantic-ir-to-rust): SIR21 T3b-2 Slice 2 -- div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.41.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive-only: adds the four new division builtin names from SIR21 T3b-2
+(`code/specs/SIR21-type-system-and-integer-semantics.md` §E3). Bare `"/"`
+keeps working unchanged — no frontend emits any of the new names yet.
+
+- `div_floor` is a bare dispatch-table rename of the existing `divide`
+  (Ruby's `/` already floors ints and true-divides floats — zero new
+  logic).
+- `div_trunc`/`udiv_trunc` (signed/unsigned truncating division, rounds
+  toward zero) are genuinely new: `runtime.rs`'s `trunc_div`/
+  `utrunc_div`. Rust's own `i64`/`u64` `/` already truncates toward
+  zero, so unlike `divide`'s floor path these need no adjustment — the
+  unsigned variant exists because a `u64` ≥ 2^63 misreads as negative
+  unless reinterpreted before dividing.
+- `div_true` (always coerces to float, models Python's `/`) is also new:
+  `runtime.rs`'s `true_div`.
+- All three new functions raise a typed `ZeroDivisionError` on a zero
+  divisor — on every operand — matching `divide`'s own convention (never
+  let a bare host `/` leak IEEE `inf`/`NaN` through).
+- Added dispatch entries to both call sites: the emitter's
+  `(helper, variadic)` match table in `emit.rs`, and the by-name
+  `call_builtin_by_name` forward-compat dispatcher in `runtime.rs`.
+- New `tests/compile_and_run_division_ops.rs`: real `rustc`-compile-and-
+  execute proof for all four ops, including a zero-divisor case for
+  each (an uncaught raise exits non-zero and prints
+  `"ZeroDivisionError: divided by 0"` on stderr).
+
 ## 0.40.0 — SIR28 §7: remove dead bare `print`/`puts` handling
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -12,9 +12,14 @@ keeps working unchanged — no frontend emits any of the new names yet.
 - `div_trunc`/`udiv_trunc` (signed/unsigned truncating division, rounds
   toward zero) are genuinely new: `runtime.rs`'s `trunc_div`/
   `utrunc_div`. Rust's own `i64`/`u64` `/` already truncates toward
-  zero, so unlike `divide`'s floor path these need no adjustment — the
-  unsigned variant exists because a `u64` ≥ 2^63 misreads as negative
-  unless reinterpreted before dividing.
+  zero, so unlike `divide`'s floor path these need no rounding
+  adjustment — the unsigned variant exists because a `u64` ≥ 2^63
+  misreads as negative unless reinterpreted before dividing.
+  `trunc_div` uses `wrapping_div`, not plain `/`: `i64::MIN / -1`
+  overflows `i64` and plain `/` panics uncatchably on that one input
+  pair (caught in security review) — `wrapping_div` wraps to `i64::MIN`
+  instead, matching this runtime's existing saturate-on-overflow
+  convention (`floor_div_i64`'s own `wrapping_rem` does the same).
 - `div_true` (always coerces to float, models Python's `/`) is also new:
   `runtime.rs`'s `true_div`.
 - All three new functions raise a typed `ZeroDivisionError` on a zero

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1619,6 +1619,15 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "-" => ("__sir::minus", true),
         "*" => ("__sir::times", true),
         "/" => ("__sir::divide", true),
+        // SIR21 T3b-2: `div_floor` is a bare rename of `divide` (Ruby's `/`
+        // already floors ints / true-divides floats — see `divide`'s own
+        // doc comment). `div_trunc`/`udiv_trunc`/`div_true` are genuinely
+        // new, strictly-binary ops (see `runtime.rs`'s doc comments above
+        // `trunc_div`/`utrunc_div`/`true_div`).
+        "div_floor" => ("__sir::divide", true),
+        "div_trunc" => ("__sir::trunc_div", false),
+        "udiv_trunc" => ("__sir::utrunc_div", false),
+        "div_true" => ("__sir::true_div", false),
         "=" => ("__sir::eq", false),
         "case_eq" => ("__sir::case_eq", false),
         "<" => ("__sir::lt", false),

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -615,6 +615,59 @@ pub const RUNTIME: &str = r##"mod __sir {
         Value::Int(acc)
     }
 
+    // ── SIR21 T3b-2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` ────
+    //
+    // `divide` above IS `div_floor` — Ruby's `/` already floors ints and
+    // true-divides floats, so `div_floor` is wired as a bare rename in the
+    // emitter's dispatch table (no new function). The three below are
+    // genuinely new: SIR21 §E3 splits the old overloaded `/` into four
+    // named ops so a non-Ruby-sourced frontend can pick its own rounding
+    // mode instead of silently inheriting Ruby's. All three are strictly
+    // binary (unlike the variadic `+`/`-`/`*`/`/`) — no frontend emits a
+    // chained `div_trunc(a, b, c)`.
+    //
+    // Both raise a typed `ZeroDivisionError` on a zero divisor, on every
+    // operand type, matching `divide`'s own convention above (never let a
+    // bare host `/` leak IEEE `inf`/`NaN` through).
+
+    /// Signed truncating division (rounds toward zero). Integer-only —
+    /// matches the C backend's `tdiv`, which `div_trunc` absorbs/replaces.
+    /// Unlike `divide`'s floor path, this needs NO adjustment: Rust's own
+    /// `i64` `/` already truncates toward zero.
+    pub fn trunc_div(a: Value, b: Value) -> Value {
+        let x = as_i64(&a);
+        let y = as_i64(&b);
+        if y == 0 {
+            raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+        }
+        Value::Int(x / y)
+    }
+
+    /// Unsigned truncating division — the twin of `trunc_div` for values
+    /// that are semantically `u64` but stored tagged as `i64`. A `u64` ≥
+    /// 2^63 misreads as negative unless reinterpreted before dividing, so
+    /// this is NOT just `trunc_div` under another name.
+    pub fn utrunc_div(a: Value, b: Value) -> Value {
+        let x = as_i64(&a) as u64;
+        let y = as_i64(&b) as u64;
+        if y == 0 {
+            raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+        }
+        Value::Int((x / y) as i64)
+    }
+
+    /// Always true-divides — coerces both operands to `f64` and divides,
+    /// even when both are ints (`6 / 3` yields `2.0`, not `2`). Models
+    /// Python's `/`. Genuinely new on every backend: no prior op in this
+    /// runtime unconditionally floats an all-integer division.
+    pub fn true_div(a: Value, b: Value) -> Value {
+        let y = as_f64(&b);
+        if y == 0.0 {
+            raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+        }
+        Value::Float(as_f64(&a) / y)
+    }
+
     // ── comparison ────────────────────────────────────────────────
     pub fn eq(a: Value, b: Value) -> Value {
         Value::Bool(value_eq(&a, &b))
@@ -1297,6 +1350,19 @@ pub const RUNTIME: &str = r##"mod __sir {
             "-" => minus(args),
             "*" => times(args),
             "/" => divide(args),
+            "div_floor" => divide(args),
+            "div_trunc" => {
+                let mut it = args.into_iter();
+                trunc_div(it.next().unwrap_or(Value::Int(0)), it.next().unwrap_or(Value::Int(0)))
+            }
+            "udiv_trunc" => {
+                let mut it = args.into_iter();
+                utrunc_div(it.next().unwrap_or(Value::Int(0)), it.next().unwrap_or(Value::Int(0)))
+            }
+            "div_true" => {
+                let mut it = args.into_iter();
+                true_div(it.next().unwrap_or(Value::Int(0)), it.next().unwrap_or(Value::Int(0)))
+            }
             // Ruby unary minus (`-x`) lowers to `BuiltinCall("neg", [x])`. It
             // was UNIMPLEMENTED here, so any negative literal panicked with
             // "unknown builtin: neg" (the JS/Python runtimes already had it).

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -632,15 +632,27 @@ pub const RUNTIME: &str = r##"mod __sir {
 
     /// Signed truncating division (rounds toward zero). Integer-only —
     /// matches the C backend's `tdiv`, which `div_trunc` absorbs/replaces.
-    /// Unlike `divide`'s floor path, this needs NO adjustment: Rust's own
-    /// `i64` `/` already truncates toward zero.
+    /// Unlike `divide`'s floor path, this needs NO rounding adjustment:
+    /// Rust's own `i64` `/` already truncates toward zero.
+    ///
+    /// Uses `wrapping_div`, not plain `/`: `i64::MIN / -1` is not
+    /// representable (the mathematical result, `2^63`, overflows `i64`) and
+    /// plain `/` PANICS on that one input pair, in both debug and release —
+    /// unlike the zero-divisor case, that panic is NOT a `SirError`, so it
+    /// cannot be `rescue`d (see `install_panic_hook`/`exc_from_payload`,
+    /// which deliberately let a non-`SirError` panic propagate uncaught).
+    /// `wrapping_div` sidesteps this the same way `floor_div_i64` already
+    /// does below, returning `i64::MIN` (the two's-complement wraparound
+    /// value) instead of panicking — consistent with this runtime's
+    /// existing saturate/wrap-on-overflow convention for fixed-width `i64`
+    /// (see `<<`'s saturation and `floor_div_i64`'s own `wrapping_rem`).
     pub fn trunc_div(a: Value, b: Value) -> Value {
         let x = as_i64(&a);
         let y = as_i64(&b);
         if y == 0 {
             raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
         }
-        Value::Int(x / y)
+        Value::Int(x.wrapping_div(y))
     }
 
     /// Unsigned truncating division — the twin of `trunc_div` for values

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_division_ops.rs
@@ -1,0 +1,261 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the Rust backend — hand-builds a module calling each op
+//! directly (bypassing the frontend, since no frontend emits these names
+//! yet), emits Rust, compiles with `rustc`, runs it, checks stdout/exit
+//! status. Mirrors `compile_and_run_floats.rs`/
+//! `compile_and_run_typed_runtime_errors.rs`'s identical pattern; gates on
+//! `rustc` being usable (and a working linker) and skips (does not fail)
+//! if either is absent.
+//!
+//! `div_floor` is a rename of this backend's existing `divide` (already
+//! exercised end-to-end by `compile_and_run_floats.rs`'s `1 = 1.0` case and
+//! `compile_and_run_typed_runtime_errors.rs`'s zero-divisor cases) —
+//! verified here by checking it computes the SAME values that already-
+//! tested helper does. `div_trunc`/`udiv_trunc`/`div_true` are genuinely
+//! new, and get the most coverage here, including the zero-divisor raise
+//! path for every op (an uncaught SIR `raise` exits non-zero and prints
+//! `"ZeroDivisionError: divided by 0"` on stderr, per `report_uncaught`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+            // Needed for the top-level `catch_unwind`/`report_uncaught`
+            // wrapper `emit_main` only emits when `Feature::Exceptions` is
+            // declared — without it an uncaught `raise` (the zero-divisor
+            // test below) surfaces as a raw, unhelpful Rust panic instead
+            // of the clean "ZeroDivisionError: divided by 0" message.
+            Feature::Exceptions,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile emitted Rust and run it. Returns `None` if `rustc` is
+/// unavailable, or the host has no usable linker — both are skips, never
+/// failures.
+fn run_raw(module: &Module, tag: &str) -> Option<std::process::Output> {
+    if !rustc_available() {
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Rust source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_rs_div_{tag}_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_rs_div_{tag}_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out =
+        cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let out = Command::new(&bin_path).output().expect("run compiled binary");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    Some(out)
+}
+
+fn run(module: &Module, tag: &str) -> Option<String> {
+    let out = run_raw(module, tag)?;
+    assert!(
+        out.status.success(),
+        "emitted Rust failed at runtime:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+fn run_expect_zero_div_failure(module: &Module, tag: &str) -> Option<()> {
+    let out = run_raw(module, tag)?;
+    assert!(
+        !out.status.success(),
+        "expected a zero-divisor failure (nonzero exit), got success with stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ZeroDivisionError: divided by 0"),
+        "expected 'ZeroDivisionError: divided by 0' on stderr, got:\n{stderr}"
+    );
+    Some(())
+}
+
+// ── §E3's own worked example, verbatim ──────────────────────────────────
+
+#[test]
+fn e3_worked_example() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_floor", ilit(7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+            print_stmt(bin("div_true", ilit(7), ilit(2))),
+        ]),
+        "e3",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-3", "3.5"]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
+// ── div_floor: a rename of `divide`'s int path ────────────────────────
+
+#[test]
+fn div_floor_floors_toward_negative_infinity() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_floor", ilit(7), ilit(2))),
+            print_stmt(bin("div_floor", ilit(-7), ilit(2))),
+            print_stmt(bin("div_floor", ilit(7), ilit(-2))),
+            print_stmt(bin("div_floor", ilit(-7), ilit(-2))),
+        ]),
+        "floor",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-4", "-4", "3"]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
+// ── div_trunc/udiv_trunc: truncate toward zero ───────────────────────────
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_trunc", ilit(7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+            print_stmt(bin("div_trunc", ilit(7), ilit(-2))),
+            print_stmt(bin("div_trunc", ilit(-7), ilit(-2))),
+        ]),
+        "trunc",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3", "-3", "-3", "3"]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    match run(
+        &div_module(vec![print_stmt(bin("udiv_trunc", ilit(7), ilit(2)))]),
+        "udiv",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3"]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
+// ── div_true: genuinely new — always true-divides ────────────────────────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    match run(
+        &div_module(vec![
+            print_stmt(bin("div_true", ilit(7), ilit(2))),
+            print_stmt(bin("div_true", ilit(-7), ilit(2))),
+            print_stmt(bin("div_true", ilit(6), ilit(3))),
+        ]),
+        "true",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3.5", "-3.5", "2.0"]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
+#[test]
+fn zero_divisor_fails_with_zero_division_error_for_every_op() {
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        match run_expect_zero_div_failure(&div_module(vec![print_stmt(bin(op, ilit(7), ilit(0)))]), op)
+        {
+            Some(()) => {}
+            None => {
+                eprintln!("skip: no rustc/linker");
+                break;
+            }
+        }
+    }
+}

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_division_ops.rs
@@ -218,6 +218,23 @@ fn div_trunc_truncates_toward_zero() {
     }
 }
 
+/// `i64::MIN / -1` is not representable (the true quotient, `2^63`,
+/// overflows `i64`) — plain Rust `/` PANICS uncatchably on exactly this
+/// input pair. `trunc_div` must use `wrapping_div` instead, so this must
+/// NOT crash the process; it wraps to `i64::MIN` (two's-complement
+/// wraparound), matching this runtime's existing saturate-on-overflow
+/// convention for fixed-width `i64` rather than an uncatchable host panic.
+#[test]
+fn div_trunc_wraps_instead_of_panicking_on_i64_min_div_neg_one() {
+    match run(
+        &div_module(vec![print_stmt(bin("div_trunc", ilit(i64::MIN), ilit(-1)))]),
+        "trunc_overflow",
+    ) {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec![i64::MIN.to_string()]),
+        None => eprintln!("skip: no rustc/linker"),
+    }
+}
+
 #[test]
 fn udiv_trunc_matches_div_trunc_on_positive_operands() {
     match run(


### PR DESCRIPTION
## Summary
- Third of Slice 2's seven backend PRs (after C #11880, Go #11883) for the SIR21 T3b-2 division-op split (`code/specs/SIR21-type-system-and-integer-semantics.md` §E3).
- Adds `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` to `semantic-ir-to-rust`'s dispatch table and runtime, purely additively -- bare `"/"` keeps working unchanged, no frontend emits the new names yet.
- `div_floor` is a bare rename of the existing `divide` (Ruby's `/` already floors ints / true-divides floats -- zero new logic).
- `div_trunc`/`udiv_trunc`/`div_true` are genuinely new runtime functions (`trunc_div`/`utrunc_div`/`true_div`), all raising a typed `ZeroDivisionError` on a zero divisor, matching `divide`'s own convention.
- Security review (2 rounds) caught and fixed a real issue: `trunc_div` originally used plain `i64` `/`, which panics uncatchably on `i64::MIN / -1` (an overflow the panic hook can't route to a `rescue`). Fixed with `wrapping_div`, matching this file's own existing `floor_div_i64` convention for the identical edge case.

## Test plan
- [x] New `tests/compile_and_run_division_ops.rs`: real `rustc`-compile-and-execute proof for all four ops, including the §E3 worked example, floor-vs-truncate divergence, a zero-divisor case for every op, and a regression test for the `i64::MIN / -1` overflow-wrap fix.
- [x] Full crate test suite green (`cargo test`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Security review: 2 rounds, PASSED (round 1 found and this PR fixes the `i64::MIN / -1` panic; round 2 confirmed the fix and found nothing else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)