### PR TITLE
feat(adj-facts-stdlib): add farm-animal-product-texture.adj (agriculture sibling table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_farmanimalproducttexture_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_farmanimalproducttexture_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end test for the agriculture FACTS library
+//! (`adj-facts-stdlib/agriculture/farm-animal-product-texture.adj`)
+//! driven through the built CLI: a native `table` naming the physical
+//! texture descriptor a source already states for a farm animal's product,
+//! decoded from a clause already sitting unused inside `farm-animals.adj`'s
+//! own already-quoted per-row CFSPH provenance -- a sibling to that table
+//! (and to `farm-animal-secondary-product.adj`,
+//! `farm-animal-product-processing.adj`, and `farm-animal-product-use.adj`,
+//! which decode the same rabbit clause's other axes: second product,
+//! processing method, and use, respectively). Resolves binding-query recall
+//! (both directions) with the source's citation, and abstains on a real,
+//! already-tabled animal/product pair (goat, milk) whose own cited span
+//! states a processing method, not a texture -- 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_farmanimalproducttexture_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("agriculture/farm-animal-product-texture.adj");
+    std::fs::copy(&src, dir.join("farm-animal-product-texture.adj"))
+        .expect("copy shipped farm-animal-product-texture.adj");
+}
+
+#[test]
+fn farm_animal_product_texture_recalls_rabbit_wool_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-texture.adj\"\n\
+         ? farm_animal_product_texture(rabbit, wool, $Texture)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_product_texture(rabbit, wool, soft)\""),
+        "rabbit wool is soft: {out}"
+    );
+    assert!(
+        out.contains("cfsph.iastate.edu") && out.contains("\"trust\":\"authoritative\""),
+        "carries the CFSPH citation: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_product_texture_recalls_backward_to_rabbit_wool() {
+    let dir = scratch("backward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-texture.adj\"\n\
+         ? farm_animal_product_texture($Animal, $Product, soft)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"term\":\"farm_animal_product_texture(rabbit, wool, soft)\""),
+        "soft names rabbit's wool: {out}"
+    );
+}
+
+#[test]
+fn farm_animal_product_texture_abstains_honestly_on_goat_milk() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"farm-animal-product-texture.adj\"\n\
+         ? farm_animal_product_texture(goat, milk, $Texture)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "goat's own cited span states a processing method for milk, not a texture -- honest abstention: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-texture.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-texture.adj
@@ -1,0 +1,80 @@
+% ============================================================================
+% farm-animal-product-texture — for the farm animal product whose SAME cited
+% CFSPH span also names a physical TEXTURE descriptor of the product itself,
+% that texture (adj-facts-stdlib, AGRICULTURE).
+% ============================================================================
+% A sibling to the already-shipped `farm-animals.adj` (`farm_animal_product
+% (animal, product)`, chicken → eggs, duck → eggs, sheep → wool, rabbit →
+% wool, goat → milk), `farm-animal-secondary-product.adj`
+% (`farm_animal_secondary_product(animal, product)`),
+% `farm-animal-product-processing.adj`
+% (`farm_animal_product_processing(animal, product, processing)`), and
+% `farm-animal-product-use.adj` (`farm_animal_product_use(animal, product,
+% use)`). Rabbit's own per-row provenance in `farm-animals.adj` already
+% quotes, VERBATIM, a physical TEXTURE descriptor of its already-recorded
+% wool -- but none of the existing tables' schemas had room for it:
+%
+%   rabbit, wool → soft
+%     "Some rabbit breeds produce a very soft wool that can be harvested
+%      regularly and used for fiber arts."
+%
+% This is the SAME CFSPH sentence `farm-animal-product-use.adj` already
+% decoded for its USE half (fiber_arts). Texture (what the product PHYSICALLY
+% FEELS LIKE) is categorically distinct from use (what the product is FOR,
+% already shipped), product (what the animal GIVES, `farm-animals.adj`),
+% secondary product (`farm-animal-secondary-product.adj`), and processing
+% (how a product is treated before use,
+% `farm-animal-product-processing.adj`) -- FIVE separate axes decoded out of
+% the same small set of CFSPH sentences, one schema per axis. Recall is a
+% binding query:
+%
+%     ? farm_animal_product_texture(rabbit, wool, $Texture)   % soft
+%
+% This is a native `table` (ADJ-TABLES RS-5, a THREE-column table -- the
+% same shape as the siblings `farm-animal-product-processing.adj` and
+% `farm-animal-product-use.adj`, and already precedented elsewhere in this
+% stdlib, e.g. `biology/amino-acids.adj`,
+% `geology/fossil-preservation-subtype.adj`): each `row` lowers to a ground
+% relation `farm_animal_product_texture(animal, product, texture)` carrying
+% the citation, so the lookup above is the ordinary SLD binding query -- the
+% engine returns the texture WITH its source, on the CPU, with zero model
+% calls, and abstains on every other animal/product pair `farm-animals.adj`
+% carries, since none of the other four cited spans (chicken, duck, sheep,
+% goat) states a texture descriptor the way rabbit's span does -- chicken's
+% and duck's spans state only a second product (meat), sheep's states two
+% second products (meat, milk), and goat's states a processing method
+% applied to its milk ("may be pasteurized"), not a texture. The query also
+% runs BACKWARD -- bind a texture and recall which animal/product pair it
+% names:
+%
+%     ? farm_animal_product_texture($Animal, $Product, soft)   % rabbit, wool
+%
+% Only ONE of `farm-animals.adj`'s five animal/product pairs has a
+% genuinely distinct texture fact in the ALREADY-cited spans; this table is
+% deliberately narrow (a single row, the same shape as several other
+% already-shipped single-row siblings in this stdlib, e.g.
+% `agriculture/farm-animal-product-processing.adj`,
+% `agriculture/farm-animal-product-use.adj`,
+% `agriculture/farm-animal-maintenance-level.adj`) rather than inventing a
+% texture the source does not state.
+%
+% Provenance: reproduces, byte-for-byte, the SAME rabbit span already
+% quoted inside `farm-animals.adj`'s own per-row provenance block (and
+% already reused by `farm-animal-product-use.adj`) -- no new WebFetch, only
+% a different schema decoding the texture half of that already-verified
+% quote. `trust authoritative` -- the same tier `farm-animals.adj` already
+% carries (Iowa State University CFSPH, a primary university educational
+% source).
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table farm_animal_product_texture {
+    columns animal, product, texture
+
+    row (rabbit, wool, soft)   % CFSPH: "...a very soft wool..."
+
+    source "Some rabbit breeds produce a very soft wool that can be harvested regularly and used for fiber arts."
+    locator "https://www.cfsph.iastate.edu/thelivestockproject/animals-for-beginning-small-farmers/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-texture.query.adj
+++ b/code/specs/data/adj-facts-stdlib/agriculture/farm-animal-product-texture.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% farm-animal-product-texture.query — a worked recall over the agriculture
+% farm-animal-product-texture library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does rabbit wool
+% feel like?": it states no agriculture fact of its own — it only `import`s
+% the grounded table and asks binding queries. The engine resolves each `?`
+% against the `farm_animal_product_texture` rows and returns the texture +
+% the table's source/locator/trust. An animal/product pair the cited spans
+% give no texture for abstains honestly — the engine never invents one.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli farm-animal-product-texture.query.adj
+% ============================================================================
+
+import "farm-animal-product-texture.adj"
+
+? farm_animal_product_texture(rabbit, wool, $Texture)             % expect soft
+? farm_animal_product_texture($Animal, $Product, soft)            % reverse bind — expect rabbit, wool
+? farm_animal_product_texture(goat, milk, $Texture)                % expect abstain — goat's own cited span states a processing method for milk, not a texture

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 315 | 318 | 314 (99.7%) | 315 (100.0%) | 315 (100.0%) | 0 (0.0%) |
+| facts | 316 | 319 | 315 (99.7%) | 316 (100.0%) | 316 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -23,7 +23,7 @@ provenance bundle whose CAS graph proves all cited source bytes.
 
 | Collection/domain | Libraries | Clauses | Queries | Tests | Source envelopes | Byte pins |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `facts/agriculture` | 5 | 5 | 5 | 5 | 5 | 0 |
+| `facts/agriculture` | 6 | 6 | 6 | 6 | 6 | 0 |
 | `facts/anatomy` | 32 | 32 | 32 | 32 | 32 | 0 |
 | `facts/art` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/astronomy` | 18 | 18 | 18 | 18 | 18 | 0 |
@@ -71,7 +71,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (541)
+### Missing pinned source bytes (542)
 
 See the JSON form of this report for the complete machine-readable list.
 


### PR DESCRIPTION
## Summary

Fourth and final slice of the agriculture/ domain sweep (117th content slice overall). Sibling to the already-shipped `farm-animals.adj`, `farm-animal-secondary-product.adj`, `farm-animal-product-processing.adj`, and `farm-animal-product-use.adj`.

Rabbit's own per-row provenance in `farm-animals.adj` already quotes, VERBATIM, a physical TEXTURE descriptor of its already-recorded wool -- but none of the existing tables' schemas had room for it: "Some rabbit breeds produce a very soft wool that can be harvested regularly and used for fiber arts." New `farm_animal_product_texture(animal, product, texture)` table decodes that clause as its own row: `rabbit, wool -> soft`.

This is the SAME CFSPH sentence `farm-animal-product-use.adj` already decoded for its USE half (`fiber_arts`). Texture (what the product physically FEELS LIKE) is categorically distinct from use (what the product is FOR), product (what the animal GIVES), secondary product, and processing (how a product is treated before use) -- FIVE separate axes now decoded out of the same small set of CFSPH sentences, one schema per axis.

No new WebFetch -- reuses the same already-cited CFSPH sentence.

- Discipline #30 (duplication check): grepped the whole stdlib tree for `texture|descriptor|soft|coarse` -- the only other domain hit was `earth-science/soil-texture-class.adj`, an unrelated soil particle-size classification (not a farm animal product); no existing agriculture table covers this axis.
- Discipline #31 (row verification): the row verbatim-grounds -- "soft" is a direct copy of "very soft wool". Honest abstention on chicken/duck/sheep/goat, whose own cited spans state no texture for their products (goat's states a processing method for milk, not a texture).

This is the LAST of the four originally-flagged agriculture/ candidates (maintenance-level, product-use, product-texture, plus the earlier product-processing). After this merges, agriculture/ is fully swept -- every candidate from `farm-animals.adj`'s rabbit/sheep/goat spans has been addressed.

## Security review

Ran a sub-agent security pass over this diff (static `.adj` data table + query companion + Rust e2e test that shells out to the locally-built CLI with a fixed argument, plus the auto-generated coverage report). Result: **SECURITY REVIEW PASSED -- no vulnerabilities found.** No CRITICAL/HIGH/MEDIUM/LOW findings requiring action; the sub-agent noted the e2e test's temp-dir naming pattern is copied verbatim from every sibling e2e test in this stdlib and poses no practical risk (no attacker-controlled input, no shell interpolation, fixed hardcoded test fixtures only).

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI query check (forward recall w/ citation, backward recall, honest abstention) -- all three correct
- [x] `cargo test -p adj-lang-cli --test facts_farmanimalproducttexture_e2e` (3/3 pass)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0, regenerated COVERAGE.md)
- [x] `adj_stdlib_manifest.py --validate-json-schema` (steady at 176 objectives -- no new objective, matches the parent tables' own precedent; confirmed identical pre-existing error set against main, no regression)
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` (clean)
- [x] Sub-agent security review -- PASSED (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)