### PR TITLE
fix(ci): stale unknown/programs/task-app prefix in 5 mosaic acceptance gates

### DIFF
--- a/code/scripts/mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_compose_runtime_ci_acceptance.py
@@ -23,10 +23,10 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/moslayout-compiler",
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
-        "unknown/programs/task-app",
+        "mosaic/programs/task-app",
     }
 )
-ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+ACCEPTANCE_PACKAGE_PREFIXES = ("mosaic/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
 

--- a/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
@@ -23,10 +23,10 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/moslayout-compiler",
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
-        "unknown/programs/task-app",
+        "mosaic/programs/task-app",
     }
 )
-ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+ACCEPTANCE_PACKAGE_PREFIXES = ("mosaic/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
 

--- a/code/scripts/mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_qt_runtime_ci_acceptance.py
@@ -23,10 +23,10 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/moslayout-compiler",
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
-        "unknown/programs/task-app",
+        "mosaic/programs/task-app",
     }
 )
-ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+ACCEPTANCE_PACKAGE_PREFIXES = ("mosaic/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
 

--- a/code/scripts/mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_swift_runtime_ci_acceptance.py
@@ -23,10 +23,10 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/moslayout-compiler",
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
-        "unknown/programs/task-app",
+        "mosaic/programs/task-app",
     }
 )
-ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+ACCEPTANCE_PACKAGE_PREFIXES = ("mosaic/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
 

--- a/code/scripts/mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/mosaic_xaml_windows_ci_acceptance.py
@@ -23,10 +23,10 @@ ACCEPTANCE_PACKAGES = frozenset(
         "rust/mosmodel-compiler",
         "rust/mosstyle-compiler",
         "rust/task-mosaic-app",
-        "unknown/programs/task-app",
+        "mosaic/programs/task-app",
     }
 )
-ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+ACCEPTANCE_PACKAGE_PREFIXES = ("mosaic/mosaic-pkg-",)
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 def requires_mosaic_xaml_windows(
     plan: dict[str, Any], *, workflow_changed: bool = False

--- a/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
@@ -64,14 +64,14 @@ class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
     def test_task_app_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_compose_runtime(
-                {"affected_packages": ["unknown/programs/task-app"]}
+                {"affected_packages": ["mosaic/programs/task-app"]}
             )
         )
 
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_compose_runtime(
-                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+                {"affected_packages": ["mosaic/mosaic-pkg-grid"]}
             )
         )
 

--- a/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
@@ -57,14 +57,14 @@ class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
     def test_task_app_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_flutter_runtime(
-                {"affected_packages": ["unknown/programs/task-app"]}
+                {"affected_packages": ["mosaic/programs/task-app"]}
             )
         )
 
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_flutter_runtime(
-                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+                {"affected_packages": ["mosaic/mosaic-pkg-grid"]}
             )
         )
 

--- a/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
@@ -60,14 +60,14 @@ class MosaicQtRuntimeCIAcceptanceTests(unittest.TestCase):
     def test_task_app_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_qt_runtime(
-                {"affected_packages": ["unknown/programs/task-app"]}
+                {"affected_packages": ["mosaic/programs/task-app"]}
             )
         )
 
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_qt_runtime(
-                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+                {"affected_packages": ["mosaic/mosaic-pkg-grid"]}
             )
         )
 

--- a/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
@@ -55,14 +55,14 @@ class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
     def test_task_app_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_swift_runtime(
-                {"affected_packages": ["unknown/programs/task-app"]}
+                {"affected_packages": ["mosaic/programs/task-app"]}
             )
         )
 
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_swift_runtime(
-                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+                {"affected_packages": ["mosaic/mosaic-pkg-grid"]}
             )
         )
 

--- a/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_xaml_windows_ci_acceptance.py
@@ -66,7 +66,7 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
                 )
 
     def test_task_app_requires_acceptance(self) -> None:
-        for package in ("unknown/programs/task-app", "rust/task-mosaic-app"):
+        for package in ("mosaic/programs/task-app", "rust/task-mosaic-app"):
             with self.subTest(package=package):
                 self.assertTrue(
                     MODULE.requires_mosaic_xaml_windows(
@@ -77,7 +77,7 @@ class MosaicXamlWindowsCIAcceptanceTests(unittest.TestCase):
     def test_standard_mosaic_package_requires_acceptance(self) -> None:
         self.assertTrue(
             MODULE.requires_mosaic_xaml_windows(
-                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+                {"affected_packages": ["mosaic/mosaic-pkg-grid"]}
             )
         )
 


### PR DESCRIPTION
## Summary

Follow-up to [PR #11876](https://github.com/adhithyan15/coding-adventures/pull/11876), which fixed the same latent bug for the venture-browser acceptance gate.

Five CI helper scripts gate native-toolchain setup steps (Swift, Compose/Kotlin, Flutter, XAML/Windows, Qt) on whether the go build-tool's build plan lists a package matching a hardcoded `ACCEPTANCE_PACKAGES` set / `ACCEPTANCE_PACKAGE_PREFIXES` prefix. All five still reference `"unknown/programs/task-app"` and `"unknown/mosaic-pkg-"`, but the build-tool now classifies `.mil/.mll/.msl`-based Mosaic packages under `language: "mosaic"` rather than the generic `"unknown"` fallback — the real package names are `"mosaic/programs/task-app"` and `"mosaic/mosaic-pkg-*"`.

A PR touching only task-app's non-Rust Mosaic sources (without touching Rust files elsewhere, which would set `needs_rust=true` independently and mask the gap) would silently skip the native runtime setup these gates control, then fail downstream in the build-plan-driven build step — the exact failure mode diagnosed and fixed for venture-browser in #11876.

## Changes

- `code/scripts/mosaic_swift_runtime_ci_acceptance.py`
- `code/scripts/mosaic_compose_runtime_ci_acceptance.py`
- `code/scripts/mosaic_flutter_runtime_ci_acceptance.py`
- `code/scripts/mosaic_xaml_windows_ci_acceptance.py`
- `code/scripts/mosaic_qt_runtime_ci_acceptance.py`
- Matching test fixtures under `code/scripts/tests/`

Purely mechanical: `"unknown/programs/task-app"` → `"mosaic/programs/task-app"`, `"unknown/mosaic-pkg-"` → `"mosaic/mosaic-pkg-"`.

## Verification

- Confirmed the real package name via the build-tool: `build-tool -force -detect-languages -emit-plan plan.json`, then grepped the emitted `packages` list for `task-app` and `mosaic-pkg-` entries — both are under `language: "mosaic"`.
- Each script's full test suite passes.
- Each script now returns `required=true` when given `{"affected_packages": ["mosaic/programs/task-app"]}` (previously `false`).
- `/security-review` sub-agent reviewed the diff and passed — it's a pure string-constant correction, no new logic or external input handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)