### PR TITLE
feat(hl-c228): exam points outrank vocabulary — and the family was never generated

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -13,6 +13,64 @@ record of what was *learned*; it is no longer the record of what is *next*, beca
 a hand-ordered list goes stale silently and in the flattering direction. The
 prioritization sections below are kept as history and are dated accordingly.
 
+## HL-C228 — exam points now outrank vocabulary, and the family had never been generated
+
+HL-C226 recorded the evidence; this acts on it. Two things changed, and the second
+is the one that mattered.
+
+**1. `exam-point` was a declared family that NOTHING GENERATED.** The plan has been
+ranking work for 22 tracks with one of its seven families permanently empty since
+HL15 shipped. Vocabulary was not beating exam points — it was **running
+unopposed**. Every "vocabulary is the top item" observation in this backlog was
+made against a queue that could not have said anything else.
+
+That is worth more than the reordering. A family declared in a type, given a
+priority and a tranche size, and never emitted, looks exactly like a family that
+was considered and lost.
+
+**2. The priority swap, 4 → 3, above vocabulary.** Made against the HL-C226/C227
+measurement rather than an argument, and scoped: vocabulary keeps its place for a
+track with **no** inventory, because there the headword count is the only
+measurement that exists — still 19 of 22 tracks.
+
+Items are ranked at the track's **in-progress** level, not the inventory's. French
+sits at pre-A1 and its A1 gap is grammar-shaped; ranking the item at A1 would sort
+it behind every pre-A1 item and change nothing.
+
+Result: French and German lead with *"cover 54 of 74 A1 exam points french does
+not teach"*. Spanish, at 100%, correctly keeps vocabulary.
+
+### The review found that a comment I wrote was false, and that is the finding
+
+The code and the changelog both said an unreadable inventory "shows up as an
+`exam-inventory` item instead". **It did not.** `listExamInventories` lists any
+file that parses and declares a string language/level; `loadExamInventory` is far
+stricter. A file in the gap between them was listed as PRESENT — so no
+`exam-inventory` item — and threw on load — so no `exam-point` item. **The track
+vanished from both families while the report asserted its inventory existed**, at
+exit 0, with nothing on stderr.
+
+No corruption is needed to trigger it: rename one file toward the `spanish → es`
+code convention the loader **already uses**, and it is unmeasurable forever.
+
+Fixed by collecting failures — stderr, removed from the presence list, their own
+projection category, exit 1. And the general lesson: **a comment asserting a
+fallback behaviour is a claim, and claims about error paths are the ones least
+likely to have been run.** This one had never been executed once.
+
+### Three more that were fail-open in the same direction
+
+- **A missing `probe` key scores as COVERED.** `covered` is `probe !== null && …`
+  and `undefined !== null` is true, so an inventory with every probe deleted
+  reports **100%** and suppresses its own work item. Never reached the try/catch.
+  The empty-array case had been refused for exactly this reason; `undefined` is
+  the same fault in a different shape.
+- **A bare `catch {}`** swallowed a `TypeError` from any future refactor exactly
+  like a missing file — turning the feature off and printing a self-contradicting
+  report, with nothing in CI to notice.
+- **`plan-cli` had no test file at all**, so every one of the review's dirty
+  controls left the suite green. It now has five, each built from a control.
+
 ## HL-C227 — German says the same thing French did, which makes it a pattern rather than a track
 
 Third inventory. **German covers 21 of 70 (30%)** against the Goethe-Zertifikat A1

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Changed - exam points now outrank vocabulary, and the plan finally emits them (HL-C228)
+
+- `exam-point` was a declared family that **nothing generated**. The plan has been ranking work for 22 tracks with one of its seven families permanently empty, which is why vocabulary won every time — it was not beating exam points, it was running unopposed.
+- `buildCompletionPlan` now takes measured `examCoverage` and emits one item per (track, level) with uncovered points, ranked at the track's **in-progress** level rather than the inventory's. That is deliberate: French sits at pre-A1 and its A1 gap is grammar-shaped, so ranking the item at A1 would sort it behind every pre-A1 item and change nothing.
+- `exam-point` moves from priority 4 to 3, above `vocabulary` — the one ordering in this spec changed against a measurement rather than an argument. See HL-C226/HL-C227: two tracks, two awarding bodies, same shape, with core vocabulary the strongest column both times and 54 of French's 74 A1 points having no corresponding atom at all.
+- **Vocabulary keeps its place for a track with no inventory**, because there the headword count is the only measurement that exists — still 19 of 22 tracks.
+- The projection is honest about its reach: it counts uncovered points across the three written inventories and names the 19 tracks that *cannot* be measured until theirs exist, rather than extrapolating.
+- A malformed inventory is skipped rather than fatal — one bad file should not stop the queue being computed, and its absence resurfaces as an `exam-inventory` item.
+- **Seven security-review findings fixed in the same change**, the first of which proved a claim in this file false. The comment and changelog both said an unreadable inventory "shows up as an `exam-inventory` item instead". It did not: `listExamInventories` lists any file that parses, `loadExamInventory` is far stricter, and a file in the gap was listed as PRESENT (no `exam-inventory` item) *and* threw on load (no `exam-point` item). The track vanished from both families while the report asserted its inventory existed — silently, at exit 0. Renaming one file toward the `spanish → es` convention the loader already uses is enough to trigger it.
+- Failures are now collected: named on stderr, removed from the presence list so the `exam-inventory` item genuinely does return, counted as their own projection category ("exist but could not be READ"), and the CLI exits **1**. A target we can see but cannot measure must not be reportable as clean.
+- The bare `catch {}` is bound and filtered — it swallowed a `TypeError` from any future refactor exactly like a missing file, which would silently disable the whole feature and print a report whose two lines contradict each other.
+- **`loadExamInventory` now refuses a point whose `probe` key is missing or non-array.** `covered` is `probe !== null && …`, and `undefined !== null` is true — so an inventory with every probe deleted reported **100% covered** and suppressed its own work item. This never reached the try/catch. The empty-array case was already refused for exactly this reason.
+- The projection's "cannot be measured" denominator counts **tracks**, not (track, level) pairs — it would have gone wrong the moment any track gained a second inventory, which the A2 work already anticipates.
+- Inventories are deduplicated on (language, level). Two files declaring the same pair produced two items with the **identical** `id` — documented as "stable and derivable" — a doubled projection, and a shrunken backlog.
+- `buildCompletionPlan` is exported, so `enumerated`/`covered` are validated as finite before use; `uncovered <= 0` is false for `NaN`, which otherwise reached `tranches` and the projected total.
+- `plan-cli` had **no test file at all**, so every one of those controls left the suite green. It now has five, each built from the review's own dirty control.
+- Result: French and German's first recommended action changes from another vocabulary tranche to *"cover 54 of 74 A1 exam points french does not teach"*. Spanish, at 100%, correctly keeps vocabulary.
+
+
 ### Added - the glyph-coverage gate (HL-C214, HL-C223, HL-C225)
 
 - Add `glyph-coverage.ts`: every character in every generated book is checked against the font that will actually render it. Twice a tranche was merged-ready and failed CI on a missing glyph — `ǣ` in Latin, `ɔ` in Bengali — because every other gate reads the corpus and **none of them opens a font**.

--- a/code/packages/typescript/human-language-data/src/completion-plan.ts
+++ b/code/packages/typescript/human-language-data/src/completion-plan.ts
@@ -60,12 +60,28 @@ export type WorkKind =
  * forever; vocabulary runs to 16,000 per track. Finite work that unblocks
  * infinite work goes first, and a vocabulary tranche authored into an unclosed
  * script is authored onto sand: the reader cannot decode the word it teaches.
+ *
+ * `exam-point` was 4 and is now 3, ABOVE vocabulary, and that reordering is the
+ * one change here made against a measurement rather than an argument. Writing the
+ * French and German A1 inventories (HL-C226, HL-C227) produced the same shape
+ * twice, from two different awarding bodies' syllabuses:
+ *
+ *     questions 0/5 and 0/4 · articles 0/4 and 0/5 · prepositions 0/4 and 0/4
+ *     core vocabulary 6/10 and 6/12 — the STRONGEST column both times
+ *
+ * German holds 123 atoms across 106 lessons and six of them are grammar. **54 of
+ * French's 74 A1 points have no corresponding atom in the corpus at all, and no
+ * quantity of headwords creates one.** Ranking vocabulary first for those tracks
+ * recommended work that cannot move the number the reader is graded on.
+ *
+ * Vocabulary keeps its place for a track with NO inventory, because there the
+ * headword count is the only measurement that exists.
  */
 export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
   "exam-inventory": 1,
   "script-closure": 2,
-  vocabulary: 3,
-  "exam-point": 4,
+  "exam-point": 3,
+  vocabulary: 4,
   reinforcement: 5,
   "atom-budget": 6,
   "spine-nodes": 7,
@@ -150,15 +166,40 @@ export interface InventoryPresence {
   level: CefrLevel;
 }
 
+/** How far one track is from one level's external point list. */
+export interface ExamCoverageSummary {
+  language: string;
+  level: CefrLevel;
+  enumerated: number;
+  covered: number;
+}
+
 export interface CompletionPlanInput {
   levelGate: LevelGateReport;
   scriptClosure: ScriptClosureReport;
   /** Which external inventories exist. Absent ones become `exam-inventory` items. */
   inventories: readonly InventoryPresence[];
+  /**
+   * Measured coverage for every inventory that exists.
+   *
+   * Kept separate from `inventories` because presence and coverage answer
+   * different questions: one says whether a target is written down, the other
+   * says how far the corpus is from it. A track can have an inventory and still
+   * need every point in it.
+   */
+  examCoverage?: readonly ExamCoverageSummary[];
   /** How far the plan runs. Defaults to C2 — the whole ladder. */
   ceiling?: CefrLevel;
   /** How many items to enumerate. Defaults to 25. */
   headSize?: number;
+  /**
+   * Inventories that exist on disk but could not be read.
+   *
+   * Reported as its own category rather than folded into either "written" or
+   * "not written", because it is neither: the target exists and is unusable, and
+   * saying "not written" sends somebody to author a file that is already there.
+   */
+  unreadableInventories?: number;
 }
 
 /** Ceil-divide, with the degenerate case that zero outstanding is zero tranches. */
@@ -258,7 +299,37 @@ export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan 
       });
     }
 
-    // 3..7. Whatever the level gate says is short, in its own units. The gate
+    // 3. Points the external list enumerates and the corpus does not cover.
+    //
+    // Ranked at the track's IN-PROGRESS level rather than at the level the
+    // inventory describes, so it competes with that track's floor work instead
+    // of sorting behind it. That is deliberate and is the whole point of
+    // HL-C226: French sits at pre-A1 and its A1 gap is grammar-shaped, so pre-A1
+    // headwords are the wrong next move however large the headword deficit looks.
+    for (const coverage of input.examCoverage ?? []) {
+      if (coverage.language !== track.language) continue;
+      if (levelRank(coverage.level) > levelRank(ceiling)) continue;
+      // `buildCompletionPlan` is exported, so these numbers are not necessarily
+      // the ones `measureExamCoverage` produced. `uncovered <= 0` is FALSE for
+      // NaN, so without the finite check a NaN reaches `tranches` and the
+      // projected total.
+      if (!Number.isFinite(coverage.enumerated) || !Number.isFinite(coverage.covered)) continue;
+      const uncovered = Math.max(0, Math.trunc(coverage.enumerated - coverage.covered));
+      if (uncovered <= 0) continue;
+      mine.push({
+        id: `exam-point/${track.language}/${coverage.level}`,
+        kind: "exam-point",
+        language: track.language,
+        level,
+        goal:
+          `cover ${uncovered} of ${coverage.enumerated} ${coverage.level} exam point(s) ` +
+          `${track.language} does not teach`,
+        outstanding: uncovered,
+        tranches: tranchesFor(uncovered, "exam-point"),
+      });
+    }
+
+    // 4..7. Whatever the level gate says is short, in its own units. The gate
     // already scopes each criterion to at-or-below the level, which is the bug
     // HL09 recorded and this module must not reintroduce by re-deriving them.
     for (const blocker of track.blockers) {
@@ -410,6 +481,21 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
 
   const counted = (kind: WorkKind) => items.filter((item) => item.kind === kind).length;
 
+  // Projectable only over inventories that EXIST. The 129 unwritten ones are
+  // counted by the `exam-inventory` family above, and guessing how many points
+  // they will hold would be inventing a number.
+  const written = input.examCoverage ?? [];
+  const examUncovered = written.reduce(
+    (sum, c) =>
+      sum + (Number.isFinite(c.enumerated) && Number.isFinite(c.covered) ? Math.max(0, Math.trunc(c.enumerated - c.covered)) : 0),
+    0,
+  );
+  // TRACKS, not (track, level) pairs. `written` is per level, so subtracting its
+  // length claims one track fewer is unmeasurable for every second inventory a
+  // track gains -- and the A2 inventories are already anticipated.
+  const measuredTracks = new Set(written.map((c) => c.language)).size;
+  const examPointItems = written.length === 0 ? null : Math.ceil(examUncovered / TRANCHE_SIZE["exam-point"]);
+
   return [
     {
       kind: "vocabulary",
@@ -430,8 +516,15 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
     },
     {
       kind: "exam-point",
-      items: null,
-      detail: "not projectable — depends on inventories not yet written",
+      items: examPointItems,
+      detail:
+        examPointItems === null
+          ? "not projectable — no inventory has been written yet"
+          : `${examUncovered} uncovered point(s) across ${(input.examCoverage ?? []).length} ` +
+            `written inventory/inventories, at ${TRANCHE_SIZE["exam-point"]} per tranche; ` +
+            `the other ${input.levelGate.tracks.length - measuredTracks} ` +
+            `track(s) cannot be measured until theirs exist` +
+            (input.unreadableInventories ? `; ${input.unreadableInventories} exist but could not be READ` : ""),
     },
     {
       kind: "reinforcement",

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -504,9 +504,15 @@ export function loadExamInventory(
     if (point.category === "__proto__" || point.category === "constructor" || point.category === "prototype") {
       throw new Error(`exam inventory: point '${point.id}' uses a reserved category name`);
     }
-    if (Array.isArray(point.probe) && point.probe.length === 0) {
+    // `covered` is `probe !== null && ...`. A MISSING key is `undefined`, which is
+    // not `null`, so the point scores COVERED while demonstrating nothing -- and
+    // an inventory with every probe deleted reports 100% and silently suppresses
+    // its own work item. The empty-array case was already refused for exactly
+    // this reason; `undefined` and a non-array are the same fault in a different
+    // shape, so all three are refused together.
+    if (!(point.probe === null || (Array.isArray(point.probe) && point.probe.length > 0))) {
       throw new Error(
-        `exam inventory: point '${point.id}' has an empty probe; use null to mean "nothing in the corpus covers this"`,
+        `exam inventory: point '${point.id}' has no usable probe; use null to mean "nothing in the corpus covers this"`,
       );
     }
   }

--- a/code/packages/typescript/human-language-data/src/plan-cli.ts
+++ b/code/packages/typescript/human-language-data/src/plan-cli.ts
@@ -15,11 +15,18 @@ import {
   listExamInventories,
   loadChapterPolicy,
   loadEverything,
+  loadExamInventory,
   loadTrackChapters,
 } from "./loader.js";
 import { policyTableWidth } from "./narration-cli.js";
 import { buildCurriculumGapReport } from "./report.js";
-import { buildCompletionPlan, renderCompletionPlan, type InventoryPresence } from "./completion-plan.js";
+import {
+  buildCompletionPlan,
+  renderCompletionPlan,
+  type ExamCoverageSummary,
+  type InventoryPresence,
+} from "./completion-plan.js";
+import { measureExamCoverage } from "./exam-inventory.js";
 import { CEFR_LEVELS, type CefrLevel } from "./levels.js";
 
 interface PlanOptions {
@@ -95,15 +102,74 @@ export function runCompletionPlan(args = process.argv.slice(2)): number {
     return 2;
   }
 
+  // Deduped on (language, level). `listExamInventories` does not, so two files
+  // declaring the same pair -- which the `spanish -> es` naming convention makes
+  // easy to create by accident -- produced two `exam-point` items carrying the
+  // IDENTICAL id, double-counted the projection, and shrank the `exam-inventory`
+  // backlog. `WorkItem.id` is documented as stable and derivable.
+  const seenInventory = new Set<string>();
   const inventories = listExamInventories(options.root).flatMap<InventoryPresence>((entry) => {
     const level = CEFR_LEVELS.find((candidate) => candidate === entry.level);
-    return level ? [{ language: entry.language, level }] : [];
+    if (!level) return [];
+    const key = `${entry.language}/${level}`;
+    if (seenInventory.has(key)) return [];
+    seenInventory.add(key);
+    return [{ language: entry.language, level }];
   });
+
+  // Coverage is measured here rather than in `buildCompletionPlan`, which stays
+  // pure over report data.
+  //
+  // AN UNREADABLE INVENTORY IS NOT AN ABSENT ONE, and an earlier version of this
+  // comment claimed it resurfaced as an `exam-inventory` item. It did not.
+  // `listExamInventories` lists any file that parses and declares a string
+  // language/level; `loadExamInventory` is far stricter. A file in the gap
+  // between them was listed as PRESENT -- so no `exam-inventory` item -- and threw
+  // on load -- so no `exam-point` item. The track vanished from both families
+  // while the report asserted its inventory existed. Renaming one file toward the
+  // `spanish -> es` code convention the loader already uses is enough to trigger
+  // it, with no corruption at all.
+  //
+  // So failures are COLLECTED: named on stderr, removed from the presence list so
+  // the `exam-inventory` item genuinely does come back, and counted separately in
+  // the projection. Unmeasured must never be reportable as clean.
+  const examCoverage: ExamCoverageSummary[] = [];
+  const unreadable: { language: string; level: CefrLevel; reason: string }[] = [];
+  const readable: InventoryPresence[] = [];
+  for (const entry of inventories) {
+    try {
+      const coverage = measureExamCoverage(loadExamInventory(entry.language, entry.level, options.root), lessons);
+      readable.push(entry);
+      examCoverage.push({
+        language: entry.language,
+        level: entry.level,
+        enumerated: coverage.enumerated,
+        covered: coverage.covered,
+      });
+    } catch (error) {
+      // Bound and filtered. A bare `catch {}` swallows a TypeError from a future
+      // refactor of `measureExamCoverage` exactly like a missing file -- which
+      // would turn this whole feature off and print a report whose two lines
+      // contradict each other, with nothing in CI to notice.
+      const cause = error as NodeJS.ErrnoException;
+      const expected =
+        error instanceof SyntaxError ||
+        cause?.code === "ENOENT" ||
+        (error instanceof Error && error.message.startsWith("exam inventory:"));
+      if (!expected) throw error;
+      unreadable.push({ ...entry, reason: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  for (const bad of unreadable) {
+    process.stderr.write(`plan: ${bad.language} ${bad.level} inventory exists but could not be read -- ${bad.reason}\n`);
+  }
 
   const plan = buildCompletionPlan({
     levelGate: report.levelGate,
     scriptClosure: report.scriptClosure,
-    inventories,
+    inventories: readable,
+    examCoverage,
+    unreadableInventories: unreadable.length,
     ceiling: options.ceiling,
     headSize: options.headSize,
   });
@@ -111,7 +177,10 @@ export function runCompletionPlan(args = process.argv.slice(2)): number {
   process.stdout.write(
     options.format === "json" ? `${JSON.stringify(plan, null, 2)}\n` : `${renderCompletionPlan(plan).join("\n")}\n`,
   );
-  return 0;
+  // Non-zero when a target we can SEE could not be measured. The queue is still
+  // printed and still usable; the exit code is what stops it being mistaken for a
+  // complete answer by anything automated.
+  return unreadable.length > 0 ? 1 : 0;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
+++ b/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
@@ -217,3 +217,70 @@ describe("completion plan", () => {
     expect(text).toContain("Projection to the ceiling");
   });
 });
+
+describe("exam points outrank vocabulary (HL-C226)", () => {
+  const gateWith = (vocabShort: number) =>
+    gate([{ language: "french", inProgressAt: "pre-A1", blockers: vocabularyBlocker(vocabShort) }]);
+
+  it("puts the exam gap first when an inventory exists", () => {
+    // The measurement this reordering was made against: French sits at pre-A1
+    // with a 254-headword deficit, and 54 of its 74 A1 exam points have no
+    // corresponding atom at all. Ranking vocabulary first recommended work that
+    // cannot move the number the reader is graded on.
+    const built = plan({
+      levelGate: gateWith(254),
+      inventories: [{ language: "french", level: "A1" }],
+      examCoverage: [{ language: "french", level: "A1", enumerated: 74, covered: 20 }],
+    });
+    expect(built.head[0]).toMatchObject({ kind: "exam-point", language: "french", outstanding: 54 });
+    expect(built.head.map((item) => item.kind)).toContain("vocabulary");
+  });
+
+  it("leaves vocabulary first for a track with NO inventory", () => {
+    // Without an external list the headword count is the only measurement there
+    // is, so the old ordering is still the right one.
+    const built = plan({ levelGate: gateWith(254) });
+    expect(built.head[0]!.kind).toBe("vocabulary");
+  });
+
+  it("emits nothing for an inventory that is fully covered", () => {
+    const built = plan({
+      levelGate: gateWith(254),
+      inventories: [{ language: "french", level: "A1" }],
+      examCoverage: [{ language: "french", level: "A1", enumerated: 74, covered: 74 }],
+    });
+    expect(built.head.filter((item) => item.kind === "exam-point")).toHaveLength(0);
+  });
+
+  it("ranks the exam gap at the track's IN-PROGRESS level, not the inventory's", () => {
+    // Otherwise it sorts behind every pre-A1 item and the reordering does
+    // nothing — an A1 inventory on a pre-A1 track is exactly the live case.
+    const built = plan({
+      levelGate: gateWith(254),
+      inventories: [{ language: "french", level: "A1" }],
+      examCoverage: [{ language: "french", level: "A1", enumerated: 74, covered: 20 }],
+    });
+    expect(built.head[0]!.level).toBe("pre-A1");
+  });
+
+  it("projects only over inventories that exist, and says so", () => {
+    const built = plan({
+      levelGate: gate([
+        { language: "french", inProgressAt: "pre-A1" },
+        { language: "tamil", inProgressAt: "pre-A1" },
+      ]),
+      inventories: [{ language: "french", level: "A1" }],
+      examCoverage: [{ language: "french", level: "A1", enumerated: 74, covered: 20 }],
+    });
+    const projection = built.projection.find((entry) => entry.kind === "exam-point")!;
+    expect(projection.items).toBe(Math.ceil(54 / 5));
+    // The denominator is the honest part: guessing how many points the unwritten
+    // inventories hold would be inventing a number.
+    expect(projection.detail).toContain("1 track(s) cannot be measured");
+  });
+
+  it("still reports not-projectable when no inventory has been written", () => {
+    const built = plan({ levelGate: gateWith(254) });
+    expect(built.projection.find((entry) => entry.kind === "exam-point")!.items).toBeNull();
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/plan-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/plan-cli.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runCompletionPlan } from "../src/plan-cli.js";
+import { defaultCurriculumRoot } from "../src/loader.js";
+
+// `plan-cli` had no test file at all, so every one of the security review's dirty
+// controls left the suite green. These pin the coupling the review found: the
+// presence list, the coverage measurement, and what happens when they disagree.
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function corpus(): string {
+  const root = mkdtempSync(join(tmpdir(), "hl-plan-"));
+  roots.push(root);
+  cpSync(defaultCurriculumRoot(), root, { recursive: true });
+  return root;
+}
+
+function run(root: string): { code: number; out: string; err: string } {
+  let out = "";
+  let err = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => ((out += chunk), true));
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => ((err += chunk), true));
+  const code = runCompletionPlan(["--root", root]);
+  return { code, out, err };
+}
+
+function editInventory(root: string, name: string, edit: (doc: Record<string, unknown>) => void): void {
+  const path = join(root, "core", name);
+  const doc = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  edit(doc);
+  writeFileSync(path, JSON.stringify(doc));
+}
+
+describe("the plan CLI", () => {
+  it("leads French and German with their exam gap on a clean corpus", () => {
+    const { code, out } = run(corpus());
+    expect(code).toBe(0);
+    expect(out).toMatch(/exam-point — french/);
+    expect(out).toMatch(/exam-point — german/);
+    // Spanish is at 100%, so it must NOT get one.
+    expect(out).not.toMatch(/exam-point — spanish/);
+  }, 120_000);
+
+  it("does not let an unreadable inventory look like an absent one", () => {
+    // The HIGH finding. `listExamInventories` lists any file that parses;
+    // `loadExamInventory` is stricter. A file in the gap was listed as PRESENT
+    // (so no `exam-inventory` item) and threw on load (so no `exam-point` item) —
+    // the track vanished from both families while the report asserted its
+    // inventory existed, silently, at exit 0.
+    const root = corpus();
+    editInventory(root, "exam-inventory-french-a1.json", (doc) => {
+      doc.points = [];
+    });
+    const { code, out, err } = run(root);
+    expect(code).toBe(1);
+    expect(err).toMatch(/french A1 inventory exists but could not be read/);
+    // It comes BACK as an inventory to write, which is what the old comment
+    // falsely claimed already happened.
+    expect(out).toMatch(/130\s+exam-inventory/);
+    expect(out).toMatch(/1 exist but could not be READ/);
+  }, 120_000);
+
+  it("refuses an inventory whose points lost their probe key", () => {
+    // `covered` is `probe !== null && …`, and a missing key is `undefined`, which
+    // is not `null` — so an inventory with every probe deleted reported 100% and
+    // suppressed its own work item. It never reached the try/catch.
+    const root = corpus();
+    editInventory(root, "exam-inventory-french-a1.json", (doc) => {
+      for (const point of doc.points as Record<string, unknown>[]) delete point.probe;
+    });
+    const { code, err } = run(root);
+    expect(code).toBe(1);
+    expect(err).toMatch(/has no usable probe/);
+  }, 120_000);
+
+  it("counts a duplicated inventory once", () => {
+    // `listExamInventories` dedupes nothing, so two files declaring the same
+    // (language, level) produced two items with the IDENTICAL id, a doubled
+    // projection, and a shrunken inventory backlog.
+    const root = corpus();
+    cpSync(
+      join(root, "core", "exam-inventory-french-a1.json"),
+      join(root, "core", "exam-inventory-fr-a1.json"),
+    );
+    const { out } = run(root);
+    expect(out).toMatch(/103 uncovered point\(s\) across 3 written/);
+    expect(out).toMatch(/the other 19 track\(s\)/);
+  }, 120_000);
+
+  it("rejects a flag used as another flag's value", () => {
+    expect(run(corpus()).code).toBe(0);
+    let err = "";
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => ((err += chunk), true));
+    expect(runCompletionPlan(["--root", "--format"])).toBe(2);
+    expect(err).toMatch(/--root requires a value/);
+  }, 120_000);
+});

--- a/code/specs/HL15-the-completion-plan.md
+++ b/code/specs/HL15-the-completion-plan.md
@@ -111,12 +111,36 @@ one track clears the floor.
 ```
 1. exam-inventory   you cannot aim at a target you have not written down
 2. script-closure   decoding is a precondition for reading, and it ENDS
-3. vocabulary       the dominant remaining mass
-4. exam-point       named gaps against the external list
+3. exam-point       named gaps against the external list  [was 4 — see below]
+4. vocabulary       the dominant remaining mass           [was 3]
 5. reinforcement    retention — what separates a corpus claim from a learner one
 6. atom-budget      a ramp that got steeper is a regression, not a backlog item
 7. spine-nodes      functional coverage, the coarsest of the six
 ```
+
+**Why `exam-point` moved above `vocabulary`, and it is the one ordering here
+changed against a measurement rather than an argument.** This spec originally put
+vocabulary third because it is the dominant mass. Writing the French and German A1
+inventories (HL-C226, HL-C227) produced the same shape twice, from two different
+awarding bodies' syllabuses:
+
+```
+                     French          German
+questions            0/5             0/4
+articles / nouns     0/4             0/5
+prepositions         0/4             0/4
+core vocabulary      6/10            6/12   <- the STRONGEST column both times
+```
+
+German holds 123 atoms across 106 lessons and **six** of them are grammar; French
+holds 109 with nine. **54 of French's 74 A1 points have no corresponding atom in
+the corpus at all, and no quantity of headwords creates one.** Leaving vocabulary
+first recommended, for those tracks, work that cannot move the number the reader
+is graded on.
+
+Vocabulary keeps its place for a track with **no** inventory, because there the
+headword count is the only measurement that exists — which is still 19 of the 22
+tracks.
 
 **Why `exam-inventory` is first and cheapest.** Until the list exists, every other
 number for that (track, level) is a proxy for something nobody is graded on. It is


### PR DESCRIPTION
#11888 recorded the evidence; this acts on it. Two changes, and **the second is the one that mattered**.

## 1. `exam-point` was a declared family that nothing generated

The plan has been ranking work for 22 tracks with one of its seven families **permanently empty** since HL15 shipped. Vocabulary wasn't beating exam points — it was **running unopposed**. Every "vocabulary is the top item" observation in this backlog was made against a queue that could not have said anything else.

That's worth more than the reordering. A family declared in a type, given a priority and a tranche size, and never emitted, looks exactly like a family that was considered and lost.

## 2. The priority swap, 4 → 3

Made against the #11888 measurement rather than an argument, and **scoped**: vocabulary keeps its place for a track with *no* inventory, because there the headword count is the only measurement that exists — still 19 of 22 tracks.

Items rank at the track's **in-progress** level, not the inventory's. French sits at pre-A1 and its A1 gap is grammar-shaped; ranking at A1 would sort it behind every pre-A1 item and change nothing.

**Result:** French and German lead with *"cover 54 of 74 A1 exam points french does not teach"*. Spanish, at 100%, correctly keeps vocabulary.

## The review found that a comment I wrote was false

The code and changelog both said an unreadable inventory *"shows up as an `exam-inventory` item instead."* **It did not.**

`listExamInventories` lists any file that parses; `loadExamInventory` is far stricter. A file in the gap was listed as **present** — so no `exam-inventory` item — *and* threw on load — so no `exam-point` item. **The track vanished from both families while the report asserted its inventory existed**, at exit 0, with nothing on stderr.

No corruption needed to trigger it: rename one file toward the `spanish → es` convention **the loader already uses**, and it's unmeasurable forever.

Fixed by collecting failures — named on stderr, removed from the presence list so the `exam-inventory` item genuinely does return, counted as their own projection category, and **exit 1**.

The general lesson: *a comment asserting a fallback behaviour is a claim, and claims about error paths are the ones least likely to have been run.* This one had never executed once.

## Three more fail-open in the same direction

- **A missing `probe` key scores as covered.** `covered` is `probe !== null && …` and `undefined !== null` is true — so an inventory with every probe deleted reports **100%** and suppresses its own work item. It never reached the try/catch.
- **A bare `catch {}`** swallowed a `TypeError` from any future refactor exactly like a missing file — disabling the feature and printing a self-contradicting report, with nothing in CI to notice.
- **`plan-cli` had no test file**, so every one of the review's dirty controls left the suite green. It now has five, each built from a control.

## Verified against the review's own controls

| control | before | after |
|---|---|---|
| unreadable inventory | silent, exit 0, report says it doesn't exist | exit 1, named, resurfaces as an item |
| every `probe` key deleted | **100% covered**, item suppressed | refused at load, point named |
| duplicate inventory file | 157 uncovered / 32 tranches / 18 tracks | 103 / 21 / 19 |

Also fixed: the "cannot be measured" denominator counted (track, level) pairs as tracks and would have broken on the first A2 inventory; inventories are deduped on (language, level), since two files for one pair produced items with the **identical** `id`; and `buildCompletionPlan` validates `enumerated`/`covered` as finite, because `uncovered <= 0` is false for `NaN`.

HL15 updated so the spec isn't left stale.

## Verification

804 tests pass at **default timeouts, no flags**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)