### PR TITLE
feat(chief-of-staff-channel-crypto): add verify_grant_signature for Ruby D18Q parity

### DIFF
--- a/code/packages/ruby/chief-of-staff-channel-crypto/CHANGELOG.md
+++ b/code/packages/ruby/chief-of-staff-channel-crypto/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- Add `verify_grant_signature`, which checks every public `D18G` binding and the
+  originator's Ed25519 signature without a receiver private key. Ruby could
+  previously reach those checks only through `open_channel_key_grant`, which
+  requires a `ReceiverKeyPair` in order to unwrap -- so an originator, holding
+  no receiver secrets, had no way to verify the grants it had just sealed. D18T
+  plan validation requires exactly that, which is why Rust, Python, and
+  TypeScript already export the equivalent. Brings Ruby to parity.
+- Refactor `open_channel_key_grant` onto a shared `verify_grant_bindings` path
+  so the receiver-key-free and unwrapping entry points cannot drift on binding
+  order or stable error codes. No behavior change: every pre-existing opening
+  fixture still produces its declared code, now asserted against both entry
+  points. A raise from `Ed25519.verify` is folded into the same
+  `invalid_signature` result the false return already produced, so the
+  post-unwrap rescue no longer has to distinguish the two.
+
 ## 0.1.0 - 2026-08-14
 
 - Add the frozen Ruby D18F message model with copied, frozen byte ownership.

--- a/code/packages/ruby/chief-of-staff-channel-crypto/README.md
+++ b/code/packages/ruby/chief-of-staff-channel-crypto/README.md
@@ -45,6 +45,28 @@ durable_grant = CodingAdventures::ChiefOfStaffChannelCrypto.grant_serialize(gran
 
 Opening enforces the normative identity, channel, signature, X25519, HKDF, and
 AEAD validation order before returning a managed `ChannelMasterKey`.
+
+### Verifying a grant you cannot open
+
+Opening needs the receiver's private key, because unwrapping performs an X25519
+agreement. An originator holds no receiver secrets, so it cannot open the grants
+it seals — yet D18T requires it to verify the originator signature on every
+receiver's grant before a rotation candidate may be offered to key custody.
+`verify_grant_signature` is that weaker, receiver-key-free check:
+
+```ruby
+CodingAdventures::ChiefOfStaffChannelCrypto.verify_grant_signature(
+  grant, expected_originator_id, expected_receiver_id, channel_id, originator_public_key
+)
+```
+
+It proves the originator signed this exact `(originator, receiver, channel,
+epoch, ephemeral key, nonce, wrapped CMK)` tuple. It proves nothing about
+whether the wrapped CMK decrypts — only unwrapping can establish that, so a
+caller verifying grants it cannot open must not treat success as proof the
+receiver will be able to use the grant. Both entry points share one verification
+path, so they always agree on binding order and stable error codes.
+
 `ReceiverEpochKeys` retains historic keys while rejecting decreasing or
 conflicting grants, and `plan_rotation` returns a complete receiver-sorted
 prospective plan without claiming D18P durable activation. Secret containers

--- a/code/packages/ruby/chief-of-staff-channel-crypto/lib/coding_adventures_chief_of_staff_channel_crypto/grant_profile.rb
+++ b/code/packages/ruby/chief-of-staff-channel-crypto/lib/coding_adventures_chief_of_staff_channel_crypto/grant_profile.rb
@@ -540,24 +540,71 @@ module CodingAdventures
       KeyGrantSupport.wipe(wrapping_key) unless wrapping_key.nil?
     end
 
-    def open_channel_key_grant(grant, expected_originator_id, expected_receiver_id, expected_channel_id,
-                               receiver_key_pair, originator_public_key)
+    # Check every public D18G binding and the originator's Ed25519 signature
+    # without needing the receiver's private key.
+    #
+    # Opening a grant answers "may I, the receiver, unwrap this CMK?" and needs
+    # a receiver secret, because unwrapping performs an X25519 agreement. Some
+    # callers need a strictly weaker answer: "is this grant authentic?" D18T is
+    # the motivating case -- before a rotation candidate may be offered to key
+    # custody it must verify the originator signature on *every* receiver's
+    # grant, and the originator holds no receiver private keys, so it cannot
+    # open any of them.
+    #
+    # A successful return proves the originator named by +originator_public_key+
+    # signed this exact (originator, receiver, channel, epoch, ephemeral key,
+    # nonce, wrapped CMK) tuple. It proves nothing about whether the wrapped CMK
+    # decrypts -- only unwrapping can establish that. A caller verifying grants
+    # it cannot open must not treat success as proof the receiver will be able
+    # to use the grant.
+    #
+    # Shares one verification path with #open_channel_key_grant, so the two can
+    # never drift on binding order or stable error codes.
+    def verify_grant_signature(grant, expected_originator_id, expected_receiver_id, expected_channel_id,
+                               originator_public_key)
+      verify_grant_bindings(
+        grant, expected_originator_id, expected_receiver_id, expected_channel_id, originator_public_key
+      )
+      nil
+    end
+
+    # Shared authenticity path. Returns the grant's destructured values so the
+    # unwrapping caller does not re-read them.
+    def verify_grant_bindings(grant, expected_originator_id, expected_receiver_id, expected_channel_id,
+                              originator_public_key)
       KeyGrantSupport.validate_grant(grant)
       expected_originator = KeyGrantSupport.copy_bytes(expected_originator_id)
       expected_receiver = KeyGrantSupport.copy_bytes(expected_receiver_id)
       expected_channel = KeyGrantSupport.fixed_copy(expected_channel_id, 16)
       public_key = KeyGrantSupport.fixed_copy(originator_public_key, 32)
-      KeyGrantSupport.fail!("invalid_field") unless receiver_key_pair.is_a?(ReceiverKeyPair)
+      values = grant.__values
       originator_id, receiver_id, channel_id, key_epoch, ephemeral_public, nonce, wrapped_cmk,
-        signature = grant.__values
+        signature = values
       KeyGrantSupport.fail!("unexpected_originator") unless KeyGrantSupport.equal_bytes(originator_id, expected_originator)
       KeyGrantSupport.fail!("unexpected_receiver") unless KeyGrantSupport.equal_bytes(receiver_id, expected_receiver)
       KeyGrantSupport.fail!("unexpected_channel") unless KeyGrantSupport.equal_bytes(channel_id, expected_channel)
       signature_input = grant_signature_values(
         originator_id, receiver_id, channel_id, key_epoch, ephemeral_public, nonce, wrapped_cmk
       )
-      signature_valid = Ed25519.verify(signature_input, signature, public_key)
+      # A raise from verify is treated exactly like a false return: the caller
+      # learns only that the signature did not check out.
+      signature_valid = begin
+        Ed25519.verify(signature_input, signature, public_key)
+      rescue StandardError
+        false
+      end
       KeyGrantSupport.fail!("invalid_signature") unless signature_valid
+      values
+    end
+    private_class_method :verify_grant_bindings
+
+    def open_channel_key_grant(grant, expected_originator_id, expected_receiver_id, expected_channel_id,
+                               receiver_key_pair, originator_public_key)
+      KeyGrantSupport.fail!("invalid_field") unless receiver_key_pair.is_a?(ReceiverKeyPair)
+      originator_id, receiver_id, channel_id, key_epoch, ephemeral_public, nonce, wrapped_cmk =
+        verify_grant_bindings(
+          grant, expected_originator_id, expected_receiver_id, expected_channel_id, originator_public_key
+        )
       shared_secret = receiver_key_pair.agree(ephemeral_public)
       wrapping_key = derive_key_grant_wrapping_key(shared_secret, channel_id, key_epoch, receiver_id)
       aad = grant_aad_values(originator_id, receiver_id, channel_id, key_epoch, ephemeral_public)
@@ -569,11 +616,10 @@ module CodingAdventures
     rescue KeyGrantProfileError
       raise
     rescue StandardError
-      if signature_valid == false || signature_valid.nil?
-        KeyGrantSupport.fail!("invalid_signature")
-      else
-        KeyGrantSupport.fail!("authentication_failed")
-      end
+      # Every pre-unwrap failure now raises KeyGrantProfileError from
+      # verify_grant_bindings and re-raises above, so anything reaching here
+      # arose during agreement or AEAD open -- after the signature checked out.
+      KeyGrantSupport.fail!("authentication_failed")
     ensure
       KeyGrantSupport.wipe(shared_secret) unless shared_secret.nil?
       KeyGrantSupport.wipe(wrapping_key) unless wrapping_key.nil?

--- a/code/packages/ruby/chief-of-staff-channel-crypto/test/test_verify_grant_signature.rb
+++ b/code/packages/ruby/chief-of-staff-channel-crypto/test/test_verify_grant_signature.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "minitest/autorun"
+require "coding_adventures_chief_of_staff_channel_crypto"
+
+# Tests for the receiver-key-free D18G authenticity check.
+#
+# D18T plan validation requires verifying the originator signature on every
+# receiver's grant using only the channel definition's public key. An
+# originator holds no receiver private keys, so it cannot open the grants it
+# just sealed -- which is why this weaker check has to exist separately.
+class TestVerifyGrantSignature < Minitest::Test
+  Crypto = CodingAdventures::ChiefOfStaffChannelCrypto
+  FIXTURE_PATH = File.expand_path(
+    "../../../../fixtures/chief-of-staff-channel-key-grant/v1/manifest.json", __dir__
+  )
+  FIXTURE = JSON.parse(File.read(FIXTURE_PATH, encoding: "UTF-8"))
+  ORIGINATOR_PUBLIC_KEY = [FIXTURE.dig("test_signing_key", "public_key_hex")].pack("H*")
+
+  # The failures reachable without a receiver key. Everything else in the
+  # manifest's opening_negative_cases -- invalid_key_agreement and the whole
+  # authentication_failed family -- happens strictly AFTER signature
+  # verification, in the X25519 agreement or the AEAD open, and must therefore
+  # VERIFY SUCCESSFULLY here.
+  #
+  # That is the sharpest statement these tests make: the receiver-key-free
+  # entry point stops at exactly the boundary where the receiver key becomes
+  # necessary, no earlier and no later.
+  PRE_UNWRAP_CODES = %w[
+    unexpected_originator unexpected_receiver unexpected_channel invalid_signature
+  ].freeze
+
+  def decode(value) = Base64.strict_decode64(value)
+  def from_hex(value) = [value].pack("H*")
+
+  def assert_grant_error(code)
+    error = assert_raises(Crypto::KeyGrantProfileError) { yield }
+    assert_equal code, error.code
+  end
+
+  def test_accepts_every_positive_fixture_using_only_public_inputs
+    cases = FIXTURE.fetch("positive_cases")
+    refute_empty cases
+    cases.each do |testcase|
+      grant = Crypto.grant_deserialize(decode(testcase.fetch("d18g_b64")))
+      # Note what is absent: receiver_private_key_hex is never read.
+      assert_nil Crypto.verify_grant_signature(
+        grant,
+        decode(testcase.fetch("originator_id_b64")),
+        decode(testcase.fetch("receiver_id_b64")),
+        from_hex(testcase.fetch("channel_id_hex")),
+        ORIGINATOR_PUBLIC_KEY
+      ), "#{testcase.fetch('name')} must verify from public inputs alone"
+    end
+  end
+
+  def test_stops_exactly_at_the_receiver_key_boundary
+    seen_pre = 0
+    seen_post = 0
+    FIXTURE.fetch("opening_negative_cases").each do |testcase|
+      grant = Crypto.grant_deserialize(decode(testcase.fetch("d18g_b64")))
+      arguments = [
+        grant,
+        decode(testcase.fetch("expected_originator_id_b64")),
+        decode(testcase.fetch("expected_receiver_id_b64")),
+        from_hex(testcase.fetch("expected_channel_id_hex")),
+        ORIGINATOR_PUBLIC_KEY
+      ]
+      expected = testcase.fetch("expected_error")
+      if PRE_UNWRAP_CODES.include?(expected)
+        seen_pre += 1
+        assert_grant_error(expected) { Crypto.verify_grant_signature(*arguments) }
+      else
+        seen_post += 1
+        assert_nil Crypto.verify_grant_signature(*arguments),
+                   "#{testcase.fetch('name')} fails only while unwrapping, so signature " \
+                   "verification must succeed (expected #{expected})"
+      end
+    end
+    # Guard against a manifest that loses one side of the split and leaves half
+    # this test vacuous.
+    refute_equal 0, seen_pre
+    refute_equal 0, seen_post
+  end
+
+  def test_agrees_with_open_channel_key_grant_on_every_pre_unwrap_fixture
+    FIXTURE.fetch("opening_negative_cases").each do |testcase|
+      expected = testcase.fetch("expected_error")
+      next unless PRE_UNWRAP_CODES.include?(expected)
+
+      grant = Crypto.grant_deserialize(decode(testcase.fetch("d18g_b64")))
+      originator = decode(testcase.fetch("expected_originator_id_b64"))
+      receiver = decode(testcase.fetch("expected_receiver_id_b64"))
+      channel = from_hex(testcase.fetch("expected_channel_id_hex"))
+      receiver_key = Crypto::ReceiverKeyPair.from_private_key(
+        from_hex(testcase.fetch("receiver_private_key_hex"))
+      )
+
+      # Both entry points share verify_grant_bindings, so they can never
+      # disagree on a pre-unwrap failure. This makes that structural claim
+      # observable rather than merely asserted in a comment.
+      assert_grant_error(expected) do
+        Crypto.verify_grant_signature(grant, originator, receiver, channel, ORIGINATOR_PUBLIC_KEY)
+      end
+      assert_grant_error(expected) do
+        Crypto.open_channel_key_grant(grant, originator, receiver, channel, receiver_key,
+                                      ORIGINATOR_PUBLIC_KEY)
+      end
+      receiver_key.destroy
+    end
+  end
+
+  def test_rejects_malformed_public_inputs
+    testcase = FIXTURE.fetch("positive_cases").first
+    grant = Crypto.grant_deserialize(decode(testcase.fetch("d18g_b64")))
+    originator = decode(testcase.fetch("originator_id_b64"))
+    receiver = decode(testcase.fetch("receiver_id_b64"))
+    channel = from_hex(testcase.fetch("channel_id_hex"))
+
+    [
+      ["short-channel-id", channel.byteslice(0, 15), ORIGINATOR_PUBLIC_KEY],
+      ["long-channel-id", "#{channel}\0", ORIGINATOR_PUBLIC_KEY],
+      ["empty-channel-id", "".b, ORIGINATOR_PUBLIC_KEY],
+      ["short-public-key", channel, ORIGINATOR_PUBLIC_KEY.byteslice(0, 31)],
+      ["long-public-key", channel, "#{ORIGINATOR_PUBLIC_KEY}\0"],
+      ["empty-public-key", channel, "".b]
+    ].each do |name, bad_channel, bad_key|
+      assert_raises(Crypto::KeyGrantProfileError, "#{name} must fail closed") do
+        Crypto.verify_grant_signature(grant, originator, receiver, bad_channel, bad_key)
+      end
+    end
+  end
+
+  def test_rejects_another_originators_public_key
+    testcase = FIXTURE.fetch("positive_cases").first
+    grant = Crypto.grant_deserialize(decode(testcase.fetch("d18g_b64")))
+    # A well-formed key belonging to somebody else must not verify. Without
+    # this, a caller could be fooled by any 32 valid bytes.
+    other = Crypto::OriginatorSigningKey.from_seed(("\0" * 32).b)
+    assert_grant_error("invalid_signature") do
+      Crypto.verify_grant_signature(
+        grant,
+        decode(testcase.fetch("originator_id_b64")),
+        decode(testcase.fetch("receiver_id_b64")),
+        from_hex(testcase.fetch("channel_id_hex")),
+        other.public_key
+      )
+    end
+    other.destroy
+  end
+end


### PR DESCRIPTION
Prerequisite for #11786. Part of #11734, #141, #128.

D18T plan validation ([spec](../blob/main/code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md), step 6) requires verifying the originator's Ed25519 signature on every receiver's D18G grant using only the channel definition's public key — explicitly *"without requiring a receiver private key"*. An originator holds no receiver secrets, so it cannot open the grants it just sealed.

**Ruby could not do this.** The verification lived only inside `open_channel_key_grant`, which takes a `ReceiverKeyPair` because it goes on to perform an X25519 agreement and unwrap the CMK.

| Language | `verify_grant_signature` | D18T adapter |
|---|---|---|
| Rust | ✅ | ✅ |
| TypeScript | ✅ | ✅ |
| Python | ✅ | ✅ |
| Go | ✅ (#11882) | ✅ (#11894) |
| **Ruby** | ❌ → **this PR** | ⬜ #11786 |
| Elixir | ❌ | ⬜ #11787 |

Same gap that blocked Go until #11882.

## What this adds

- **`verify_grant_signature(grant, originator_id, receiver_id, channel_id, public_key)`** — validation, constant-time binding comparison in D18Q's normative order, Ed25519 signature verification. Returns `nil`; no receiver secret involved.
- **`open_channel_key_grant` refactored onto a shared `verify_grant_bindings`** (`private_class_method`, matching the package's existing convention for shared helpers) so the two entry points cannot drift on binding order or stable codes.

## Exception mapping — the subtle part

The old rescue distinguished `invalid_signature` from `authentication_failed` by inspecting whether `signature_valid` was `false` or `nil`, where `nil` meant `Ed25519.verify` had itself raised:

```ruby
rescue StandardError
  if signature_valid == false || signature_valid.nil?
    KeyGrantSupport.fail!("invalid_signature")
  else
    KeyGrantSupport.fail!("authentication_failed")
  end
```

That distinction now happens where it belongs. The verify call is wrapped so a raise becomes the same `false` a failed comparison produces, and every pre-unwrap failure leaves `verify_grant_bindings` as a `KeyGrantProfileError`. Anything reaching the bare rescue therefore arose during agreement or AEAD open — *after* the signature checked out — so it maps unconditionally to `authentication_failed`.

The `ensure` block still wipes `shared_secret`, `wrapping_key`, and `plaintext`. Those locals remain lexically present before it, so an early raise leaves them `nil` rather than raising `NameError`.

## How the tests pin the boundary

The existing D18Q manifest's 14 `opening_negative_cases` split cleanly:

- **5 fail before any receiver key is needed** — `unexpected_originator`, `unexpected_receiver`, `unexpected_channel`, `invalid_signature` ×2
- **9 fail only during agreement or AEAD open** — `invalid_key_agreement`, the `authentication_failed` family

`verify_grant_signature` must reproduce the first group's codes exactly **and must succeed on the second** — pinning the split at precisely the boundary where the receiver key becomes necessary. A guard fails the test if the manifest ever stops exercising both sides.

Also covered: malformed channel-id/public-key lengths fail closed, a well-formed public key belonging to a *different* originator yields `invalid_signature`, and both entry points are asserted to agree on every pre-unwrap fixture.

## Verification

**25 runs, 4131 assertions, 0 failures**, package front door green.

The security review built a differential harness against `origin/main` — the full cross product of malformed grant × originator × receiver × channel × public key × key pair (1,728 combinations) plus all 14 opening and 3 positive fixtures — and found **1,745 outcomes byte-identical with zero divergence**, confirming the refactor is behavior-preserving. It also verified the returned `__values` cannot alias mutable state (all eight fields frozen, grant frozen), that the moved `ReceiverKeyPair` type check changes no observable code, and that the boundary test's two arms both execute (`seen_pre=5`, `seen_post=9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
