### PR TITLE
feat(semantic-ir-to-typescript): SIR21 T3b-2 Slice 2 -- div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.14.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
+
+Additive-only: adds the four new division builtin names from SIR21 T3b-2
+(`code/specs/SIR21-type-system-and-integer-semantics.md` §E3) to the
+emitter's dispatch table. Bare `"/"` keeps working unchanged — no
+frontend emits any of the new names yet.
+
+- `div_floor` is a bare alias for the pre-existing `div` — **a
+  documented, unfixed limitation, not a fix**: this runtime's `Val` (see
+  `sir-runtime-core`'s `arithmetic.ts`) has no boxed-float tag, so it
+  cannot distinguish a Ruby Integer from a Ruby Float at runtime the way
+  `semantic-ir-to-javascript`'s `SirFloat` does, and `div_floor`'s
+  floor-vs-true-divide dispatch cannot be made correct without first
+  adding that tagging throughout this runtime — out of scope for this
+  additive slice. `div_floor` therefore inherits `div`'s existing
+  truncating behavior unchanged.
+- `div_trunc`/`udiv_trunc` route to a new `truncDiv` function — fully
+  correct (not a workaround): truncation toward zero needs no int/float
+  distinction, so it is well-defined in this runtime's untagged numeric
+  model. `udiv_trunc` computes identically (no fixed-width
+  signed/unsigned distinction to reinterpret, unlike C/Go/Rust).
+- `div_true` routes to a new `trueDiv` function — also fully correct for
+  the same reason: unconditional float coercion needs no tagging either.
+- New `tests/compile_and_run_division_ops.rs`: real `node`-execution
+  proof (via the crate's established strip-and-stub harness) asserting
+  BOTH `div_trunc`/`udiv_trunc`/`div_true`'s correct values AND
+  `div_floor`'s actual (truncating, not floor) output — the test
+  documents the limitation rather than hiding it.
+
 ## 0.13.0 — APL display convention (found via the first real array-codegen execution proof)
 
 `emit_module` now emits `__Sir.setDisplayConvention("apl")` for an

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -2401,6 +2401,19 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         "-" => "__Sir.sub",
         "*" => "__Sir.mul",
         "/" => "__Sir.div",
+        // SIR21 T3b-2: `div_floor` is a bare alias for `div` (a documented
+        // pre-existing limitation — this runtime's untagged `Val` model
+        // cannot distinguish Ruby Integer from Ruby Float at runtime, so
+        // `div_floor`'s floor-vs-true-divide dispatch cannot be made
+        // correct without a larger, out-of-scope value-tagging change —
+        // see `div`'s own doc comment in `arithmetic.ts`). `div_trunc`/
+        // `udiv_trunc` both route to `truncDiv` (identical here — no
+        // fixed-width signed/unsigned distinction to reinterpret).
+        // `div_true` is genuinely new.
+        "div_floor" => "__Sir.div",
+        "div_trunc" => "__Sir.truncDiv",
+        "udiv_trunc" => "__Sir.truncDiv",
+        "div_true" => "__Sir.trueDiv",
         "=" => "__Sir.eq",
         "<" => "__Sir.lt",
         ">" => "__Sir.gt",

--- a/code/packages/rust/semantic-ir-to-typescript/tests/compile_and_run_division_ops.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/tests/compile_and_run_division_ops.rs
@@ -1,0 +1,314 @@
+//! SIR21 T3b-2 execution proof: `div_floor`/`div_trunc`/`udiv_trunc`/
+//! `div_true` on the TypeScript backend — hand-builds a module calling
+//! each op directly (bypassing the frontend, since no frontend emits
+//! these names yet), runs it with `node`, and asserts stdout/exit status.
+//!
+//! As with every other node proof in this crate (see `run_with_node.rs`'s
+//! module doc-comment), the TypeScript backend emits genuine TypeScript
+//! that bare `node` cannot parse, so we swap the `@coding-adventures/
+//! sir-runtime-core`/`sir-runtime-exceptions` imports for inline stubs
+//! and strip the fixed set of type annotations the emitter adds. The
+//! stubs TRANSCRIBE the real `arithmetic.ts`/`runtime.ts`/exceptions
+//! logic (not a fake shape check), so this proof genuinely exercises the
+//! division behavior, not just that the emitted call site is present.
+//! Skips gracefully when no `node` is on `PATH`.
+//!
+//! **`div_floor` is NOT Ruby-floor-faithful here — a documented, unfixed
+//! limitation.** Every sibling backend's `div_floor` either aliases
+//! already-floor-faithful logic, or (for the closest sibling,
+//! `semantic-ir-to-javascript`) uses a boxed-float runtime tag to
+//! dispatch floor-vs-true-divide correctly. This runtime's `Val` has NO
+//! such tag (see `arithmetic.ts`'s `div` doc comment for the full
+//! writeup), so `div_floor` is a bare alias for the pre-existing `div`,
+//! which TRUNCATES instead of floors. The test below asserts the ACTUAL
+//! (truncating) behavior, not the Ruby-correct one — this is deliberate,
+//! not an oversight; flip it only alongside the value-tagging work that
+//! doc comment describes as a prerequisite. `div_trunc`/`udiv_trunc`/
+//! `div_true` have no such gap (see their own doc comments for why) and
+//! are asserted against their fully-correct values.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module,
+    RescueClause, Span, Stmt,
+};
+use semantic_ir_to_typescript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// A minimal `__SirExc` runtime stub, mirroring `run_with_node.rs`'s own
+/// `SIR_EXC_STUB` (kept local to this file rather than shared, since the
+/// two test binaries don't share a module tree).
+const SIR_EXC_STUB: &str = r#"const __SirExc = (() => {
+  const ANCESTRY = { ZeroDivisionError: "StandardError", StandardError: "Exception" };
+  class SirError extends Error {
+    constructor(sirClass, message) {
+      super(message == null ? sirClass : String(message));
+      this.sirClass = sirClass;
+    }
+  }
+  const raiseError = (c, m) => { throw new SirError(c ?? "RuntimeError", m); };
+  const classOfThrown = (e) => (e instanceof SirError ? e.sirClass : "StandardError");
+  const rescueMatches = (e, names) => {
+    if (names.length === 0) return true;
+    const actual = classOfThrown(e);
+    let cur = actual;
+    const seen = new Set();
+    while (cur !== undefined && !seen.has(cur)) {
+      if (names.includes(cur)) return true;
+      seen.add(cur);
+      cur = ANCESTRY[cur];
+    }
+    return false;
+  };
+  return { raiseError, rescueMatches, classOfThrown };
+})();
+"#;
+
+/// A `__Sir` stub carrying `write` (for `print_stmt`'s output) plus the
+/// SIR21 T3b-2 division family, TRANSCRIBING `arithmetic.ts`'s real
+/// `div`/`truncDiv`/`trueDiv` (see their doc comments there for why
+/// `div` truncates — a documented, unfixed limitation, not a stub
+/// shortcut).
+const SIR_DIV_STUB: &str = r#"const __Sir = {
+  toDisplay: (v) => (v === null ? "nil" : String(v)),
+  write: (stream, terminator, unpackArrays, ...values) => {
+    const out = stream === "stderr" ? process.stderr : process.stdout;
+    if (terminator === "once") {
+      out.write(values.map((v) => __Sir.toDisplay(v)).join(" ") + "\n");
+      return null;
+    }
+    for (const v of values) { out.write(__Sir.toDisplay(v)); }
+    return null;
+  },
+  div: (...args) => {
+    if (args.length === 0) return 0;
+    let acc = args[0];
+    for (let i = 1; i < args.length; i++) {
+      const d = args[i];
+      if (d === 0) __SirExc.raiseError("ZeroDivisionError", "divided by 0");
+      acc = Math.trunc(acc / d);
+    }
+    return acc;
+  },
+  truncDiv: (a, b) => {
+    if (b === 0) __SirExc.raiseError("ZeroDivisionError", "divided by 0");
+    return Math.trunc(a / b);
+  },
+  trueDiv: (a, b) => {
+    if (b === 0) __SirExc.raiseError("ZeroDivisionError", "divided by 0");
+    return a / b;
+  },
+};
+"#;
+
+fn ts_to_runnable_js(ts: &str) -> String {
+    let mut js = ts.to_string();
+    js = js.replace(
+        "import * as __Sir from \"@coding-adventures/sir-runtime-core\";\n",
+        SIR_DIV_STUB,
+    );
+    js = js.replace(
+        "import * as __SirExc from \"@coding-adventures/sir-runtime-exceptions\";\n",
+        SIR_EXC_STUB,
+    );
+    js = js.replace(" as { [k: string]: __Sir.Val }", "");
+    js = js.replace(" as __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val[]", "");
+    js = js.replace(": __Sir.Val", "");
+    js
+}
+
+/// Compile a `div_module`, transform to JS, run under `node`, and return
+/// trimmed stdout, or `None` to skip when no usable `node` is present.
+fn run(module: &Module, tag: &str) -> Option<String> {
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let artifact = compile(module).expect("compile to typescript");
+    let js = ts_to_runnable_js(&artifact.source);
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_ts_div_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &js).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        js,
+    );
+    Some(
+        String::from_utf8(output.stdout)
+            .expect("utf8 stdout")
+            .replace("\r\n", "\n"),
+    )
+}
+
+// ── div_floor: DOCUMENTED to truncate, not floor (see module doc) ────────
+
+#[test]
+fn div_floor_currently_truncates_not_floors_documented_limitation() {
+    let m = div_module(vec![
+        print_stmt(bin("div_floor", ilit(7), ilit(2))),
+        // Ruby-correct would be -4 (floor); this runtime gives -3
+        // (truncate) — see the module doc comment and `div`'s own doc
+        // comment in `arithmetic.ts` for why.
+        print_stmt(bin("div_floor", ilit(-7), ilit(2))),
+    ]);
+    if let Some(out) = run(&m, "floor") {
+        assert_eq!(out, "3\n-3\n");
+    }
+}
+
+// ── div_trunc/udiv_trunc: fully correct — truncation needs no int/float tag ──
+
+#[test]
+fn div_trunc_truncates_toward_zero() {
+    let m = div_module(vec![
+        print_stmt(bin("div_trunc", ilit(7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(2))),
+        print_stmt(bin("div_trunc", ilit(7), ilit(-2))),
+        print_stmt(bin("div_trunc", ilit(-7), ilit(-2))),
+    ]);
+    if let Some(out) = run(&m, "trunc") {
+        assert_eq!(out, "3\n-3\n-3\n3\n");
+    }
+}
+
+#[test]
+fn udiv_trunc_matches_div_trunc_on_positive_operands() {
+    let m = div_module(vec![print_stmt(bin("udiv_trunc", ilit(7), ilit(2)))]);
+    if let Some(out) = run(&m, "udiv") {
+        assert_eq!(out, "3\n");
+    }
+}
+
+// ── div_true: fully correct — always true-divides, no tag needed ─────────
+
+#[test]
+fn div_true_always_true_divides_even_on_integer_operands() {
+    let m = div_module(vec![
+        print_stmt(bin("div_true", ilit(7), ilit(2))),
+        print_stmt(bin("div_true", ilit(-7), ilit(2))),
+        // No boxed-float tag in this runtime (see module doc comment), so
+        // an integral float result prints as a bare "2", not "2.0" —
+        // unlike every sibling backend. A real, documented divergence,
+        // not a test bug.
+        print_stmt(bin("div_true", ilit(6), ilit(3))),
+    ]);
+    if let Some(out) = run(&m, "true") {
+        assert_eq!(out, "3.5\n-3.5\n2\n");
+    }
+}
+
+// ── zero-divisor: proves the fault raises AND is rescue-catchable ────────
+
+fn rescue(types: &[&str], binding: Option<&str>, body: Vec<Stmt>) -> RescueClause {
+    RescueClause {
+        exception_types: types.iter().map(|t| (*t).to_string()).collect(),
+        binding: binding.map(|b| b.to_string()),
+        body,
+        span: s(),
+    }
+}
+
+/// Wrap `fault` in `begin <fault>; rescue ZeroDivisionError => e; print
+/// marker; end`, run it, and assert the process exits 0 printing only the
+/// marker — proving the op both RAISES the typed error and that a Ruby
+/// `rescue ZeroDivisionError` catches it (matches `run_with_node.rs`'s T2
+/// `assert_typed_rescue_catches`-style pattern, rather than depending on
+/// Node's uncaught-exception stderr formatting).
+fn assert_zero_divisor_raises_and_is_caught(op: &str) {
+    let fault = bin(op, ilit(7), ilit(0));
+    let tc = Stmt::TryCatch {
+        body: vec![print_stmt(fault)],
+        rescues: vec![rescue(&["ZeroDivisionError"], Some("e"), vec![print_stmt(ilit(1))])],
+        ensure_body: None,
+        span: s(),
+    };
+    let m = Module {
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+            Feature::Exceptions,
+        ]),
+        ..div_module(vec![tc])
+    };
+    if let Some(out) = run(&m, op) {
+        assert_eq!(out, "1\n", "[{op}] expected only the rescue marker; got {out:?}");
+    }
+}
+
+#[test]
+fn zero_divisor_raises_zero_division_error_for_every_op() {
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        assert_zero_divisor_raises_and_is_caught(op);
+    }
+}

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.6.0] - 2026-08-17
+
+### Added — SIR21 T3b-2 Slice 2: `truncDiv`/`trueDiv`
+
+Adds the two genuinely-new division functions from the SIR21 T3b-2
+four-way `/` split (`code/specs/SIR21-type-system-and-integer-semantics.md`
+§E3). `div` (already present) is `div_floor`'s dispatch target — see the
+note below on why that stays unchanged.
+
+- `truncDiv(a, b)` — signed/unsigned truncating division (rounds toward
+  zero, matching C's integer `/`). This is exactly what `div` already
+  computes; exported under its own correctly-scoped name (`div_trunc`/
+  `udiv_trunc` in the SIR builtin table) purely so this package exposes
+  the same four division-op names every sibling runtime does. Fully
+  correct — truncation toward zero needs no int/float distinction, so it
+  is well-defined in this package's untagged `Val` numeric model.
+- `trueDiv(a, b)` — always true-divides, even when both operands are
+  meant as Ruby Integers. Models Python's `/`. Also fully correct for the
+  same reason: unconditional float coercion needs no tagging either.
+
+### Known limitation — `div_floor` still truncates, not floors
+
+`div`'s existing truncating behavior (documented since its original
+implementation, item 2 of the module doc comment) is NOT Ruby-floor-
+faithful, and `div_floor` (the new SIR21 T3b-2 name) dispatches to it
+unchanged. Every sibling backend's `div_floor` is either a bare rename of
+already-floor-faithful logic, or (`semantic-ir-to-javascript`, the
+closest sibling) uses a boxed-float runtime tag (`SirFloat`/`isFloat`) to
+dispatch floor-vs-true-divide correctly. This package's `Val` has no such
+tag — every number, whether it came from a Ruby `Integer` or `Float`
+literal, is an indistinguishable plain JS `number` by the time it reaches
+`div` — so `div_floor` cannot be made correct without first adding
+value-level float tagging throughout this package (touching `add`/`sub`/
+`mul`/comparisons/display, not division alone). That is out of scope for
+the additive SIR21 T3b-2 rollout; see `arithmetic.ts`'s `div` doc comment
+for the full writeup. Logged as follow-up work, not silently left
+undocumented.
+
 ## [0.5.0] - 2026-08-13
 
 ### Added — APL display convention + NDArray display support

--- a/code/packages/typescript/sir-runtime-core/README.md
+++ b/code/packages/typescript/sir-runtime-core/README.md
@@ -18,10 +18,19 @@ namespace into every file:
 | `eq`, `toDisplay` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
 | `write` | [SIR28](../../../specs/SIR28-syscall-primitives.md) `__sys_write__`: the general console-output primitive every frontend lowers `print`/`puts`/`console.log`/etc. to — `write(stream, terminator, unpackArrays, ...values)`, stream `"stdout"`\|`"stderr"`, terminator `"none"`\|`"per_value"`\|`"once"`. |
 | `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic numeric folds + truncating-integer `/`. `add`/`mul` are **type-polymorphic** like Ruby (dispatched on the first operand's runtime tag): `"a"+"b"`→`"ab"`, `[1]+[2]`→`[1,2]` (fresh array), `"ab"*3`→`"ababab"`, `[0]*3`→`[0,0,0]`, `[1,2]*", "`→`"1, 2"`. `*` repeat guards against oversize allocation (`Error("argument too big")`). |
+| `truncDiv`/`trueDiv` | SIR21 T3b-2's two fully-correct new division ops (`div` above is `div_floor`'s dispatch target, unchanged — see the note below). `truncDiv` always rounds toward zero (matches C's integer `/`); `trueDiv` always coerces to float and divides, even on two Integer operands (`trueDiv(6, 3) === 2`, the plain JS number — this package has no boxed-float type to re-tag the result with). Both need no int/float distinction to be correct, unlike `div_floor`. |
 | `Closure`/`apply`/`makeClosure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
 
 It implements **SIR** semantics, not any one source language's — so a Ruby
 frontend today and a JavaScript or Python frontend tomorrow all reuse it.
+
+**Known limitation — `div_floor` is not Ruby-floor-faithful.** `Val` (below)
+has no boxed-float tag, so `div`/`div_floor` cannot distinguish a Ruby
+`Integer` from a Ruby `Float` at runtime and always truncates toward zero
+instead of flooring for negative operands (`div(-7, 2) === -3`, not Ruby's
+`-4`). Fixing this needs value-level float tagging throughout this package
+(mirroring the JS backend's `SirFloat`), not a division-only change — see
+`arithmetic.ts`'s `div` doc comment for the full writeup.
 
 ## How emitted code uses it
 

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/sir-runtime-core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/sir-runtime-exceptions": "file:../sir-runtime-exceptions",

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
+++ b/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
@@ -295,6 +295,33 @@ export function mul(...args: Val[]): Val {
  * (`div(10, 2, 0)` raises on the trailing 0). We test `=== 0` rather than
  * "falsy" so a legitimate non-zero divisor is never mistaken; the message is
  * Ruby's exact `"divided by 0"`.
+ *
+ * **SIR21 T3b-2 `div_floor` dispatches here unchanged (known limitation).**
+ * The spec's `div_floor` is Ruby's own `/`: `Integer#/` FLOORS toward −∞
+ * (`-7 / 2 == -4` in real Ruby), while `Float#/` true-divides. This
+ * function always TRUNCATES instead (`div(-7, 2) === -3`, not `-4`) —
+ * every sibling backend's `div_floor` is either a bare rename of
+ * already-Ruby-floor-faithful logic, or (for `semantic-ir-to-javascript`,
+ * the closest sibling to this one) built on a boxed `SirFloat`/`isFloat`
+ * runtime tag that lets it dispatch floor-vs-true-divide correctly. This
+ * runtime's `Val` (see the module doc comment) has NO such tag — every
+ * number, whether it came from an `IntLit` or a `FloatLit`, is an
+ * indistinguishable plain JS `number` by the time it reaches here — so
+ * there is no way to tell "this operand is a Ruby Integer" from "this
+ * operand is a Ruby Float holding a whole number" at this point, and
+ * `div_floor` cannot be made floor-vs-true-divide-correct without first
+ * adding value-level float tagging throughout this runtime (mirroring
+ * `semantic-ir-to-javascript`'s `SirFloat`/`mkFloat`/`isFloat` — a
+ * runtime-wide change touching `add`/`sub`/`mul`/comparisons/display, not
+ * a division-only fix). That is out of scope for the additive SIR21
+ * T3b-2 Slice 2 rollout (backend dispatch-table wiring only); `div_floor`
+ * therefore deliberately inherits this pre-existing truncating behavior
+ * rather than silently changing it here — matching the precedent set by
+ * this same arc's `semantic-ir-to-c`/`semantic-ir-to-ruby` PRs, whose own
+ * `div_floor` aliases likewise inherited THEIR backends' pre-existing
+ * zero-divisor quirks rather than being retroactively "fixed" mid-slice.
+ * `div_trunc`/`udiv_trunc`/`div_true` below do NOT have this problem —
+ * see their own doc comments for why.
  */
 export function div(...args: Val[]): Val {
   if (args.length === 0) {
@@ -309,6 +336,55 @@ export function div(...args: Val[]): Val {
     acc = Math.trunc(acc / divisor);
   }
   return acc;
+}
+
+/**
+ * SIR21 T3b-2 `div_trunc` / `udiv_trunc` — signed/unsigned truncating
+ * division (rounds toward zero, matching C's integer `/`). This is
+ * exactly what {@link div} above already computes — exported under its
+ * own correctly-scoped name purely so this backend exposes the same four
+ * division-op names every sibling backend does.
+ *
+ * Unlike `div_floor` (see the dispatch-table comment in `emit.rs` for why
+ * that name is NOT fixed here), `div_trunc`'s spec — "always round toward
+ * zero" — needs no int/float distinction to be correct: truncation
+ * toward zero is the SAME operation regardless of whether an operand is
+ * semantically a Ruby Integer or Float. That is what makes this a
+ * genuinely well-defined function in this runtime, where {@link div}'s
+ * int-vs-float polymorphism is not.
+ *
+ * `udiv_trunc` (the twin C/Go/Rust need bit-reinterpretation for, since a
+ * tagged `u64` >= 2^63 misreads as negative in their fixed-width models)
+ * computes IDENTICALLY here: this runtime's `Val` has no fixed width and
+ * no separate signed/unsigned representation (see the module doc comment
+ * — every number is a plain JS `number`), so there is nothing to
+ * reinterpret. Both SIR names route to this one function.
+ */
+export function truncDiv(a: Val, b: Val): Val {
+  const bn = num(b);
+  if (bn === 0) {
+    raiseError("ZeroDivisionError", "divided by 0");
+  }
+  return Math.trunc(num(a) / bn);
+}
+
+/**
+ * SIR21 T3b-2 `div_true` — ALWAYS true-divides, even when both operands
+ * are meant as Ruby Integers (`trueDiv(6, 3) === 2`, the plain JS number
+ * — this runtime has no boxed-float type to re-tag the result with, see
+ * the module doc comment). Models Python's `/`.
+ *
+ * Unlike {@link div}/`div_floor`, this needs no int/float distinction
+ * either: it unconditionally treats both operands as numeric and
+ * true-divides, so it is fully and correctly implementable in this
+ * runtime's untagged numeric model — genuinely new, not a rename.
+ */
+export function trueDiv(a: Val, b: Val): Val {
+  const bn = num(b);
+  if (bn === 0) {
+    raiseError("ZeroDivisionError", "divided by 0");
+  }
+  return num(a) / bn;
 }
 
 /** Less-than. */

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -29,7 +29,7 @@ export {
   setDisplayConvention,
 } from "./values.js";
 export type { Val, ClosureLike } from "./values.js";
-export { add, shiftLeft, sub, mul, div, lt, gt } from "./arithmetic.js";
+export { add, shiftLeft, sub, mul, div, truncDiv, trueDiv, lt, gt } from "./arithmetic.js";
 export {
   Closure,
   LocalJumpError,

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -10,7 +10,7 @@
  *   value; `callBuiltin` looks one up by SIR name.
  */
 
-import { add, div, gt, lt, mul, shiftLeft, sub } from "./arithmetic.js";
+import { add, div, gt, lt, mul, shiftLeft, sub, trueDiv, truncDiv } from "./arithmetic.js";
 import { car, cdr, cons, isPair } from "./pairs.js";
 import { Sym } from "./symbols.js";
 import { eq, isNull, isNumber, isSymbol, toDisplay } from "./values.js";
@@ -214,6 +214,16 @@ const builtins: Record<string, (...args: Val[]) => Val> = Object.assign(Object.c
   "-": sub,
   "*": mul,
   "/": div,
+  // SIR21 T3b-2: `div_floor` is a bare alias for `div` (a documented,
+  // pre-existing limitation — see `div`'s own doc comment in
+  // `arithmetic.ts` for why it is NOT fixed here). `div_trunc`/
+  // `udiv_trunc` both route to `truncDiv` (identical in this runtime's
+  // untagged numeric model — see `truncDiv`'s own doc comment).
+  // `div_true` is genuinely new.
+  div_floor: div,
+  div_trunc: truncDiv,
+  udiv_trunc: truncDiv,
+  div_true: trueDiv,
   "=": (a: Val, b: Val) => eq(a!, b!),
   "<": (a: Val, b: Val) => lt(a!, b!),
   ">": (a: Val, b: Val) => gt(a!, b!),

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -299,6 +299,49 @@ describe("arithmetic", () => {
     expect(sir.lt(1, 2)).toBe(true);
     expect(sir.gt(2, 1)).toBe(true);
   });
+
+  // ── SIR21 T3b-2: `truncDiv` / `trueDiv` ──────────────────────────────
+  //
+  // `div` above IS `div_floor`'s dispatch target (a documented, unfixed
+  // pre-existing limitation — see `div`'s own doc comment in
+  // `arithmetic.ts`), so no separate test is needed for that name here.
+
+  it("truncDiv rounds toward zero on every sign combination", () => {
+    expect(sir.truncDiv(7, 2)).toBe(3);
+    expect(sir.truncDiv(-7, 2)).toBe(-3);
+    expect(sir.truncDiv(7, -2)).toBe(-3);
+    expect(sir.truncDiv(-7, -2)).toBe(3);
+    expect(sir.truncDiv(-6, 2)).toBe(-3); // exact division: trunc == floor
+  });
+
+  it("truncDiv by zero raises a typed ZeroDivisionError", () => {
+    expect(() => sir.truncDiv(1, 0)).toThrow(SirError);
+    try {
+      sir.truncDiv(1, 0);
+    } catch (e) {
+      expect((e as InstanceType<typeof SirError>).sirClass).toBe("ZeroDivisionError");
+      expect((e as Error).message).toBe("divided by 0");
+    }
+  });
+
+  it("trueDiv always true-divides, even on two integer operands", () => {
+    // `div`'s own test above asserts `sir.div(7, 2) === 3` (truncated);
+    // trueDiv on the SAME operands must be the exact float `3.5` — the
+    // entire point of a separate always-float op.
+    expect(sir.trueDiv(7, 2)).toBe(3.5);
+    expect(sir.trueDiv(-7, 2)).toBe(-3.5);
+    expect(sir.trueDiv(6, 3)).toBe(2);
+  });
+
+  it("trueDiv by zero raises a typed ZeroDivisionError", () => {
+    expect(() => sir.trueDiv(1, 0)).toThrow(SirError);
+    try {
+      sir.trueDiv(1, 0);
+    } catch (e) {
+      expect((e as InstanceType<typeof SirError>).sirClass).toBe("ZeroDivisionError");
+      expect((e as Error).message).toBe("divided by 0");
+    }
+  });
 });
 
 describe("polymorphic + (string/array concat)", () => {


### PR DESCRIPTION
## Summary
- Seventh and final of Slice 2's backend PRs (after C #11880, Go #11883, Rust #11885, Python #11889, Ruby #11891, JS #11893) for the SIR21 T3b-2 division-op split (`code/specs/SIR21-type-system-and-integer-semantics.md` §E3).
- Adds `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` to `semantic-ir-to-typescript`'s dispatch table plus two new functions in `@coding-adventures/sir-runtime-core` (`truncDiv`/`trueDiv`), purely additively -- bare `"/"` keeps working unchanged, no frontend emits the new names yet.
- `div_trunc`/`udiv_trunc`/`div_true` are fully correct: neither needs an int/float distinction, so both are well-defined in this runtime's untagged `Val` numeric model (every number is a plain JS `number`, no `Integer`/`Float` tag).

**`div_floor` is deliberately NOT fixed here** -- a documented, unfixed limitation, not an oversight. It stays a bare alias for the pre-existing `div()`, which truncates instead of floors. Investigating this backend specifically surfaced that it has no boxed-float tag (unlike `semantic-ir-to-javascript`'s `SirFloat`), so `div_floor`'s Ruby floor-vs-true-divide dispatch can't be made correct without adding value-level float tagging throughout the whole runtime (touching `add`/`sub`/`mul`/comparisons/display, not division alone) -- out of scope for this additive slice. This is explained at length in `arithmetic.ts`'s doc comment, the CHANGELOG, the README, and the new execution-proof test, which asserts the *actual* truncating output rather than papering over the gap.

## Test plan
- [x] New `tests/compile_and_run_division_ops.rs`: real `node`-execution proof (via this crate's established strip-and-stub harness) covering `div_trunc`/`udiv_trunc`/`div_true`'s correct values, `div_floor`'s documented (truncating) output, and a zero-divisor raise-and-rescue-catch proof for every op.
- [x] Full Rust crate test suite green (`cargo test`, 121+ across all binaries) and `cargo clippy --all-targets -- -D warnings` clean.
- [x] Full `sir-runtime-core` TS suite green (`vitest run`, 68 passed, 93%+ coverage) and `tsc --noEmit` clean.
- [x] Security review: PASSED (specifically verified the null-prototype `builtins` table's new entries are static literal keys with no interaction with its prototype-pollution guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)