### PR TITLE
fix(mos6502-backend): track real BRK emission instead of trailing-byte comparison

### DIFF
--- a/code/packages/rust/mos6502-backend/CHANGELOG.md
+++ b/code/packages/rust/mos6502-backend/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — mos6502-backend
 
+## [0.1.1] - 2026-08-17
+
+### Fixed
+
+- The defensive "already terminated?" check in `compile_to_bytes` compared
+  the trailing emitted byte value against `HALT_BYTE` (`0x00`), instead of
+  tracking whether a real `BRK` was actually emitted. Since `0` is also a
+  valid 8-bit `LDA` immediate, `const 0` with no following `ret_*` produced
+  a trailing byte identical to `HALT_BYTE`, fooling the check into skipping
+  the real terminator. (On real 6502 hardware this specific case still
+  halted at runtime by coincidence — `BRK`'s opcode is also `0x00`, so
+  falling into zero-filled memory hit a real `BRK` anyway — but that
+  coincidence wasn't load-bearing by design and doesn't generalise to
+  memory that isn't zero-filled.) Now tracks an explicit `terminated: bool`,
+  set only when a real `BRK` is pushed by a `ret_*`/`ret_void` arm. Same bug
+  class found and fixed in the Intel 8051 and Intel 8080 lanes of the
+  9-architecture expansion this crate is part of.
+
 ## [0.1.0] - 2026-08-17
 
 ### Added

--- a/code/packages/rust/mos6502-backend/Cargo.toml
+++ b/code/packages/rust/mos6502-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mos6502-backend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "MOS 6502 backend for jit-core / aot-core.  Lowers a Vec<CIRInstr> into MOS 6502 machine code via mos6502-encoder.  Emit-only -- bytes go to mos6502-simulator.  Minimal viable: const_*/ret_* only, trivial single-register (accumulator) allocator; ret_* lowers to BRK, the pre-existing HALT convention documented in mos6502-simulator (ported from the Python original), not a newly-invented pseudo-halt.  Mirror of mips-r2000-backend / arm1-backend / armv7-backend / intel8008-backend in shape and intent.  Fifth lane of the 9-architecture expansion."
 

--- a/code/packages/rust/mos6502-backend/src/lib.rs
+++ b/code/packages/rust/mos6502-backend/src/lib.rs
@@ -74,7 +74,7 @@
 
 use jit_core::backend::{Backend, FunctionContext};
 use jit_core::cir::{CIRInstr, CIROperand};
-use mos6502_encoder::{encode_brk, encode_lda_imm, HALT_BYTE};
+use mos6502_encoder::{encode_brk, encode_lda_imm};
 use std::fmt;
 use vm_core::value::Value;
 
@@ -132,12 +132,24 @@ fn compile_to_bytes(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
     // the accumulator.  Programs that need more than one live var fall
     // through to `UnsupportedOp`.
     let mut last_const_var: Option<String> = None;
+    // Tracks whether a REAL BRK was emitted -- NOT whether the trailing
+    // byte happens to equal HALT_BYTE (0x00). `LDA #0` ends in a byte
+    // that is numerically identical to BRK's own opcode despite not
+    // being one, which would fool a trailing-byte comparison into
+    // skipping the real terminator for `const 0` with no following
+    // `ret_*`. (On real 6502 hardware this specific case still halts
+    // by coincidence, since zero-filled memory decodes as BRK too --
+    // see the comment this replaced -- but that coincidence shouldn't
+    // be load-bearing, and it doesn't generalise to a simulator or
+    // board whose unused memory isn't zero-filled.)
+    let mut terminated = false;
 
     for instr in cir {
         let op = instr.op.as_str();
 
         if op == "ret_void" {
             bytes.extend_from_slice(&encode_brk());
+            terminated = true;
             continue;
         }
 
@@ -153,6 +165,7 @@ fn compile_to_bytes(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
                 )));
             }
             bytes.extend_from_slice(&encode_brk());
+            terminated = true;
             continue;
         }
 
@@ -162,17 +175,16 @@ fn compile_to_bytes(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
             // const_* always targets the accumulator in this minimal backend.
             bytes.extend_from_slice(&encode_lda_imm(imm));
             last_const_var = Some(dest.to_string());
+            terminated = false;
             continue;
         }
 
         return Err(BackendError::UnsupportedOp(op.to_string()));
     }
 
-    // Defensive -- if no terminator was emitted, append BRK so the
-    // program halts instead of running off the end (which would read
-    // zeroed memory as instructions -- opcode 0x00 happens to decode as
-    // BRK too, but relying on that would be an accident, not a design).
-    if bytes.last() != Some(&HALT_BYTE) {
+    // Defensive -- if no real terminator was emitted, append BRK so the
+    // program halts instead of relying on whatever follows in memory.
+    if !terminated {
         bytes.extend_from_slice(&encode_brk());
     }
     Ok(bytes)

--- a/code/packages/rust/mos6502-backend/tests/test_backend.rs
+++ b/code/packages/rust/mos6502-backend/tests/test_backend.rs
@@ -166,3 +166,25 @@ fn backend_trait_compile_matches_free_function() {
     let via_free_fn = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("free-fn compile");
     assert_eq!(via_trait, via_free_fn);
 }
+
+/// CIR ending in `const_*` with NO following `ret_*` must still be
+/// terminated by a REAL emitted `BRK`, not by coincidentally falling
+/// into zero-filled memory that happens to decode as `BRK` too. This
+/// specifically exercises `const 0`: `LDA #0` ends in a byte (0x00)
+/// numerically identical to `BRK`'s own opcode, which a trailing-byte
+/// comparison (the bug this check replaced, and the same class of bug
+/// found and fixed in the Intel 8051 and Intel 8080 lanes of this
+/// campaign) would misread as "already terminated" and skip appending
+/// the real BRK.
+#[test]
+fn dangling_const_zero_with_no_ret_still_gets_a_real_terminator() {
+    let cir = vec![ci("const_i64", Some("v"), vec![CIROperand::Int(0)], "i64")];
+    let bytes = compile(&ctx("dangling_const_zero", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0xA9, 0x00, 0x00], "LDA #0 then a real BRK");
+
+    let mut sim = Mos6502Simulator::new(65536);
+    sim.load_program(&bytes);
+    let result = sim.run_loaded_with_limit(1000);
+    assert!(result.halted, "program should halt, not run out the step budget");
+    assert_eq!(result.steps, 2, "should halt after exactly LDA + the real BRK");
+}


### PR DESCRIPTION
## Summary
Follow-up fix for `mos6502-backend` (merged in #11904, part of the 9-architecture expansion campaign). While implementing/reviewing a later lane (Zilog Z80), I found the same bug class the Intel 8051 lane's security review caught also existed here, unreviewed:

`compile_to_bytes`'s defensive "already terminated?" check compared the trailing emitted *byte value* against `HALT_BYTE` (`0x00`, the BRK opcode). Since `0` is also a valid 8-bit `LDA` immediate, `const 0` with no following `ret_*` produced a trailing byte identical to the sentinel, fooling the check into skipping the real terminator.

At runtime this specific case still happened to halt — `BRK`'s opcode is also `0x00`, so falling into zero-filled memory hit a real `BRK` anyway — but that coincidence wasn't load-bearing by design and doesn't generalize to memory that isn't zero-filled. Fixed by tracking an explicit `terminated: bool`, set only when a real `BRK` is pushed by a `ret_*`/`ret_void` arm.

## Test plan
- [x] `cargo build`/`cargo test`/`cargo clippy --all-targets -D warnings` — clean, 15 tests.
- [x] New regression test empirically verified against the old logic (reconstructed the pre-fix check in a scratch edit, confirmed the test fails exactly as predicted — `[169, 0]` vs expected `[169, 0, 0]` — then reverted and confirmed the fix passes).
- [x] `/security-review` — SECURITY REVIEW PASSED. Traced every code path, confirmed no other path reaches the final check with `terminated` incorrectly set, confirmed the unused `HALT_BYTE` import removal is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)