### PR TITLE
feat(adj-facts-stdlib): add farm-animal-product-use.adj (agriculture sibling table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_farmanimalproductuse_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_farmanimalproductuse_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end test for the agriculture FACTS library
+//! (`adj-facts-stdlib/agriculture/farm-animal-product-use.adj`)
+//! driven through the built CLI: a native `table` naming the use a source
+//! already states for a farm animal's product, decoded from a clause
+//! already sitting unused inside `farm-animals.adj`'s own already-quoted
+//! per-row CFSPH provenance -- a sibling to that table (and to
+//! `farm-animal-secondary-product.adj` and
+//! `farm-animal-product-processing.adj`, whose own headers already flag
+//! this exact rabbit clause as neither a second product nor a processing
+//! method). Resolves binding-query recall (both directions) with the
+//! source's citation, and abstains on a real, already-tabled animal/product
+//! pair (goat, milk) whose own cited span states a processing method, not a
+//! use -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_farmanimalproductuse_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("agriculture/farm-animal-product-use.adj");
+    std::fs::copy(&src, dir.join("farm-animal-product-use.adj"))
+        .expect("copy shipped farm-animal-product-use.adj");
+}
+
+#[test]
+fn farm_animal_product_use_recalls_rabbit_wool_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-use.adj\"\n\
+         ? farm_animal_product_use(rabbit, wool, $Use)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_product_use(rabbit, wool, fiber_arts)\""),
+        "rabbit wool is used for fiber arts: {out}"
+    );
+    assert!(
+        out.contains("cfsph.iastate.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the CFSPH citation: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_product_use_recalls_backward_to_rabbit_wool() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-use.adj\"\n\
+         ? farm_animal_product_use($Animal, $Product, fiber_arts)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_product_use(rabbit, wool, fiber_arts)\""),
+        "fiber_arts names rabbit's wool: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_product_use_abstains_honestly_on_goat_milk() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-use.adj\"\n\
+         ? farm_animal_product_use(goat, milk, $Use)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "goat's own cited span states a processing method for milk, not a use -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-use.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-use.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% farm-animal-product-use — for the farm animal product whose SAME cited
+% CFSPH span also names what it is used FOR, that use
+% (adj-facts-stdlib, AGRICULTURE).
+% ============================================================================
+% A sibling to the already-shipped `farm-animals.adj` (`farm_animal_product
+% (animal, product)`, chicken → eggs, duck → eggs, sheep → wool, rabbit →
+% wool, goat → milk), `farm-animal-secondary-product.adj`
+% (`farm_animal_secondary_product(animal, product)`), and
+% `farm-animal-product-processing.adj`
+% (`farm_animal_product_processing(animal, product, processing)`). Rabbit's
+% own per-row provenance in `farm-animals.adj` already quotes, VERBATIM, a
+% USE for its already-recorded wool -- but none of the existing tables'
+% schemas had room for it:
+%
+%   rabbit, wool → fiber_arts
+%     "Some rabbit breeds produce a very soft wool that can be harvested
+%      regularly and used for fiber arts."
+%
+% This is explicitly the SAME clause `farm-animal-secondary-product.adj`'s
+% own header already flags as NOT a second product ("rabbit's own cited
+% span states only a USE for its already-recorded wool ('used for fiber
+% arts,' not a second distinct product)") and the SAME clause
+% `farm-animal-product-processing.adj`'s own header already flags as
+% "a USE for its wool ('used for fiber arts'), not a processing method
+% applied to it" -- leaving the use itself unshipped until now. "Use"
+% (what the product is FOR) is categorically distinct from "product"
+% (what the animal GIVES) and from "processing" (how a product is
+% treated before use) -- three separate axes of the same small set of
+% CFSPH sentences. Recall is a binding query:
+%
+%     ? farm_animal_product_use(rabbit, wool, $Use)   % fiber_arts
+%
+% This is a native `table` (ADJ-TABLES RS-5, a THREE-column table -- the
+% same shape as the sibling `farm-animal-product-processing.adj`, and
+% already precedented elsewhere in this stdlib, e.g.
+% `biology/amino-acids.adj`, `geology/fossil-preservation-subtype.adj`):
+% each `row` lowers to a ground relation
+% `farm_animal_product_use(animal, product, use)` carrying the citation,
+% so the lookup above is the ordinary SLD binding query -- the engine
+% returns the use WITH its source, on the CPU, with zero model calls, and
+% abstains on every other animal/product pair `farm-animals.adj` carries,
+% since none of the other four cited spans (chicken, duck, sheep, goat)
+% states a use the way rabbit's span does -- chicken's and duck's spans
+% state only a second product (meat), sheep's states two second products
+% (meat, milk), and goat's states a processing method applied to its milk
+% ("may be pasteurized"), not a use for it. The query also runs BACKWARD --
+% bind a use and recall which animal/product pair it names:
+%
+%     ? farm_animal_product_use($Animal, $Product, fiber_arts)   % rabbit, wool
+%
+% Only ONE of `farm-animals.adj`'s five animal/product pairs has a
+% genuinely distinct use fact in the ALREADY-cited spans; this table is
+% deliberately narrow (a single row, the same shape as several other
+% already-shipped single-row siblings in this stdlib, e.g.
+% `agriculture/farm-animal-product-processing.adj`,
+% `agriculture/farm-animal-maintenance-level.adj`) rather than inventing a
+% use the source does not state.
+%
+% Provenance: reproduces, byte-for-byte, the SAME rabbit span already
+% quoted inside `farm-animals.adj`'s own per-row provenance block -- no new
+% WebFetch, only a different schema decoding the use half of that
+% already-verified quote. `trust authoritative` -- the same tier
+% `farm-animals.adj` already carries (Iowa State University CFSPH, a
+% primary university educational source).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table farm_animal_product_use {
+    columns animal, product, use
+
+    row (rabbit, wool, fiber_arts)   % CFSPH: "...used for fiber arts."
+
+    source "Some rabbit breeds produce a very soft wool that can be harvested regularly and used for fiber arts."
+    locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-use.query.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-use.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% farm-animal-product-use.query — a worked recall over the agriculture
+% farm-animal-product-use library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is rabbit wool
+% used for?": it states no agriculture fact of its own — it only `import`s
+% the grounded table and asks binding queries. The engine resolves each `?`
+% against the `farm_animal_product_use` rows and returns the use + the
+% table's source/locator/trust. An animal/product pair the cited spans give
+% no use for abstains honestly — the engine never invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli farm-animal-product-use.query.adj
+% ============================================================================
+
+import "farm-animal-product-use.adj"
+
+? farm_animal_product_use(rabbit, wool, $Use)                % expect fiber_arts
+? farm_animal_product_use($Animal, $Product, fiber_arts)     % reverse bind — expect rabbit, wool
+? farm_animal_product_use(goat, milk, $Use)                  % expect abstain — goat's own cited span states a processing method for milk, not a use

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -8,47 +8,48 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 ## Summary
 
-| Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-pinned |
+| Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 141 | 142 | 141 (100.0%) | 141 (100.0%) | 141 (100.0%) | 0 (0.0%) |
-| formulas | 155 | 387 | 155 (100.0%) | 155 (100.0%) | 155 (100.0%) | 0 (0.0%) |
+| facts | 315 | 318 | 314 (99.7%) | 315 (100.0%) | 315 (100.0%) | 0 (0.0%) |
+| formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
 A complete source envelope means every grounded clause has `source`,
-`locator`, and `trust`. Byte-pinned additionally requires every clause to
-have `quote ... at ... snapshot <sha256>`, which
-lets `adj-verify --snapshots` check the exact bytes rather than trust a label.
+`locator`, and `trust`. Pin syntax requires `quote ... at ... snapshot
+<sha256>` for every clause. Byte-verified additionally requires a resolved
+provenance bundle whose CAS graph proves all cited source bytes.
 
 ## Domains
 
 | Collection/domain | Libraries | Clauses | Queries | Tests | Source envelopes | Byte pins |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `facts/agriculture` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `facts/anatomy` | 19 | 19 | 19 | 19 | 19 | 0 |
+| `facts/agriculture` | 5 | 5 | 5 | 5 | 5 | 0 |
+| `facts/anatomy` | 32 | 32 | 32 | 32 | 32 | 0 |
 | `facts/art` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `facts/astronomy` | 5 | 5 | 5 | 5 | 5 | 0 |
-| `facts/biology` | 33 | 33 | 33 | 33 | 33 | 0 |
+| `facts/astronomy` | 18 | 18 | 18 | 18 | 18 | 0 |
+| `facts/biology` | 58 | 58 | 57 | 58 | 58 | 0 |
 | `facts/calendar` | 2 | 2 | 2 | 2 | 2 | 0 |
-| `facts/chemistry` | 16 | 16 | 16 | 16 | 16 | 0 |
-| `facts/earth-science` | 7 | 7 | 7 | 7 | 7 | 0 |
-| `facts/environment` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `facts/geography` | 4 | 4 | 4 | 4 | 4 | 0 |
-| `facts/geology` | 2 | 2 | 2 | 2 | 2 | 0 |
-| `facts/geometry` | 8 | 9 | 8 | 8 | 8 | 0 |
-| `facts/language` | 5 | 5 | 5 | 5 | 5 | 0 |
+| `facts/chemistry` | 18 | 18 | 18 | 18 | 18 | 0 |
+| `facts/earth-science` | 11 | 11 | 11 | 11 | 11 | 0 |
+| `facts/environment` | 3 | 3 | 3 | 3 | 3 | 0 |
+| `facts/geography` | 12 | 12 | 12 | 12 | 12 | 0 |
+| `facts/geology` | 11 | 11 | 11 | 11 | 11 | 0 |
+| `facts/geometry` | 14 | 15 | 14 | 14 | 14 | 0 |
+| `facts/language` | 58 | 59 | 58 | 58 | 58 | 0 |
 | `facts/mathematics` | 5 | 5 | 5 | 5 | 5 | 0 |
-| `facts/meteorology` | 3 | 3 | 3 | 3 | 3 | 0 |
-| `facts/metrology` | 4 | 4 | 4 | 4 | 4 | 0 |
-| `facts/money` | 2 | 2 | 2 | 2 | 2 | 0 |
-| `facts/music` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `facts/nutrition` | 1 | 1 | 1 | 1 | 1 | 0 |
+| `facts/meteorology` | 11 | 11 | 11 | 11 | 11 | 0 |
+| `facts/metrology` | 5 | 5 | 5 | 5 | 5 | 0 |
+| `facts/money` | 4 | 4 | 4 | 4 | 4 | 0 |
+| `facts/music` | 2 | 2 | 2 | 2 | 2 | 0 |
+| `facts/nutrition` | 3 | 3 | 3 | 3 | 3 | 0 |
+| `facts/oceanography` | 8 | 8 | 8 | 8 | 8 | 0 |
 | `facts/optics` | 1 | 1 | 1 | 1 | 1 | 0 |
-| `facts/physics` | 19 | 19 | 19 | 19 | 19 | 0 |
-| `facts/transportation` | 1 | 1 | 1 | 1 | 1 | 0 |
+| `facts/physics` | 31 | 32 | 31 | 31 | 31 | 0 |
+| `facts/transportation` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `formulas/arithmetic` | 10 | 20 | 10 | 10 | 10 | 0 |
 | `formulas/chemistry` | 7 | 26 | 7 | 7 | 7 | 0 |
 | `formulas/clinical` | 84 | 263 | 84 | 84 | 84 | 0 |
-| `formulas/mathematics` | 1 | 4 | 1 | 1 | 1 | 0 |
+| `formulas/mathematics` | 9 | 21 | 9 | 9 | 9 | 0 |
 | `formulas/metrology` | 1 | 3 | 1 | 1 | 1 | 0 |
 | `formulas/physics` | 13 | 32 | 13 | 13 | 13 | 0 |
 | `formulas/reference` | 39 | 39 | 39 | 39 | 39 | 0 |
@@ -56,9 +57,9 @@ lets `adj-verify --snapshots` check the exact bytes rather than trust a label.
 
 ## Structural Gaps
 
-### Missing worked-query import (0)
+### Missing worked-query import (1)
 
-None.
+- `code/specs/data/adj-facts-stdlib/biology/mitosis-phase-order.adj`
 
 ### Not named by a repository test (0)
 
@@ -70,7 +71,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (359)
+### Missing pinned source bytes (541)
 
 See the JSON form of this report for the complete machine-readable list.
 
@@ -78,8 +79,8 @@ See the JSON form of this report for the complete machine-readable list.
 
 - It cannot measure curriculum coverage because shipped libraries have no
   objective IDs, grade bands, prerequisites, or standards crosswalk.
-- It cannot prove quoted text came from a locator because the stdlib does not
-  currently pin source snapshots and byte offsets.
+- Pin-shaped syntax alone cannot prove quoted text came from a locator; only
+  a verified provenance bundle establishes that byte path.
 - It cannot prove a domain is complete from library count or green examples.
 - It cannot measure retrieval quality, decomposition quality, multi-hop
   composition, conflict handling, calibration, or held-out exam performance.


### PR DESCRIPTION
## Summary

Third slice of the agriculture/ domain sweep (116th content slice overall). Sibling to the already-shipped `farm-animals.adj`, `farm-animal-secondary-product.adj`, and `farm-animal-product-processing.adj`.

Rabbit's own per-row provenance in `farm-animals.adj` already quotes, VERBATIM, a USE for its already-recorded wool -- but none of the existing tables' schemas had room for it: "Some rabbit breeds produce a very soft wool that can be harvested regularly and used for fiber arts." New `farm_animal_product_use(animal, product, use)` table decodes that clause as its own row: `rabbit, wool -> fiber_arts`.

"Use" (what the product is FOR) is categorically distinct from "product" (what the animal GIVES) and "processing" (how a product is treated before use) -- `farm-animal-secondary-product.adj`'s own header already flags this exact clause as NOT a second product, and `farm-animal-product-processing.adj`'s own header already flags it as NOT a processing method, leaving the use itself unshipped until now.

No new WebFetch -- reuses the same already-cited CFSPH sentence.

- Discipline #30 (duplication check): grepped the whole stdlib tree for a "use"/"purpose" column on any table -- `chemistry/lab-equipment.adj` has an unrelated `purpose` column (lab equipment, not farm animals) and `physics/band-secondary-use.adj` has an unrelated `use` column (EM-spectrum bands, not farm animals); no existing agriculture table covers this axis.
- Discipline #31 (row verification): the row verbatim-grounds. Honest abstention on chicken/duck/sheep/goat, whose own cited spans state no use for their products (goat's states a processing method for milk, not a use).

Also regenerates `code/specs/data/adj-stdlib-coverage/COVERAGE.md`, which was stale since PR #9468/#9462 (auto-generated file, no manual edits).

## Security review

Ran a sub-agent security pass over this diff (static `.adj` data table + query companion + Rust e2e test that shells out to the locally-built CLI with a fixed argument, plus the auto-generated coverage report). Result: no CRITICAL/HIGH/MEDIUM findings. One LOW/INFO note: the e2e test's `scratch()` helper uses a predictable temp-dir name (prefix + tag + PID, no random component) under the shared system temp dir -- a pre-existing pattern copied verbatim from every sibling e2e test in this stdlib (`facts_farmanimalproductprocessing_e2e.rs`, `facts_farmanimalmaintenancelevel_e2e.rs`, etc.), not introduced by this PR. Not a blocker.

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI query check (forward recall w/ citation, backward recall, honest abstention) -- all three correct
- [x] `cargo test -p adj-lang-cli --test facts_farmanimalproductuse_e2e` (3/3 pass)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0, regenerated COVERAGE.md)
- [x] `adj_stdlib_manifest.py --validate-json-schema` (steady at 176 objectives -- no new objective, matches the parent tables' own precedent)
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` (clean)
- [x] Sub-agent security review -- no blocking findings (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)