### PR TITLE
test(sir-conformance): SIR21 T3b-2 Slice 3 -- direct-call coverage for div_floor/div_trunc/udiv_trunc/div_true

### DIFF
--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.26.0] - SIR21 T3b-2 Slice 3: direct-call coverage for div_floor/div_trunc/udiv_trunc/div_true
+
+Adds `pub fn run_module(name, module, target) -> RunOutcome` — a new
+module-level primitive alongside the existing source-level `run`/
+`run_source_via`, for callers that construct a `Module` directly rather
+than lowering it from source. Needed because Slice 2's four new division
+builtin names (`div_floor`/`div_trunc`/`udiv_trunc`/`div_true`) have no
+frontend emitting them yet (that's Slices 4-6 of this arc), so there is
+no source text that would lower to the desired `BuiltinCall` — the only
+way to reach them is a hand-built `Module`. `run_source_via` now delegates
+to `run_module` internally; no behavior change for existing callers.
+
+`tests/division.rs` gains five new tests using `run_module` directly,
+proving all 7 of Slice 2's backend PRs actually wired their dispatch
+tables correctly, independent of any frontend:
+
+- `direct_call_div_floor_matches_ruby_floor_on_every_backend`
+- `direct_call_div_trunc_truncates_toward_zero_on_every_backend`
+- `direct_call_udiv_trunc_matches_div_trunc_on_nonnegative_operands_every_backend`
+  (scoped to non-negative operands deliberately — a negative operand's
+  "unsigned" interpretation genuinely differs across backends, per each
+  Slice 2 PR's own documentation, not something this parity check should
+  paper over)
+- `direct_call_div_true_always_true_divides_on_every_backend`
+- `direct_call_zero_divisor_raises_for_every_op_on_every_backend` — the
+  first zero-divisor case anywhere in this file; asserts `RunOutcome::Failed`
+  is the EXPECTED outcome (an uncaught raise is a non-zero exit) and that
+  `Ran` (meaning the zero check silently failed to fire) is the bug.
+
+Caught one real bug while writing these: `assert_direct_call_matches_on_
+every_backend`'s first draft passed a constant temp-file name to
+`run_module` for every case, and since `cargo test` runs test functions
+concurrently, two calls sharing a name AND target raced on the identical
+temp path — a `div_floor` case's Python subprocess ran a `div_true` case's
+freshly-overwritten source file mid-race, printing `3.5` where `3` was
+expected. Fixed by deriving the name from `op`/`lhs`/`rhs` per call.
+
+TypeScript's own node-execution proof (the plan's other Slice 3 goal) is
+**not** duplicated here: `semantic-ir-to-typescript`'s own Slice 2 PR
+(`tests/compile_and_run_division_ops.rs`) already covers it end-to-end,
+including asserting `div_floor`'s documented (truncating, not floor)
+behavior for that backend specifically — see that crate's 0.14.0
+changelog entry. `sir-conformance`'s own `Target::all()` still does not
+include `Target::TypeScript` (a separate, larger infrastructure
+investment, unchanged from prior scoping).
+
 ## [0.25.0] - JavaScript OOP surface corpus: THIRD frontend, zero backend changes
 
 Adds `js_oop_method`, `js_counter_state`, `js_inheritance` — the SAME

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real source from any registered frontend and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -165,7 +165,12 @@ cargo test -p sir-conformance -- --nocapture
 
 As a library, `run(&program, target) -> RunOutcome` and `lower(&program)` are
 public so other harnesses (e.g. the eventual typed-integer conformance suite)
-can reuse the emit-and-run plumbing.
+can reuse the emit-and-run plumbing. `run_module(name, &module, target) ->
+RunOutcome` is the module-level sibling of `run`/`run_source_via` for a
+caller that already has a hand-built `Module` rather than source text to
+lower — e.g. `tests/division.rs`'s SIR21 T3b-2 direct-call cases, which
+call `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` directly since no
+frontend emits those names yet and so no source text would reach them.
 
 ## The reference oracle (`oracle` module, SIR21 §P2)
 
@@ -185,8 +190,14 @@ pinned to: `INT32_MAX + 1 == INT32_MIN` (i32 wrap), `0u32 - 1 == 4294967295`,
 honest rounding modes SIR21 §E3 splits apart: `Floor` rounds toward −∞ (Ruby
 `/`, Python `//`; `−7 / 2 == −4`), `Trunc` toward 0 (C/Rust/Go/Java; `−7 / 2 ==
 −3`). Division by zero is `Outcome::DivByZero` (a backend must *raise*), and the
-lone `i128::MIN / -1` overflow is `BeyondOracle`. `div_true` (Python's float
-`/`) is a future float-oracle op, not modelled here.
+lone `i128::MIN / -1` overflow is `BeyondOracle`. Every backend now implements
+the corresponding SIR builtins (`div_floor`/`div_trunc`/`udiv_trunc`, SIR21
+T3b-2 Slice 2) and `tests/division.rs`'s direct-call cases exercise them
+against this oracle on every `Target`. `div_true` (always true-divides,
+models Python's `/`) has no `DivOp` oracle variant — the integer oracle's
+overflow/rounding model doesn't apply to an op that unconditionally floats —
+so its direct-call test hand-computes expected values the same way the
+existing `FLOAT_CASES` in that file already do.
 
 ## The oracle-derived differential runner (`tests/arithmetic.rs`, SIR21 §P1)
 

--- a/code/packages/rust/sir-conformance/src/lib.rs
+++ b/code/packages/rust/sir-conformance/src/lib.rs
@@ -275,13 +275,27 @@ pub fn run_source_via(name: &str, source: &str, frontend: Frontend, target: Targ
         Ok(m) => m,
         Err(e) => return RunOutcome::Failed(e),
     };
+    run_module(name, &module, target)
+}
+
+/// Run a hand-built `module` (named `name`) through one `target` directly —
+/// the module-level primitive [`run_source_via`] delegates to once it has a
+/// `Module` in hand. Exposed publicly for callers that construct a `Module`
+/// themselves rather than lowering it from source — e.g. exercising a
+/// builtin no frontend emits yet (SIR21 T3b-2's `div_floor`/`div_trunc`/
+/// `udiv_trunc`/`div_true`), where there is no source text that would lower
+/// to the desired `BuiltinCall` in the first place.
+pub fn run_module(name: &str, module: &Module, target: Target) -> RunOutcome {
+    if !target.available() {
+        return RunOutcome::Skipped(format!("{} not on PATH", target.toolchain()));
+    }
     match target {
-        Target::Python => run_python(name, &module),
-        Target::JavaScript => run_javascript(name, &module),
-        Target::Go => run_go(name, &module),
-        Target::Rust => run_rust(name, &module),
-        Target::C => run_c(name, &module),
-        Target::Ruby => run_ruby(name, &module),
+        Target::Python => run_python(name, module),
+        Target::JavaScript => run_javascript(name, module),
+        Target::Go => run_go(name, module),
+        Target::Rust => run_rust(name, module),
+        Target::C => run_c(name, module),
+        Target::Ruby => run_ruby(name, module),
     }
 }
 

--- a/code/packages/rust/sir-conformance/tests/division.rs
+++ b/code/packages/rust/sir-conformance/tests/division.rs
@@ -48,8 +48,12 @@
 //! remains as a granular per-backend guard. The toolchain-free control below
 //! always runs.
 
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
 use sir_conformance::oracle::{DivOp, Outcome};
-use sir_conformance::{run_source, RunOutcome, Target};
+use sir_conformance::{run_module, run_source, RunOutcome, Target};
 
 /// `(lhs, rhs)` pairs covering every sign combination plus exact division.
 /// Ruby evaluates each with **floor** `/`.
@@ -210,4 +214,207 @@ fn python_division_is_ruby_floor_faithful() {
             "python_division_is_ruby_floor_faithful: python3 / sir-runtime-* unavailable — skipped"
         );
     }
+}
+
+// ── SIR21 T3b-2 Slice 3: direct-call coverage for the new division ops ─────
+//
+// `division_matches_ruby_floor_on_every_backend` above sources through Ruby,
+// so it only ever exercises bare `/` (no frontend emits `div_floor`/
+// `div_trunc`/`udiv_trunc`/`div_true` yet — that's Slices 4-6 of this arc).
+// This section calls each new op DIRECTLY by name via a hand-built `Module`
+// (`sir_conformance::run_module`, added alongside these tests specifically
+// because no source text exists that would lower to these builtins), so it
+// proves every one of Slice 2's 7 backend PRs actually wired the dispatch
+// table correctly — independent of any frontend migration.
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    call(name, vec![a, b])
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn div_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "divdirect".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ConsoleIO,
+            Feature::Strings,
+            Feature::Floats,
+            Feature::Exceptions,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Every backend that runs a `bin(op, lhs, rhs)` case must reproduce
+/// `expected`. Mirrors [`division_matches_ruby_floor_on_every_backend`]'s
+/// own accounting: `Skipped` is not asserted (no toolchain), `Failed` is a
+/// hard failure naming the offending backend, and at least one backend must
+/// have actually run or the assertion proved nothing.
+fn assert_direct_call_matches_on_every_backend(op: &str, lhs: i64, rhs: i64, expected: &str) {
+    let m = div_module(vec![print_stmt(bin(op, ilit(lhs), ilit(rhs)))]);
+    // `run_module`'s temp filename is built from `name` + target + PID only
+    // (no per-call nonce) — since `cargo test` runs test functions
+    // concurrently within one process, two calls sharing a name AND target
+    // race on the same temp path, so distinguish every case explicitly.
+    let name = format!("divdirect_{op}_{lhs}_{rhs}").replace('-', "n");
+    let mut ran = 0usize;
+    for &target in Target::all() {
+        match run_module(&name, &m, target) {
+            RunOutcome::Ran(out) => {
+                assert_eq!(
+                    out,
+                    expected,
+                    "\nDIRECT-CALL {op}: backend {} computed {op}({lhs}, {rhs}) = {out}, expected {expected}\n",
+                    target.tag(),
+                );
+                ran += 1;
+            }
+            RunOutcome::Failed(msg) => panic!(
+                "DIRECT-CALL {op}: backend {} failed on {op}({lhs}, {rhs}): {}",
+                target.tag(),
+                msg.lines().next().unwrap_or("")
+            ),
+            RunOutcome::Skipped(_) => {}
+        }
+    }
+    assert!(ran > 0, "DIRECT-CALL {op}({lhs}, {rhs}): no backend toolchain available");
+}
+
+#[test]
+fn direct_call_div_floor_matches_ruby_floor_on_every_backend() {
+    for &(lhs, rhs) in CASES {
+        let expected = floor_expected(lhs, rhs);
+        assert_direct_call_matches_on_every_backend(
+            "div_floor",
+            lhs as i64,
+            rhs as i64,
+            &expected,
+        );
+    }
+}
+
+#[test]
+fn direct_call_div_trunc_truncates_toward_zero_on_every_backend() {
+    for &(lhs, rhs) in CASES {
+        let expected = match DivOp::Trunc.eval(lhs, rhs) {
+            Outcome::Value(v) => v.to_string(),
+            other => panic!("div_trunc case {lhs}/{rhs}: oracle gave {other:?}, expected a Value"),
+        };
+        assert_direct_call_matches_on_every_backend(
+            "div_trunc",
+            lhs as i64,
+            rhs as i64,
+            &expected,
+        );
+    }
+}
+
+/// `udiv_trunc` is only exercised on NON-NEGATIVE operands here — a negative
+/// operand's "unsigned" interpretation genuinely differs across backends
+/// (C/Go/Rust reinterpret the bit pattern as `u64`; Python/Ruby/JS/TS have
+/// no fixed width and no signed/unsigned distinction to reinterpret, so
+/// they'd compute plain signed truncation instead), which is exactly the
+/// documented, intentional per-backend divergence each Slice 2 PR already
+/// recorded — not something this cross-backend parity check should paper
+/// over by picking one interpretation. On non-negative operands every
+/// backend agrees, which is what this asserts.
+#[test]
+fn direct_call_udiv_trunc_matches_div_trunc_on_nonnegative_operands_every_backend() {
+    const NONNEGATIVE_CASES: &[(i128, i128)] = &[(7, 2), (6, 3), (0, 5)];
+    for &(lhs, rhs) in NONNEGATIVE_CASES {
+        let expected = match DivOp::Trunc.eval(lhs, rhs) {
+            Outcome::Value(v) => v.to_string(),
+            other => panic!("udiv_trunc case {lhs}/{rhs}: oracle gave {other:?}, expected a Value"),
+        };
+        assert_direct_call_matches_on_every_backend(
+            "udiv_trunc",
+            lhs as i64,
+            rhs as i64,
+            &expected,
+        );
+    }
+}
+
+/// `div_true` always true-divides — no `DivOp` oracle variant exists for it
+/// (the integer oracle's overflow/rounding model doesn't apply to an op that
+/// unconditionally floats), so expected values are hand-computed the same
+/// way [`FLOAT_CASES`] above already does.
+#[test]
+fn direct_call_div_true_always_true_divides_on_every_backend() {
+    const TRUE_DIV_CASES: &[(i64, i64, &str)] = &[
+        (7, 2, "3.5"),
+        (-7, 2, "-3.5"),
+        (6, 3, "2.0"), // exact division still true-divides, not "2"
+    ];
+    for &(lhs, rhs, expected) in TRUE_DIV_CASES {
+        assert_direct_call_matches_on_every_backend("div_true", lhs, rhs, expected);
+    }
+}
+
+/// Every one of the four new division ops must raise on a zero divisor, on
+/// every backend — a case entirely untested before this Slice 3 addition
+/// (no zero-divisor case existed anywhere in this file). An uncaught raise
+/// is a non-zero exit, which `run_module` reports as `RunOutcome::Failed`
+/// — so here (uniquely in this file) `Failed` is the EXPECTED outcome, not
+/// a test failure; a `Ran` outcome means the zero check silently failed to
+/// fire, which IS the bug this test exists to catch.
+#[test]
+fn direct_call_zero_divisor_raises_for_every_op_on_every_backend() {
+    let mut ran = 0usize;
+    for op in ["div_floor", "div_trunc", "udiv_trunc", "div_true"] {
+        let m = div_module(vec![print_stmt(bin(op, ilit(7), ilit(0)))]);
+        let name = format!("divdirectzero_{op}");
+        for &target in Target::all() {
+            match run_module(&name, &m, target) {
+                RunOutcome::Ran(out) => panic!(
+                    "DIRECT-CALL ZERO-DIVISOR: backend {} did NOT raise for {op}(7, 0) — \
+                     printed {out:?} instead of failing",
+                    target.tag(),
+                ),
+                RunOutcome::Failed(_) => ran += 1,
+                RunOutcome::Skipped(_) => {}
+            }
+        }
+    }
+    assert!(ran > 0, "DIRECT-CALL ZERO-DIVISOR: no backend toolchain available");
 }


### PR DESCRIPTION
## Summary
- Slice 3 of the SIR21 T3b-2 division-op split arc (`code/specs/SIR21-type-system-and-integer-semantics.md` §E3), following Slice 2's 7 backend PRs (all merged: C #11880, Go #11883, Rust #11885, Python #11889, Ruby #11891, JS #11893, TS #11896).
- Adds `pub fn run_module(name, module, target) -> RunOutcome` to `sir-conformance` -- a module-level sibling of `run`/`run_source_via` for callers with a hand-built `Module` rather than source text. Needed because no frontend emits `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` yet (that's Slices 4-6), so there is no source text that would lower to those builtins in the first place. `run_source_via` now delegates to it internally; no behavior change for existing callers.
- Adds 5 new direct-call tests to `tests/division.rs` proving all 7 of Slice 2's backend PRs actually wired their dispatch tables correctly, independent of any frontend migration -- including the first zero-divisor case anywhere in this file.
- `udiv_trunc` coverage is deliberately scoped to non-negative operands: a negative operand's "unsigned" interpretation genuinely differs across backends (documented per-backend in each Slice 2 PR), so this cross-backend parity check doesn't paper over that by picking one interpretation.
- TypeScript's own node-execution proof is **not** duplicated here -- `semantic-ir-to-typescript`'s Slice 2 PR (#11896) already covers it end-to-end via `tests/compile_and_run_division_ops.rs`, including asserting that backend's documented (truncating, not floor) `div_floor` behavior. `sir-conformance`'s `Target::all()` still doesn't include TypeScript (a separate, larger infra investment, unchanged scoping).

**Caught a real bug while writing these**: the first draft of `assert_direct_call_matches_on_every_backend` passed a constant temp-file name to `run_module` for every case. Since `cargo test` runs test functions concurrently, two calls sharing a name AND target raced on the identical temp path -- a `div_floor` case's Python subprocess ran a `div_true` case's freshly-overwritten source file mid-race, printing `3.5` where `3` was expected. Fixed by deriving the name from `op`/`lhs`/`rhs` per call; security review specifically verified this fix is sufficient against every current call site.

## Test plan
- [x] Full `sir-conformance` test suite green (all test binaries, 0 failures, real toolchain execution across Python/JS/Go/Rust/C/Ruby).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Security review: PASSED (specifically verified the temp-file race fix is sufficient for every current call site under `cargo test`'s concurrent scheduling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)