### PR TITLE
feat(arm1): add ARM1 encoder + backend (minimal viable AOT target)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -879,6 +879,8 @@ members = [
     "ge225-backend",
     "ibm704-encoder",
     "ibm704-backend",
+    "arm1-encoder",
+    "arm1-backend",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/arm1-backend/BUILD
+++ b/code/packages/rust/arm1-backend/BUILD
@@ -1,0 +1,1 @@
+cargo test -p arm1-backend

--- a/code/packages/rust/arm1-backend/CHANGELOG.md
+++ b/code/packages/rust/arm1-backend/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog — arm1-backend
+
+## v0.1.0 — 2026-08-17 — second lane of the 9-architecture expansion
+
+Initial release.  Minimal viable `Backend` trait impl for ARM1
+(ARMv1).  Covers `const_*` + `ret_*` — enough to compile the
+canonical Twig `42` program to
+`[0x2A, 0x00, 0xA0, 0xE3, 0x56, 0x34, 0x12, 0xEF]`
+(`MOV R0, #42; SWI #0x123456`), verified byte-for-byte and by
+actually executing the emitted bytes in `arm1-simulator`.
+
+### Public API
+
+- `pub struct Arm1Backend` with `impl Backend`:
+  - `name() -> "arm1"`
+  - `compile(&[CIRInstr]) -> Option<Vec<u8>>` (little-endian flattened)
+  - `compile_function(&FunctionContext, &[CIRInstr]) -> Option<Vec<u8>>`
+  - `run(_, _)` panics with "arm1 backend is emit-only; load bytes
+    into arm1-simulator to execute"
+- `pub fn compile(ctx, cir) -> Result<Vec<u8>, BackendError>`
+- `pub enum BackendError` — 4 diagnostic variants.
+
+### Covered CIR ops
+
+- `const_*` (unrotated 8-bit range `[0, 255]`) → `MOV R0, #imm`
+- `ret_*`, `ret_void` → pseudo-halt `SWI #0x123456`
+- Anything else → `None` (graceful AOT/JIT fallback)
+
+### Why a pseudo-halt instead of `BX LR`
+
+ARM1/ARMv1 predates the link-register-return convention `armv7-backend`
+uses — there is no `BX` instruction, and the era's `MOVS PC, R14`
+return idiom needs a live `R14` set by a preceding `BL` (i.e. a
+caller), which the minimal-viable scope never establishes.
+`arm1-simulator` already defines a pseudo-halt (`SWI #0x123456`,
+intercepted by `execute_swi` to set `halted() == true`) for exactly
+this "the program is done" signal, so `ret_*`/`ret_void` lower to it.
+See `src/lib.rs`'s crate-level doc comment for the full derivation.
+
+### What's NOT in this PR
+
+Full op coverage (add/sub/and/or/xor/cmp/branches/calls) is
+intentionally out of scope for the minimal-viable lane.  Future
+increments can add them, along with a real register allocator over
+ARM1's other 14 general-purpose registers.
+
+### Tests
+
+14 unit/integration tests pin the canonical
+`MOV R0, #42; SWI #0x123456` byte sequence and edge cases (zero,
+8-bit range boundaries — negative and >255 — bool, multi-var
+fallthrough, unsupported op, empty CIR, `ret_void`, `Backend::run`
+panics, `Backend::compile` vs the free `compile` function agree),
+plus one test that loads the compiled bytes into `arm1-simulator`
+and asserts `R0 == 42` and `halted() == true` after execution — not
+just a hand-asserted byte array.

--- a/code/packages/rust/arm1-backend/Cargo.toml
+++ b/code/packages/rust/arm1-backend/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "arm1-backend"
+version = "0.1.0"
+edition = "2021"
+description = "ARM1 (ARMv1) backend for jit-core / aot-core.  Lowers a Vec<CIRInstr> into ARM1 machine code via arm1-encoder.  Emit-only -- bytes go to arm1-simulator.  Minimal viable: const_*/ret_* only, trivial single-register (r0) allocator; ret_* lowers to the arm1-simulator pseudo-halt (SWI #0x123456) rather than BX LR, since ARM1/ARMv1 predates the link-register-return convention.  Mirror of mips-r2000-backend / armv7-backend / intel8008-backend in shape and intent.  Second lane of the 9-architecture expansion following the historical-arch backend migration pattern."
+
+[lib]
+name = "arm1_backend"
+path = "src/lib.rs"
+
+[dependencies]
+arm1-encoder = { path = "../arm1-encoder" }
+jit-core     = { path = "../jit-core" }
+vm-core      = { path = "../vm-core" }
+
+[dev-dependencies]
+arm1-simulator = { path = "../arm1-simulator" }

--- a/code/packages/rust/arm1-backend/README.md
+++ b/code/packages/rust/arm1-backend/README.md
@@ -1,0 +1,23 @@
+# arm1-backend
+
+ARM1 (ARMv1) backend for `jit-core` / `aot-core`.  Second lane of the
+9-architecture expansion following the pattern documented in
+[`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).
+
+**v0.1.0 scope**: minimal viable — covers `const_*` (unrotated 8-bit
+imm into `R0`) + `ret_*` (pseudo-halt `SWI #0x123456`). Enough to
+compile the canonical Twig `42` program to `lang-aot --emit=arm1`
+byte-for-byte, verified against the in-tree `arm1-simulator`.
+
+ARM1/ARMv1 (1985) predates the `BX`/link-register-return convention
+`armv7-backend` (its architectural descendant) uses, so `ret_*` lowers
+to `arm1-simulator`'s pseudo-halt instruction instead of `BX LR` — see
+the crate-level doc comment in `src/lib.rs` for the full rationale.
+
+Full op coverage (add/sub/cmp/branches/calls) is **not** ported in
+this PR — future increments can add them.  Per the GUIDING
+CONSTRAINT, the architectural fix (IIR → CIR via `Backend` trait) is
+delivered as soon as the AOT path is wired, regardless of op-set
+parity.
+
+See [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).

--- a/code/packages/rust/arm1-backend/src/lib.rs
+++ b/code/packages/rust/arm1-backend/src/lib.rs
@@ -1,0 +1,238 @@
+//! # `arm1-backend` — ARM1 (ARMv1) backend for jit-core / aot-core.
+//!
+//! Lowers a `Vec<CIRInstr>` into ARM1 machine code via
+//! [`arm1_encoder`].  Output is `Vec<u8>` (little-endian-encoded
+//! ARM1 words — ARM1's byte order, matching
+//! `arm1_simulator::ARM1::read_word`/`write_word`) so callers can
+//! write it straight to a `.bin` file.
+//!
+//! Mirror of [`mips_r2000_backend`] / [`armv7_backend`] /
+//! [`intel8008_backend`] in shape.  Second lane of the
+//! 9-architecture expansion following the pattern documented in
+//! [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).
+//!
+//! ## Scope (v0.1.0 — minimal viable)
+//!
+//! Minimal viable backend — covers the trivial-ROM case (`const_*`
+//! immediate + `ret_*`) needed by the `lang-aot` ARM1 e2e smoke
+//! test:
+//!
+//! | CIR op | Lowering |
+//! |--------|----------|
+//! | `const_*` (8-bit unrotated imm) | `MOV R0, #imm` |
+//! | `ret_*`, `ret_void` | pseudo-halt `SWI #0x123456` (see below) |
+//! | Anything else | returns `None` |
+//!
+//! There is no real register allocator: a trivial "last const var"
+//! scheme tracks which single variable the most recent `const_*`
+//! wrote, and `ret_*` only succeeds if it returns exactly that
+//! variable — the same scheme `mips-r2000-backend`/
+//! `armv7-backend`/`intel8008-backend` use.  Full op coverage
+//! (add/sub/cmp/branches/calls) is intentionally **not** ported
+//! here; future increments to this crate can add them, including a
+//! real allocator over ARM1's other 14 general-purpose registers.
+//!
+//! Per the migration spec, this is acceptable: the architectural
+//! correctness win (IIR → CIR via `Backend` trait) is delivered as
+//! soon as the AOT path is wired, regardless of op-set parity.
+//!
+//! ## Why does `ret_*` lower to a pseudo-halt, not `BX LR`?
+//!
+//! ARMv7's `BX LR` return-from-function convention doesn't exist in
+//! ARMv1 (1985) — there is no `BX` instruction, and the era's
+//! subroutine-return idiom, `MOVS PC, R14`, requires a live `R14`
+//! that only a preceding `BL` sets up (i.e. it needs a *caller*).
+//! The minimal-viable `const_*`/`ret_*` scope compiles a whole
+//! program's worth of CIR with no caller in the picture — the
+//! trivial ROM just needs to compute a value and stop.
+//!
+//! `arm1-simulator` already defines exactly this: a pseudo-halt
+//! instruction, `SWI #0x123456` (`arm1_simulator::HALT_SWI`), that
+//! its `execute_swi` intercepts specially — when the SWI's 24-bit
+//! comment field equals `HALT_SWI`, the simulator sets its internal
+//! `halted` flag (observable via `ARM1::halted()`) instead of
+//! entering Supervisor mode like a genuine SWI would.  This is a
+//! simulator-level halt convention (parallel to the Intel 8008
+//! backend's `HLT` byte or the GE-225 backend's `HLT` word), not
+//! real ARM1 silicon behaviour.  Lowering `ret_*`/`ret_void` to this
+//! pseudo-halt is the semantically correct choice here: it is the
+//! only instruction that actually stops the fetch-decode-execute
+//! loop, leaving the computed value in `R0` for the caller to read
+//! via `read_register(0)` — see `arm1_encoder`'s crate-level doc
+//! comment for the full derivation.
+//!
+//! ## Why is `Backend::run` not implemented?
+//!
+//! Emit-only target per the migration spec.  Bytes go to
+//! `arm1-simulator`.
+
+use arm1_encoder::{encode_halt, encode_mov_imm, COND_AL, HALT_WORD, R0};
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+use std::fmt;
+use vm_core::value::Value;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Arm1Backend;
+
+impl Arm1Backend {
+    pub fn new() -> Self {
+        Arm1Backend
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendError {
+    UnsupportedOp(String),
+    InvalidOperand(String),
+    UndefinedVariable(String),
+    ImmediateOutOfRange(i64),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedOp(op) => write!(f, "arm1-backend: unsupported op {op:?}"),
+            Self::InvalidOperand(d) => write!(f, "arm1-backend: invalid operand: {d}"),
+            Self::UndefinedVariable(n) => {
+                write!(f, "arm1-backend: undefined variable {n:?}")
+            }
+            Self::ImmediateOutOfRange(n) => write!(
+                f,
+                "arm1-backend: const {n} exceeds 8-bit MOV-immediate range [0, 255]; \
+                 wider values require the barrel shifter's rotated-immediate form, \
+                 which is out of scope for the minimal-viable backend"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+/// Compile a single function's CIR into ARM1 bytes (little-endian
+/// ARM1 words flattened to `u8`).
+pub fn compile(_ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    let words = compile_to_words(cir)?;
+    let mut bytes = Vec::with_capacity(words.len() * 4);
+    for w in &words {
+        bytes.extend_from_slice(&w.to_le_bytes());
+    }
+    Ok(bytes)
+}
+
+fn compile_to_words(cir: &[CIRInstr]) -> Result<Vec<u32>, BackendError> {
+    if cir.is_empty() {
+        // Empty CIR → just the pseudo-halt so the program stops
+        // immediately.
+        return Ok(vec![encode_halt()]);
+    }
+
+    let mut words = Vec::new();
+    // v0.1.0 uses a trivial single-register allocator: the most
+    // recent `const_*` puts its value into R0, and `ret_*` returns
+    // R0.  Programs that need more than one live var fall through
+    // to `UnsupportedOp` (returned as `None` from the Backend
+    // trait).
+    let mut last_const_var: Option<String> = None;
+
+    for instr in cir {
+        let op = instr.op.as_str();
+
+        if op == "ret_void" {
+            words.push(encode_halt());
+            continue;
+        }
+
+        if op.strip_prefix("ret_").is_some() {
+            let src_name = parse_var_src(instr, 0, op)?;
+            // We only support the case where src is the most recent
+            // const'd var (i.e. it's already in R0).  Multi-var
+            // requires a real register allocator.
+            if last_const_var.as_deref() != Some(src_name.as_str()) {
+                return Err(BackendError::UnsupportedOp(format!(
+                    "ret of {src_name:?} which is not the current R0 var; \
+                     multi-register allocation lands in a future increment"
+                )));
+            }
+            words.push(encode_halt());
+            continue;
+        }
+
+        if op.strip_prefix("const_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let imm8 = encode_immediate_8(instr.srcs.first())?;
+            // const_* always targets R0 in this minimal backend.
+            words.push(encode_mov_imm(COND_AL, R0, imm8 as u32));
+            last_const_var = Some(dest.to_string());
+            continue;
+        }
+
+        return Err(BackendError::UnsupportedOp(op.to_string()));
+    }
+
+    // Defensive — if no terminator was emitted, append the
+    // pseudo-halt so the program stops instead of running off the
+    // end (which would read zeroed memory as instructions).
+    if words.last() != Some(&HALT_WORD) {
+        words.push(encode_halt());
+    }
+    Ok(words)
+}
+
+fn require_dest<'a>(instr: &'a CIRInstr, op: &str) -> Result<&'a str, BackendError> {
+    instr
+        .dest
+        .as_deref()
+        .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))
+}
+
+fn parse_var_src(instr: &CIRInstr, idx: usize, op: &str) -> Result<String, BackendError> {
+    match instr.srcs.get(idx) {
+        Some(CIROperand::Var(s)) => Ok(s.clone()),
+        _ => Err(BackendError::InvalidOperand(format!(
+            "{op} srcs[{idx}] must be Var"
+        ))),
+    }
+}
+
+/// ARM1's `MOV Rd, #imm8` (as `arm1_encoder::encode_mov_imm` wraps
+/// it) carries an unrotated 8-bit immediate — no barrel-shifter
+/// rotation is applied in this minimal-viable backend.  Accept the
+/// unsigned range `[0, 255]`; wider or negative constants need the
+/// rotated-immediate form (or `MVN`), which is out of scope here.
+fn encode_immediate_8(op: Option<&CIROperand>) -> Result<u8, BackendError> {
+    let n: i64 = match op {
+        Some(CIROperand::Int(n)) => *n,
+        Some(CIROperand::Bool(b)) => i64::from(*b),
+        _ => {
+            return Err(BackendError::InvalidOperand(
+                "const_* srcs[0] must be Int or Bool".into(),
+            ));
+        }
+    };
+    if (0..=255).contains(&n) {
+        Ok(n as u8)
+    } else {
+        Err(BackendError::ImmediateOutOfRange(n))
+    }
+}
+
+impl Backend for Arm1Backend {
+    fn name(&self) -> &str {
+        "arm1"
+    }
+
+    fn compile(&self, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        compile_to_words(ir)
+            .ok()
+            .map(|words| words.iter().flat_map(|w| w.to_le_bytes()).collect())
+    }
+
+    fn compile_function(&self, _ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        self.compile(ir)
+    }
+
+    fn run(&self, _binary: &[u8], _args: &[Value]) -> Value {
+        panic!("arm1 backend is emit-only; load bytes into arm1-simulator to execute");
+    }
+}

--- a/code/packages/rust/arm1-backend/tests/test_backend.rs
+++ b/code/packages/rust/arm1-backend/tests/test_backend.rs
@@ -1,0 +1,179 @@
+use arm1_backend::{compile, Arm1Backend, BackendError};
+use arm1_simulator::ARM1;
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+
+fn ctx<'a>(name: &'a str, params: &'a [(String, String)], ret_ty: &'a str) -> FunctionContext<'a> {
+    FunctionContext {
+        name,
+        params,
+        return_type: ret_ty,
+    }
+}
+
+fn ci(op: &str, dest: Option<&str>, srcs: Vec<CIROperand>, ty: &str) -> CIRInstr {
+    CIRInstr::new(op, dest, srcs, ty)
+}
+
+#[test]
+fn empty_cir_emits_halt() {
+    let bytes = compile(&ctx("empty", &[], "void"), &[]).expect("lowering");
+    // SWI #0x123456 (AL) = 0xEF12_3456, little-endian = 56 34 12 EF
+    assert_eq!(bytes, vec![0x56, 0x34, 0x12, 0xEF]);
+}
+
+#[test]
+fn backend_name_is_arm1() {
+    assert_eq!(Arm1Backend.name(), "arm1");
+}
+
+#[test]
+#[should_panic(expected = "arm1 backend is emit-only")]
+fn backend_run_panics_per_spec() {
+    Arm1Backend.run(&[], &[]);
+}
+
+/// `const_i64 v=42; ret_i64 v` -> `MOV R0, #42; SWI #0x123456` =
+/// `0xE3A0_002A 0xEF12_3456`.  Little-endian:
+/// `2A 00 A0 E3 56 34 12 EF`.
+///
+/// This is the EXACT byte sequence `lang-aot --emit=arm1` produces
+/// for the trivial IIR program `const 42; ret`.
+#[test]
+fn canonical_const_42_then_ret() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(42)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x2A, 0x00, 0xA0, 0xE3, // MOV R0, #42  (LE)
+            0x56, 0x34, 0x12, 0xEF, // SWI #0x123456 (LE)
+        ]
+    );
+}
+
+/// Byte-for-byte parity is necessary but not sufficient — genuinely
+/// execute the emitted bytes in the ARM1 simulator and check the
+/// register state, not just assert a hand-derived byte array.
+#[test]
+fn canonical_const_42_then_ret_actually_executes_to_r0_equals_42() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(42)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("lowering");
+
+    let mut cpu = ARM1::new(4096);
+    cpu.load_program(&bytes, 0);
+    // Two instructions: MOV R0, #42 (materialises 42 into R0) then
+    // the pseudo-halt SWI #0x123456, which arm1-simulator's
+    // execute_swi intercepts to set halted() = true and stop the
+    // fetch-decode-execute loop.
+    let traces = cpu.run(100);
+    assert_eq!(traces.len(), 2);
+    assert_eq!(cpu.read_register(0), 42);
+    assert!(cpu.halted());
+}
+
+#[test]
+fn const_zero_then_ret_emits_eight_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(0)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("zero", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes.len(), 8);
+    assert_eq!(bytes[0..4], [0x00, 0x00, 0xA0, 0xE3], "MOV R0, #0");
+    assert_eq!(bytes[4..8], [0x56, 0x34, 0x12, 0xEF], "SWI #0x123456");
+}
+
+#[test]
+fn const_max_8bit_immediate_works() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(255)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("max", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes[0..4], [0xFF, 0x00, 0xA0, 0xE3], "MOV R0, #255");
+}
+
+#[test]
+fn const_negative_out_of_range_errors() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(-1)], "i64"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("neg", &[], "void"), &cir)
+        .expect_err("-1 is below the unrotated 8-bit MOV immediate range");
+    assert!(matches!(err, BackendError::ImmediateOutOfRange(-1)));
+}
+
+#[test]
+fn const_over_255_out_of_range_errors() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(256)], "i64"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("big", &[], "void"), &cir)
+        .expect_err("256 overflows the unrotated 8-bit MOV immediate");
+    assert!(matches!(err, BackendError::ImmediateOutOfRange(256)));
+}
+
+#[test]
+fn ret_void_alone_emits_just_halt() {
+    let cir = vec![ci("ret_void", None, vec![], "void")];
+    let bytes = compile(&ctx("noop", &[], "void"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x56, 0x34, 0x12, 0xEF]);
+}
+
+#[test]
+fn const_bool_true() {
+    let cir = vec![
+        ci("const_bool", Some("b"), vec![CIROperand::Bool(true)], "bool"),
+        ci("ret_bool", None, vec![CIROperand::Var("b".into())], "bool"),
+    ];
+    let bytes = compile(&ctx("btrue", &[], "bool"), &cir).expect("lowering");
+    assert_eq!(bytes[0..4], [0x01, 0x00, 0xA0, 0xE3], "MOV R0, #1");
+}
+
+#[test]
+fn unsupported_op_returns_err() {
+    let cir = vec![ci(
+        "add_i64",
+        Some("c"),
+        vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+        "i64",
+    )];
+    let err = compile(&ctx("addtest", &[], "i64"), &cir).expect_err("add not yet supported");
+    assert!(matches!(err, BackendError::UnsupportedOp(s) if s == "add_i64"));
+}
+
+#[test]
+fn multi_const_ret_falls_through_to_unsupported() {
+    // Two consts where ret targets the first — currently unsupported
+    // since v0.1.0 only handles single-var-in-R0 case.
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(1)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(2)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("a".into())], "i64"),
+    ];
+    // Should produce MOV R0,#1 ; MOV R0,#2 (b clobbers a) ; then ret
+    // tries to return 'a' which isn't in R0 — error.
+    let err = compile(&ctx("two_const_ret_first", &[], "i64"), &cir)
+        .expect_err("multi-var ret should fall through");
+    assert!(matches!(err, BackendError::UnsupportedOp(_)));
+}
+
+#[test]
+fn backend_trait_compile_matches_free_function() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(42)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let via_trait = Arm1Backend.compile(&cir).expect("trait compile");
+    let via_free_fn = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("free-fn compile");
+    assert_eq!(via_trait, via_free_fn);
+}

--- a/code/packages/rust/arm1-encoder/BUILD
+++ b/code/packages/rust/arm1-encoder/BUILD
@@ -1,0 +1,1 @@
+cargo test -p arm1-encoder

--- a/code/packages/rust/arm1-encoder/CHANGELOG.md
+++ b/code/packages/rust/arm1-encoder/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog — arm1-encoder
+
+## v0.1.0 — 2026-08-17 — initial carve-out
+
+Second lane of the 9-architecture expansion following the pattern
+documented in `HISTORICAL-ARCH-BACKEND-MIGRATION.md`.
+
+### Added
+
+- Re-exports of `encode_mov_imm`, `encode_halt`, `COND_AL` from
+  `arm1_simulator`.
+- Register-role constant: `R0` (0) — the ARM1 return-value register.
+- `HALT_WORD = 0xEF12_3456` — the pseudo-halt `SWI #0x123456`
+  (`AL`-conditioned) that `arm1-simulator::ARM1::execute_swi`
+  intercepts to stop the fetch-decode-execute loop.  Unlike
+  `armv7-backend`'s `BX_LR` (ARM1 predates the `BX`/link-register
+  return convention entirely), this is a simulator-level pseudo-halt
+  rather than a real subroutine return.
+
+### Tests
+
+7 unit tests pin every constant, the canonical
+`MOV R0, #42 = 0xE3A0_002A` value the ARM1 e2e smoke test pins, and
+both constants' little-endian byte layout.

--- a/code/packages/rust/arm1-encoder/Cargo.toml
+++ b/code/packages/rust/arm1-encoder/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "arm1-encoder"
+version = "0.1.0"
+edition = "2021"
+description = "Pure-Rust ARM1 (ARMv1) instruction encoder.  Re-exports the canonical encode_mov_imm/encode_halt helpers (plus the COND_AL condition constant) from arm1-simulator (which is the in-tree source of truth for ARM1 encoding) and adds the register-role constant and canonical HALT_WORD (SWI #0x123456, AL) the LANG VM arm1-backend uses to lower CIR to little-endian 32-bit ARM1 instruction words.  No IR knowledge.  Second lane of the 9-architecture expansion following the historical-arch backend migration pattern."
+
+[lib]
+name = "arm1_encoder"
+path = "src/lib.rs"
+
+[dependencies]
+# Source of truth for ARM1 bit-level encoding.  We re-export rather
+# than duplicate so any future opcode/condition-field fix in the
+# simulator propagates to encoder consumers automatically.
+arm1-simulator = { path = "../arm1-simulator" }

--- a/code/packages/rust/arm1-encoder/README.md
+++ b/code/packages/rust/arm1-encoder/README.md
@@ -1,0 +1,23 @@
+# arm1-encoder
+
+Pure-Rust ARM1 (ARMv1) instruction encoder.  Mirror of
+`mips-r2000-encoder` / `armv7-encoder` / `intel8008-encoder`.
+
+Second lane of the 9-architecture expansion following the pattern
+documented in
+[`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).
+
+## What's inside
+
+* Re-exports of `encode_mov_imm`, `encode_halt`, `COND_AL` from
+  `arm1_simulator` (the in-tree source of truth for ARM1 bit layout).
+* Register-role constant: `R0` — the value ARM1's `MOV R0, #imm`
+  writes to and `read_register(0)` reads back.
+* Canonical word constant: `HALT_WORD = 0xEF12_3456` (i.e.
+  `SWI #0x123456`, `AL`-conditioned — the pseudo-halt
+  `arm1-simulator` intercepts to stop execution; see the crate-level
+  doc comment in `src/lib.rs` for why ARM1 uses a pseudo-halt rather
+  than `BX LR`).
+
+No IR knowledge.  `arm1-backend` is the consumer that maps CIR ops
+onto encoder calls.

--- a/code/packages/rust/arm1-encoder/src/lib.rs
+++ b/code/packages/rust/arm1-encoder/src/lib.rs
@@ -1,0 +1,167 @@
+//! # `arm1-encoder` — pure ARM1 (ARMv1) instruction encoder.
+//!
+//! Mirror of [`mips_r2000_encoder`] / [`armv7_encoder`] /
+//! [`intel8008_encoder`] for the ARM1 (1985) — Sophie Wilson and
+//! Steve Furber's original Acorn RISC Machine, the first commercially
+//! successful RISC chip and architectural ancestor of the
+//! already-migrated `armv7-backend` lane.  Second lane of the
+//! 9-architecture expansion following the pattern documented in
+//! [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).
+//!
+//! ## What's inside
+//!
+//! 1. **Encoder re-exports** — the canonical `encode_mov_imm` /
+//!    `encode_halt` helpers (plus the `COND_AL` condition constant)
+//!    come from [`arm1_simulator`].  We re-export them here so that
+//!    `arm1-backend` (Backend trait over CIR) can depend on a small,
+//!    IR-agnostic surface without pulling the full simulator's
+//!    decode/execute machinery into every consumer.  Future
+//!    ISA-spec updates land in `arm1_simulator` and propagate
+//!    automatically.
+//! 2. **Register-role constant** — `R0`, the return-value register
+//!    `arm1-backend` writes `const_*` results into.  ARM1/ARMv1
+//!    predates the AAPCS calling-convention documents, but `R0` is
+//!    the register every hand-written ARM1 example in
+//!    `code/specs/07e-arm1-simulator.md` (and the simulator's own
+//!    `test_mov_imm_and_halt`) uses to carry a computed value —
+//!    the same role AAPCS32 later formalised, and the same role
+//!    `armv7-backend`'s `r0`/`mips-r2000-backend`'s `$v0` play in
+//!    their respective lanes.
+//! 3. **Canonical word constant** — `HALT_WORD` for the pseudo-halt
+//!    `SWI #0x123456` (AL-conditioned) that terminates a program;
+//!    a fixed encoding since `encode_halt()` takes no arguments.
+//!
+//! No IR knowledge lives here.  Consumers map their IR onto encoder
+//! calls + the register constant.
+//!
+//! ## Why `SWI`, not `BX LR`?
+//!
+//! `armv7-backend` (ARMv7-A, 2 decades newer) returns via `BX LR`,
+//! the link-register-return convention every modern ARM ABI uses.
+//! ARM1/ARMv1 (1985) predates that convention entirely — there is
+//! no `BX` instruction, and `MOVS PC, R14` (the ARMv1-era subroutine
+//! return) requires a live `R14` set by a preceding `BL`, which the
+//! minimal-viable `const_*`/`ret_*` scope never establishes (there
+//! is no caller).  `arm1-simulator` instead defines a **pseudo-halt**
+//! instruction — `SWI #0x123456` — that its `execute_swi` intercepts
+//! specially (see `arm1_simulator::ARM1::execute_swi`): when the
+//! 24-bit SWI comment field equals `HALT_SWI` (`0x123456`), the
+//! simulator sets its internal `halted` flag and stops, rather than
+//! entering Supervisor mode like a real SWI would.  This is a
+//! simulator-level convention (analogous to the Intel 8008 backend's
+//! `HLT` or the GE-225 backend's `HLT` word), not real ARM1 silicon
+//! behaviour — real ARM1 silicon has no way to "halt"; a real
+//! program would branch to itself or await an interrupt.  Since
+//! `arm1_simulator::ARM1::halted()` is the only way to observe
+//! "the program is done" from outside the simulator, lowering
+//! `ret_*`/`ret_void` to this pseudo-halt is the semantically
+//! correct choice for a `const_*`-only minimal-viable backend: it
+//! is what actually stops the fetch-decode-execute loop and leaves
+//! the computed value sitting in `R0` for the caller to read via
+//! `read_register(0)`.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use arm1_encoder::{encode_mov_imm, HALT_WORD, COND_AL, R0, encode_halt};
+//!
+//! // const_i64 v=42 lowered to `MOV R0, #42` — the first word
+//! // `arm1-backend` emits for the canonical Twig `42` program.
+//! let const_word = encode_mov_imm(COND_AL, R0, 42);
+//! assert_eq!(const_word, 0xE3A0_002A);
+//!
+//! // ret  lowered to the pseudo-halt `SWI #0x123456`.
+//! assert_eq!(HALT_WORD, encode_halt());
+//! assert_eq!(HALT_WORD, 0xEF12_3456);
+//! ```
+
+// ===========================================================================
+// Encoder re-exports
+// ===========================================================================
+//
+// `arm1_simulator` is the in-tree source of truth for the ARM1 bit
+// layout — it's the only place the condition/opcode field packing
+// logic lives.  We re-export the subset of `encode_*` helpers (and
+// the `COND_AL` condition constant) that `arm1-backend` actually
+// uses.
+
+pub use arm1_simulator::{encode_halt, encode_mov_imm, COND_AL};
+
+// ===========================================================================
+// Register layout (the one register arm1-backend touches by index)
+// ===========================================================================
+//
+// The ARM1 has 16 visible general-purpose registers, R0-R15 (with
+// R13/R14/R15 carrying architectural roles — stack pointer, link
+// register, and combined PC/status register respectively).
+// `arm1-backend` v0.1.0 only needs to name the one it writes
+// computed values into.
+
+/// `R0` — the ARM1 return-value register.  `const_*` writes its
+/// literal here; the caller reads the result via
+/// `arm1_simulator::ARM1::read_register(0)` once the pseudo-halt
+/// stops execution.  Mirrors `armv7-backend`'s `r0` and
+/// `mips-r2000-backend`'s `$v0`/`V0`.
+pub const R0: u32 = 0;
+
+// ===========================================================================
+// Canonical instruction-word constants
+// ===========================================================================
+//
+// Pre-computed words for the sequence the e2e smoke tests pin.
+
+/// The pseudo-halt instruction — `SWI #0x123456`, `AL`-conditioned.
+/// Encoded value: `0xEF12_3456`.  Stored little-endian on disk as
+/// `[0x56, 0x34, 0x12, 0xEF]` (ARM1's byte order — see
+/// `arm1_simulator::ARM1::read_word`/`write_word`, which use
+/// `u32::from_le_bytes`/`to_le_bytes`).
+///
+/// `encode_halt()` takes no arguments, so its result is fixed
+/// regardless of caller context — safe to precompute as a constant
+/// rather than a function call, mirroring
+/// `mips_r2000_encoder::RET_WORD`.
+pub const HALT_WORD: u32 = 0xEF12_3456;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn halt_word_matches_encode_halt() {
+        assert_eq!(HALT_WORD, encode_halt());
+    }
+
+    #[test]
+    fn halt_word_value() {
+        assert_eq!(HALT_WORD, 0xEF12_3456);
+    }
+
+    #[test]
+    fn halt_word_little_endian_bytes() {
+        assert_eq!(HALT_WORD.to_le_bytes(), [0x56, 0x34, 0x12, 0xEF]);
+    }
+
+    #[test]
+    fn r0_is_register_zero() {
+        assert_eq!(R0, 0);
+    }
+
+    #[test]
+    fn cond_al_matches_simulator_constant() {
+        assert_eq!(COND_AL, 0xE);
+    }
+
+    #[test]
+    fn canonical_const_42_word() {
+        // First instruction of the Twig `42` lowering: MOV R0, #42
+        assert_eq!(encode_mov_imm(COND_AL, R0, 42), 0xE3A0_002A);
+    }
+
+    #[test]
+    fn canonical_const_42_little_endian_bytes() {
+        assert_eq!(
+            encode_mov_imm(COND_AL, R0, 42).to_le_bytes(),
+            [0x2A, 0x00, 0xA0, 0xE3]
+        );
+    }
+}

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -35,6 +35,8 @@ ge225-backend         = { path = "../ge225-backend" }
 ge225-encoder         = { path = "../ge225-encoder" }
 ibm704-backend        = { path = "../ibm704-backend" }
 ibm704-encoder        = { path = "../ibm704-encoder" }
+arm1-backend          = { path = "../arm1-backend" }
+arm1-encoder          = { path = "../arm1-encoder" }
 aot-core              = { path = "../aot-core" }
 jit-core              = { path = "../jit-core" }
 # JIT McCarthy path (W15): the universal bytecode JIT (`jit-core`) executes

--- a/code/packages/rust/lang-aot/bin/lang_aot.rs
+++ b/code/packages/rust/lang-aot/bin/lang_aot.rs
@@ -47,6 +47,7 @@ fn main() -> ExitCode {
     //   * Intel8008Bin → .bin (foo.oct → foo.bin), shares the `.bin` convention with RV32I
     //   * Armv7Bin     → .bin (foo.twig → foo.bin), shares the `.bin` convention
     //   * Intel4004Bin → .bin (foo.bf → foo.bin), shares the `.bin` convention
+    //   * Arm1Bin       → .bin (foo.twig → foo.bin), shares the `.bin` convention
     let output = cmd.output.unwrap_or_else(|| match cmd.emit {
         EmitMode::Native       => input.with_extension(""),
         EmitMode::LlvmIr       => input.with_extension("ll"),
@@ -56,6 +57,7 @@ fn main() -> ExitCode {
         EmitMode::Intel4004Bin => input.with_extension("bin"),
         EmitMode::Ge225Bin => input.with_extension("bin"),
         EmitMode::Ibm704Bin => input.with_extension("bin"),
+        EmitMode::Arm1Bin => input.with_extension("bin"),
     });
 
     let language = match cmd.language {
@@ -125,6 +127,14 @@ enum EmitMode {
     /// 1959 — the closing half of the **CAR/CDR birthplace
     /// round-trip**.
     Ibm704Bin,
+    /// Flat `.bin` of little-endian 32-bit ARM1 (ARMv1) instruction
+    /// words via `arm1-backend`.  Cross-platform.  Downstream
+    /// consumers: the in-tree `arm1-simulator` or any external
+    /// ARM1/ARMv1 emulator.  The ARM1 (1985) is Sophie Wilson and
+    /// Steve Furber's original Acorn RISC Machine — the first
+    /// commercially successful RISC chip and architectural ancestor
+    /// of the already-migrated ARMv7 lane.
+    Arm1Bin,
 }
 
 struct CliArgs {
@@ -205,9 +215,10 @@ fn parse_emit_value(v: &str) -> Result<EmitMode, String> {
         "intel4004" | "i4004" | "4004" => Ok(EmitMode::Intel4004Bin),
         "ge225" | "ge-225" | "225" => Ok(EmitMode::Ge225Bin),
         "ibm704" | "ibm-704" | "704" => Ok(EmitMode::Ibm704Bin),
+        "arm1" | "armv1" | "arm-1" => Ok(EmitMode::Arm1Bin),
         other => Err(format!(
             "unknown --emit value {other:?}; expected one of: \
-             native | llvm-ir | riscv32 | intel8008 | armv7 | intel4004 | ge225 | ibm704"
+             native | llvm-ir | riscv32 | intel8008 | armv7 | intel4004 | ge225 | ibm704 | arm1"
         )),
     }
 }
@@ -281,6 +292,15 @@ Options:
                                                 — the birthplace round-trip (CAR/CDR
                                                 are literal 704 instruction-field
                                                 mnemonics)
+                             arm1 | armv1 | arm-1
+                                              → flat .bin of little-endian 32-bit
+                                                ARM1 (ARMv1) instruction words via
+                                                arm1-backend; cross-platform; load
+                                                into arm1-simulator or an external
+                                                ARM1/ARMv1 emulator (Sophie Wilson
+                                                and Steve Furber's original Acorn
+                                                RISC Machine, 1985 — architectural
+                                                ancestor of the ARMv7 lane above)
   -h, --help               Show this help.\
 ");
 }
@@ -350,6 +370,16 @@ fn dispatch(
     // mnemonics.  Downstream is always an emulator or replica.
     if emit == EmitMode::Ibm704Bin {
         return lang_aot::compile_file_to_ibm704_bin(input, output, language)
+            .map_err(|e| format!("{e}"));
+    }
+    // ARM1 .bin emission is also cross-platform — flatten each
+    // 32-bit ARM1 word to little-endian bytes (ARM1's byte order —
+    // see arm1_simulator::ARM1::read_word/write_word).  No linker,
+    // no host gating (no modern dev host is ARM1 silicon);
+    // downstream is always arm1-simulator or an external ARM1/ARMv1
+    // emulator.
+    if emit == EmitMode::Arm1Bin {
+        return lang_aot::compile_file_to_arm1_bin(input, output, language)
             .map_err(|e| format!("{e}"));
     }
     #[cfg(target_os = "linux")]

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -205,6 +205,14 @@ pub enum LangAotError {
     /// L4 of the McCarthy Lisp implementation — closes the
     /// round-trip to the silicon Lisp was born on.
     Ibm704BackendError(String),
+    /// The ARM1 (ARMv1) backend rejected the IIR.
+    ///
+    /// Carries the human-readable string from `arm1-backend` (which
+    /// already includes the failing function name and the
+    /// unsupported op/type/operand).  Second lane of the
+    /// 9-architecture expansion following the historical-arch
+    /// backend migration pattern.
+    Arm1BackendError(String),
     /// The WebAssembly backend rejected the IIR.
     ///
     /// Carries the string from `iir-to-wasm` (a validation failure, or an
@@ -254,6 +262,7 @@ impl fmt::Display for LangAotError {
             LangAotError::Intel4004BackendError(m) => write!(f, "intel4004: {m}"),
             LangAotError::Ge225BackendError(m) => write!(f, "ge225: {m}"),
             LangAotError::Ibm704BackendError(m) => write!(f, "ibm704: {m}"),
+            LangAotError::Arm1BackendError(m) => write!(f, "arm1: {m}"),
         }
     }
 }
@@ -1410,6 +1419,86 @@ pub fn compile_file_to_armv7_bin(
         let fn_bytes = armv7_backend::compile(&ctx, &cir)
             .map_err(|e| LangAotError::Armv7BackendError(format!("{e}")))?;
         bytes.extend_from_slice(&fn_bytes);
+    }
+
+    std::fs::write(out, &bytes)?;
+    Ok(())
+}
+
+/// Cross-platform: source → IIR → ARM1 (ARMv1) machine code (`.bin`) on
+/// disk.
+///
+/// Unlike the native-executable pipelines, this one does **not** link
+/// or run any toolchain — it just writes a flat `.bin` of 32-bit ARM1
+/// instruction words encoded as **little-endian** bytes (ARM1's byte
+/// order — see `arm1_simulator::ARM1::read_word`/`write_word`, which
+/// use `u32::from_le_bytes`/`to_le_bytes`).  Downstream consumers:
+///
+/// * [`arm1-simulator`](../arm1-simulator) — load + execute
+///   in-process.
+/// * Any external ARM1/ARMv1 emulator that consumes little-endian
+///   byte streams.
+///
+/// No `cfg(target_os = ...)` gating: emitting bytes is platform-
+/// agnostic.
+///
+/// # Wire format
+///
+/// Each emitted ARM1 word is written as **little-endian** bytes,
+/// mirroring `compile_file_to_armv7_bin`.
+///
+/// # Why no host gating?
+///
+/// ARM1 (1985) is Acorn's original RISC chip — no modern host is
+/// ARM1 silicon.  The downstream consumer is always a simulator
+/// (in-tree `arm1-simulator` or external) or replica hardware.  All
+/// host OSes can write a flat byte file, so the pipeline is
+/// universally available.
+///
+/// # Errors
+///
+/// * `FrontendError` — the language-specific frontend rejected the source.
+/// * `Arm1BackendError` — the IIR contained an op or type the ARM1
+///   backend does not yet handle (the message names the function and
+///   op).
+/// * `Io` — failed to read the input or write the output.
+///
+/// # Example downstream invocation
+///
+/// ```bash
+/// lang-aot foo.twig --emit=arm1 -o foo.bin
+/// # Then load foo.bin into arm1-simulator
+/// ```
+pub fn compile_file_to_arm1_bin(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
+    let module = compile_source_to_iir(language, &source, stem)?;
+
+    // Second lane of the 9-architecture expansion: route through
+    // `aot_core` + `arm1-backend` (which itself returns
+    // little-endian-flattened bytes), same per-function-loop pattern
+    // as `compile_file_to_armv7_bin`/`compile_file_to_mips_r2000_bin`.
+    let _ = stem;
+    let mut bytes = Vec::new();
+    let empty_params: Vec<(String, String)> = Vec::new();
+    for f in &module.functions {
+        let inferred = aot_core::infer::infer_types(f);
+        let cir = aot_core::specialise::aot_specialise(f, Some(&inferred));
+        let ctx = jit_core::backend::FunctionContext {
+            name: f.name.as_str(),
+            params: &empty_params,
+            return_type: f.return_type.as_str(),
+        };
+        let fn_bytes = arm1_backend::compile(&ctx, &cir)
+            .map_err(|e| LangAotError::Arm1BackendError(format!("{e}")))?;
+        bytes.extend_from_slice(&fn_bytes);
+    }
+    if bytes.is_empty() {
+        bytes.extend_from_slice(&arm1_encoder::HALT_WORD.to_le_bytes());
     }
 
     std::fs::write(out, &bytes)?;

--- a/code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md
+++ b/code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md
@@ -113,6 +113,39 @@ spec files are kept as a historical record of the original
 Each phase = 1 PR + babysitter cron + auto-merge + next-phase
 kickoff.  Same cadence as the A5 cascade.
 
+## New architectures — the 9-architecture expansion
+
+With the five-arch migration complete, later lanes add **brand-new**
+`{arch}-encoder` + `{arch}-backend` pairs for architectures that
+never had an `iir-to-{arch}` predecessor to migrate away from — they
+start at the correct `Backend`-trait-over-CIR layer from day one,
+following exactly the pattern this document established.
+
+**ARM1 (ARMv1)** — `arm1-encoder` + `arm1-backend`, minimal viable
+(`const_*`/`ret_*` only, single-register `R0` allocator, same
+trivial-ROM scope as `armv7-backend`).  Unlike a from-scratch lane,
+ARM1's behavioral simulator (`arm1-simulator`, 2270 lines) already
+existed complete in-tree, so this lane only needed the
+encoder/backend split on top of it — no new simulator work.  One
+architecture-specific design decision: ARM1/ARMv1 (1985) predates
+the `BX`/link-register-return convention `armv7-backend` (its direct
+architectural descendant, ARMv7-A) uses, so `ret_*`/`ret_void` lower
+to `arm1-simulator`'s existing pseudo-halt instruction
+(`SWI #0x123456`, intercepted by `execute_swi` to set
+`halted() == true`) rather than a return-from-subroutine instruction
+— see `code/specs/arm1-backend.md` for the full rationale.  Byte-for-
+byte parity for the canonical `MOV R0, #42; SWI #0x123456` sequence
+(`[0x2A, 0x00, 0xA0, 0xE3, 0x56, 0x34, 0x12, 0xEF]`, little-endian)
+is verified both as a hand-derived byte array and by actually
+executing the emitted bytes in `arm1-simulator` and asserting
+`R0 == 42`.
+
+Other lanes in this expansion (e.g. MIPS R2000, first lane) may land
+in parallel PRs and are not enumerated here to avoid merge
+conflicts with concurrently-landing work — see each lane's own
+`code/specs/{arch}-encoder.md` / `code/specs/{arch}-backend.md` for
+its specifics.
+
 ## What about `Backend::run` — and JIT in general?
 
 For the real native backends (`aarch64`, `x86_64`), `Backend::run`

--- a/code/specs/arm1-backend.md
+++ b/code/specs/arm1-backend.md
@@ -1,0 +1,158 @@
+# `arm1-backend` spec
+
+> **Status:** v0.1.0 — second lane of the 9-architecture expansion,
+> 2026-08-17.
+
+## Purpose
+
+ARM1 (ARMv1, 1985) implementation of the `jit_core::backend::Backend`
+trait.  Mirror of `mips-r2000-backend` / `armv7-backend` /
+`intel8008-backend` / `ge225-backend` (the *minimal viable* shape).
+ARM1 is architecturally the direct ancestor of the already-migrated
+`armv7-backend` lane — Sophie Wilson and Steve Furber's original
+Acorn RISC Machine, designed in 1985, the first commercially
+successful RISC chip, and the chip family ARM/Acorn later grew into
+ARMv7-A (deployed in billions of Cortex-A-class SoCs).
+
+Lowers `Vec<CIRInstr>` (typed, monomorphised) to a little-endian
+`Vec<u8>` of ARM1 machine code via `arm1-encoder`.
+
+## Why this crate exists
+
+This is the second lane of a 9-architecture expansion that
+replicates the pattern established by the historical-arch backend
+migration (see
+[`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md)):
+consume typed **CIR** (not dynamically-typed IIR) via the shared
+`Backend` trait, so `lang-aot --emit=arm1` routes through the same
+`aot_core::infer` + `aot_core::specialise` + `Backend::compile`
+pipeline every other arch backend (including `aarch64-backend` /
+`x86_64-backend`) uses.  ARM1 never had an `iir-to-arm1` predecessor
+to migrate away from — this crate starts at the correct layer from
+day one, same as `mips-r2000-backend`.
+
+Unlike `mips-r2000-backend` (which needed a brand-new
+`mips-r2000-simulator` alongside it), ARM1's behavioral simulator
+(`arm1-simulator`, 2270 lines) already existed, complete, in-tree —
+this lane only needed the `{arch}-encoder` + `{arch}-backend` split
+on top of it.
+
+## Current scope — minimal viable
+
+| CIR op family | Lowering |
+|----------------|----------|
+| `const_*` (unrotated 8-bit literal, `[0, 255]`) | `MOV R0, #imm` |
+| `ret_*` | pseudo-halt `SWI #0x123456` (only if returning the most recently `const_*`'d variable) |
+| `ret_void` | pseudo-halt `SWI #0x123456` |
+| Empty CIR body | pseudo-halt `SWI #0x123456` |
+| Anything else | `UnsupportedOp` from `compile()`; `None` from the `Backend::compile` trait method |
+
+There is **no real register allocator** — a trivial "last const var"
+scheme tracks which single variable the most recent `const_*` wrote
+into `R0`; `ret_*` only succeeds if it returns exactly that
+variable.  Programs needing more than one live value fall through to
+`UnsupportedOp`.  AOT treats `None` as a per-function compile
+failure; JIT keeps execution on the interpreter tier.
+
+Full op coverage (arithmetic, comparisons, branches, calls) that a
+mature backend would carry is **intentionally not ported** in this
+PR — future increments can extend `compile_to_words` using ARM1's
+other 14 general-purpose registers and the barrel shifter's rotated-
+immediate form (which would also widen `const_*`'s literal range
+past `[0, 255]`).
+
+## Why `ret_*` lowers to a pseudo-halt, not `BX LR`
+
+`armv7-backend` (ARMv7-A, 2 decades newer) returns via `BX LR` — the
+link-register-return convention every modern ARM ABI uses.  ARM1/
+ARMv1 predates that convention entirely: there is no `BX`
+instruction, and the era's subroutine-return idiom, `MOVS PC, R14`,
+requires a live `R14` that only a preceding `BL` sets up (i.e. it
+needs a *caller*).  The minimal-viable `const_*`/`ret_*` scope
+compiles a whole program's worth of CIR with no caller in the
+picture — the trivial ROM just needs to compute a value and stop.
+
+`arm1-simulator` already defines exactly this: a pseudo-halt
+instruction, `SWI #0x123456` (`arm1_simulator::HALT_SWI`), that its
+`execute_swi` intercepts specially — when the SWI's 24-bit comment
+field equals `HALT_SWI`, the simulator sets its internal `halted`
+flag (observable via `ARM1::halted()`) instead of entering
+Supervisor mode like a genuine SWI would.  This is a simulator-level
+halt convention (parallel to the Intel 8008 backend's `HLT` byte or
+the GE-225 backend's `HLT` word), not real ARM1 silicon behaviour.
+Lowering `ret_*`/`ret_void` to this pseudo-halt is the semantically
+correct choice: it is the only instruction that actually stops the
+fetch-decode-execute loop, leaving the computed value in `R0` for
+the caller to read via `read_register(0)`.
+
+## Wire format
+
+Each instruction is a 32-bit ARM1 word, flattened to
+**little-endian** bytes — ARM1's byte order (see
+`arm1_simulator::ARM1::read_word`/`write_word`, which use
+`u32::from_le_bytes`/`to_le_bytes`).  Per-function byte streams can
+be concatenated directly; `lang-aot` writes them straight to disk as
+a flat `.bin`.
+
+## Pinned byte sequence
+
+| Program | CIR | Emitted bytes |
+|---------|-----|----------------|
+| Twig `42` | `const_i64 v=42; ret_i64 v` | `[0x2A, 0x00, 0xA0, 0xE3, 0x56, 0x34, 0x12, 0xEF]` |
+| `ret_void` only | `ret_void` | `[0x56, 0x34, 0x12, 0xEF]` |
+| Empty CIR | (none) | `[0x56, 0x34, 0x12, 0xEF]` |
+
+`MOV R0, #42` = `0xE3A0_002A`; `SWI #0x123456` (`AL`) = `0xEF12_3456`.
+
+## Backend trait surface
+
+| Trait method | Behaviour |
+|---------------|-----------|
+| `name()` | returns `"arm1"` |
+| `compile(ir)` | returns `Some(bytes)` for supported CIR ops; `None` otherwise |
+| `compile_function(ctx, ir)` | ignores `FunctionContext` (no parameter marshalling in v0.1.0); delegates to `compile` |
+| `run(binary, args)` | **panics** with `"arm1 backend is emit-only; load bytes into arm1-simulator to execute"` — emit-only per the migration spec |
+
+## Error variants
+
+| `BackendError` variant | Trigger |
+|--------------------------|---------|
+| `UnsupportedOp(String)` | CIR operation outside `const_*`/`ret_*` |
+| `InvalidOperand(String)` | Malformed CIR operands or missing `dest` |
+| `UndefinedVariable(String)` | Reserved for a future register allocator (unused in v0.1.0's single-var scheme, where the "not the current `R0` var" case surfaces as `UnsupportedOp` instead) |
+| `ImmediateOutOfRange(i64)` | A `const_*` literal falls outside `[0, 255]` — `MOV Rd, #imm8`'s unrotated immediate field; wider or negative values need the barrel shifter's rotated-immediate form (or `MVN`), out of scope for v0.1.0 |
+
+## Tests
+
+14 unit/integration tests in `tests/test_backend.rs` (mirroring
+`mips-r2000-backend`'s/`armv7-backend`'s test shape) pin the
+canonical byte sequence and edge cases (zero, 8-bit range boundaries
+— negative and `>255` — bool, multi-var fallthrough, unsupported op,
+empty CIR, `ret_void`, `Backend::run` panics, `Backend::compile` vs
+the free `compile` function agree).
+
+One test additionally loads the compiled bytes into `arm1-simulator`,
+runs it, and asserts `R0 == 42` and `halted() == true` after
+execution — byte-for-byte parity is necessary but not sufficient;
+the emitted bytes must actually execute correctly (and actually
+halt) in the existing simulator.
+
+## Backlog
+
+1. [ ] Real register allocator over ARM1's other 14 general-purpose
+   registers, removing the single-var limitation.
+2. [ ] Rotated-immediate `const_*` (widens the `[0, 255]` literal
+   range using the barrel shifter's 4-bit rotate field).
+3. [ ] Arithmetic/bitwise CIR ops (`add`/`sub`/`and`/`or`/`xor`) via
+   `encode_alu_reg` (already re-exportable from `arm1_simulator`).
+4. [ ] Comparisons and conditional branches, using ARM1's per-
+   instruction condition codes (`encode_data_processing`'s `cond`
+   parameter) rather than separate compare-then-branch pairs.
+5. [ ] Direct calls (`BL`/`MOVS PC, R14` pairing) and a stack frame
+   — once this lands, `ret_*` could switch from the pseudo-halt to
+   the historically authentic ARMv1 return idiom for called
+   functions (the pseudo-halt would remain for the outermost
+   program-exit case).
+6. [ ] `Backend::run` wired to `arm1-simulator` for JIT execution
+   (best-effort per the migration spec — "no working JIT" is an
+   acceptable outcome for a historical-arch target).

--- a/code/specs/arm1-encoder.md
+++ b/code/specs/arm1-encoder.md
@@ -1,0 +1,148 @@
+# `arm1-encoder` spec
+
+> **Status:** v0.1.0 — second lane of the 9-architecture expansion,
+> 2026-08-17.
+
+## Purpose
+
+Pure-Rust encoder for the ARM1 (ARMv1, 1985) instruction set —
+Sophie Wilson and Steve Furber's original Acorn RISC Machine, the
+first commercially successful RISC chip, and the architectural
+ancestor of the already-migrated `armv7-backend` lane (ARMv7-A,
+2 decades newer).  Has no IR knowledge — its job is to turn a
+register/condition/immediate tuple into a 32-bit instruction word
+that matches the ISA bit-for-bit.
+
+Mirror of `mips-r2000-encoder` / `armv7-encoder` / `intel8008-encoder`
+/ `ge225-encoder`.
+
+## Public surface
+
+### Re-exported helpers (from `arm1-simulator`)
+
+`arm1-simulator` is the canonical in-tree source of truth for the
+ARM1 bit layout — it owns the condition/opcode field packing logic
+in `encode_data_processing`, plus the specialised wrappers built on
+top of it.  `arm1-encoder` re-exports the subset that
+`arm1-backend` actually uses today:
+
+| Item | Kind | Purpose |
+|------|------|---------|
+| `encode_mov_imm(cond, rd, imm8)` | fn | `MOV Rd, #imm8` (unrotated 8-bit immediate) |
+| `encode_halt()` | fn | the pseudo-halt `SWI #0x123456`, `AL`-conditioned |
+| `COND_AL` | const (`0xE`) | "always execute" condition code |
+
+The full `encode_*` surface (data processing, load/store, block
+transfer, branch — see `arm1-simulator`'s own module docs) lives in
+`arm1_simulator` for the simulator's own test suite; this crate
+re-exports only what the minimal-viable backend needs today.  A
+future increment can widen the re-export list alongside
+`arm1-backend`'s op coverage (e.g. `encode_alu_reg` for
+arithmetic, `encode_branch` for control flow).
+
+### Register-role constant
+
+| Constant | Value | Role |
+|----------|-------|------|
+| `R0` | `0` | return-value register — `const_*` writes here; the caller reads it back via `ARM1::read_register(0)` after the pseudo-halt stops execution |
+
+ARM1/ARMv1 predates the AAPCS calling-convention documents, but `R0`
+is the register every hand-written example in
+`code/specs/07e-arm1-simulator.md` (and `arm1-simulator`'s own
+`test_mov_imm_and_halt`) uses to carry a computed value — the same
+role AAPCS32 later formalised for ARMv7, and the same role
+`armv7-backend`'s `r0` / `mips-r2000-backend`'s `$v0` play in their
+respective lanes.
+
+### Canonical word constant
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `HALT_WORD` | `0xEF12_3456` | `SWI #0x123456`, `AL`-conditioned — the pseudo-halt `arm1-simulator::ARM1::execute_swi` intercepts to stop the fetch-decode-execute loop |
+
+`encode_halt()` takes no arguments, so its result is fixed
+regardless of caller context — `HALT_WORD` is a plain constant
+rather than requiring a function call to derive, mirroring
+`mips_r2000_encoder::RET_WORD`.
+
+## Why `SWI`, not `BX LR`?
+
+`armv7-backend` returns via `BX LR`, the link-register-return
+convention every modern ARM ABI uses.  ARM1/ARMv1 predates that
+convention entirely: there is no `BX` instruction, and the era's
+subroutine-return idiom (`MOVS PC, R14`) needs a live `R14` set by a
+preceding `BL`, which the minimal-viable `const_*`/`ret_*` scope
+never establishes — there is no caller in a trivial ROM.
+
+`arm1-simulator` already defines a pseudo-halt for exactly this
+situation: `SWI #0x123456`.  Its `execute_swi` method special-cases
+the 24-bit SWI comment field — when it equals `HALT_SWI`
+(`0x123456`), the simulator sets its internal `halted` flag
+(observable via `ARM1::halted()`) and stops, instead of entering
+Supervisor mode as a genuine SWI would.  This is a simulator-level
+convention (parallel to the Intel 8008 backend's `HLT` byte or the
+GE-225 backend's `HLT` word), not real ARM1 silicon behaviour — real
+ARM1 silicon has no way to "halt"; a real program would branch to
+itself or await an interrupt.  Since `ARM1::halted()` is the only
+externally observable "the program is done" signal, lowering
+`ret_*`/`ret_void` to this pseudo-halt is the semantically correct
+choice for the minimal-viable backend.
+
+## `arm1-simulator`: behavioral Rust port, distinct from the gate-level sim
+
+`code/specs/07e-arm1-simulator.md` documents the **behavioral**
+ARM1 simulator this crate wraps — it executes ARMv1 machine code
+directly using host-language arithmetic (no gate-level modelling).
+`code/specs/07e2-arm1-gatelevel.md` documents a **separate**,
+gate-level ARM1 simulation (routes every operation through actual
+logic-gate primitives) — that spec is unrelated to this lane; do not
+confuse the two when reading `code/packages/rust/arm1-simulator/`
+(behavioral) vs. `code/packages/rust/arm1-gatelevel/` (gate-level).
+`07e-arm1-simulator.md` predates this crate's existence and
+describes the behavioral simulator's design at the spec level (its
+`Public API` section is written in a Python-flavoured pseudo-class
+form since the spec is shared across the project's per-language
+simulator ports); `code/packages/rust/arm1-simulator/src/lib.rs` is
+the concrete, already-complete Rust port this encoder depends on.
+
+## Why this crate exists
+
+Mirrors the encoder/backend split every other historical-arch lane
+uses (see
+[`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md)):
+`arm1-backend` (the `Backend` trait implementation over CIR) depends
+on this crate rather than reaching directly into `arm1_simulator`'s
+decode/execute machinery, so the backend can evolve independently of
+simulator internals and the simulator crate stays a leaf dependency
+for exactly one direct consumer (this encoder).
+
+Re-exporting (rather than duplicating) the encode functions keeps
+`arm1_simulator` the single source of truth.  Any future fix to a
+condition/opcode field layout lands in one place and propagates
+automatically.
+
+## Tests (7 unit tests + 1 doctest)
+
+* `HALT_WORD == encode_halt()` and `HALT_WORD == 0xEF12_3456`.
+* `HALT_WORD.to_le_bytes() == [0x56, 0x34, 0x12, 0xEF]` — the
+  little-endian tail the `lang-aot` ARM1 e2e smoke test pins.
+* `R0 == 0`.
+* `COND_AL == 0xE`.
+* `encode_mov_imm(COND_AL, R0, 42) == 0xE3A0_002A` — first
+  instruction of the Twig `42` lowering.
+* Little-endian byte layout of the canonical `const 42` word.
+
+Plus a doctest walking through the canonical `const 42; ret` word
+derivation.
+
+## Out of scope
+
+* R-type ALU/register-shift encoders, load/store, block-transfer,
+  and branch encoders — these exist in `arm1_simulator` for the
+  simulator's own test suite but are not yet re-exported here, since
+  `arm1-backend` v0.1.0 does not use them.  A future backend
+  increment (real register allocator, arithmetic ops, control flow)
+  re-exports the additional helpers it needs.
+* Disassembly or simulation — `arm1-simulator` handles both.
+* Symbol resolution, linker relocations — that's `aot_core::link`
+  territory.


### PR DESCRIPTION
## Summary
- Second lane of the 9-architecture expansion (mirrors `code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md`'s pattern: `IIR -> aot_core::infer/specialise -> CIR -> Backend::compile -> bytes`).
- No new simulator needed — `arm1-simulator` already exists (2270 lines, unmodified by this PR) and already exports the needed `encode_mov_imm`/`encode_halt` helpers.
- Adds `arm1-encoder` (thin re-export + register/condition-code constants) and `arm1-backend` (minimal-viable `Backend` impl: `const_*`/`ret_*`/`ret_void` only, same "last const var" scheme as `mips-r2000-backend`/`armv7-backend`/`intel8008-backend`).
- Design note: ARMv1 (1985) predates the `BX LR` return convention `armv7-backend` uses (`BX` doesn't exist yet, and the era's `MOVS PC, R14` idiom needs a live `R14` only a caller's `BL` would set). `ret_*`/`ret_void` instead lower to `arm1-simulator`'s existing pseudo-halt convention (`SWI #0x123456`, already intercepted by the pre-existing, unmodified `execute_swi`) — the only instruction that actually stops the fetch-decode-execute loop for a caller-less trivial ROM, leaving the computed value in `R0` for `read_register(0)`. Confirmed safe from sentinel collision: `const_*`/`ret_*` only ever emit two fixed, disjoint bit patterns (`0xE3A0_00XX` MOV-immediate vs. the fixed `0xEF12_3456` halt word), never data-derived arbitrary words.
- Wires `lang-aot --emit=arm1` (aliases `armv1`, `arm-1`) end-to-end.
- New specs: `arm1-encoder.md`, `arm1-backend.md`, plus a new-architecture-addition note on `HISTORICAL-ARCH-BACKEND-MIGRATION.md`.

## Test plan
- [x] `cargo build`/`cargo test`/`cargo clippy -D warnings` on all 4 touched crates — independently re-verified, all clean; `arm1-simulator`'s 51 pre-existing tests pass unmodified.
- [x] Byte-for-byte parity smoke test in `arm1-backend/tests/test_backend.rs` genuinely loads compiled bytes into `ARM1`, runs it, and asserts `read_register(0) == 42 && halted() == true`.
- [x] Manual CLI check: `lang-aot const42.twig --emit=arm1` produces exactly `2A 00 A0 E3 56 34 12 EF` (`MOV R0, #42; SWI #0x123456`).
- [x] `/security-review` — SECURITY REVIEW PASSED, no findings (no `unsafe`, no new truncating-cast paths, sentinel-collision analysis confirmed no reachable collision, path/DoS/secrets checks all clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)