### PR TITLE
feat(python-to-semantic-ir,javascript-to-semantic-ir): / lowers to div_true (SIR21 T3b-2 Slice 5a)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/javascript-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,33 @@ All notable changes to `javascript-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.10.0 — SIR21 T3b-2 Slice 5a: `/` lowers to `div_true`
+
+Part of the SIR21 T3b-2 arc (splitting the overloaded `/` builtin into
+`div_floor`/`div_trunc`/`udiv_trunc`/`div_true` — see
+`code/specs/SIR21-type-system-and-integer-semantics.md` §E3). All 7
+backends implement `div_true` (Slice 2, merged); this crate migrates
+alongside `python-to-semantic-ir` (Slice 5a).
+
+**Behavior change**: the `/` operator (in `build_binary_op`) no longer
+lowers to bare `BuiltinCall("/", args)`. It now lowers to
+`BuiltinCall("div_true", args)` — native JS has no separate integer-
+division operator to conflate `/` with, so it always true-divides, and
+this closes a real, previously-untested gap: `7 / 2` from JS source used
+to reach whichever bare-`/` behavior a given backend's runtime dispatch
+table happened to implement, rather than JS's own unambiguous
+true-divide semantics.
+
+Verified with a new `sir-conformance` source-level regression test
+(`javascript_division_always_true_divides_from_source_on_every_backend`):
+`console.log(7 / 2);` from real JS source, run through every backend's
+real toolchain, prints `3.5` — not `3`, the value Ruby's floor-dividing
+`/` would give for the same literal operands.
+
+Other arithmetic/comparison builtins (`+`, `-`, `*`, `%`, `<`, `>`, `<=`,
+`>=`, `==`/`===`, `!=`/`!==`) are untouched — only `/` is in scope for
+this slice.
+
 ## 0.9.0 — SIR28 Slice 5: `console.log(...)` lowers to `__sys_write__`
 
 Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive

--- a/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/javascript-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javascript-to-semantic-ir"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "JavaScript (GrammarASTNode CST) → narrow-waist Semantic IR. SIR19 frontend, milestone M5 (collections) + default parameters + member-method dispatch (C3) + the OOP declaration surface (SIR25 §2)."
 

--- a/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lib.rs
@@ -428,7 +428,9 @@ mod tests {
         assert_eq!(binop_name("a + b"), "+");
         assert_eq!(binop_name("a - b"), "-");
         assert_eq!(binop_name("a * b"), "*");
-        assert_eq!(binop_name("a / b"), "/");
+        // `/` maps to `div_true` (SIR21 T3b-2), not the operator-spelling
+        // passthrough `+`/`-`/`*`/`%` use — JS's `/` always true-divides.
+        assert_eq!(binop_name("a / b"), "div_true");
         assert_eq!(binop_name("a % b"), "%");
     }
 

--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -3639,7 +3639,12 @@ impl Lowerer {
         // loose and strict equality collapse to the strict-shaped IR
         // comparison — a deliberate semantic change (see module docs).
         let builtin = match op.value.as_str() {
-            "+" | "-" | "*" | "/" | "%" | "<" | ">" | "<=" | ">=" => op.value.as_str(),
+            // SIR21 T3b-2: JS's `/` always true-divides (native JS has no
+            // separate integer-division operator to conflate with), so it
+            // maps to `div_true`, not the operator-spelling passthrough
+            // every other arm here uses.
+            "/" => "div_true",
+            "+" | "-" | "*" | "%" | "<" | ">" | "<=" | ">=" => op.value.as_str(),
             "==" | "===" => "=",
             "!=" | "!==" => "!=",
             other => {

--- a/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/python-to-semantic-ir/CHANGELOG.md
@@ -7,6 +7,35 @@ All notable changes to `python-to-semantic-ir` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to semantic versioning.
 
+## 0.11.0 — SIR21 T3b-2 Slice 5a: `/` lowers to `div_true`
+
+Part of the SIR21 T3b-2 arc (splitting the overloaded `/` builtin into
+`div_floor`/`div_trunc`/`udiv_trunc`/`div_true` — see
+`code/specs/SIR21-type-system-and-integer-semantics.md` §E3). All 7
+backends implement `div_true` (Slice 2, merged); `ruby-to-semantic-ir`
+already migrated its own `/` to `div_floor` (Slice 4); this crate is the
+first to emit `div_true`, alongside `javascript-to-semantic-ir`.
+
+**Behavior change**: the `/` operator (in `try_binary_arith`) no longer
+lowers to bare `BuiltinCall("/", args)`. It now lowers to
+`BuiltinCall("div_true", args)` — Python's `/` always true-divides (there
+is no `Integer#/`-style floor to conflate it with; Python's floor
+division is the separate `//` operator, not lowered by this arm), so this
+closes a real, previously-untested gap: `7 / 2` from Python source used
+to reach whichever bare-`/` behavior a given backend's runtime dispatch
+table happened to implement — Ruby-floor-faithful on some, wrong on
+others — rather than Python's own, unambiguous true-divide semantics.
+
+Verified with a new `sir-conformance` source-level regression test
+(`python_division_always_true_divides_from_source_on_every_backend`):
+`print(7 / 2)` from real Python source, run through every backend's real
+toolchain, prints `3.5` — not `3`, the value Ruby's floor-dividing `/`
+would give for the same literal operands.
+
+Other arithmetic builtins (`+`, `-`, `*`, `%`) are untouched — only `/`
+is in scope for this slice; Python has no `//` (floor) operator lowered
+today, so there is no floor/true conflation risk to worry about.
+
 ## 0.10.0 — SIR28 Slice 5: `print(...)` lowers to `__sys_write__`
 
 Part of the SIR28 arc (`__sys_write__`, the general syscall-primitive

--- a/code/packages/rust/python-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/python-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-to-semantic-ir"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Python CST → narrow-waist Semantic IR (SIR17). Second frontend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/python-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lib.rs
@@ -388,11 +388,14 @@ mod tests {
 
     #[test]
     fn arithmetic_operators_lower_to_builtin_calls() {
+        // `/` maps to `div_true` (SIR21 T3b-2), not the operator-spelling
+        // passthrough `+`/`-`/`*`/`%` use — Python's `/` always
+        // true-divides.
         for (src, op) in [
             ("a = 1\na + 1\n", "+"),
             ("a = 1\na - 1\n", "-"),
             ("a = 1\na * 2\n", "*"),
-            ("a = 1\na / 2\n", "/"),
+            ("a = 1\na / 2\n", "div_true"),
             ("a = 1\na % 2\n", "%"),
         ] {
             let m = lower(src);

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -3639,8 +3639,14 @@ impl Lowerer {
                         (None, _) => operand,
                         (Some(lhs), Some(op)) => {
                             let span = lhs.span().clone();
+                            // SIR21 T3b-2: Python's `/` always true-divides
+                            // (no `Integer#/`-style floor — that's `//`,
+                            // not lowered here), so it maps to `div_true`,
+                            // not the operator-spelling passthrough `+`/
+                            // `-`/`*`/`%` use.
+                            let name = if op == "/" { "div_true".to_string() } else { op };
                             Expr::BuiltinCall {
-                                name: op,
+                                name,
                                 args: vec![lhs, operand],
                                 effects: EffectSet::PURE,
                                 span,

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.27.0] - SIR21 T3b-2 Slice 5a: source-level regression for Python/JS division
+
+Adds `tests/division.rs::python_division_always_true_divides_from_source_on_every_backend`
+and `::javascript_division_always_true_divides_from_source_on_every_backend`
+— the SOURCE-level companion to Slice 3's direct-call coverage. Both
+`python-to-semantic-ir` and `javascript-to-semantic-ir` now lower `/` to
+`div_true` instead of bare `/` (their own crates' CHANGELOGs); these tests
+prove the end-to-end regression that migration closes: `print(7 / 2)` /
+`console.log(7 / 2);` from real source, run through every backend's real
+toolchain via `run_source_via(..., Frontend::Python/JavaScript, target)`,
+prints `3.5` on every backend — not `3`, the value a bare `/` misrouted
+to Ruby-floor-faithful dispatch would give for the same literal operands.
+
 ## [0.26.0] - SIR21 T3b-2 Slice 3: direct-call coverage for div_floor/div_trunc/udiv_trunc/div_true
 
 Adds `pub fn run_module(name, module, target) -> RunOutcome` — a new

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real source from any registered frontend and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/division.rs
+++ b/code/packages/rust/sir-conformance/tests/division.rs
@@ -53,7 +53,7 @@ use semantic_ir::{
     Stmt,
 };
 use sir_conformance::oracle::{DivOp, Outcome};
-use sir_conformance::{run_module, run_source, RunOutcome, Target};
+use sir_conformance::{run_module, run_source, run_source_via, Frontend, RunOutcome, Target};
 
 /// `(lhs, rhs)` pairs covering every sign combination plus exact division.
 /// Ruby evaluates each with **floor** `/`.
@@ -417,4 +417,68 @@ fn direct_call_zero_divisor_raises_for_every_op_on_every_backend() {
         }
     }
     assert!(ran > 0, "DIRECT-CALL ZERO-DIVISOR: no backend toolchain available");
+}
+
+// ── SIR21 T3b-2 Slice 5a: source-level regression — Python/JS `/` now
+// true-divides ────────────────────────────────────────────────────────────
+//
+// Before this slice, Python's and JavaScript's own frontends lowered `/` to
+// bare `BuiltinCall("/", ...)` — the SAME name Ruby's floor-dividing `/`
+// used — so a backend's runtime dispatch table decided the rounding mode,
+// not the SOURCE LANGUAGE. `python-to-semantic-ir`/`javascript-to-semantic-ir`
+// now emit `div_true` instead (their own crates' unit tests prove the
+// SHAPE); this proves the source-level BEHAVIOR end-to-end: `7 / 2` from
+// real Python/JS source, run through every backend's real toolchain, must
+// be `3.5` — never `3` (the floor/trunc value Ruby's `/` would give for the
+// SAME literal operands) — regardless of which backend runs it.
+
+#[test]
+fn python_division_always_true_divides_from_source_on_every_backend() {
+    let mut ran = 0usize;
+    for &target in Target::all() {
+        match run_source_via("py_div_true", "print(7 / 2)\n", Frontend::Python, target) {
+            RunOutcome::Ran(out) => {
+                assert_eq!(
+                    out,
+                    "3.5",
+                    "\nPYTHON SOURCE DIVISION: backend {} computed `7 / 2` = {out}, expected 3.5\n",
+                    target.tag(),
+                );
+                ran += 1;
+            }
+            RunOutcome::Failed(msg) => panic!(
+                "PYTHON SOURCE DIVISION: backend {} failed on `7 / 2`: {}",
+                target.tag(),
+                msg.lines().next().unwrap_or("")
+            ),
+            RunOutcome::Skipped(_) => {}
+        }
+    }
+    assert!(ran > 0, "PYTHON SOURCE DIVISION: no backend toolchain available");
+}
+
+#[test]
+fn javascript_division_always_true_divides_from_source_on_every_backend() {
+    let mut ran = 0usize;
+    for &target in Target::all() {
+        match run_source_via("js_div_true", "console.log(7 / 2);\n", Frontend::JavaScript, target)
+        {
+            RunOutcome::Ran(out) => {
+                assert_eq!(
+                    out,
+                    "3.5",
+                    "\nJAVASCRIPT SOURCE DIVISION: backend {} computed `7 / 2` = {out}, expected 3.5\n",
+                    target.tag(),
+                );
+                ran += 1;
+            }
+            RunOutcome::Failed(msg) => panic!(
+                "JAVASCRIPT SOURCE DIVISION: backend {} failed on `7 / 2`: {}",
+                target.tag(),
+                msg.lines().next().unwrap_or("")
+            ),
+            RunOutcome::Skipped(_) => {}
+        }
+    }
+    assert!(ran > 0, "JAVASCRIPT SOURCE DIVISION: no backend toolchain available");
 }


### PR DESCRIPTION
## Summary
- Slice 5a of the SIR21 T3b-2 division-op split arc, following Slice 2 (all 7 backends implement `div_true`, merged) and Slice 4 (Ruby frontend migrates to `div_floor`, PR #11907, in flight).
- Both Python and JavaScript frontends now lower `/` to `div_true` instead of bare `/` -- Python's `/` always true-divides (`//` is the separate floor operator, not touched) and native JS has no integer-division operator to conflate `/` with, so both languages' `/` is unambiguously `div_true`.
- This closes a real, previously-untested gap: `7 / 2` from Python/JS source used to reach whichever bare-`/` behavior a given backend's runtime dispatch table happened to implement (Ruby-floor-faithful on some, wrong on others), rather than the source language's own true-divide semantics.
- Other arithmetic/comparison builtins are untouched -- only `/` is in scope.

## Test plan
- [x] Full `python-to-semantic-ir` (147 tests) and `javascript-to-semantic-ir` (133+16 tests) suites green, including updated shape assertions for `/`'s new builtin name.
- [x] `cargo clippy --all-targets -- -D warnings` clean on both crates.
- [x] New `sir-conformance` source-level regression tests (`python_division_always_true_divides_from_source_on_every_backend`, `javascript_division_always_true_divides_from_source_on_every_backend`): `print(7 / 2)` / `console.log(7 / 2);` from real source, run through every backend's real toolchain, print `3.5` -- not `3`.
- [x] Full `sir-conformance` suite green (0 failures across all test binaries).
- [x] Security review: PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)