### PR TITLE
feat(semantic-ir-to-ruby): SIR21 T3b-2 Slice 2 -- div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.23.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive-only: adds the four new division builtin names from SIR21 T3b-2
+(`code/specs/SIR21-type-system-and-integer-semantics.md` §E3) to
+`SUPPORTED_BUILTINS` (the validator allowlist gate) and `emit_builtin`'s
+match. Bare `"/"` and `tdiv`/`utdiv` keep working unchanged — no frontend
+emits any of the new names yet.
+
+- `div_floor` renders IDENTICALLY to bare `/` (a pure alias, not a new
+  code path) — Ruby's own `/` already floors ints and true-divides
+  floats. It deliberately inherits `/`'s existing float-zero-divisor
+  behavior (native Ruby `1.0 / 0` silently returns `Infinity`, unlike
+  `Integer#/0`, which raises) rather than retroactively "fixing" it here
+  — this additive slice changes zero pre-existing behavior, matching the
+  precedent set by this arc's C backend PR.
+- `div_trunc`/`udiv_trunc` reuse the pre-existing `sir_tdiv` helper —
+  identical to `tdiv`/`utdiv` today (this pair is slated to replace those
+  names in a later cleanup slice; both stay wired to the same helper in
+  the meantime, per the spec's absorbs/replaces decision). Zero-divisor
+  raises via Ruby's own native `Integer#/0` — no explicit check needed.
+- `div_true` is genuinely new: `sir_true_div`, a new runtime function.
+  Ruby's native `/` can't be reused directly for two reasons —
+  `Integer#/` floors instead of true-dividing, and `Float#/0` silently
+  returns `Infinity` rather than raising — so `sir_true_div` explicitly
+  checks for a zero divisor before the float divide runs, closing the
+  gap a naive `a.to_f / b` would leave open.
+- New `tests/division_ops_tests.rs`: real `ruby`-execution proof for all
+  four ops, including the §E3 worked example, floor-vs-truncate
+  divergence, and a zero-divisor case for every op.
+
 ## 0.22.0 — SIR28 §7: remove dead bare `print`/`puts` handling
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -57,6 +57,19 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "tmod",
     "utdiv",
     "utmod",
+    // SIR21 T3b-2: the four-way division-op split. `div_floor` is a bare
+    // alias for the pre-existing `/` (Ruby's own `Integer#/`/`Float#/`
+    // ALREADY are floor/true-divide, respectively — no runtime helper
+    // needed). `div_trunc`/`udiv_trunc` reuse the existing `sir_tdiv`
+    // helper above (same as `tdiv`/`utdiv`, which this pair will
+    // eventually replace — see the spec's "absorbs/replaces" note).
+    // `div_true` is genuinely new: see `sir_true_div`'s doc comment in
+    // `runtime.rs` for why it needs an explicit zero-check (Ruby's native
+    // `Float#/0` silently returns `Infinity`, unlike `Integer#/0`).
+    "div_floor",
+    "div_trunc",
+    "udiv_trunc",
+    "div_true",
     // Numeric conversions (SIR27 milestone 9, floating point): `to_f` widens an
     // integer to `double`, `to_i` truncates a `double` toward zero to an integer
     // (the frontend then masks it to the target width with a `Convert`).
@@ -1482,6 +1495,24 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         // non-negative Integer, for which truncation and flooring coincide.
         "tdiv" | "utdiv" => format!("sir_tdiv({}, {})", arg(&a, 0), arg(&a, 1)),
         "tmod" | "utmod" => format!("sir_tmod({}, {})", arg(&a, 0), arg(&a, 1)),
+        // SIR21 T3b-2: `div_floor` renders IDENTICALLY to bare `/` — Ruby's
+        // own `/` already is `div_floor` (floors ints, true-divides
+        // floats), so this is a pure alias, not a new code path. It
+        // deliberately inherits `/`'s existing float-zero-divisor
+        // behavior (native Ruby `1.0 / 0` silently returns `Infinity`,
+        // unlike `Integer#/0`, which raises) rather than retroactively
+        // "fixing" it here — this additive slice changes zero pre-existing
+        // behavior, matching the precedent set by this arc's C backend PR
+        // (whose `div_floor` alias inherited that backend's own
+        // pre-existing float-zero gap for the identical reason).
+        "div_floor" => format!("({})", join_op(&a, " / ", "1")),
+        // `div_trunc`/`udiv_trunc` reuse the existing `sir_tdiv` helper —
+        // identical to `tdiv`/`utdiv` today (this pair is slated to
+        // replace those names in a later cleanup slice; both stay wired
+        // to the same helper in the meantime, per the spec's
+        // absorbs/replaces decision).
+        "div_trunc" | "udiv_trunc" => format!("sir_tdiv({}, {})", arg(&a, 0), arg(&a, 1)),
+        "div_true" => format!("sir_true_div({}, {})", arg(&a, 0), arg(&a, 1)),
         // `to_f`/`to_i`: Ruby's native `Numeric#to_f` (int → Float) and
         // `Float#to_i` (truncates toward zero, matching C's `(int)double` cast).
         "to_f" => format!("({}).to_f", arg(&a, 0)),

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -138,6 +138,19 @@ end
 def sir_tdiv(a, b) = (a - a.remainder(b)) / b
 def sir_tmod(a, b) = a.remainder(b)
 
+# SIR21 T3b-2 `div_true` — ALWAYS true-divides, even for two Integer
+# operands (`sir_true_div(6, 3) == 2.0`, not `2`).  Ruby's native `/`
+# can't be reused directly for two reasons: `Integer#/` floors instead of
+# true-dividing, and `Float#/0` silently returns `Infinity` (Ruby does
+# NOT raise there, unlike `Integer#/0`) — so a naive `a.to_f / b` would
+# let a zero divisor through as IEEE `Infinity`/`NaN` rather than the
+# typed `ZeroDivisionError` every sibling division op raises.  The
+# explicit check below closes that gap before the float divide ever runs.
+def sir_true_div(a, b)
+  raise ZeroDivisionError, "divided by 0" if b == 0
+  a.to_f / b.to_f
+end
+
 # The key is normalised with to_s so a name that arrives as a Symbol (how the
 # _init function's global_set passes it) and the same name as a String (how a
 # VarRef Global reads it) hit the same entry.

--- a/code/packages/rust/semantic-ir-to-ruby/tests/division_ops_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/division_ops_tests.rs
@@ -1,0 +1,201 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the Ruby backend — hand-builds a module calling each op
+//! directly (bypassing the frontend, since no frontend emits these names
+//! yet), emits Ruby, runs it with a real `ruby` interpreter, and asserts
+//! stdout/exit status. Mirrors `sys_write_tests.rs`'s pattern; skips
+//! (does not fail) when no `ruby` is on `PATH`.
+//!
+//! `div_floor` is a bare alias for the pre-existing `/` (already exercised
+//! everywhere `/` is used) — verified here by checking it computes the SAME
+//! values that op already produces. `div_trunc`/`udiv_trunc`/`div_true` are
+//! the ones with real new logic (`div_trunc`/`udiv_trunc` share the
+//! pre-existing `sir_tdiv` helper `tdiv`/`utdiv` already use; `div_true` is
+//! entirely new), and get the most coverage here, including the
+//! zero-divisor case — where `div_floor`/`div_trunc`/`udiv_trunc` raise via
+//! Ruby's own native `Integer#/0`, but `div_true` needs its own explicit
+//! check (Ruby's native `Float#/0` silently returns `Infinity`).
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Run emitted Ruby, returning `(stdout, stderr, success)`, or `None` to
+/// skip when no `ruby` is on `PATH`. Unlike `sys_write_tests.rs`'s
+/// `run_ruby` (which panics on non-zero exit), this surfaces the exit
+/// status too, since the zero-divisor tests below expect a NON-zero exit.
+fn run_division_program(m: &Module) -> Option<(String, String, bool)> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    let source = semantic_ir_to_ruby::compile(m).expect("ruby emit").source;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "sir_ruby_div_{}_{}.rb",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::File::create(&path).ok()?.write_all(source.as_bytes()).ok()?;
+    let out = std::process::Command::new("ruby").arg(&path).output().ok()?;
+    let _ = std::fs::remove_file(&path);
+    Some((
+        String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n"),
+        String::from_utf8_lossy(&out.stderr).replace("\r\n", "\n"),
+        out.status.success(),
+    ))
+}
+
+fn run_division_ok(m: &Module) -> Option<String> {
+    let (out, err, ok) = run_division_program(m)?;
+    assert!(ok, "emitted ruby exited non-zero:\n{err}");
+    Some(out)
+}
+
+// ── §E3's own worked example, verbatim ──────────────────────────────────
+
+#[test]
+fn e3_worked_example() {
+    let m = div_module(vec![
+        print_stmt(bin("div_floor", ilit(7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+        print_stmt(bin("div_true", ilit(7), ilit(2))),
+    ]);
+    match run_division_ok(&m) {
+        Some(out) => assert_eq!(out, "3\n-3\n3.5\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── div_floor: a bare alias for `/`'s existing floor logic ───────────────
+
+#[test]
+fn div_floor_floors_toward_negative_infinity() {
+    let m = div_module(vec![
+        print_stmt(bin("div_floor", ilit(7), ilit(2))),
+        print_stmt(bin("div_floor", ilit(-7), ilit(2))),
+        print_stmt(bin("div_floor", ilit(7), ilit(-2))),
+        print_stmt(bin("div_floor", ilit(-7), ilit(-2))),
+    ]);
+    match run_division_ok(&m) {
+        Some(out) => assert_eq!(out, "3\n-4\n-4\n3\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── div_trunc/udiv_trunc: truncate toward zero ───────────────────────────
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    let m = div_module(vec![
+        print_stmt(bin("div_trunc", ilit(7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(7), ilit(-2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(-2))),
+    ]);
+    match run_division_ok(&m) {
+        Some(out) => assert_eq!(out, "3\n-3\n-3\n3\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    let m = div_module(vec![print_stmt(bin("udiv_trunc", ilit(7), ilit(2)))]);
+    match run_division_ok(&m) {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── div_true: genuinely new — always true-divides ────────────────────────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    let m = div_module(vec![
+        print_stmt(bin("div_true", ilit(7), ilit(2))),
+        print_stmt(bin("div_true", ilit(-7), ilit(2))),
+        print_stmt(bin("div_true", ilit(6), ilit(3))),
+    ]);
+    match run_division_ok(&m) {
+        Some(out) => assert_eq!(out, "3.5\n-3.5\n2.0\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+/// `div_floor`/`div_trunc`/`udiv_trunc` raise via Ruby's own NATIVE
+/// `Integer#/0` (no explicit check needed in the emitted code — confirmed
+/// by `sir_tdiv`'s own doc comment: "Division by zero raises (as in C it
+/// is undefined)"). `div_true` needs its own explicit check in
+/// `sir_true_div` — Ruby's native `Float#/0` silently returns `Infinity`
+/// rather than raising, which this op must NOT let through.
+#[test]
+fn zero_divisor_raises_zero_division_error_for_every_op() {
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        let m = div_module(vec![print_stmt(bin(op, ilit(7), ilit(0)))]);
+        let Some((out, err, ok)) = run_division_program(&m) else {
+            eprintln!("skip: no ruby on PATH");
+            break;
+        };
+        assert!(!ok, "[{op}] expected a non-zero exit; stdout={out:?}");
+        assert!(
+            err.contains("ZeroDivisionError") && err.contains("divided by 0"),
+            "[{op}] expected 'ZeroDivisionError'/'divided by 0' on stderr, got:\n{err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fifth of Slice 2's seven backend PRs (after C #11880, Go #11883, Rust #11885, Python #11889) for the SIR21 T3b-2 division-op split (`code/specs/SIR21-type-system-and-integer-semantics.md` §E3).
- Adds `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` to `semantic-ir-to-ruby`'s `SUPPORTED_BUILTINS` allowlist and dispatch table, purely additively -- bare `"/"` and `tdiv`/`utdiv` keep working unchanged, no frontend emits the new names yet.
- `div_floor` renders identically to bare `/` (a pure alias) -- Ruby's own `/` already floors ints and true-divides floats. It deliberately inherits `/`'s existing float-zero-divisor behavior (native Ruby `1.0 / 0` silently returns `Infinity`, unlike `Integer#/0`, which raises) rather than retroactively fixing it here, matching the precedent set by this arc's C backend PR.
- `div_trunc`/`udiv_trunc` reuse the pre-existing `sir_tdiv` helper (identical to `tdiv`/`utdiv` today; this pair is slated to replace those names in a later cleanup slice).
- `div_true` is genuinely new (`sir_true_div`): Ruby's native `/` can't be reused directly since `Integer#/` floors and `Float#/0` silently returns `Infinity` rather than raising, so the new helper explicitly checks for a zero divisor before the float divide runs.

## Test plan
- [x] New `tests/division_ops_tests.rs`: real `ruby`-execution proof for all four ops, covering the §E3 worked example, floor-vs-truncate divergence, and a zero-divisor case for every op.
- [x] Full crate test suite green (`cargo test`, 130 passed across unit + integration tests).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Security review: PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)