### PR TITLE
feat(c-to-semantic-ir): migrate division to div_true/div_trunc/udiv_trunc (SIR21 T3b-2 Slice 6)

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [0.3.0] - 2026-08-17
+
+### Changed — SIR21 T3b-2 Slice 6: `combine()`'s division reconciliation
+
+Part of the SIR21 T3b-2 arc (splitting the overloaded `/` builtin into
+`div_floor`/`div_trunc`/`udiv_trunc`/`div_true` — see
+`code/specs/SIR21-type-system-and-integer-semantics.md` §E3). All 7
+backends implement all four ops (Slice 2, merged). This crate is its own
+slice because `combine()` needed two *different* renames in the same
+function — more mistake surface than the mechanical single-op-name swaps
+every other frontend slice did.
+
+**Behavior change 1 — the float (`double`) arm**: `/` no longer lowers to
+bare `BuiltinCall("/", args)`. It now lowers to `BuiltinCall("div_true",
+args)`. C's usual arithmetic conversions always promote both operands to
+`double` before a floating division runs, so there is no int/float
+distinction left to conflate `/` with once this arm is reached — it always
+true-divides, the exact shape `div_true` exists for.
+
+**Behavior change 2 — the integer arm**: `/` no longer lowers to the
+`tdiv`/`utdiv` builtin names. It now lowers to `div_trunc` (signed) /
+`udiv_trunc` (unsigned) — the exact same underlying semantics (truncate
+toward zero, matching C's own `/` on integers), just under T3b-2's
+canonical name family instead of this crate's own pre-existing ad hoc
+names. This is a pure rename, not new logic: `semantic-ir-to-c`'s
+`div_trunc`/`udiv_trunc` dispatch entries point at the *same*
+`_sir_itdiv`/`_sir_utdiv` runtime functions the old `tdiv`/`utdiv` entries
+already called (unchanged by this PR). `tdiv`/`utdiv` themselves are now
+dead dispatch entries — no frontend emits them anymore — left in place for
+Slice 7 (task #29) to delete, per this arc's established
+additive-then-cleanup discipline. `%`/`tmod` are untouched; this arc
+explicitly does not touch modulo (see the spec's own forward pointer to a
+future, unnumbered milestone).
+
+Verified via this crate's own `tests::double_division_is_true_division_
+not_truncating` and `tests::division_and_modulo_lower_to_truncating_
+builtins` (both updated to assert the new names), `tests::int_min_div_is_
+guarded` (unchanged — runtime-behavior assertion, not name-based, still
+passes: the `INT64_MIN/-1` two's-complement-wrap guard lives in
+`_sir_itdiv` itself and this rename doesn't touch that function), and the
+full `tests/three_way_conformance.rs` corpus (byte-identical against real
+`cc`-compiled output, unchanged and still green).
+
+`c-to-semantic-ir` 0.2.0 -> 0.3.0.
+
 ## [0.2.0] - 2026-08-11
 
 ### Changed — SIR28 Slice 6 (batch 3): `printf` lowers to `__sys_write__`

--- a/code/packages/rust/c-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/c-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-to-semantic-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "C (integer-core subset) → Semantic IR (SIR27). Assigns a concrete IntSpec to every expression and inserts Convert nodes per C's integer promotions, so C's width/wrap/truncate semantics survive the narrow waist."
 

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -190,11 +190,16 @@ mod tests {
 
     #[test]
     fn double_division_is_true_division_not_truncating() {
-        // `/` on doubles must be the plain `/` builtin (true division), never the
-        // integer `tdiv`/`utdiv` truncating helpers.
+        // `/` on doubles must lower to `div_true` (SIR21 T3b-2 — always
+        // true-divides, no int/float distinction left once both sides are
+        // promoted to `double`), never the integer `div_trunc`/`udiv_trunc`
+        // truncating builtins (formerly `tdiv`/`utdiv`).
         let m = lower("int main(void) { double q = 7.0 / 2.0; return 0; }");
         let text = semantic_ir::print_module(&m);
-        assert!(text.contains("(builtin-call /"), "no true `/`:\n{text}");
+        assert!(
+            text.contains("(builtin-call div_true"),
+            "no div_true:\n{text}"
+        );
         assert!(!text.contains("tdiv"), "double `/` used tdiv:\n{text}");
     }
 
@@ -491,9 +496,11 @@ mod tests {
     #[test]
     fn division_and_modulo_lower_to_truncating_builtins() {
         // C `/` truncates toward zero (unlike SIR/Ruby floor), so it must lower
-        // to the dedicated `tdiv`/`tmod` builtins, not the flooring `/`/`%`.
+        // to `div_trunc` (SIR21 T3b-2 — absorbed and renamed from the old
+        // `tdiv`, which is now dead code removed in Slice 7), not the
+        // flooring `/`. `%` is untouched by this arc — `tmod` stays as-is.
         let m = lower("int f(int a, int b) { return a / b; }");
-        assert!(semantic_ir::print_module(&m).contains("(builtin-call tdiv"));
+        assert!(semantic_ir::print_module(&m).contains("(builtin-call div_trunc"));
         let m = lower("int f(int a, int b) { return a % b; }");
         assert!(semantic_ir::print_module(&m).contains("(builtin-call tmod"));
     }

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -1816,7 +1816,12 @@ impl Lowerer {
             let le = convert_ct(le, lp, CType::Double);
             let re = convert_ct(re, rp, CType::Double);
             let sir_op = match op {
-                "+" | "-" | "*" | "/" => op,
+                "+" | "-" | "*" => op,
+                // SIR21 T3b-2: C's `/` on `double` operands always
+                // true-divides (there is no int/float distinction left to
+                // conflate it with once both sides are promoted to
+                // `double`), so it maps to `div_true`, not bare `/`.
+                "/" => "div_true",
                 other => {
                     return Err(CLowerError {
                         message: format!("operator `{other}` is not defined on `double`"),
@@ -1889,13 +1894,22 @@ impl Lowerer {
             // Signedness matters for the same reason it does for `>>`: the
             // backends store values in a signed int64, so an unsigned operand
             // ≥ 2^63 is a negative int64 and a signed division would be wrong.
-            // Unsigned `/`/`%` therefore route to `utdiv`/`utmod` (which the C
-            // backend does over uint64).
+            // Unsigned `/` therefore routes to `udiv_trunc` (which the C
+            // backend does over uint64). `%` stays on `tmod`/`utmod` for now
+            // — modulo is explicitly out of scope for the SIR21 T3b-2
+            // division-op split (a future milestone's territory).
+            //
+            // SIR21 T3b-2: `tdiv`/`utdiv` are ABSORBED by `div_trunc`/
+            // `udiv_trunc` (one canonical truncating-division name family,
+            // not two synonyms for the same rounding mode) — this is a
+            // rename of these exact two names, not a new builtin. The old
+            // `tdiv`/`utdiv` dispatch entries are dead code once this
+            // frontend (their only emitter) migrates; removed in Slice 7.
             "/" => {
                 if c.signed {
-                    "tdiv"
+                    "div_trunc"
                 } else {
-                    "utdiv"
+                    "udiv_trunc"
                 }
             }
             "%" => {


### PR DESCRIPTION
## Summary
- Part of the SIR21 T3b-2 arc: splitting the overloaded `/` builtin into `div_floor`/`div_trunc`/`udiv_trunc`/`div_true` (see `code/specs/SIR21-type-system-and-integer-semantics.md` §E3). All 7 backends already implement all four ops (Slice 2, merged).
- `combine()`'s float (`double`) arm: `/` now lowers to `div_true` instead of bare `/` — always true-divides once both operands are promoted to `double`.
- `combine()`'s integer arm: `/` now lowers to `div_trunc`/`udiv_trunc` instead of `tdiv`/`utdiv` — a pure rename (`semantic-ir-to-c`'s dispatch entries for the new names already point at the same `_sir_itdiv`/`_sir_utdiv` runtime functions the old names called). `tdiv`/`utdiv` become dead dispatch entries, removed in Slice 7. `%`/`tmod` are untouched — modulo is explicitly out of scope for this arc.
- Own slice (not batched with other frontends) because this function needed two different renames — more mistake surface than a mechanical single-name swap.

## Test plan
- [x] `cargo test -p c-to-semantic-ir` — 57/57 lib tests pass (2 test-shape assertions updated for the new names), plus `tests/three_way_conformance.rs` (byte-identical against real `cc`-compiled output, ~101 call sites, unchanged and green)
- [x] `cargo test -p semantic-ir-to-c` — full backend suite green (round-trip tests, since no `Frontend::C` exists in `sir-conformance`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `tests::int_min_div_is_guarded` (INT64_MIN/-1 two's-complement-wrap guard) still passes unchanged — confirms the rename didn't touch the guard logic in `_sir_itdiv`
- [x] `/security-review` — PASSED, no vulnerabilities found (pure mechanical rename, no unsafe code, no new I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)