### PR TITLE
feat(semantic-ir-to-javascript): SIR21 T3b-2 Slice 2 -- div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.53.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive-only: adds the four new division builtin names from SIR21 T3b-2
+(`code/specs/SIR21-type-system-and-integer-semantics.md` §E3) to both the
+emitter's inline 2-arg fast path and the `builtins` forward-compat
+dispatch table. Bare `"/"` keeps working unchanged — no frontend emits
+any of the new names yet.
+
+- `div_floor` is a bare alias for the pre-existing `divide` (already
+  zero-check-correct on both int and float paths — Ruby's `/` already
+  floors ints and true-divides floats, so zero new logic).
+- `div_trunc`/`udiv_trunc`/`div_true` route to three new runtime
+  functions (`truncDiv`/`utruncDiv`/`trueDiv`). All three raise the same
+  typed `ZeroDivisionError` `divide` does — never let a bare `/` leak
+  native JS `Infinity`/`NaN` through.
+- JS numbers are IEEE-754 doubles with no fixed width and no separate
+  signed/unsigned representation, so unlike C/Go/Rust's `udiv_trunc`
+  (which must reinterpret bits to avoid a `u64` ≥ 2^63 misreading as
+  negative), this backend's `udiv_trunc` computes identically to
+  `truncDiv` — documented in `runtime.rs`, not a bug.
+- New `tests/compile_and_run_division_ops.rs`: real `node`-execution
+  proof for all four ops, including the §E3 worked example,
+  floor-vs-truncate divergence, and a zero-divisor case for every op.
+
 ## 0.52.0 — SIR28 §7: remove dead bare `print`/`puts` handling (final backend)
 
 Every frontend now emits `__sys_write__` instead of bare `print`/`puts`

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1744,6 +1744,15 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             // not a `ZeroDivisionError`) AND picks Integer#/ floor vs Float#/
             // true-division from the operand tags.  See `runtime::divide`.
             "/" => Some("__Sir.divide"),
+            // SIR21 T3b-2: `div_floor` is a bare alias for `divide` above
+            // (Ruby's `/` already floors ints / true-divides floats — no
+            // new logic). `div_trunc`/`udiv_trunc`/`div_true` are
+            // genuinely new — see `runtime::truncDiv`/`utruncDiv`/
+            // `trueDiv`'s doc comments.
+            "div_floor" => Some("__Sir.divide"),
+            "div_trunc" => Some("__Sir.truncDiv"),
+            "udiv_trunc" => Some("__Sir.utruncDiv"),
+            "div_true" => Some("__Sir.trueDiv"),
             // `-` and `%` route through runtime helpers (not native infix)
             // because their result must be RE-TAGGED: a boxed Float operand
             // yields a boxed Float result (`7.0 - 1 == 6.0`), which native

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -616,6 +616,18 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "/": (...a) => a.length === 1
       ? (isFloat(a[0]) ? mkFloat(1 / numOf(a[0])) : 1 / numOf(a[0]))
       : numFold(a.slice(1), a[0], (x, y) => x / y),
+    // SIR21 T3b-2: `div_floor` is a bare alias for `divide` (Ruby's `/`
+    // already floors ints / true-divides floats — see `divide`'s own doc
+    // comment above). `div_trunc`/`udiv_trunc`/`div_true` route to the
+    // three genuinely-new functions just above this table. Unlike the
+    // legacy `"/"` entry above (a variadic fold with no zero-check, kept
+    // as-is for backward compat), all four of these route through the
+    // zero-checking helpers directly — there is no pre-existing lenient
+    // behavior to preserve for brand-new names.
+    "div_floor": (a, b) => divide(a, b),
+    "div_trunc": (a, b) => truncDiv(a, b),
+    "udiv_trunc": (a, b) => utruncDiv(a, b),
+    "div_true": (a, b) => trueDiv(a, b),
     "=": (x, y) => eq(x, y),
     // `==` is a synonym for `=`; `!=` its negation.  Present in this table (not
     // only the emitter's infix map) so a first-class `:==`/`:!=` symbol
@@ -967,6 +979,51 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // so floor — matching the SIR21 §E3 oracle `DivOp::Floor` on every sign
     // combination.  (A boxed Float is unwrapped via `numOf` for the math.)
     return (isFloat(a) || isFloat(b)) ? mkFloat(an / bn) : Math.floor(an / bn);
+  }
+
+  // ── SIR21 T3b-2: `div_trunc`/`udiv_trunc`/`div_true` ────────────
+  //
+  // `divide` above IS `div_floor` — no separate function needed for that
+  // name (the emitter aliases it directly, see `emit.rs`). The three
+  // below are genuinely new: SIR21 §E3 splits the old overloaded `/`
+  // into four named ops so a non-Ruby-sourced frontend can pick its own
+  // rounding mode instead of silently inheriting Ruby's. All three raise
+  // the same typed `ZeroDivisionError` `divide` does — never let a bare
+  // `/` leak native JS `Infinity`/`NaN` through.
+
+  // Signed truncating division (rounds toward zero) — matches C's
+  // integer `/`. `Math.trunc` (not `Math.floor`) is the entire
+  // difference from `divide`'s int path above.
+  function truncDiv(a, b) {
+    const an = numOf(a), bn = numOf(b);
+    if (bn === 0) {
+      raiseError("ZeroDivisionError", "divided by 0");
+    }
+    return Math.trunc(an / bn);
+  }
+
+  // Unsigned truncating division — the twin of `truncDiv` for values a
+  // frontend intends as unsigned. On the fixed-width C/Go/Rust backends
+  // this needs bit reinterpretation (a tagged `i64`/`int64` ≥ 2^63
+  // misreads as negative otherwise); JS numbers are IEEE-754 doubles with
+  // no fixed width and no separate signed/unsigned representation, so
+  // this backend's `udiv_trunc` computes identically to `truncDiv` —
+  // documented, not a bug. Kept as a distinct function purely so every
+  // sibling backend's four names are all present here too.
+  function utruncDiv(a, b) {
+    return truncDiv(a, b);
+  }
+
+  // Always true-divides — coerces to float and divides, even when both
+  // operands are Ruby Integers (`trueDiv(6, 3)` boxes `2.0`, not `2`).
+  // Models Python's `/`. Genuinely new: no prior op in this runtime
+  // unconditionally floats an all-integer division.
+  function trueDiv(a, b) {
+    const an = numOf(a), bn = numOf(b);
+    if (bn === 0) {
+      raiseError("ZeroDivisionError", "divided by 0");
+    }
+    return mkFloat(an / bn);
   }
 
   // ── method dispatch (`__method__`) ─────────────────────────────
@@ -6507,6 +6564,10 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, matlabTruthy, format, write,
     plus, times, divide, shiftLeft,
+    // SIR21 T3b-2: `div_trunc`/`udiv_trunc`/`div_true` — the three
+    // genuinely-new division ops (`div_floor` is `divide` above, exported
+    // under its existing name).
+    truncDiv, utruncDiv, trueDiv,
     // Tagged floats (Ruby Integer vs Float). Exported so the emitter can
     // mint a boxed float at a `FloatLit` and route `-`/`%`/`neg` through
     // the re-tagging helpers. `mkFloat` is the sole factory.

--- a/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/compile_and_run_division_ops.rs
@@ -1,0 +1,198 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the JavaScript backend — hand-builds a module calling
+//! each op directly (bypassing the frontend, since no frontend emits
+//! these names yet), runs it with `node`, and asserts stdout/exit status.
+//! Mirrors `compile_and_run_sys_write.rs`'s pattern; skips gracefully when
+//! no `node` is on `PATH`.
+//!
+//! `div_floor` is a bare alias for this backend's existing `divide`
+//! (already zero-check-correct on both int and float paths) — verified
+//! here by checking it computes the SAME values that helper already
+//! produces. `div_trunc`/`udiv_trunc`/`div_true` are genuinely new, and
+//! get the most coverage here, including the zero-divisor case for every
+//! op (an uncaught `SirError` — a native `Error` subclass — prints its
+//! `name: message` via Node's default uncaught-exception handler and
+//! exits non-zero).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt, CURRENT_SIR_VERSION,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Run a `div_module` under `node`, returning `(stdout, stderr, success)`,
+/// or `None` to skip when no usable `node` is present. Unlike
+/// `compile_and_run_sys_write.rs`'s `run` (which asserts success
+/// unconditionally), this surfaces the exit status too, since the
+/// zero-divisor tests below expect a NON-zero exit.
+fn run_raw(module: &Module, tag: &str) -> Option<(String, String, bool)> {
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let artifact = compile(module).expect("compile to javascript");
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_div_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    Some((
+        String::from_utf8(output.stdout).expect("utf8 stdout").replace("\r\n", "\n"),
+        String::from_utf8(output.stderr).expect("utf8 stderr").replace("\r\n", "\n"),
+        output.status.success(),
+    ))
+}
+
+fn run(module: &Module, tag: &str) -> Option<String> {
+    let (out, err, ok) = run_raw(module, tag)?;
+    assert!(ok, "node exited non-zero for `{tag}`:\nstderr: {err}");
+    Some(out)
+}
+
+// ── §E3's own worked example, verbatim ──────────────────────────────────
+
+#[test]
+fn e3_worked_example() {
+    let m = div_module(vec![
+        print_stmt(bin("div_floor", ilit(7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+        print_stmt(bin("div_true", ilit(7), ilit(2))),
+    ]);
+    if let Some(out) = run(&m, "e3") {
+        assert_eq!(out, "3\n-3\n3.5\n");
+    }
+}
+
+// ── div_floor: a bare alias for `divide`'s existing floor logic ─────────
+
+#[test]
+fn div_floor_floors_toward_negative_infinity() {
+    let m = div_module(vec![
+        print_stmt(bin("div_floor", ilit(7), ilit(2))),
+        print_stmt(bin("div_floor", ilit(-7), ilit(2))),
+        print_stmt(bin("div_floor", ilit(7), ilit(-2))),
+        print_stmt(bin("div_floor", ilit(-7), ilit(-2))),
+    ]);
+    if let Some(out) = run(&m, "floor") {
+        assert_eq!(out, "3\n-4\n-4\n3\n");
+    }
+}
+
+// ── div_trunc/udiv_trunc: truncate toward zero ───────────────────────────
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    let m = div_module(vec![
+        print_stmt(bin("div_trunc", ilit(7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(7), ilit(-2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(-2))),
+    ]);
+    if let Some(out) = run(&m, "trunc") {
+        assert_eq!(out, "3\n-3\n-3\n3\n");
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    let m = div_module(vec![print_stmt(bin("udiv_trunc", ilit(7), ilit(2)))]);
+    if let Some(out) = run(&m, "udiv") {
+        assert_eq!(out, "3\n");
+    }
+}
+
+// ── div_true: genuinely new — always true-divides ────────────────────────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    let m = div_module(vec![
+        print_stmt(bin("div_true", ilit(7), ilit(2))),
+        print_stmt(bin("div_true", ilit(-7), ilit(2))),
+        print_stmt(bin("div_true", ilit(6), ilit(3))),
+    ]);
+    if let Some(out) = run(&m, "true") {
+        assert_eq!(out, "3.5\n-3.5\n2.0\n");
+    }
+}
+
+#[test]
+fn zero_divisor_raises_zero_division_error_for_every_op() {
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        let m = div_module(vec![print_stmt(bin(op, ilit(7), ilit(0)))]);
+        let Some((out, err, ok)) = run_raw(&m, op) else {
+            eprintln!("skip: no node on PATH");
+            break;
+        };
+        assert!(!ok, "[{op}] expected a non-zero exit; stdout={out:?}");
+        assert!(
+            err.contains("ZeroDivisionError") && err.contains("divided by 0"),
+            "[{op}] expected 'ZeroDivisionError'/'divided by 0' on stderr, got:\n{err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Sixth of Slice 2's seven backend PRs (after C #11880, Go #11883, Rust #11885, Python #11889, Ruby #11891) for the SIR21 T3b-2 division-op split (`code/specs/SIR21-type-system-and-integer-semantics.md` §E3).
- Adds `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` to `semantic-ir-to-javascript`'s dispatch table (both the emitter's 2-arg inline fast path and the runtime's `builtins` forward-compat table), purely additively -- bare `"/"` keeps working unchanged, no frontend emits the new names yet.
- `div_floor` is a bare alias for the pre-existing `divide` (already zero-check-correct on both int and float paths -- Ruby's `/` already floors ints / true-divides floats, so zero new logic).
- `div_trunc`/`udiv_trunc`/`div_true` route to three new runtime functions (`truncDiv`/`utruncDiv`/`trueDiv`), all raising the same typed `ZeroDivisionError` `divide` does.
- JS numbers are IEEE-754 doubles with no fixed width and no separate signed/unsigned representation, so unlike C/Go/Rust's `udiv_trunc` (which must reinterpret bits to avoid a `u64` >= 2^63 misreading as negative), this backend's `udiv_trunc` computes identically to `truncDiv` -- documented in `runtime.rs`, not a bug.

## Test plan
- [x] New `tests/compile_and_run_division_ops.rs`: real `node`-execution proof for all four ops, covering the §E3 worked example, floor-vs-truncate divergence, and a zero-divisor case for every op.
- [x] Full crate test suite green (`cargo test`, 292 passed across all test binaries).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Security review: PASSED (specifically verified the new `builtins` table entries are static literal keys with no prototype-pollution interaction, and the export pattern matches pre-existing entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)