### PR TITLE
feat(vault-pm): author api-key conflict merges

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package are documented here.
 
+## [0.58.0] - 2026-08-17
+
+### Added
+
+- Add an opaque audited authored API-key conflict merge preparation with a
+  complete wipe-on-drop replacement form, exact-current API-key base, and
+  application-owned closed scope-line and expiry validation.
+
+### Security
+
+- Keep the token, scope line, and prior candidate documents inside application
+  ownership, publish host and closed form-validation failures before returning
+  them, and publish success atomically with the all-current-parent revision.
+
 ## [0.57.0] - 2026-08-12
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -180,6 +180,14 @@ validation remains application-owned so invalid forms publish their failed
 `ItemConflictMerge` event before returning. Successful card merges retain only
 the base's non-form metadata and never return prior card values to the host.
 
+API-key authored merges use that same opaque preparation. The scope and expiry
+lines arrive exactly as typed and are turned into a record only behind the
+boundary, so the closed rules — a bounded comma-split scope line of trimmed,
+unique, non-empty components and a canonical nonzero expiry or none — publish
+their failed `ItemConflictMerge` event before returning. Successful API-key
+merges retain only the base's non-form metadata and never return the prior
+token to the host.
+
 Compare-and-replace is available through the same session-consuming boundary.
 It requires the requested item to have exactly one current live candidate equal
 to the caller's expected revision, then writes a new revision whose sole direct

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -63,13 +63,14 @@ pub use mutation::{
     RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
-    open_active_vault, recover_pending_publication, AuditedCardConflictMergePreparationV1,
-    AuditedLoginConflictMergePreparationV1, AuditedLoginEditPreparationV1,
-    AuditedSecureNoteConflictMergePreparationV1, CardConflictMergeInputV1,
-    CardConflictMergePreparationV1, ItemHistoryViewV1, LoginConflictMergePreparationV1,
-    LoginEditInputV1, LoginEditPreparationV1, SecureNoteConflictMergeInputV1,
-    SecureNoteConflictMergePreparationV1, UnlockedVaultV1, DEFAULT_ITEM_HISTORY_LIMIT,
-    MAX_ITEM_HISTORY_LIMIT,
+    open_active_vault, recover_pending_publication, ApiKeyConflictMergeInputV1,
+    ApiKeyConflictMergePreparationV1, AuditedApiKeyConflictMergePreparationV1,
+    AuditedCardConflictMergePreparationV1, AuditedLoginConflictMergePreparationV1,
+    AuditedLoginEditPreparationV1, AuditedSecureNoteConflictMergePreparationV1,
+    CardConflictMergeInputV1, CardConflictMergePreparationV1, ItemHistoryViewV1,
+    LoginConflictMergePreparationV1, LoginEditInputV1, LoginEditPreparationV1,
+    SecureNoteConflictMergeInputV1, SecureNoteConflictMergePreparationV1, UnlockedVaultV1,
+    DEFAULT_ITEM_HISTORY_LIMIT, MAX_ITEM_HISTORY_LIMIT,
 };
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -22,7 +22,7 @@ use coding_adventures_vault_pm_domain::{
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
 use coding_adventures_vault_records::{AnyRecord, ApiKey, Card, Login, SecureNote};
-use coding_adventures_zeroize::Zeroizing;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -718,7 +718,7 @@ fn parse_api_key_scope_line(line: &str) -> Result<Vec<String>, ApplicationError>
         return Ok(Vec::new());
     }
     let mut seen = BTreeSet::new();
-    let mut scopes = Vec::new();
+    let mut scopes: Vec<String> = Vec::new();
     for scope in line.split(',') {
         if scopes.len() == MAX_API_KEY_SCOPES
             || scope.is_empty()
@@ -726,6 +726,11 @@ fn parse_api_key_scope_line(line: &str) -> Result<Vec<String>, ApplicationError>
             || scope.len() > MAX_API_KEY_SCOPE_BYTES
             || !seen.insert(scope)
         {
+            // A rejected line is still authored user data. The components
+            // accepted before the rejection are owned plaintext copies, and on
+            // this path they never reach the zeroizing record that would wipe
+            // them, so wipe them here rather than freeing them intact.
+            scopes.iter_mut().for_each(Zeroize::zeroize);
             return Err(ApplicationError::InvalidInput);
         }
         scopes.push(scope.to_owned());
@@ -762,8 +767,9 @@ fn replacement_api_key_document(
         return Err(ApplicationError::InternalInvariant);
     };
     let expires_at = parse_api_key_expiry_line(&input.expiry)?;
-    // Parsed last so the only owned plaintext scope copies are handed straight
-    // to the zeroizing record with no fallible step in between.
+    // Parsed last so that on the success path the owned plaintext scope copies
+    // are handed straight to the zeroizing record with no fallible step in
+    // between; the parser wipes them itself when it rejects the line.
     let scopes = parse_api_key_scope_line(&input.scopes)?;
     ItemDocument::new(
         current.id(),

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -21,7 +21,7 @@ use coding_adventures_vault_pm_domain::{
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
-use coding_adventures_vault_records::{AnyRecord, Card, Login, SecureNote};
+use coding_adventures_vault_records::{AnyRecord, ApiKey, Card, Login, SecureNote};
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
@@ -33,6 +33,12 @@ pub const DEFAULT_ITEM_HISTORY_LIMIT: usize = 100;
 /// Hard maximum number of historical revisions returned for one item.
 pub const MAX_ITEM_HISTORY_LIMIT: usize = 4_096;
 const MAX_LOGIN_URLS: usize = 16;
+/// Largest complete API-key scope line accepted behind the audited boundary.
+const MAX_API_KEY_SCOPE_LINE_BYTES: usize = 2_048;
+/// Largest number of comma-separated components in one API-key scope line.
+const MAX_API_KEY_SCOPES: usize = 64;
+/// Largest single API-key scope component in UTF-8 bytes.
+const MAX_API_KEY_SCOPE_BYTES: usize = 256;
 
 /// Owned wipe-on-drop caller fields for one complete login edit.
 pub struct LoginEditInputV1 {
@@ -79,6 +85,38 @@ impl CardConflictMergeInputV1 {
             expiry_year,
             cvv,
             billing_zip,
+        }
+    }
+}
+
+/// Owned wipe-on-drop caller fields for one complete API-key merge.
+///
+/// The scope line and expiry arrive exactly as the terminal collected them so
+/// that their closed shape rules are re-checked behind the audited boundary
+/// rather than being trusted from the host.
+pub struct ApiKeyConflictMergeInputV1 {
+    label: Zeroizing<String>,
+    service: Zeroizing<String>,
+    token: Zeroizing<String>,
+    scopes: Zeroizing<String>,
+    expiry: Zeroizing<String>,
+}
+
+impl ApiKeyConflictMergeInputV1 {
+    /// Take the complete bounded API-key form collected by a trusted host.
+    pub const fn new(
+        label: Zeroizing<String>,
+        service: Zeroizing<String>,
+        token: Zeroizing<String>,
+        scopes: Zeroizing<String>,
+        expiry: Zeroizing<String>,
+    ) -> Self {
+        Self {
+            label,
+            service,
+            token,
+            scopes,
+            expiry,
         }
     }
 }
@@ -323,6 +361,36 @@ pub enum AuditedCardConflictMergePreparationV1 {
 impl AuditedCardConflictMergePreparationV1 {
     /// Return the opaque preparation or its already-durable operation failure.
     pub fn into_preparation(self) -> Result<CardConflictMergePreparationV1, ApplicationError> {
+        match self {
+            Self::Ready(preparation) => Ok(*preparation),
+            Self::Failed(failure) => match failure.into_operation() {
+                Ok(()) => Err(ApplicationError::InternalInvariant),
+                Err(error) => Err(error),
+            },
+        }
+    }
+}
+
+/// Opaque application-owned state for one validated authored API-key conflict
+/// merge.
+pub struct ApiKeyConflictMergePreparationV1 {
+    session: UnlockedVaultV1,
+    item_id: ItemId,
+    base: Zeroizing<ItemDocument>,
+    failure_audit: ConflictMergeFailureAuditV1,
+}
+
+/// Audited result of validating one authored API-key conflict merge.
+pub enum AuditedApiKeyConflictMergePreparationV1 {
+    /// The application retains the base document and complete conflict set.
+    Ready(Box<ApiKeyConflictMergePreparationV1>),
+    /// The closed precondition failure and its next owner state are durable.
+    Failed(Box<crate::AuditedAccessResultV1<()>>),
+}
+
+impl AuditedApiKeyConflictMergePreparationV1 {
+    /// Return the opaque preparation or its already-durable operation failure.
+    pub fn into_preparation(self) -> Result<ApiKeyConflictMergePreparationV1, ApplicationError> {
         match self {
             Self::Ready(preparation) => Ok(*preparation),
             Self::Failed(failure) => match failure.into_operation() {
@@ -578,6 +646,139 @@ fn replacement_card_document(
             expiry_year,
             cvv: input.cvv.into_inner(),
             billing_zip: input.billing_zip.map(Zeroizing::into_inner),
+        }),
+        current.attachments().clone(),
+    )
+    .map_err(|_| ApplicationError::InvalidInput)
+}
+
+impl ApiKeyConflictMergePreparationV1 {
+    /// Record a host-side prompt or entropy failure before exposing it.
+    pub fn record_audited_host_failure(
+        self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let audited =
+            self.publish_audited_failure(ApplicationError::InvalidInput, local_state_store)?;
+        Ok(audited.into_parts().0)
+    }
+
+    /// Complete the user-authored API-key merge and its atomic audit event.
+    pub fn complete_audited(
+        self,
+        input: ApiKeyConflictMergeInputV1,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        let document = match replacement_api_key_document(
+            &self.base,
+            input,
+            self.failure_audit.wall_time_ms,
+        ) {
+            Ok(document) => document,
+            Err(error) => return self.publish_audited_failure(error, local_state_store),
+        };
+        let active = self.session.merge_item_conflict(
+            document,
+            self.failure_audit.wall_time_ms,
+            randomness,
+            local_state_store,
+        )?;
+        Ok(crate::AuditedAccessResultV1::new(active, Ok(())))
+    }
+
+    fn publish_audited_failure(
+        self,
+        error: ApplicationError,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<crate::AuditedAccessResultV1<()>, ApplicationError> {
+        self.session.finish_audited_access(
+            AuditActionV1::ItemConflictMerge,
+            Some(self.item_id),
+            None,
+            self.failure_audit.wall_time_ms,
+            self.failure_audit.randomness,
+            local_state_store,
+            Err(error),
+        )
+    }
+}
+
+/// Split one already-bounded API-key scope line into its closed component list.
+///
+/// The line is authoritative exactly as typed: it is split only on commas, and
+/// every component must already be trimmed. Rejecting untrimmed components
+/// instead of silently trimming them keeps one scope line from denoting two
+/// different records depending on who normalized it.
+fn parse_api_key_scope_line(line: &str) -> Result<Vec<String>, ApplicationError> {
+    if line.len() > MAX_API_KEY_SCOPE_LINE_BYTES {
+        return Err(ApplicationError::InvalidInput);
+    }
+    if line.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut seen = BTreeSet::new();
+    let mut scopes = Vec::new();
+    for scope in line.split(',') {
+        if scopes.len() == MAX_API_KEY_SCOPES
+            || scope.is_empty()
+            || scope.trim() != scope
+            || scope.len() > MAX_API_KEY_SCOPE_BYTES
+            || !seen.insert(scope)
+        {
+            return Err(ApplicationError::InvalidInput);
+        }
+        scopes.push(scope.to_owned());
+    }
+    Ok(scopes)
+}
+
+/// Interpret one already-bounded API-key expiry line as optional Unix seconds.
+///
+/// An empty line means "no expiry". Anything else must be one canonical
+/// unsigned decimal: no sign, no leading zero, and not zero itself, so a single
+/// stored instant always has exactly one accepted spelling.
+fn parse_api_key_expiry_line(line: &str) -> Result<Option<u64>, ApplicationError> {
+    if line.is_empty() {
+        return Ok(None);
+    }
+    if line.starts_with('0') || !line.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(ApplicationError::InvalidInput);
+    }
+    let seconds = line
+        .parse::<u64>()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    (seconds != 0)
+        .then_some(Some(seconds))
+        .ok_or(ApplicationError::InvalidInput)
+}
+
+fn replacement_api_key_document(
+    current: &ItemDocument,
+    input: ApiKeyConflictMergeInputV1,
+    updated_at_ms: u64,
+) -> Result<ItemDocument, ApplicationError> {
+    let AnyRecord::ApiKey(_) = current.payload() else {
+        return Err(ApplicationError::InternalInvariant);
+    };
+    let expires_at = parse_api_key_expiry_line(&input.expiry)?;
+    // Parsed last so the only owned plaintext scope copies are handed straight
+    // to the zeroizing record with no fallible step in between.
+    let scopes = parse_api_key_scope_line(&input.scopes)?;
+    ItemDocument::new(
+        current.id(),
+        current.schema().clone(),
+        current.created_at_ms(),
+        updated_at_ms.max(current.updated_at_ms()),
+        current.favorite().clone(),
+        current.collection_ids().clone(),
+        current.tags().clone(),
+        AnyRecord::ApiKey(ApiKey {
+            label: input.label.into_inner(),
+            service: input.service.into_inner(),
+            token: input.token.into_inner(),
+            scopes,
+            expires_at,
         }),
         current.attachments().clone(),
     )
@@ -2452,6 +2653,55 @@ impl UnlockedVaultV1 {
         Ok(base)
     }
 
+    /// Validate one exact current live API key as the opaque metadata base for
+    /// an authored conflict merge, or publish the failed precondition.
+    pub fn prepare_audited_api_key_conflict_merge(
+        self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+        wall_time_ms: u64,
+        failure_randomness: AuditedAccessRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<AuditedApiKeyConflictMergePreparationV1, ApplicationError> {
+        self.require_audit_epoch()?;
+        match self.api_key_conflict_merge_precondition(item_id, base_revision) {
+            Ok(base) => Ok(AuditedApiKeyConflictMergePreparationV1::Ready(Box::new(
+                ApiKeyConflictMergePreparationV1 {
+                    session: self,
+                    item_id,
+                    base,
+                    failure_audit: ConflictMergeFailureAuditV1 {
+                        wall_time_ms,
+                        randomness: failure_randomness,
+                    },
+                },
+            ))),
+            Err(error) => self
+                .finish_audited_access(
+                    AuditActionV1::ItemConflictMerge,
+                    Some(item_id),
+                    None,
+                    wall_time_ms,
+                    failure_randomness,
+                    local_state_store,
+                    Err(error),
+                )
+                .map(|failure| AuditedApiKeyConflictMergePreparationV1::Failed(Box::new(failure))),
+        }
+    }
+
+    fn api_key_conflict_merge_precondition(
+        &self,
+        item_id: ItemId,
+        base_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let base = self.conflict_merge_base_precondition(item_id, base_revision)?;
+        let AnyRecord::ApiKey(_) = base.payload() else {
+            return Err(ApplicationError::Unsupported);
+        };
+        Ok(base)
+    }
+
     fn conflict_merge_base_precondition(
         &self,
         item_id: ItemId,
@@ -3678,6 +3928,72 @@ mod tests {
             ObjectKind::Catalog,
             &catalog.encode().unwrap(),
             &ObjectRandomness::new([0xe7; 32], [0xe8; 24], [0xe9; 24]),
+        )
+        .unwrap();
+        (
+            publication_for_catalog(active, objects, catalog_frame),
+            revisions,
+        )
+    }
+
+    fn pending_api_key_conflict_publication(
+        active: &ActiveStateV1,
+        item_id: ItemId,
+    ) -> (PublicationJournalV1, Vec<RevisionId>) {
+        let fixture = generation_zero_bytes();
+        let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+        let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let mut objects = Vec::new();
+        let mut revisions = Vec::new();
+        for (index, (label, token)) in [
+            ("Keep key left", "left-token-value"),
+            ("Keep key right", "right-token-value"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let document = ItemDocument::new(
+                item_id,
+                ContentType::new(coding_adventures_vault_records::API_KEY_V1).unwrap(),
+                500,
+                500,
+                LwwRegister::new(true, 500, OperationId::new([0xf0; 32])),
+                ObservedSet::new(),
+                ObservedSet::new(),
+                AnyRecord::ApiKey(ApiKey {
+                    label: label.to_owned(),
+                    service: "github.com".to_owned(),
+                    token: token.to_owned(),
+                    scopes: vec!["repo".to_owned()],
+                    expires_at: Some(1_900_000_000),
+                }),
+                ObservedSet::new(),
+            )
+            .unwrap();
+            let candidate = ItemCandidate::new(
+                RevisionId::new([0; 32]),
+                [],
+                ItemState::Live(Box::new(document)),
+            )
+            .unwrap();
+            let base = 0xf1u8.wrapping_add(index as u8 * 3);
+            let frame = seal_object(
+                &keys,
+                ObjectKind::ItemRevision,
+                &encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap(),
+                &ObjectRandomness::new([base; 32], [base + 1; 24], [base + 2; 24]),
+            )
+            .unwrap();
+            revisions.push(RevisionId::new(*frame.id().unwrap().as_bytes()));
+            objects.push(frame);
+        }
+        revisions.sort_unstable();
+        let catalog = CatalogV1::new(BTreeMap::from([(item_id, revisions.clone())])).unwrap();
+        let catalog_frame = seal_object(
+            &keys,
+            ObjectKind::Catalog,
+            &catalog.encode().unwrap(),
+            &ObjectRandomness::new([0xf7; 32], [0xf8; 24], [0xf9; 24]),
         )
         .unwrap();
         (
@@ -8594,6 +8910,506 @@ mod tests {
         .unwrap()
         .into_preparation();
         assert!(matches!(result, Err(ApplicationError::Unsupported)));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn authored_api_key_scope_and_expiry_lines_are_closed() {
+        assert_eq!(parse_api_key_scope_line("").unwrap(), Vec::<String>::new());
+        assert_eq!(
+            parse_api_key_scope_line("repo,read:org").unwrap(),
+            vec!["repo".to_owned(), "read:org".to_owned()]
+        );
+        // Order is preserved exactly as typed, never sorted or deduplicated.
+        assert_eq!(
+            parse_api_key_scope_line("write,read").unwrap(),
+            vec!["write".to_owned(), "read".to_owned()]
+        );
+        for rejected in [
+            "repo,repo",                                // duplicate component
+            "repo, read",                               // untrimmed component
+            "repo ",                                    // untrimmed single component
+            "repo,",                                    // empty trailing component
+            ",repo",                                    // empty leading component
+            &"a".repeat(MAX_API_KEY_SCOPE_BYTES + 1),   // oversized component
+            &"a,".repeat(MAX_API_KEY_SCOPE_LINE_BYTES), // oversized line
+            &(0..=MAX_API_KEY_SCOPES)
+                .map(|index| index.to_string())
+                .collect::<Vec<_>>()
+                .join(","), // too many components
+        ] {
+            assert!(
+                matches!(
+                    parse_api_key_scope_line(rejected),
+                    Err(ApplicationError::InvalidInput)
+                ),
+                "scope line must be rejected"
+            );
+        }
+
+        assert_eq!(parse_api_key_expiry_line("").unwrap(), None);
+        assert_eq!(parse_api_key_expiry_line("1").unwrap(), Some(1));
+        assert_eq!(
+            parse_api_key_expiry_line("1900000000").unwrap(),
+            Some(1_900_000_000)
+        );
+        for rejected in [
+            "0",                    // zero is not an instant
+            "01",                   // leading zero is not canonical
+            "+1",                   // signs are not accepted
+            "-1",                   // signs are not accepted
+            "1 ",                   // trailing space is not a digit
+            "1e9",                  // no exponent form
+            "18446744073709551616", // one past u64::MAX
+        ] {
+            assert!(
+                matches!(
+                    parse_api_key_expiry_line(rejected),
+                    Err(ApplicationError::InvalidInput)
+                ),
+                "expiry line must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn audited_authored_api_key_merge_records_host_validation_failure_and_success() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x26; 16]);
+        let (publication, revisions) = pending_api_key_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(507, audited_access_randomness(0x6d), &local)
+        .unwrap();
+
+        let base_revision = revisions[0];
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_api_key_conflict_merge(
+            item_id,
+            base_revision,
+            508,
+            audited_access_randomness(0x6e),
+            &local,
+        )
+        .unwrap()
+        .into_preparation()
+        .unwrap()
+        .record_audited_host_failure(&local)
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        session
+            .prepare_audited_api_key_conflict_merge(
+                item_id,
+                base_revision,
+                509,
+                audited_access_randomness(0x6f),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                ApiKeyConflictMergeInputV1::new(
+                    Zeroizing::new("Authored key".to_owned()),
+                    Zeroizing::new("github.com".to_owned()),
+                    Zeroizing::new("authored-token-value".to_owned()),
+                    Zeroizing::new("repo,repo".to_owned()),
+                    Zeroizing::new("1900000001".to_owned()),
+                ),
+                resolve_item_conflict_randomness(0x70),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .expect_err("invalid API-key form must remain a closed failed operation");
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&session),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+        let base_document = session.current_catalog.items[&item_id]
+            .iter()
+            .find(|candidate| candidate.revision_id() == base_revision)
+            .and_then(|candidate| match candidate.state() {
+                ItemState::Live(document) => Some(document),
+                ItemState::Tombstone(_) => None,
+            })
+            .unwrap();
+        let expected_favorite = base_document.favorite().clone();
+        let expected_collections = base_document.collection_ids().clone();
+        let expected_tags = base_document.tags().clone();
+        let expected_attachments = base_document.attachments().clone();
+
+        session
+            .prepare_audited_api_key_conflict_merge(
+                item_id,
+                base_revision,
+                510,
+                audited_access_randomness(0x71),
+                &local,
+            )
+            .unwrap()
+            .into_preparation()
+            .unwrap()
+            .complete_audited(
+                ApiKeyConflictMergeInputV1::new(
+                    Zeroizing::new("Authored key".to_owned()),
+                    Zeroizing::new("api.example".to_owned()),
+                    Zeroizing::new("authored-token-value".to_owned()),
+                    Zeroizing::new("repo,read:org".to_owned()),
+                    Zeroizing::new("1900000001".to_owned()),
+                ),
+                resolve_item_conflict_randomness(0x72),
+                &local,
+            )
+            .unwrap()
+            .into_operation()
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Succeeded,
+                Some(item_id),
+                None,
+            )
+        );
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored API-key merge must be the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions.iter().copied().collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored API-key merge must publish a live document")
+        };
+        assert_eq!(document.created_at_ms(), 500);
+        assert_eq!(document.updated_at_ms(), 510);
+        assert_eq!(document.favorite(), &expected_favorite);
+        assert_eq!(document.collection_ids(), &expected_collections);
+        assert_eq!(document.tags(), &expected_tags);
+        assert_eq!(document.attachments(), &expected_attachments);
+        let AnyRecord::ApiKey(api_key) = document.payload() else {
+            panic!("authored API-key merge must retain its schema")
+        };
+        assert_eq!(api_key.label, "Authored key");
+        assert_eq!(api_key.service, "api.example");
+        assert_eq!(api_key.token, "authored-token-value");
+        assert_eq!(
+            api_key.scopes,
+            vec!["repo".to_owned(), "read:org".to_owned()]
+        );
+        assert_eq!(api_key.expires_at, Some(1_900_000_001));
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn audited_authored_api_key_merge_accepts_an_empty_scope_and_expiry_form() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x27; 16]);
+        let (publication, revisions) = pending_api_key_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(511, audited_access_randomness(0x73), &local)
+        .unwrap();
+
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_api_key_conflict_merge(
+            item_id,
+            revisions[1],
+            512,
+            audited_access_randomness(0x74),
+            &local,
+        )
+        .unwrap()
+        .into_preparation()
+        .unwrap()
+        .complete_audited(
+            ApiKeyConflictMergeInputV1::new(
+                Zeroizing::new("Authored key".to_owned()),
+                Zeroizing::new("api.example".to_owned()),
+                Zeroizing::new("authored-token-value".to_owned()),
+                Zeroizing::new(String::new()),
+                Zeroizing::new(String::new()),
+            ),
+            resolve_item_conflict_randomness(0x75),
+            &local,
+        )
+        .unwrap()
+        .into_operation()
+        .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored API-key merge must be the sole current candidate")
+        };
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored API-key merge must publish a live document")
+        };
+        let AnyRecord::ApiKey(api_key) = document.payload() else {
+            panic!("authored API-key merge must retain its schema")
+        };
+        assert!(api_key.scopes.is_empty());
+        assert_eq!(api_key.expires_at, None);
+    }
+
+    #[test]
+    fn audited_authored_api_key_merge_rejects_a_card_base() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x28; 16]);
+        let (publication, revisions) = pending_card_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(513, audited_access_randomness(0x76), &local)
+        .unwrap();
+
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_api_key_conflict_merge(
+            item_id,
+            revisions[0],
+            514,
+            audited_access_randomness(0x77),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(matches!(result, Err(ApplicationError::Unsupported)));
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 1);
+        assert_eq!(
+            latest_audit_facts(&reopened),
+            (
+                AuditActionV1::ItemConflictMerge,
+                AuditOutcomeV1::Failed,
+                Some(item_id),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn audited_authored_api_key_merge_requires_an_exact_current_base() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x29; 16]);
+        let (publication, _) = pending_api_key_conflict_publication(&active, item_id);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .activate_audit_epoch(515, audited_access_randomness(0x78), &local)
+        .unwrap();
+
+        // A revision that is not a current candidate of this item is refused,
+        // and the refusal is durable before the caller ever sees it.
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .prepare_audited_api_key_conflict_merge(
+            item_id,
+            RevisionId::new([0x7a; 32]),
+            516,
+            audited_access_randomness(0x79),
+            &local,
+        )
+        .unwrap()
+        .into_preparation();
+        assert!(result.is_err());
         let reopened = open_active_vault(
             Zeroizing::new(b"active passphrase".to_vec()),
             locator,

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added audit-required `conflict merge api-key ITEM BASE_REVISION`, which
+  retains the exact current API key opaquely, collects the token through a
+  hidden prompt, forwards the scope and expiry lines verbatim for
+  application-owned closed validation, durably records host and validation
+  failures, and publishes one authored all-current-parent result without
+  exposing prior candidate values.
 - Added audit-required `conflict merge card ITEM BASE_REVISION`, which retains
   the exact current card opaquely, collects PAN/CVV through hidden prompts,
   durably records host and validation failures, and publishes one authored

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -223,6 +223,14 @@ forms are audited before their closed error. The base and every former
 candidate value remain opaque, success names all current candidates as parents,
 and ordinary output contains only the merged item selector.
 
+`conflict merge api-key ITEM BASE_REVISION` extends that ceremony to a complete
+API-key form. The token uses a hidden prompt, and the scope and expiry lines are
+forwarded verbatim so their closed shape is validated inside the
+application-owned preparation and invalid forms are audited before their closed
+error. The base and every former candidate value remain opaque, success names
+all current candidates as parents, and ordinary output contains only the merged
+item selector.
+
 `item reveal ITEM FIELD` requires an active audit epoch and accepts only closed
 schema-specific selectors. It reserves time and audit entropy before
 unlock, then requires exact `yes` through a fixed controlling-terminal prompt.

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -7,10 +7,10 @@ use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, open_portable_with_passphrase, portable_import_random_bytes,
     prepare_audited_generation_zero, rehydrate_prepared_init, AddItemRandomnessV1,
-    ApplicationError, AuditEventViewV1, AuditVerificationV1, AuditedAccessRandomnessV1,
-    AuditedGenerationZeroRandomness, BootstrapLocator, BootstrapStore, BootstrapStoreError,
-    CardConflictMergeInputV1, DeleteItemRandomnessV1, GenerationZeroPolicyV1, ItemHistoryViewV1,
-    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
+    ApiKeyConflictMergeInputV1, ApplicationError, AuditEventViewV1, AuditVerificationV1,
+    AuditedAccessRandomnessV1, AuditedGenerationZeroRandomness, BootstrapLocator, BootstrapStore,
+    BootstrapStoreError, CardConflictMergeInputV1, DeleteItemRandomnessV1, GenerationZeroPolicyV1,
+    ItemHistoryViewV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, LoginEditInputV1,
     PortableExportPolicyV1, PortableExportRandomnessV1, PortableImportRandomnessV1,
     PortableOpenPolicyV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
     RestoreItemRandomnessV1, RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1,
@@ -54,7 +54,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -655,6 +655,10 @@ enum Command {
         item_id: ItemId,
         base_revision: RevisionId,
     },
+    ConflictMergeApiKey {
+        item_id: ItemId,
+        base_revision: RevisionId,
+    },
     Help,
 }
 
@@ -882,6 +886,13 @@ fn parse_conflict(arguments: &[String]) -> Result<Command, CliFailure> {
                     .map_err(|_| CliFailure::InvalidCommand)?,
             })
         }
+        [action, kind, item, revision] if action == "merge" && kind == "api-key" => {
+            Ok(Command::ConflictMergeApiKey {
+                item_id: ItemId::from_user_string(item).map_err(|_| CliFailure::InvalidCommand)?,
+                base_revision: RevisionId::from_user_string(revision)
+                    .map_err(|_| CliFailure::InvalidCommand)?,
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -1100,6 +1111,17 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             item_id,
             base_revision,
         } => conflict_merge_card(
+            host,
+            prepared.paths(),
+            &writer,
+            selected_vault,
+            item_id,
+            base_revision,
+        ),
+        Command::ConflictMergeApiKey {
+            item_id,
+            base_revision,
+        } => conflict_merge_api_key(
             host,
             prepared.paths(),
             &writer,
@@ -2738,6 +2760,72 @@ fn conflict_merge_card(
             host.read_card_expiry_year()?,
             host.read_card_cvv()?,
             host.read_card_billing_postal_code()?,
+        ))
+    })();
+    let input = match input {
+        Ok(input) => input,
+        Err(error) => {
+            preparation
+                .record_audited_host_failure(&application_store)
+                .map_err(map_application)?;
+            return Err(map_host(error));
+        }
+    };
+    let mut mutation_random = [0_u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+    if let Err(error) = host.fill_entropy(&mut mutation_random) {
+        preparation
+            .record_audited_host_failure(&application_store)
+            .map_err(map_application)?;
+        return Err(map_host(error));
+    }
+    preparation
+        .complete_audited(
+            input,
+            ResolveItemConflictRandomnessV1::new(mutation_random),
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_operation()
+        .map_err(map_application)?;
+    Ok(CliOutput::success(format!(
+        "Conflict merged: {}\n",
+        item_id.to_user_string()
+    )))
+}
+
+fn conflict_merge_api_key(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    item_id: ItemId,
+    base_revision: RevisionId,
+) -> Result<CliOutput, CliFailure> {
+    let (wall_time_ms, failure_randomness) = audited_access_inputs(host)?;
+    let (access, application_store) = authenticated_access(host, paths, writer, selected_vault)?;
+    let preparation = access
+        .into_unlocked()
+        .map_err(map_application)?
+        .prepare_audited_api_key_conflict_merge(
+            item_id,
+            base_revision,
+            wall_time_ms,
+            failure_randomness,
+            &application_store,
+        )
+        .map_err(map_application)?
+        .into_preparation()
+        .map_err(map_application)?;
+    // The scope and expiry lines travel to the application exactly as typed:
+    // the audited preparation, not the CLI, is what turns them into a record,
+    // so an invalid form is recorded before its error is ever returned.
+    let input = (|| {
+        Ok::<_, HostError>(ApiKeyConflictMergeInputV1::new(
+            host.read_api_key_label()?,
+            host.read_api_key_service()?,
+            host.read_api_key_token()?,
+            host.read_api_key_scopes()?,
+            host.read_api_key_expiry()?,
         ))
     })();
     let input = match input {
@@ -4650,6 +4738,37 @@ mod tests {
             parse([
                 "conflict",
                 "merge",
+                "api-key",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            default_invocation(Command::ConflictMergeApiKey {
+                item_id,
+                base_revision: revision_id,
+            })
+        );
+        assert_eq!(
+            parse([
+                "--vault",
+                "work",
+                "conflict",
+                "merge",
+                "api-key",
+                item.as_str(),
+                revision.as_str(),
+            ]),
+            Ok(Invocation {
+                selected_vault: Some(ConfigName::new("work".to_owned()).unwrap()),
+                command: Command::ConflictMergeApiKey {
+                    item_id,
+                    base_revision: revision_id,
+                },
+            })
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
                 "login",
                 item.as_str(),
                 revision.to_lowercase().as_str(),
@@ -4664,6 +4783,20 @@ mod tests {
                 item.as_str(),
                 revision.to_lowercase().as_str(),
             ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse([
+                "conflict",
+                "merge",
+                "api-key",
+                item.as_str(),
+                revision.to_lowercase().as_str(),
+            ]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["conflict", "merge", "api-key", item.as_str()]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -7127,6 +7260,21 @@ mod tests {
             "{note_merged:?}"
         );
         assert!(note_merged.stdout().is_empty());
+
+        // The authored API-key merge must also stop at the unconflicted
+        // precondition, before any label, token, scope, or expiry is asked for.
+        let api_key_merge_host =
+            TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 128);
+        let api_key_merged = run(
+            ["conflict", "merge", "api-key", item, revision.as_str()],
+            &api_key_merge_host,
+        );
+        assert_eq!(
+            api_key_merged.exit_code(),
+            ExitCode::Conflict,
+            "{api_key_merged:?}"
+        );
+        assert!(api_key_merged.stdout().is_empty());
 
         let choose_host = TestHost::with_entropy_seed(paths.clone(), [passphrase.clone()], 127);
         let chosen = run(

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exposed audited authored API-key conflict merge with a hidden token prompt,
+  opaque base retention, closed scope/expiry validation, and all-current-parent
+  publication.
 - Exposed audited authored payment-card conflict merge with hidden PAN/CVV,
   opaque base retention, closed validation, and all-current-parent publication.
 - Exposed audited authored secure-note conflict merge with hidden body input,

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -40,6 +40,7 @@ vault-pm [--vault NAME] conflict choose ITEM REVISION
 vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION
+vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION
 ```
 
 `init` and every authenticated command require a controlling terminal even
@@ -55,8 +56,8 @@ bytes through stdin, verifies redacted canonical history across another fresh
 process, proves candidate-reveal denial and unconflicted failure advance the
 audit chain without entering stdout or disclosing a secret, proves an
 unconflicted authored-login merge fails before form collection and advances
-the merge audit action, repeats that gate for authored secure-note and
-payment-card merges before their secret forms, deletes to a causal
+the merge audit action, repeats that gate for authored secure-note,
+payment-card, and API-key merges before their secret forms, deletes to a causal
 tombstone, restores an exact live ancestor into a new revision, activates the
 signed audit epoch, forces an invalid edit prompt in
 a later process, verify that failure event from another process, inspect the

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -297,6 +297,16 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     assert!(!failed_card_merge_transcript.contains("Card number: "));
     assert_transcript_excludes_secrets(&failed_card_merge_transcript);
 
+    let (failed_api_key_merge_status, failed_api_key_merge_transcript) = run_unlock_in_pty(
+        &home,
+        &["conflict", "merge", "api-key", &item_id, &original_revision],
+        b"vault-pm: recovery or conflict required",
+    );
+    assert_eq!(failed_api_key_merge_status.code(), Some(5));
+    assert!(!failed_api_key_merge_transcript.contains("Label: "));
+    assert!(!failed_api_key_merge_transcript.contains("Token: "));
+    assert_transcript_excludes_secrets(&failed_api_key_merge_transcript);
+
     let expected_delete = format!("Item deleted: {item_id}");
     let (delete_status, delete_transcript) = run_unlock_in_pty(
         &home,
@@ -376,7 +386,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(
         post_failure_transcript
-            .contains("commits=26 catalogs=6 revisions=5 items=2 audit_events=26"),
+            .contains("commits=27 catalogs=6 revisions=5 items=2 audit_events=27"),
         "unexpected post-failure audit totals: {post_failure_transcript}"
     );
     assert_transcript_excludes_secrets(&post_failure_transcript);
@@ -435,7 +445,7 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
         "final audit verification failed: {final_audit_transcript}"
     );
     assert!(
-        final_audit_transcript.contains("audit_events=30"),
+        final_audit_transcript.contains("audit_events=31"),
         "unexpected final audit total: {final_audit_transcript}"
     );
     assert_transcript_excludes_secrets(&final_audit_transcript);

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1582,8 +1582,13 @@ changelog, focused build, and downstream validation.
                 and CVV collection, application-owned closed validation,
                 durable failures, and an atomic all-current-parent result,
                 using `VLT-PM35-cli-authored-card-conflict-merge.md`.
-9b-3b-2b-2b-3. remaining authored merge ceremonies for API keys, database
-                credentials, TOTP, and opaque records.
+9b-3b-2b-2b-3. completed audit-required user-authored API-key conflict merge
+                using an opaque exact-current metadata base, hidden token
+                collection, application-owned closed scope/expiry validation,
+                durable failures, and an atomic all-current-parent result,
+                using `VLT-PM36-cli-authored-api-key-conflict-merge.md`.
+9b-3b-2b-2b-4. remaining authored merge ceremonies for database credentials,
+                TOTP, and opaque records.
 9b-4a. completed authenticated encrypted portable export with a separately
         confirmed hidden passphrase, pre-authentication audit reservation,
         publish-before-release ordering, and an explicit create-new durable
@@ -1697,7 +1702,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   `VLT-PM32-cli-conflict-candidate-reveal.md`, and
   `VLT-PM33-cli-authored-login-conflict-merge.md`, and
   `VLT-PM34-cli-authored-secure-note-conflict-merge.md`, and
-  `VLT-PM35-cli-authored-card-conflict-merge.md` —
+  `VLT-PM35-cli-authored-card-conflict-merge.md`, and
+  `VLT-PM36-cli-authored-api-key-conflict-merge.md` —
   product repository wire,
   object-store, domain, verified-DAG, application, local-host, configuration,
   terminal/entropy, executable composition, authenticated verification, and
@@ -1717,7 +1723,9 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
   audited user-authored secure-note conflict merge using
   `VLT-PM34-cli-authored-secure-note-conflict-merge.md`, plus audited
   user-authored payment-card conflict merge using
-  `VLT-PM35-cli-authored-card-conflict-merge.md`.
+  `VLT-PM35-cli-authored-card-conflict-merge.md`, plus audited user-authored
+  API-key conflict merge using
+  `VLT-PM36-cli-authored-api-key-conflict-merge.md`.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM36-cli-authored-api-key-conflict-merge.md
+++ b/code/specs/VLT-PM36-cli-authored-api-key-conflict-merge.md
@@ -1,0 +1,73 @@
+# VLT-PM36 — Audited Authored API-Key Conflict Merge
+
+## Status
+
+Normative Phase 1A contract for resolving one current API-key conflict with a
+complete user-authored API-key record.
+
+## 1. Command and boundary
+
+```text
+vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION
+```
+
+The exact current live API-key base supplies immutable identity/creation time
+and the favorite, collection, tag, and attachment state not editable by the
+Phase 1A form. The controlling terminal collects a complete label, service,
+hidden token, an optional comma-separated scope line, and an optional expiry in
+Unix seconds. Existing tokens are inspected only through `conflict reveal`; the
+merge command never prefills candidate values, accepts inline fields, or
+chooses a winner. Other schemas remain separate backlog ceremonies.
+
+## 2. Closed form validation
+
+The host bounds every field before application entry. The application also
+requires a scope line of at most 2,048 UTF-8 bytes that, when non-empty, splits
+only on commas into at most 64 already-trimmed, non-empty, unique components of
+at most 256 UTF-8 bytes each in their original order, and an expiry that is
+either empty or one canonical nonzero unsigned decimal integer with no sign and
+no leading zero. This defense-in-depth validation occurs inside the opaque
+preparation so every invalid complete form publishes its failed audit event
+before the closed error returns. Phase 1A intentionally performs no network,
+issuer, token-verification, revocation, rotation, or scope lookup.
+
+## 3. Opaque preparation and audit ordering
+
+Time and audit-failure randomness are reserved before authentication. The
+application consumes the unlocked session and requires an active audit epoch,
+at least two current candidates, exact current membership of `BASE_REVISION`,
+a live item-bound API-key base, and compatible identity/schema/creation time
+across every retained live candidate.
+
+A ready opaque preparation owns the complete wipe-on-drop base without
+returning it to the CLI. Missing, unconflicted, noncurrent, tombstone,
+cross-item, and wrong-schema bases publish failed item-scoped
+`ItemConflictMerge` events before their closed error. Prompt, form-validation,
+or mutation-entropy failure consumes the preparation and publishes the same
+failure before the host error. Stale pins fail closed; ambiguous publication
+retains the exact journal.
+
+Success replaces the complete API-key payload, preserves base non-form
+metadata, names the entire former current set as direct causal parents, and
+publishes a succeeded `ItemConflictMerge` atomically. Because the result is
+authored, its event intentionally omits selected revision. Events contain no
+base/candidate identity, API-key fields, token length or prefix, scope, expiry,
+prompt progress, provider detail, or arbitrary error.
+
+## 4. Output and storage neutrality
+
+Success emits only `Conflict merged: ITEM`; failure has empty stdout. The token
+is a hidden terminal input and all authored fields stay in wipe-on-drop
+ownership until sealed. No API-key value enters arguments, stdout/stderr, audit
+history, debug output, config, or durable plaintext. Repository and local-state
+access remain injected and provider neutral.
+
+## 5. Acceptance gates
+
+Tests must prove exact default/named grammar; audited missing, unconflicted,
+noncurrent, tombstone, wrong-schema, prompt, validation, and entropy failures;
+one all-current-parent success that preserves base metadata and immutable
+history; restart-backed redacted observation; token exclusion; named-target
+isolation; formatting, Clippy, rustdoc, application/CLI tests; and a real
+executable PTY failure journey that stops before the authored form when the
+target is not a conflict.


### PR DESCRIPTION
Adds the fourth authored conflict-merge ceremony from VLT-PM00 §23 (9b-3b-2b-2b-3), mirroring the payment-card merge (VLT-PM35) against the API-key record schema. Database credentials, TOTP, and opaque records remain separate future items.

## Spec

- New `code/specs/VLT-PM36-cli-authored-api-key-conflict-merge.md`, written to the same structure and rigor as VLT-PM35.
- `VLT-PM00` §23 updated: API keys move from "remaining" to completed, and the remaining list renumbers to 9b-3b-2b-2b-4.

## Behavior

`vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION`

The exact current live API-key base supplies immutable identity/creation time plus the favorite, collection, tag, and attachment state the Phase 1A form cannot edit. The terminal collects a label, service, hidden token, an optional comma-separated scope line, and an optional expiry in Unix seconds. The command never prefills candidate values, accepts inline fields, or chooses a winner.

Scope-line and expiry shape rules live **inside** the opaque preparation rather than in the CLI, so an invalid complete form publishes its failed `ItemConflictMerge` event before the closed error returns. The application-side validators are a strict superset of the `item add api-key` create-path checks — same 64-component / 256-byte / trimmed / unique / non-empty rules, plus a whole-line cap matching the host's own bound — so the merge path can only ever be stricter than create, never looser.

Invariants held to the same standard as the three shipped merges: publish-before-release audit ordering on every precondition, prompt, validation, and entropy failure; atomic all-current-parent success; fail-closed preconditions; wipe-on-drop ownership of every authored field; and audit events carrying nothing but action, outcome, and item.

## Tests

- Five application tests: closed scope/expiry parsers across every rejection branch; audited host failure and validation failure followed by an all-current-parent success that preserves base metadata and immutable history; an empty scope/expiry form; a wrong-schema (card) base; and a non-current base.
- CLI grammar tests for default and named targets, lowercase-revision and arity rejection, plus an unconflicted-merge run through the command function.
- A real-process PTY leg in `local_cli_e2e.rs` proving the ceremony stops before the label and token prompts when the target is not a conflict, with audit totals updated accordingly.

Formatting, Clippy (`-D warnings`), rustdoc, both CLI crates, the application crate, and the downstream `vault-pm-application-storage-core` and `vault-pm-cli-host` suites all pass.

## Security review

Ran `/security-review`; passed on round 2. Round 1 raised one LOW finding — `parse_api_key_scope_line` accumulated owned plaintext scope components into a plain `Vec<String>` that was dropped intact on a rejection, leaving them in freed heap. Fixed in a follow-up commit by wiping the accumulator before the error escapes, and by correcting the ordering comment that overclaimed. Round 2 verified the wipe covers every early return, that this repo's `String::zeroize` volatile-writes the full capacity, and that no copy escapes via `Vec` reallocation or the borrowed `BTreeSet<&str>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)