### PR TITLE
feat(ruby-to-semantic-ir): / lowers to div_floor (SIR21 T3b-2 Slice 4)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## 0.11.0 — SIR21 T3b-2 Slice 4: `/` lowers to `div_floor`
+
+Part of the SIR21 T3b-2 arc (splitting the overloaded `/` builtin into
+`div_floor`/`div_trunc`/`udiv_trunc`/`div_true` — see
+[SIR21-type-system-and-integer-semantics.md](../../specs/SIR21-type-system-and-integer-semantics.md)
+§E3). All 7 backends implement `div_floor` (Slice 2, merged); this crate
+is the first frontend to emit it.
+
+**Behavior change**: the `/` operator (both the general binary-op chain
+and the `/=` compound-assign desugaring) no longer lowers to bare
+`BuiltinCall("/", args)`. It now lowers to `BuiltinCall("div_floor",
+args)` — the SIR name for exactly Ruby's own `/` semantics (`Integer#/`
+floors, `Float#/` true-divides), so this is a pure rename with **zero**
+observable behavior change: `div_floor` computes identically to what `/`
+already did on every backend (each backend's Slice 2 PR wired it as a
+bare alias to its existing, already-Ruby-floor-faithful division helper).
+Verified via `sir-conformance`'s existing Ruby-sourced regression gate
+(`division_matches_ruby_floor_on_every_backend`,
+`float_division_true_divides_on_every_backend`,
+`python_division_is_ruby_floor_faithful`), all of which continue passing
+unchanged.
+
+Other arithmetic builtins (`+`, `-`, `*`, `%`, `**`, `<<`, `>>`, `&`,
+`|`, `^`) are untouched — only `/` is in scope for this slice.
+
 ## 0.10.0 — SIR28 Slice 4: `print`/`puts` lower to `__sys_write__`
 
 Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -3885,7 +3885,7 @@ mod tests {
     //     name: "x",
     //     scope: Local,
     //     value: Expr::BuiltinCall {
-    //       name: "<op>",   // "+", "-", "*", "/", "or", "and"
+    //       name: "<op>",   // "+", "-", "*", "div_floor" ("/="; SIR21 T3b-2), "or", "and"
     //       args: [VarRef("x"), <rhs>],
     //     },
     //   }
@@ -3922,8 +3922,9 @@ mod tests {
     #[test]
     fn all_arithmetic_compound_assigns_lower_correctly() {
         // Each of +=, -=, *=, /= maps to the corresponding binary
-        // op builtin.
-        for (op_src, op_builtin) in [("+=", "+"), ("-=", "-"), ("*=", "*"), ("/=", "/")] {
+        // op builtin. `/=` maps to `div_floor` (SIR21 T3b-2), not bare
+        // `/` — see `token_lexeme_for_op`'s `TokenType::Slash` arm.
+        for (op_src, op_builtin) in [("+=", "+"), ("-=", "-"), ("*=", "*"), ("/=", "div_floor")] {
             let src = format!("x = 1\nx {op_src} 2\n");
             let m = lower(&src);
             let b = main_body(&m);

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -5799,7 +5799,12 @@ impl Lowerer {
                 "+=" => ("+", EffectSet::PURE),
                 "-=" => ("-", EffectSet::PURE),
                 "*=" => ("*", EffectSet::PURE),
-                "/=" => ("/", EffectSet::PURE),
+                // SIR21 T3b-2: `/=` desugars to `x = x.div_floor(rhs)`, not
+                // bare `/` — Ruby's `/=` uses `Integer#/`'s floor semantics,
+                // which is exactly what `div_floor` names explicitly (see
+                // the general binary-op site's own note below, and
+                // `token_lexeme_for_op`'s `TokenType::Slash` arm).
+                "/=" => ("div_floor", EffectSet::PURE),
                 "%=" => ("%", EffectSet::PURE),
                 "**=" => ("**", EffectSet::PURE),
                 "<<=" => ("<<", EffectSet::PURE),
@@ -10105,7 +10110,14 @@ fn token_lexeme_for_op(t: TokenType) -> &'static str {
         TokenType::Plus => "+",
         TokenType::Minus => "-",
         TokenType::Star => "*",
-        TokenType::Slash => "/",
+        // SIR21 T3b-2: `/` lowers to the `div_floor` builtin, not bare
+        // `/` — Ruby's `/` is polymorphic (`Integer#/` floors,
+        // `Float#/` true-divides), and `div_floor` names exactly that
+        // combined behavior (SIR21 §E3). Despite this function's name,
+        // the return value here is a BuiltinCall NAME, not a literal
+        // source lexeme — the other three arms happen to coincide with
+        // their own lexeme, `/` no longer does.
+        TokenType::Slash => "div_floor",
         _ => "?",
     }
 }


### PR DESCRIPTION
## Summary
- Slice 4 of the SIR21 T3b-2 division-op split arc, following Slice 2 (all 7 backends implement `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`, merged) and Slice 3 (`sir-conformance` direct-call coverage, merged #11901).
- The Ruby frontend is first to migrate: both the general binary-op emission site and the `/=` compound-assign desugaring arm now emit `div_floor` instead of bare `/`.
- Pure rename, zero observable behavior change: `div_floor` is exactly Ruby's own `/` semantics (`Integer#/` floors, `Float#/` true-divides), and every backend already computes it identically to what `/` did before (each backend's Slice 2 PR wired `div_floor` as a bare alias to its existing, already-Ruby-floor-faithful division helper).
- Other arithmetic builtins (`+`, `-`, `*`, `%`, `**`, `<<`, `>>`, `&`, `|`, `^`) are untouched -- only `/` is in scope.

## Test plan
- [x] Full `ruby-to-semantic-ir` test suite green (441 tests), including an updated shape assertion for `/=`'s new builtin name.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] The regression gate: `sir-conformance`'s existing Ruby-sourced tests (`division_matches_ruby_floor_on_every_backend`, `float_division_true_divides_on_every_backend`, `python_division_is_ruby_floor_faithful`) all pass **unchanged** against this migrated frontend.
- [x] Full `sir-conformance` suite green (0 failures across all test binaries, real toolchain execution).
- [x] Security review: PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)