### PR TITLE
feat(d18t): Elixir durable epoch-activation adapter completes the six-language surface

### DIFF
--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/BUILD
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/BUILD
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/BUILD_windows
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/BUILD_windows
@@ -1,0 +1,1 @@
+mix deps.get --quiet && mix test --cover

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Elixir D18T durable epoch-activation adapter, consuming the canonical
+  Rust-authored manifest at
+  `code/fixtures/chief-of-staff-channel-epoch-activation/v1/` directly. Elixir
+  reproduces the canonical D18T plan bytes and every D18G grant byte-for-byte
+  from the labelled test-only secrets. Completes the six-language surface.
+- Add the exact `D18S` version 2 state codec (active epoch, next sequence,
+  optional pending D18H reservation) and the immutable `D18T` version 1
+  activation-plan codec, with canonical ordering enforced on decode rather than
+  normalized on construction.
+- Add the injected atomic originator-key custody boundary: three-valued
+  selection (`selected` / `idempotent` / `conflict`), indivisible
+  plan-plus-grants-plus-CMK bundles, constant-time CMK comparison delegated to
+  `CodingAdventures.CtCompare`, handles and candidates that redact every field
+  under `Inspect`, and an explicitly non-durable in-memory implementation that
+  the production constructor refuses.
+- Add the orchestration surface: create, migrate from D18P version 1, prepare,
+  recover, activate, reserve-publish against the active epoch, abandon pending,
+  read the public plan, and apply destruction.
+- Enforce the shared-CAS invariant: the active epoch and the pending publish
+  reservation live in one versioned record, so publication and activation
+  contend on a single revision and exactly one wins.
+- Enforce invariant 3, "all grants before visibility": replay re-reads every
+  grant from public storage and byte-compares before activation may advance the
+  epoch, rather than trusting the record the backend echoed from its own write.
+- Settle the channel definition before importing the caller's CMK, so a
+  mismatched definition cannot claim an unclaimed custody slot and wedge the
+  legitimate import at `conflicting_active_key`.
+- Validate that a plan's `channel_id` is a real UUID v7 — version nibble and
+  variant bits — not merely 16 octets, matching Rust, Python, and Ruby.
+- Report Elixir's honest `not_enforceable` secret-erasure capability rather than
+  echoing the manifest's Rust-authored `guaranteed`. Immutable, garbage-collected
+  BEAM values cannot promise physical overwrite.
+- Perform the D18Q grant epoch comparison locally. `verify_grant_signature`
+  deliberately takes no expected epoch, so a validly signed grant for another
+  epoch would otherwise pass; D18T step 5 owns that check.

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/README.md
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/README.md
@@ -1,0 +1,113 @@
+# coding_adventures_chief_of_staff_channel_epoch_activation
+
+The Elixir implementation of **D18T**, the durable channel epoch-activation
+profile — the transaction that makes a rotated channel key actually *current*.
+This completes the six-language D18T surface.
+
+Spec: [`code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md`](../../../specs/D18T-chief-of-staff-durable-epoch-activation-profile.md)
+
+## Where this sits in the stack
+
+```
+D18P channel-store   durable messages, grants, cursors, sequence reservations
+D18Q channel-crypto  mints the next CMK and seals one grant per receiver
+D18T (this package)  makes epoch E+1 current, crash-safely, without racing publication
+```
+
+D18P can store. D18Q can rotate. Neither can *activate* — and the naive
+implementation of activation has two ways to lose data:
+
+- write "epoch E+1 is current", then crash before the new CMK is durable, and
+  nothing published afterwards can be decrypted;
+- activate E+1 while a concurrent publisher is reserving a slot at E, and the
+  message ends up encrypted under a key its header disagrees with.
+
+## The one idea worth remembering
+
+**The active epoch lives in the same versioned record as the pending publish
+reservation.** A separate mutable "epoch head" would not be conforming: two
+independent compare-and-swap operations cannot exclude each other, so a
+publisher could reserve against the old epoch in the window between activation
+reading the head and writing it. One record means one revision means one CAS,
+and exactly one of {publish, activate} wins.
+
+The second idea: **custody is claimed before anything becomes public.** The
+secret CMK and the complete public recovery bundle are stored together,
+atomically, by a single custody call — before the plan or any grant is written.
+A crash before that call leaves no candidate at all; a crash after it is fully
+recoverable from custody plus the public store, with no byte regenerated.
+
+## Usage
+
+```elixir
+alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Store, as: EpochStore
+
+store = EpochStore.open(backend, custody, channel_id)
+
+# Create a D18T-aware channel: the CMK enters custody before any public state.
+state = EpochStore.create_epoch_channel(store, definition, initial_cmk)
+
+# Rotate. The trusted D18Q plan plus the target roster go in; nothing public
+# changes until custody has selected this candidate.
+"prepared" = EpochStore.prepare_rotation(store, definition, target_roster, rotation)
+
+# Resume after a crash. Replays the exact selected bundle; never picks another.
+"idempotent" = EpochStore.recover_preparation(store, definition, new_epoch)
+
+# Commit the transition on the shared CAS.
+"activated" = EpochStore.activate_prepared_epoch(store, definition, new_epoch)
+
+# Publish against whatever epoch is currently active.
+reservation = EpochStore.reserve_publish_using_active_epoch(store, definition, request, plaintext)
+```
+
+`open/3` refuses custody whose `durable?/1` reports `false`. Use
+`open_for_testing/3` with `Custody.InMemory` in tests — that module honestly
+declares itself non-durable, so it cannot be wired into a real channel by
+accident.
+
+## What the errors will and will not tell you
+
+Every failure is an `ActivationError` carrying one of the 19 stable codes in
+`error_codes/0`, and the exception message is *exactly* the code — no channel
+bytes, no epoch numbers, no key material. Match on `.code` rather than on
+message text.
+
+Wire failures are deliberately undifferentiated: truncation, a bad version, and
+trailing bytes all report `corrupt_record`, because telling a forger how far
+they got is itself a leak.
+
+## Secret handling
+
+`EpochKeyHandle` and `PreparedEpoch` derive `Inspect` with an empty field list,
+so neither can print anything under `inspect/1`. CMK comparison delegates to
+`CodingAdventures.CtCompare.ct_eq_fixed/2` rather than being reimplemented here.
+
+`secret_erasure_capability/0` reports `not_enforceable` — immutable,
+garbage-collected BEAM values cannot promise physical overwrite of every runtime
+copy. The Rust reference reports `guaranteed`; Elixir does not claim that, and
+the fixture test asserts the difference rather than papering over it.
+
+## Conformance
+
+The tests consume the canonical Rust-authored manifest directly — no local
+regeneration, no shelling out to another language. The strongest of them
+rebuilds the rotation candidate from the manifest's labelled test-only secrets
+using Elixir's own D18Q and D18T code and requires byte-for-byte equality with
+the plan and grant Rust authored. If Elixir disagrees with Rust about a single
+octet, it fails.
+
+Also proven here: v1→v2 migration preserving sequence and in-flight
+reservations, crash-replay from custody alone, competing candidates where
+exactly one is selected, publication and activation contending on the shared CAS
+in both directions, invariant 3 verified against a backend that accepts writes
+but diverges on reads, tampered custody bundles rejected, grants signed by
+another originator rejected, and destruction wiping secrets while public history
+stays append-only.
+
+## Development
+
+```sh
+mix deps.get
+mix test --cover
+```

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation.ex
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation.ex
@@ -1,0 +1,387 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation do
+  @moduledoc """
+  Portable D18T durable channel epoch-activation profile.
+
+  ## The problem D18T solves
+
+  D18P makes a channel's messages, grants, cursors, and sequence reservations
+  durable. D18Q can mint a fresh channel master key (CMK) for epoch E+1 and seal
+  one grant per authorized receiver. Neither can make E+1 *current*.
+
+  That gap is not cosmetic. The obvious implementation — write a "current epoch"
+  record, then publish with the new key — loses data two ways:
+
+      crash here  ->  the new epoch is visible, but its CMK was never durably
+                      stored, so nothing published afterwards can be decrypted
+      crash here  ->  a concurrent publisher reserved a slot at epoch E while
+                      activation committed E+1; whose key is right?
+
+  D18T defines the missing transaction without assuming the storage backend
+  offers multi-record transactions. Three authorities cooperate:
+
+      D18P channel store   public records and the publish-reservation CAS
+      injected custody     prepared CMKs and their recovery bundles
+      D18Q                 grant creation, parsing, and verification
+
+  ## The one idea worth remembering
+
+  The active epoch lives in the *same versioned record* as the pending publish
+  reservation. That is deliberate and load-bearing. A separate mutable "epoch
+  head" record would not be conforming, because two independent compare-and-swap
+  operations cannot exclude each other: a publisher could reserve a slot against
+  the old epoch in the window between activation reading the head and writing
+  it. One record means one revision means one CAS, and exactly one of
+  {publish, activate} wins.
+  """
+
+  import Bitwise
+
+  alias CodingAdventures.ChiefOfStaffChannelStore, as: Store
+
+  @epoch_state_content_type "application/vnd.coding-adventures.chief-channel-state-v2"
+  @activation_plan_content_type "application/vnd.coding-adventures.chief-channel-epoch-activation-v1"
+  @max_plan_receivers 1024
+  @max_u64 (1 <<< 64) - 1
+  @max_epoch_cas_attempts 16
+  @state_magic "D18S"
+  @plan_magic "D18T"
+
+  @error_codes ~w(not_initialized channel_destroyed invalid_plan corrupt_record
+                  pending_append unactivated_epoch active_key_missing
+                  conflicting_active_key preparation_missing conflicting_preparation
+                  conflicting_plan conflicting_grant unexpected_epoch decreasing_epoch
+                  epoch_exhausted concurrent_update storage_error custody_error
+                  crypto_error)
+
+  defmodule ActivationError do
+    @moduledoc """
+    Stable D18T failure. The message is exactly the code: no channel bytes, no
+    epoch numbers, no key material, nothing an operator might paste into a bug
+    report and regret.
+    """
+    defexception [:code]
+
+    @impl true
+    def message(%__MODULE__{code: code}), do: code
+  end
+
+  defmodule EpochState do
+    @moduledoc """
+    Decoded `D18S` version 2 record.
+
+        offset  field           encoding
+        0       magic           ascii("D18S")
+        4       version         0x02
+        5       active_epoch    u64be
+        13      next_sequence   u64be
+        21      pending_flag    u8: 0 none, 1 header follows
+        22      header_length   u32be, max 16384   (only when flag = 1)
+        26      reserved_header exact D18H v1 bytes (only when flag = 1)
+
+    With no pending header the record is exactly 22 octets; with one it is
+    exactly `26 + header_length`. Trailing bytes are never permitted.
+    """
+    @enforce_keys [:active_epoch, :next_sequence]
+    defstruct [:active_epoch, :next_sequence, pending_header: nil]
+  end
+
+  defmodule ActivationPlanEntry do
+    @moduledoc """
+    One receiver's commitment pair. The plan carries no raw receiver ID and no
+    grant body — only hashes — so the public plan record leaks neither the
+    membership roster nor any key material.
+    """
+    @enforce_keys [:receiver_id_hash, :grant_hash]
+    defstruct @enforce_keys
+  end
+
+  defmodule ActivationPlan do
+    @moduledoc """
+    Immutable `D18T` version 1 activation plan.
+
+        offset  field            encoding
+        0       magic            ascii("D18T")
+        4       version          0x01
+        5       channel_id       bytes[16], UUID v7
+        21      base_epoch       u64be
+        29      new_epoch        u64be
+        37      receiver_count   u32be, 1 through 1024
+        41      receivers        repeated: receiver_id_hash[32] grant_hash[32]
+
+    Entries are strictly sorted by `receiver_id_hash` with no duplicate receiver
+    or grant commitment. Strict sorting makes the encoding canonical: the same
+    rotation always produces the same bytes, so a byte comparison is a complete
+    equality test during replay.
+    """
+    @enforce_keys [:channel_id, :base_epoch, :new_epoch, :receivers]
+    defstruct @enforce_keys
+  end
+
+  @doc "Content type tagging the D18S version 2 state record."
+  def epoch_state_content_type, do: @epoch_state_content_type
+
+  @doc "Content type tagging the immutable D18T version 1 plan record."
+  def activation_plan_content_type, do: @activation_plan_content_type
+
+  @doc "Largest rotation a single plan may carry."
+  def max_plan_receivers, do: @max_plan_receivers
+
+  @doc "Largest epoch or sequence value. Reaching it is an error, never a wrap."
+  def max_u64, do: @max_u64
+
+  @doc "Bound on every public compare-and-swap loop."
+  def max_epoch_cas_attempts, do: @max_epoch_cas_attempts
+
+  @doc "Closed, ordered stable D18T error roster."
+  def error_codes, do: @error_codes
+
+  @doc """
+  Report Elixir's honest erasure capability, inherited from D18Q rather than
+  claimed independently. The Rust reference reports "guaranteed"; overstating
+  Elixir's position to match it would be the dishonest kind of portability.
+  """
+  def secret_erasure_capability do
+    CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile.secret_erasure_capability()
+  end
+
+  @doc false
+  def fail!(code) when code in @error_codes, do: raise(ActivationError, code: code)
+
+  @doc false
+  def wire_fail!, do: fail!("corrupt_record")
+
+  # ---------------------------------------------------------------------------
+  # D18S v2 state
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Validate every cross-field invariant D18T requires of a state record.
+
+  A pending header must name this channel, sit exactly one below
+  `next_sequence`, and carry the currently active epoch — that last check is
+  what prevents a reservation from surviving across an activation it never
+  agreed to.
+  """
+  def new_epoch_state!(channel_id, active_epoch, next_sequence, pending_header \\ nil) do
+    require_u64!(active_epoch)
+    require_u64!(next_sequence)
+    channel = require_fixed!(channel_id, 16)
+
+    unless is_nil(pending_header) do
+      unless pending_header.channel_id == channel and
+               pending_header.sequence != @max_u64 and
+               pending_header.sequence + 1 == next_sequence and
+               pending_header.key_epoch == active_epoch do
+        wire_fail!()
+      end
+    end
+
+    %EpochState{
+      active_epoch: active_epoch,
+      next_sequence: next_sequence,
+      pending_header: pending_header
+    }
+  end
+
+  @doc "Activation transition: change only the epoch."
+  def with_active_epoch!(%EpochState{} = state, channel_id, active_epoch) do
+    new_epoch_state!(channel_id, active_epoch, state.next_sequence, state.pending_header)
+  end
+
+  @doc "Reservation transition: change only the sequence and pending header."
+  def with_pending!(%EpochState{} = state, channel_id, next_sequence, pending_header \\ nil) do
+    new_epoch_state!(channel_id, state.active_epoch, next_sequence, pending_header)
+  end
+
+  @doc "Encode canonical D18S version 2 bytes."
+  def epoch_state_serialize(%EpochState{} = state) do
+    prefix =
+      @state_magic <> <<2>> <> u64be(state.active_epoch) <> u64be(state.next_sequence)
+
+    case state.pending_header do
+      nil ->
+        prefix <> <<0>>
+
+      header ->
+        encoded = Store.header_serialize(header)
+        if byte_size(encoded) > Store.max_pending_header_bytes(), do: wire_fail!()
+        prefix <> <<1>> <> u32be(byte_size(encoded)) <> encoded
+    end
+  end
+
+  @doc "Decode and fully validate canonical D18S version 2 bytes."
+  def epoch_state_deserialize(data, channel_id) when is_binary(data) do
+    case data do
+      <<@state_magic, 2, active_epoch::unsigned-big-64, next_sequence::unsigned-big-64,
+        0::unsigned-8>> ->
+        new_epoch_state!(channel_id, active_epoch, next_sequence)
+
+      <<@state_magic, 2, active_epoch::unsigned-big-64, next_sequence::unsigned-big-64,
+        1::unsigned-8, length::unsigned-big-32, rest::binary>> ->
+        if length > Store.max_pending_header_bytes() or byte_size(rest) != length do
+          wire_fail!()
+        end
+
+        header =
+          try do
+            Store.header_deserialize(rest)
+          rescue
+            _ -> wire_fail!()
+          end
+
+        new_epoch_state!(channel_id, active_epoch, next_sequence, header)
+
+      _ ->
+        wire_fail!()
+    end
+  end
+
+  def epoch_state_deserialize(_, _), do: wire_fail!()
+
+  # ---------------------------------------------------------------------------
+  # D18T v1 activation plan
+  # ---------------------------------------------------------------------------
+
+  @doc "Build one commitment pair from 32-octet hashes."
+  def new_plan_entry!(receiver_id_hash, grant_hash) do
+    %ActivationPlanEntry{
+      receiver_id_hash: require_fixed!(receiver_id_hash, 32),
+      grant_hash: require_fixed!(grant_hash, 32)
+    }
+  end
+
+  @doc """
+  Sort, validate, and own the plan entries.
+
+  Two distinct receiver IDs hashing to the same value would be a SHA-256
+  collision — but D18T does not treat a collision as equal authorization, it
+  treats it as invalid input. Rejecting rather than merging is the fail-closed
+  choice.
+  """
+  def new_activation_plan!(channel_id, base_epoch, new_epoch, receivers) do
+    channel = require_uuid_v7!(channel_id)
+    require_u64!(base_epoch)
+    require_u64!(new_epoch)
+    if base_epoch == @max_u64 or new_epoch != base_epoch + 1, do: wire_fail!()
+
+    ordered = Enum.sort_by(receivers, & &1.receiver_id_hash)
+    count = length(ordered)
+    unless count >= 1 and count <= @max_plan_receivers, do: wire_fail!()
+    if length(Enum.uniq_by(ordered, & &1.receiver_id_hash)) != count, do: wire_fail!()
+    if length(Enum.uniq_by(ordered, & &1.grant_hash)) != count, do: wire_fail!()
+
+    %ActivationPlan{
+      channel_id: channel,
+      base_epoch: base_epoch,
+      new_epoch: new_epoch,
+      receivers: ordered
+    }
+  end
+
+  @doc "Encode canonical D18T version 1 bytes."
+  def activation_plan_serialize(%ActivationPlan{} = plan) do
+    count = length(plan.receivers)
+    unless count >= 1 and count <= @max_plan_receivers, do: wire_fail!()
+
+    entries =
+      Enum.map_join(plan.receivers, fn entry -> entry.receiver_id_hash <> entry.grant_hash end)
+
+    @plan_magic <>
+      <<1>> <>
+      plan.channel_id <> u64be(plan.base_epoch) <> u64be(plan.new_epoch) <> u32be(count) <> entries
+  end
+
+  @doc """
+  Decode canonical D18T version 1 bytes.
+
+  Sort order is checked on the wire BEFORE the entries reach
+  `new_activation_plan!/4`, which sorts its input and would otherwise silently
+  canonicalize a mis-ordered record. Rejecting first is what makes the encoding
+  canonical rather than merely normalized.
+  """
+  def activation_plan_deserialize(data) when is_binary(data) do
+    case data do
+      <<@plan_magic, 1, channel_id::binary-size(16), base_epoch::unsigned-big-64,
+        new_epoch::unsigned-big-64, count::unsigned-big-32, rest::binary>> ->
+        unless count >= 1 and count <= @max_plan_receivers, do: wire_fail!()
+        if byte_size(rest) != count * 64, do: wire_fail!()
+
+        entries =
+          for <<receiver::binary-size(32), grant::binary-size(32) <- rest>>,
+            do: new_plan_entry!(receiver, grant)
+
+        entries
+        |> Enum.chunk_every(2, 1, :discard)
+        |> Enum.each(fn [left, right] ->
+          if left.receiver_id_hash >= right.receiver_id_hash, do: wire_fail!()
+        end)
+
+        plan = new_activation_plan!(channel_id, base_epoch, new_epoch, entries)
+        if plan.receivers != entries, do: wire_fail!()
+        plan
+
+      _ ->
+        wire_fail!()
+    end
+  end
+
+  def activation_plan_deserialize(_), do: wire_fail!()
+
+  @doc """
+  Deterministic storage key for a plan.
+
+  The epoch is zero-padded to 20 digits so lexicographic key order and numeric
+  epoch order agree, which is what lets a prefix listing walk epochs in
+  sequence.
+  """
+  def activation_plan_record_key(channel_id, new_epoch) do
+    channel = require_fixed!(channel_id, 16)
+    require_u64!(new_epoch)
+
+    Base.encode16(channel, case: :lower) <>
+      "/epochs/" <> String.pad_leading(Integer.to_string(new_epoch), 20, "0") <> "/activation"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared validation helpers
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  def require_u64!(value) do
+    unless is_integer(value) and value >= 0 and value <= @max_u64, do: wire_fail!()
+    value
+  end
+
+  @doc false
+  def require_fixed!(value, length) do
+    unless is_binary(value) and byte_size(value) == length, do: wire_fail!()
+    value
+  end
+
+  @doc """
+  A channel identifier must be a real UUID v7 — version nibble 7 and variant
+  bits 0b10 — not merely 16 octets. The Rust reference and the Python port both
+  check this, so accepting a malformed identifier would mean two conforming
+  implementations disagreed about whether the same plan record is valid.
+  """
+  def require_uuid_v7!(value) do
+    channel = require_fixed!(value, 16)
+
+    # Byte 6's high nibble is the version; byte 8's top two bits are the
+    # variant. Byte 7 sits between them and is unconstrained.
+    case channel do
+      <<_::binary-size(6), 7::4, _::4, _::binary-size(1), 2::2, _::6, _::binary-size(7)>> ->
+        channel
+
+      _ ->
+        wire_fail!()
+    end
+  end
+
+  defp u32be(value) do
+    unless is_integer(value) and value >= 0 and value < 1 <<< 32, do: wire_fail!()
+    <<value::unsigned-big-32>>
+  end
+
+  defp u64be(value), do: <<require_u64!(value)::unsigned-big-64>>
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation/custody.ex
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation/custody.ex
@@ -1,0 +1,273 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.EpochKeyHandle do
+  @moduledoc """
+  Opaque, redacted reference to one retained epoch key.
+
+  Carries no key bytes and no reversible locator — only the channel and epoch,
+  both already public. Resolving a handle to an actual CMK is the sole privilege
+  of the originator encryption boundary, via `with_key/3`.
+  """
+  @derive {Inspect, only: []}
+  @enforce_keys [:channel_id, :epoch]
+  defstruct @enforce_keys
+end
+
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.PublicPreparation do
+  @moduledoc """
+  Exact secret-free recovery bundle retained beside a prepared CMK. After any
+  crash this is enough to replay every public write without regenerating a
+  single byte.
+  """
+  @enforce_keys [:channel_id, :base_epoch, :new_epoch, :plan_bytes, :grants]
+  defstruct @enforce_keys
+end
+
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.PreparedEpoch do
+  @moduledoc """
+  One indivisible candidate offered to custody: the public recovery bundle *and*
+  the secret CMK, together.
+
+  "Indivisible" is the whole point. Custody must never store the plan without the
+  key or the key without the plan — either half alone leaves a channel that
+  cannot recover. That is why this is a single struct with a single custody entry
+  point rather than two calls a caller could interleave.
+  """
+  @derive {Inspect, only: []}
+  @enforce_keys [:public_preparation, :cmk]
+  defstruct @enforce_keys
+end
+
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody do
+  @moduledoc """
+  Injected atomic originator-key custody, plus a deterministic non-durable
+  implementation for conformance tests.
+
+  A production implementation MUST survive process and machine restart.
+  `durable?/1` is how an implementation declares that honestly; the production
+  constructor refuses anything answering `false`, so a test double cannot be
+  wired into a real channel by accident.
+  """
+
+  alias CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile, as: Grants
+
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation, as: Epoch
+
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.{
+    EpochKeyHandle,
+    PreparedEpoch,
+    PublicPreparation
+  }
+
+  @selected "selected"
+  @idempotent "idempotent"
+  @conflict "conflict"
+
+  @doc """
+  Three-valued result of an atomic custody claim.
+
+  Three values, not two, and the distinction is the heart of D18T. `selected`
+  and `idempotent` are both successes but mean different things: the first says
+  *you* won the slot, the second says you are retrying something already won
+  with byte-identical inputs. `conflict` means somebody else owns it and you
+  must not proceed — notably, you may not look at what they stored.
+  """
+  def selected, do: @selected
+  def idempotent, do: @idempotent
+  def conflict, do: @conflict
+
+  @doc """
+  Constant-time CMK comparison.
+
+  Both operands are secrets, so a content-dependent early exit would leak
+  information about the stored key to a caller who controls the candidate.
+  Delegates to the repository's audited primitive rather than reimplementing it.
+  """
+  def same_cmk?(left, right) do
+    CodingAdventures.CtCompare.ct_eq_fixed(
+      Grants.channel_master_key_bytes(left),
+      Grants.channel_master_key_bytes(right)
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # In-memory, explicitly non-durable custody
+  # ---------------------------------------------------------------------------
+
+  defmodule InMemory do
+    @moduledoc """
+    Deterministic, explicitly non-durable custody for conformance tests.
+
+    `durable?/1` returns `false`, so `Store.open/3` refuses it and only
+    `Store.open_for_testing/3` will accept it.
+    """
+    use Agent
+
+    alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody
+
+    @enforce_keys [:pid]
+    defstruct @enforce_keys
+
+    def new! do
+      {:ok, pid} = Agent.start_link(fn -> %{keys: %{}, preparations: %{}} end)
+      %__MODULE__{pid: pid}
+    end
+
+    def durable?(%__MODULE__{}), do: false
+
+    @doc """
+    Claim an already-active epoch key. Used only at channel creation and at
+    version 1 migration — never to invent a key.
+    """
+    def import_active_if_absent(%__MODULE__{pid: pid}, channel_id, epoch, cmk) do
+      Agent.get_and_update(pid, fn state ->
+        slot = {channel_id, epoch}
+
+        case Map.get(state.keys, slot) do
+          nil ->
+            {Custody.selected(), put_in(state.keys[slot], cmk)}
+
+          current ->
+            # Deliberately does not reveal *how* the stored secret differs.
+            outcome =
+              if Custody.same_cmk?(current, cmk),
+                do: Custody.idempotent(),
+                else: Custody.conflict()
+
+            {outcome, state}
+        end
+      end)
+    end
+
+    def resolve_handle(%__MODULE__{pid: pid}, channel_id, epoch) do
+      Agent.get(pid, fn state ->
+        if Map.has_key?(state.keys, {channel_id, epoch}) do
+          %CodingAdventures.ChiefOfStaffChannelEpochActivation.EpochKeyHandle{
+            channel_id: channel_id,
+            epoch: epoch
+          }
+        end
+      end)
+    end
+
+    @doc """
+    Atomically claim the epoch slot for one complete bundle.
+
+    Both halves are checked before either is written, and a partially present
+    slot (key without bundle, or bundle without key) is a conflict rather than
+    something to repair — a half-written slot means an invariant already broke,
+    and guessing at the missing half is exactly the fallback D18T forbids.
+    """
+    def prepare_if_absent(%__MODULE__{pid: pid}, prepared) do
+      Agent.get_and_update(pid, fn state ->
+        public = prepared.public_preparation
+        slot = {public.channel_id, public.new_epoch}
+        current_public = Map.get(state.preparations, slot)
+        current_cmk = Map.get(state.keys, slot)
+
+        cond do
+          is_nil(current_public) and is_nil(current_cmk) ->
+            updated =
+              state
+              |> put_in([:preparations, slot], public)
+              |> put_in([:keys, slot], prepared.cmk)
+
+            {Custody.selected(), updated}
+
+          is_nil(current_public) or is_nil(current_cmk) ->
+            {Custody.conflict(), state}
+
+          current_public != public ->
+            {Custody.conflict(), state}
+
+          Custody.same_cmk?(current_cmk, prepared.cmk) ->
+            {Custody.idempotent(), state}
+
+          true ->
+            {Custody.conflict(), state}
+        end
+      end)
+    end
+
+    def load_preparation(%__MODULE__{pid: pid}, channel_id, new_epoch) do
+      Agent.get(pid, fn state -> Map.get(state.preparations, {channel_id, new_epoch}) end)
+    end
+
+    @doc "Lend the CMK for exactly one operation."
+    def with_key(%__MODULE__{pid: pid}, handle, operation) do
+      cmk =
+        Agent.get(pid, fn state -> Map.get(state.keys, {handle.channel_id, handle.epoch}) end)
+
+      if is_nil(cmk), do: Epoch.fail!("custody_error")
+      operation.(cmk)
+    end
+
+    @doc """
+    Erase every retained secret for one channel. Public history is untouched —
+    that is the store's business, and D18T keeps it append-only.
+    """
+    def destroy_channel(%__MODULE__{pid: pid}, channel_id) do
+      Agent.update(pid, fn state ->
+        %{
+          state
+          | keys: reject_channel(state.keys, channel_id),
+            preparations: reject_channel(state.preparations, channel_id)
+        }
+      end)
+    end
+
+    def retained_key_count(%__MODULE__{pid: pid}), do: Agent.get(pid, &map_size(&1.keys))
+
+    defp reject_channel(map, channel_id) do
+      Map.reject(map, fn {{channel, _epoch}, _value} -> channel == channel_id end)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Dispatch, mirroring the D18P Backend pattern
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  def durable?(custody), do: invoke!(custody, :durable?, [])
+
+  @doc false
+  def import_active_if_absent!(custody, channel_id, epoch, cmk),
+    do: invoke!(custody, :import_active_if_absent, [channel_id, epoch, cmk])
+
+  @doc false
+  def resolve_handle!(custody, channel_id, epoch),
+    do: invoke!(custody, :resolve_handle, [channel_id, epoch])
+
+  @doc false
+  def prepare_if_absent!(custody, %PreparedEpoch{} = prepared),
+    do: invoke!(custody, :prepare_if_absent, [prepared])
+
+  @doc false
+  def load_preparation!(custody, channel_id, new_epoch),
+    do: invoke!(custody, :load_preparation, [channel_id, new_epoch])
+
+  @doc false
+  def with_key!(custody, %EpochKeyHandle{} = handle, operation),
+    do: invoke!(custody, :with_key, [handle, operation])
+
+  @doc false
+  def destroy_channel!(custody, channel_id), do: invoke!(custody, :destroy_channel, [channel_id])
+
+  @doc false
+  def new_public_preparation(channel_id, base_epoch, new_epoch, plan_bytes, grants) do
+    %PublicPreparation{
+      channel_id: channel_id,
+      base_epoch: base_epoch,
+      new_epoch: new_epoch,
+      plan_bytes: plan_bytes,
+      grants: grants
+    }
+  end
+
+  defp invoke!(custody, function, arguments) do
+    apply(custody.__struct__, function, [custody | arguments])
+  rescue
+    error in [Epoch.ActivationError] -> raise error
+    _ -> Epoch.fail!("custody_error")
+  catch
+    _, _ -> Epoch.fail!("custody_error")
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation/store.ex
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/lib/coding_adventures/chief_of_staff_channel_epoch_activation/store.ex
@@ -1,0 +1,812 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.ActiveEpochAppendRequest do
+  @moduledoc """
+  Asks to publish at whatever epoch is currently active. `key_epoch` is
+  optional: leave it `nil` to accept the active epoch, or set it to assert an
+  expectation that is checked before any encryption.
+  """
+  @enforce_keys [:message_id, :timestamp_ns, :originator_id, :content_type]
+  defstruct [:message_id, :timestamp_ns, :originator_id, :content_type, key_epoch: nil]
+end
+
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.EpochReservation do
+  @moduledoc "Durable D18H reservation plus the redacted handle it was bound to."
+  @enforce_keys [:header, :key_handle]
+  defstruct @enforce_keys
+end
+
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.Store do
+  @moduledoc """
+  D18T coordinator over injected public storage and secret custody.
+  """
+
+  alias CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile, as: Grants
+  alias CodingAdventures.Sha256
+
+  alias CodingAdventures.ChiefOfStaffChannelStore, as: Profile
+
+  alias CodingAdventures.ChiefOfStaffChannelStore.{
+    Backend,
+    ChannelDefinitionStore,
+    ProfileError,
+    StorageConflictError,
+    StoragePut
+  }
+
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation, as: Epoch
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.ActiveEpochAppendRequest
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.EpochReservation
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.PreparedEpoch
+
+  @enforce_keys [:backend, :custody, :channel_id]
+  defstruct @enforce_keys
+
+  @doc """
+  Open a production coordinator. Refuses custody that reports itself
+  non-durable, so a test double cannot be wired into a real channel.
+  """
+  def open(backend, custody, channel_id) do
+    unless Custody.durable?(custody), do: Epoch.fail!("custody_error")
+    initialize!(backend)
+    %__MODULE__{backend: backend, custody: custody, channel_id: channel_id}
+  end
+
+  @doc "Open a coordinator that accepts non-durable custody, for tests only."
+  def open_for_testing(backend, custody, channel_id) do
+    initialize!(backend)
+    %__MODULE__{backend: backend, custody: custody, channel_id: channel_id}
+  end
+
+  @doc """
+  Create a D18T-aware channel, custody before any D18S state.
+
+  The definition is settled *before* the custody import. Custody slots are keyed
+  by `{channel_id, epoch}` and the first writer wins permanently, so importing
+  first would let a caller presenting a mismatched definition claim an unclaimed
+  slot and then fail — leaving the legitimate import to hit
+  `conflicting_active_key` forever. Fail closed, but permanently wedged. D18T
+  only requires custody before *state*.
+  """
+  def create_epoch_channel(%__MODULE__{} = store, definition, initial_cmk) do
+    unless definition.channel_id == store.channel_id and definition.lifecycle == "active" do
+      Epoch.fail!("invalid_plan")
+    end
+
+    definitions = ChannelDefinitionStore.new(store.backend)
+
+    try do
+      case ChannelDefinitionStore.load!(definitions, store.channel_id) do
+        nil -> ChannelDefinitionStore.create!(definitions, definition)
+        %{lifecycle: "destroyed"} -> Epoch.fail!("channel_destroyed")
+        existing when existing != definition -> Epoch.fail!("invalid_plan")
+        _ -> :ok
+      end
+    rescue
+      error in [Epoch.ActivationError] -> raise error
+      error in [ProfileError] -> raise translate_store_error(error)
+    end
+
+    import_initial_key(store, definition.key_epoch, initial_cmk)
+    migrate_epoch_state(store, definition)
+  end
+
+  @doc """
+  Bring a channel to D18S version 2, whether new or created under D18P version 1.
+
+  Publishing version 2 is the rolling-upgrade boundary: a version 1 process
+  rejects the record rather than misreading it, so operators must deploy
+  D18T-aware readers and writers before migrating. Nothing here ever clears a
+  pending publish, resets a sequence, or generates key material.
+  """
+  def migrate_epoch_state(%__MODULE__{} = store, definition, current_cmk \\ nil) do
+    require_definition!(store, definition, false)
+    migrate_loop(store, definition, current_cmk, Epoch.max_epoch_cas_attempts())
+  end
+
+  @doc "Load the canonical D18S version 2 state."
+  def state(%__MODULE__{} = store) do
+    case state_record(store) do
+      nil -> Epoch.fail!("not_initialized")
+      record -> decode_v2_state_record(store, record)
+    end
+  end
+
+  @doc """
+  Run the full prepare-and-replay protocol for one candidate.
+
+  Custody comes first, before any public write, because it is the only operation
+  that both selects a winner and makes everything needed for replay durable in
+  one atomic step. A crash before it leaves no candidate; a crash after it is
+  fully recoverable from custody plus the public store.
+  """
+  def prepare_rotation(%__MODULE__{} = store, definition, target_roster, rotation) do
+    require_definition!(store, definition, false)
+    current = state(store)
+    unless is_nil(current.pending_header), do: Epoch.fail!("pending_append")
+    if current.active_epoch == Epoch.max_u64(), do: Epoch.fail!("epoch_exhausted")
+    expected = current.active_epoch + 1
+    unless rotation.new_epoch == expected, do: Epoch.fail!("unexpected_epoch")
+
+    prepared = prepare_rotation_candidate(definition, current.active_epoch, target_roster, rotation)
+    selection = Custody.prepare_if_absent!(store.custody, prepared)
+    if selection == Custody.conflict(), do: Epoch.fail!("conflicting_preparation")
+
+    replay_preparation(store, definition, expected)
+    if selection == Custody.selected(), do: "prepared", else: "idempotent"
+  end
+
+  @doc """
+  Replay the durable bundle after a crash. Never generates a CMK, reseals a
+  grant, accepts replacement bytes, or picks a different candidate.
+  """
+  def recover_preparation(%__MODULE__{} = store, definition, new_epoch) do
+    require_definition!(store, definition, false)
+    active = state(store).active_epoch
+    if new_epoch < active, do: Epoch.fail!("decreasing_epoch")
+
+    unless new_epoch == active do
+      if active == Epoch.max_u64(), do: Epoch.fail!("epoch_exhausted")
+      unless new_epoch == active + 1, do: Epoch.fail!("unexpected_epoch")
+    end
+
+    replay_preparation(store, definition, new_epoch)
+    "idempotent"
+  end
+
+  @doc """
+  Commit the epoch transition with a bounded CAS.
+
+  Every precondition is re-checked inside the retry loop, because a CAS conflict
+  means somebody else changed the state and any fact read before it may now be
+  stale.
+  """
+  def activate_prepared_epoch(%__MODULE__{} = store, definition, new_epoch) do
+    require_definition!(store, definition, false)
+
+    case Custody.load_preparation!(store.custody, store.channel_id, new_epoch) do
+      nil -> Epoch.fail!("preparation_missing")
+      prepared -> activate_loop(store, definition, new_epoch, prepared, Epoch.max_epoch_cas_attempts())
+    end
+  end
+
+  @doc """
+  Build a D18H reservation bound to the current active epoch and its resolved
+  key handle.
+
+  This is the publication half of the shared CAS. If activation wins the race,
+  this loop's put conflicts, reloads, and rebuilds against E+1. If this wins,
+  activation observes the pending header and reports `pending_append`.
+  Encryption never falls back to an old epoch and never invents a missing key.
+  """
+  def reserve_publish_using_active_epoch(
+        %__MODULE__{} = store,
+        definition,
+        %ActiveEpochAppendRequest{} = request,
+        plaintext
+      ) do
+    require_definition!(store, definition, false)
+
+    unless request.originator_id == definition.originator.agent_id do
+      Epoch.fail!("invalid_plan")
+    end
+
+    reserve_loop(store, request, plaintext, Epoch.max_epoch_cas_attempts())
+  end
+
+  @doc """
+  Clear an in-flight reservation without publishing, releasing the CAS so a
+  blocked activation can proceed. The sequence is not rewound — D18P sequences
+  are append-only, so the abandoned slot simply stays empty.
+  """
+  def abandon_pending(%__MODULE__{} = store),
+    do: abandon_loop(store, Epoch.max_epoch_cas_attempts())
+
+  @doc "Load the immutable public plan for an epoch, or nil."
+  def activation_plan(%__MODULE__{} = store, new_epoch) do
+    key = Epoch.activation_plan_record_key(store.channel_id, new_epoch)
+
+    case backend!(fn -> Backend.get!(store.backend, Profile.storage_namespace(), key) end) do
+      nil ->
+        nil
+
+      record ->
+        require_envelope!(record, key, Epoch.activation_plan_content_type())
+        plan = Epoch.activation_plan_deserialize(record.body)
+
+        unless plan.channel_id == store.channel_id and plan.new_epoch == new_epoch do
+          Epoch.fail!("corrupt_record")
+        end
+
+        plan
+    end
+  end
+
+  @doc """
+  Wipe custody for a destroyed channel while leaving every public plan, grant,
+  and message exactly where it is. D18T revocation is prospective: it stops
+  future access, it does not rewrite history.
+  """
+  def apply_destruction(%__MODULE__{} = store, definition) do
+    require_definition!(store, definition, true)
+    Custody.destroy_channel!(store.custody, store.channel_id)
+    :ok
+  end
+
+  @doc """
+  Build one pure custody candidate from a trusted D18Q plan.
+
+  Two orderings matter here and they are different. D18Q grants are ordered by
+  *raw* receiver ID, because that is the order D18Q produces and the order the
+  grants must be replayed in. The public D18T plan entries are sorted by
+  receiver ID *hash*, because the plan must not reveal the raw roster. The two
+  orders are unrelated, so entries are derived from the D18Q order and
+  `new_activation_plan!/4` re-sorts for the wire.
+  """
+  def prepare_rotation_candidate(definition, base_epoch, target_roster, rotation) do
+    grants = rotation.grants
+    roster = Enum.to_list(target_roster)
+    count = length(roster)
+
+    unless count >= 1 and count <= Epoch.max_plan_receivers() and count == length(grants) do
+      Epoch.fail!("invalid_plan")
+    end
+
+    ordered = Enum.sort_by(roster, & &1.agent_id)
+
+    if length(Enum.uniq_by(ordered, & &1.agent_id)) != count, do: Epoch.fail!("invalid_plan")
+
+    ordered
+    |> Enum.zip(grants)
+    |> Enum.each(fn {receiver, grant} ->
+      # The epoch check lives here, not in verify_grant_signature: D18Q's
+      # signature covers the epoch but the verifier deliberately takes no
+      # expected epoch, so a validly signed grant for the wrong epoch would
+      # otherwise pass. D18T step 5 owns this comparison.
+      unless receiver.agent_id == grant.receiver_id and grant.key_epoch == rotation.new_epoch do
+        Epoch.fail!("invalid_plan")
+      end
+
+      verify_grant_public!(definition, grant, receiver.agent_id)
+    end)
+
+    if base_epoch == Epoch.max_u64(), do: Epoch.fail!("epoch_exhausted")
+    unless rotation.new_epoch == base_epoch + 1, do: Epoch.fail!("unexpected_epoch")
+
+    grant_bytes = Enum.map(grants, &serialize_grant!/1)
+
+    entries =
+      grants
+      |> Enum.zip(grant_bytes)
+      |> Enum.map(fn {grant, data} ->
+        Epoch.new_plan_entry!(Sha256.sha256(grant.receiver_id), Sha256.sha256(data))
+      end)
+
+    plan =
+      Epoch.new_activation_plan!(
+        definition.channel_id,
+        base_epoch,
+        rotation.new_epoch,
+        entries
+      )
+
+    public =
+      Custody.new_public_preparation(
+        definition.channel_id,
+        base_epoch,
+        rotation.new_epoch,
+        Epoch.activation_plan_serialize(plan),
+        grant_bytes
+      )
+
+    %PreparedEpoch{public_preparation: public, cmk: rotation.new_cmk}
+  end
+
+  @doc """
+  Re-derive the entire plan from the durable grants and require it to equal the
+  stored plan bytes.
+
+  This runs on every replay, including recovery after a crash, and is
+  deliberately not a shortcut comparison of the plan commitment. Recomputing
+  from the grants is what makes a tampered custody bundle detectable.
+  """
+  def validate_public_preparation(definition, prepared) do
+    grant_count = length(prepared.grants)
+
+    unless prepared.channel_id == definition.channel_id and
+             prepared.base_epoch != Epoch.max_u64() and
+             prepared.new_epoch == prepared.base_epoch + 1 and
+             grant_count >= 1 and grant_count <= Epoch.max_plan_receivers() do
+      Epoch.fail!("invalid_plan")
+    end
+
+    plan =
+      try do
+        Epoch.activation_plan_deserialize(prepared.plan_bytes)
+      rescue
+        _ -> Epoch.fail!("corrupt_record")
+      end
+
+    unless plan.channel_id == prepared.channel_id and plan.base_epoch == prepared.base_epoch and
+             plan.new_epoch == prepared.new_epoch and length(plan.receivers) == grant_count do
+      Epoch.fail!("invalid_plan")
+    end
+
+    {entries, _} =
+      Enum.map_reduce(prepared.grants, nil, fn data, previous ->
+        grant = deserialize_grant!(data)
+
+        unless grant.channel_id == prepared.channel_id and
+                 grant.key_epoch == prepared.new_epoch and
+                 (is_nil(previous) or previous < grant.receiver_id) do
+          Epoch.fail!("invalid_plan")
+        end
+
+        verify_grant_public!(definition, grant, grant.receiver_id)
+
+        entry = Epoch.new_plan_entry!(Sha256.sha256(grant.receiver_id), Sha256.sha256(data))
+        {entry, grant.receiver_id}
+      end)
+
+    expected =
+      Epoch.new_activation_plan!(
+        prepared.channel_id,
+        prepared.base_epoch,
+        prepared.new_epoch,
+        entries
+      )
+
+    unless plan == expected, do: Epoch.fail!("invalid_plan")
+    plan
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internal loops and helpers
+  # ---------------------------------------------------------------------------
+
+  defp migrate_loop(_store, _definition, _cmk, 0), do: Epoch.fail!("concurrent_update")
+
+  defp migrate_loop(store, definition, current_cmk, remaining) do
+    record = state_record(store)
+
+    if not is_nil(record) and record.content_type == Epoch.epoch_state_content_type() do
+      decoded = decode_v2_state_record(store, record)
+      # An existing version 2 state is an idempotent success only once custody
+      # proves its active epoch is still resolvable. Its epoch is never reset
+      # from the immutable definition.
+      if is_nil(resolve_handle(store, decoded.active_epoch)) do
+        Epoch.fail!("active_key_missing")
+      end
+
+      decoded
+    else
+      ensure_initial_key(store, definition.key_epoch, current_cmk)
+      next = build_migration_state(store, definition, record)
+
+      try do
+        stored =
+          backend_put!(
+            store.backend,
+            public_put(
+              Profile.state_key(store.channel_id),
+              Epoch.epoch_state_content_type(),
+              Epoch.epoch_state_serialize(next),
+              if_absent: is_nil(record),
+              if_revision: record && record.revision
+            )
+          )
+
+        decode_v2_state_record(store, stored)
+      rescue
+        StorageConflictError -> migrate_loop(store, definition, nil, remaining - 1)
+      end
+    end
+  end
+
+  defp activate_loop(_store, _definition, _new_epoch, _prepared, 0),
+    do: Epoch.fail!("concurrent_update")
+
+  defp activate_loop(store, definition, new_epoch, prepared, remaining) do
+    require_definition!(store, definition, false)
+    record = state_record(store)
+    if is_nil(record), do: Epoch.fail!("not_initialized")
+    current = decode_v2_state_record(store, record)
+    active = current.active_epoch
+
+    cond do
+      active == new_epoch ->
+        validate_and_replay(store, definition, prepared)
+        require_handle!(store, new_epoch)
+        "idempotent"
+
+      active > new_epoch ->
+        Epoch.fail!("decreasing_epoch")
+
+      active == Epoch.max_u64() ->
+        Epoch.fail!("epoch_exhausted")
+
+      active + 1 != new_epoch or prepared.base_epoch != active or prepared.new_epoch != new_epoch ->
+        Epoch.fail!("unexpected_epoch")
+
+      true ->
+        validate_and_replay(store, definition, prepared)
+        require_handle!(store, new_epoch)
+        # Checked last, immediately before the CAS: a reservation that landed
+        # during replay must still block this activation.
+        unless is_nil(current.pending_header), do: Epoch.fail!("pending_append")
+
+        updated = Epoch.with_active_epoch!(current, store.channel_id, new_epoch)
+
+        try do
+          stored =
+            backend_put!(
+              store.backend,
+              public_put(
+                Profile.state_key(store.channel_id),
+                Epoch.epoch_state_content_type(),
+                Epoch.epoch_state_serialize(updated),
+                if_revision: record.revision
+              )
+            )
+
+          unless decode_v2_state_record(store, stored) == updated do
+            Epoch.fail!("corrupt_record")
+          end
+
+          "activated"
+        rescue
+          StorageConflictError ->
+            activate_loop(store, definition, new_epoch, prepared, remaining - 1)
+        end
+    end
+  end
+
+  defp reserve_loop(_store, _request, _plaintext, 0), do: Epoch.fail!("concurrent_update")
+
+  defp reserve_loop(store, request, plaintext, remaining) do
+    record = state_record(store)
+    if is_nil(record), do: Epoch.fail!("not_initialized")
+    current = decode_v2_state_record(store, record)
+
+    if not is_nil(request.key_epoch) and request.key_epoch != current.active_epoch do
+      Epoch.fail!("unactivated_epoch")
+    end
+
+    handle = require_handle!(store, current.active_epoch)
+    unless is_nil(current.pending_header), do: Epoch.fail!("pending_append")
+    if current.next_sequence == Epoch.max_u64(), do: Epoch.fail!("crypto_error")
+
+    header =
+      try do
+        Profile.new_header!(%{
+          message_id: request.message_id,
+          timestamp_ns: request.timestamp_ns,
+          originator_id: request.originator_id,
+          channel_id: store.channel_id,
+          sequence: current.next_sequence,
+          key_epoch: current.active_epoch,
+          content_type: request.content_type,
+          plaintext_hash: Sha256.sha256(plaintext)
+        })
+      rescue
+        _ -> Epoch.fail!("crypto_error")
+      end
+
+    updated = Epoch.with_pending!(current, store.channel_id, current.next_sequence + 1, header)
+
+    try do
+      backend_put!(
+        store.backend,
+        public_put(
+          Profile.state_key(store.channel_id),
+          Epoch.epoch_state_content_type(),
+          Epoch.epoch_state_serialize(updated),
+          if_revision: record.revision
+        )
+      )
+
+      %EpochReservation{header: header, key_handle: handle}
+    rescue
+      StorageConflictError -> reserve_loop(store, request, plaintext, remaining - 1)
+    end
+  end
+
+  defp abandon_loop(_store, 0), do: Epoch.fail!("concurrent_update")
+
+  defp abandon_loop(store, remaining) do
+    record = state_record(store)
+    if is_nil(record), do: Epoch.fail!("not_initialized")
+    current = decode_v2_state_record(store, record)
+
+    case current.pending_header do
+      nil ->
+        nil
+
+      pending ->
+        updated = Epoch.with_pending!(current, store.channel_id, current.next_sequence)
+
+        try do
+          backend_put!(
+            store.backend,
+            public_put(
+              Profile.state_key(store.channel_id),
+              Epoch.epoch_state_content_type(),
+              Epoch.epoch_state_serialize(updated),
+              if_revision: record.revision
+            )
+          )
+
+          pending
+        rescue
+          StorageConflictError -> abandon_loop(store, remaining - 1)
+        end
+    end
+  end
+
+  defp build_migration_state(store, definition, nil) do
+    Epoch.new_epoch_state!(store.channel_id, definition.key_epoch, 0)
+  end
+
+  defp build_migration_state(store, definition, record) do
+    require_envelope!(record, Profile.state_key(store.channel_id), Profile.state_content_type())
+
+    prior =
+      try do
+        Profile.state_deserialize(record.body, store.channel_id)
+      rescue
+        _ -> Epoch.fail!("corrupt_record")
+      end
+
+    if not is_nil(prior.pending_header) and
+         prior.pending_header.key_epoch != definition.key_epoch do
+      Epoch.fail!("corrupt_record")
+    end
+
+    Epoch.new_epoch_state!(
+      store.channel_id,
+      definition.key_epoch,
+      prior.next_sequence,
+      prior.pending_header
+    )
+  end
+
+  defp ensure_initial_key(store, epoch, current_cmk) do
+    if is_nil(resolve_handle(store, epoch)) do
+      if is_nil(current_cmk), do: Epoch.fail!("active_key_missing")
+      import_initial_key(store, epoch, current_cmk)
+    end
+
+    :ok
+  end
+
+  defp import_initial_key(store, epoch, current_cmk) do
+    if is_nil(current_cmk), do: Epoch.fail!("active_key_missing")
+
+    selection =
+      Custody.import_active_if_absent!(store.custody, store.channel_id, epoch, current_cmk)
+
+    if selection == Custody.conflict(), do: Epoch.fail!("conflicting_active_key")
+    :ok
+  end
+
+  defp replay_preparation(store, definition, new_epoch) do
+    case Custody.load_preparation!(store.custody, store.channel_id, new_epoch) do
+      nil -> Epoch.fail!("preparation_missing")
+      prepared -> validate_and_replay(store, definition, prepared)
+    end
+  end
+
+  # Replay phases 3 through 6: re-validate the durable bundle, write the plan
+  # and every grant with create-if-absent, then reload and compare.
+  defp validate_and_replay(store, definition, prepared) do
+    plan = validate_public_preparation(definition, prepared)
+
+    put_immutable(
+      store,
+      Epoch.activation_plan_record_key(store.channel_id, plan.new_epoch),
+      Epoch.activation_plan_content_type(),
+      prepared.plan_bytes,
+      "conflicting_plan"
+    )
+
+    Enum.each(prepared.grants, fn data ->
+      grant = deserialize_grant!(data)
+
+      put_immutable(
+        store,
+        Profile.grant_key(store.channel_id, grant.key_epoch, grant.receiver_id),
+        Profile.grant_content_type(),
+        data,
+        "conflicting_grant"
+      )
+    end)
+
+    stored = activation_plan(store, plan.new_epoch)
+    if is_nil(stored) or stored != plan, do: Epoch.fail!("corrupt_record")
+
+    # Phase 6 reloads every grant too. This is invariant 3, "all grants before
+    # visibility" — not paranoia about our own writes. The record a put echoes
+    # back sits on the same trust boundary as the write itself, so against a
+    # write-behind or eventually-consistent backend an echoed success does not
+    # prove the grant is retrievable. Activation may only advance the epoch once
+    # every receiver's grant can actually be read.
+    Enum.each(prepared.grants, fn data ->
+      grant = deserialize_grant!(data)
+      key = Profile.grant_key(store.channel_id, grant.key_epoch, grant.receiver_id)
+
+      case backend!(fn -> Backend.get!(store.backend, Profile.storage_namespace(), key) end) do
+        nil ->
+          Epoch.fail!("corrupt_record")
+
+        record ->
+          require_envelope!(record, key, Profile.grant_content_type())
+          # corrupt_record, not conflicting_grant: put_immutable already reports
+          # a genuine slot conflict, so reaching here means the backend returned
+          # something other than what it acknowledged writing.
+          unless record.body == data, do: Epoch.fail!("corrupt_record")
+      end
+    end)
+
+    :ok
+  end
+
+  defp require_handle!(store, epoch) do
+    case resolve_handle(store, epoch) do
+      nil -> Epoch.fail!("active_key_missing")
+      handle -> handle
+    end
+  end
+
+  defp resolve_handle(store, epoch),
+    do: Custody.resolve_handle!(store.custody, store.channel_id, epoch)
+
+  defp require_definition!(store, expected, require_destroyed) do
+    unless expected.channel_id == store.channel_id, do: Epoch.fail!("invalid_plan")
+
+    actual =
+      try do
+        ChannelDefinitionStore.load!(ChannelDefinitionStore.new(store.backend), store.channel_id)
+      rescue
+        error in [ProfileError] -> raise translate_store_error(error)
+      end
+
+    if is_nil(actual), do: Epoch.fail!("not_initialized")
+    unless actual == expected, do: Epoch.fail!("invalid_plan")
+
+    cond do
+      require_destroyed and actual.lifecycle != "destroyed" -> Epoch.fail!("invalid_plan")
+      not require_destroyed and actual.lifecycle == "destroyed" -> Epoch.fail!("channel_destroyed")
+      true -> :ok
+    end
+  end
+
+  # Every backend call goes through here.
+  #
+  # D18P's own Backend.get!/put! already map an injected-backend failure to a
+  # ProfileError, which is a *foreign* exception as far as a D18T caller is
+  # concerned. The stable-error contract says every failure this API raises is
+  # an ActivationError carrying one of the 19 codes, so a caller rescuing
+  # ActivationError would otherwise miss storage failures entirely. Rust and
+  # Ruby both translate at this boundary; this keeps Elixir from being the
+  # outlier.
+  #
+  # StorageConflictError deliberately passes through untouched: the CAS loops
+  # rescue it to retry, and turning it into an ActivationError here would break
+  # every one of them.
+  defp backend!(operation) when is_function(operation, 0) do
+    operation.()
+  rescue
+    error in [Epoch.ActivationError] -> raise error
+    error in [StorageConflictError] -> raise error
+    error in [ProfileError] -> raise translate_store_error(error)
+  end
+
+  # The CAS loops call this instead of Backend.put! directly, so a backend
+  # failure becomes an ActivationError while a genuine conflict still reaches
+  # the surrounding retry rescue untouched.
+  defp backend_put!(backend, value), do: backend!(fn -> Backend.put!(backend, value) end)
+
+  defp state_record(store) do
+    backend!(fn ->
+      Backend.get!(store.backend, Profile.storage_namespace(), Profile.state_key(store.channel_id))
+    end)
+  end
+
+  defp decode_v2_state_record(store, record) do
+    require_envelope!(
+      record,
+      Profile.state_key(store.channel_id),
+      Epoch.epoch_state_content_type()
+    )
+
+    Epoch.epoch_state_deserialize(record.body, store.channel_id)
+  end
+
+  defp require_envelope!(record, key, content_type) do
+    unless record.namespace == Profile.storage_namespace() and record.key == key and
+             record.content_type == content_type do
+      Epoch.fail!("corrupt_record")
+    end
+
+    :ok
+  end
+
+  defp put_immutable(store, key, content_type, body, conflict_code) do
+    record =
+      backend!(fn ->
+        Backend.put!(store.backend, public_put(key, content_type, body, if_absent: true))
+      end)
+    require_envelope!(record, key, content_type)
+    unless record.body == body, do: Epoch.fail!("corrupt_record")
+    :ok
+  rescue
+    StorageConflictError ->
+      case backend!(fn -> Backend.get!(store.backend, Profile.storage_namespace(), key) end) do
+        nil ->
+          Epoch.fail!("corrupt_record")
+
+        existing ->
+          require_envelope!(existing, key, content_type)
+          unless existing.body == body, do: Epoch.fail!(conflict_code)
+          :ok
+      end
+  end
+
+  defp public_put(key, content_type, body, options) do
+    %StoragePut{
+      namespace: Profile.storage_namespace(),
+      key: key,
+      content_type: content_type,
+      body: body,
+      if_absent: Keyword.get(options, :if_absent, false),
+      if_revision: Keyword.get(options, :if_revision)
+    }
+  end
+
+  defp initialize!(backend) do
+    Backend.initialize!(backend)
+  rescue
+    _ -> Epoch.fail!("storage_error")
+  end
+
+  defp serialize_grant!(grant) do
+    Grants.grant_serialize(grant)
+  rescue
+    error in [Epoch.ActivationError] -> raise error
+    _ -> Epoch.fail!("crypto_error")
+  end
+
+  defp deserialize_grant!(data) do
+    Grants.grant_deserialize(data)
+  rescue
+    error in [Epoch.ActivationError] -> raise error
+    _ -> Epoch.fail!("crypto_error")
+  end
+
+  defp verify_grant_public!(definition, grant, receiver_id) do
+    Grants.verify_grant_signature(
+      grant,
+      definition.originator.agent_id,
+      receiver_id,
+      definition.channel_id,
+      definition.originator.public_key
+    )
+  rescue
+    error in [Epoch.ActivationError] -> raise error
+    _ -> Epoch.fail!("crypto_error")
+  end
+
+  # Map D18P codes onto the D18T roster. Anything without a D18T meaning becomes
+  # storage_error rather than leaking a foreign code.
+  defp translate_store_error(%ProfileError{code: code}) do
+    mapped =
+      case code do
+        "channel_destroyed" -> "channel_destroyed"
+        code when code in ["conflicting_definition", "definition_changed"] -> "invalid_plan"
+        code when code in ["corrupt_definition", "corrupt_record"] -> "corrupt_record"
+        code when code in ["definition_not_found", "not_initialized"] -> "not_initialized"
+        _ -> "storage_error"
+      end
+
+    %Epoch.ActivationError{code: mapped}
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/mix.exs
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/mix.exs
@@ -1,0 +1,28 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :coding_adventures_chief_of_staff_channel_epoch_activation,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      test_coverage: [summary: [threshold: 80]]
+    ]
+  end
+
+  def application, do: [extra_applications: [:logger]]
+
+  defp deps do
+    [
+      {:coding_adventures_chief_of_staff_channel_crypto,
+       path: "../chief-of-staff-channel-crypto"},
+      {:coding_adventures_chief_of_staff_channel_store,
+       path: "../chief-of-staff-channel-store"},
+      {:coding_adventures_ct_compare, path: "../ct-compare"},
+      {:coding_adventures_sha256, path: "../sha256"},
+      {:jason, "~> 1.4"}
+    ]
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/mix.lock
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "jason": {:hex, :jason, "1.4.5", "2e3a008590b0b8d7388c20293e9dcc9cf3e5d642fd2a114e4cbbb52e595d940a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684"},
+}

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/required_capabilities.json
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/required_capabilities.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "package": "elixir/chief-of-staff-channel-epoch-activation",
+  "capabilities": [],
+  "justification": "Pure D18T epoch-activation codecs and transitions over caller-supplied bytes, an injected public storage backend, and an injected secret-custody boundary. Opens no files and no sockets; the canonical fixture manifest is read only by tests."
+}

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/d18t_fixtures_test.exs
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/d18t_fixtures_test.exs
@@ -1,0 +1,241 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.D18TFixturesTest do
+  @moduledoc """
+  Direct consumers of the canonical Rust-authored D18T manifest.
+
+  These never regenerate expected bytes locally and never shell out to another
+  language — that is the whole point of a shared fixture. If Elixir disagrees
+  with Rust about a single octet, they fail.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile, as: Grants
+  alias CodingAdventures.ChiefOfStaffChannelStore, as: Profile
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation, as: Epoch
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.ActivationError
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Store, as: EpochStore
+
+  @fixture_path Path.expand(
+                  "../../../../fixtures/chief-of-staff-channel-epoch-activation/v1/manifest.json",
+                  __DIR__
+                )
+  @fixture_text File.read!(@fixture_path)
+  @fixture Jason.decode!(@fixture_text)
+  @channel_id Base.decode16!("018f47a09b6c7def923456789abcdef0", case: :lower)
+
+  defp decode(value), do: Base.decode64!(value)
+  defp from_hex(value), do: Base.decode16!(value, case: :lower)
+
+  defp assert_code(code, operation) do
+    error = assert_raise ActivationError, operation
+    assert error.code == code
+    error
+  end
+
+  test "manifest contract, roster, and secret boundary" do
+    assert @fixture["fixture_format"] == "D18T-durable-epoch-activation-fixtures-v1"
+
+    assert @fixture["spec"] ==
+             "code/specs/D18T-chief-of-staff-durable-epoch-activation-profile.md"
+
+    assert @fixture["warning"] =~ "Never log"
+
+    assert @fixture["constants"] == %{
+             "state_magic_ascii" => "D18S",
+             "state_version" => "2",
+             "plan_magic_ascii" => "D18T",
+             "plan_version" => "1",
+             "state_content_type" => Epoch.epoch_state_content_type(),
+             "plan_content_type" => Epoch.activation_plan_content_type(),
+             "max_cas_attempts" => Integer.to_string(Epoch.max_epoch_cas_attempts())
+           }
+
+    # The error roster is closed AND ordered. A gate that only checked
+    # membership would not notice a reordering, and six languages index it.
+    assert @fixture["stable_error_codes"] == Epoch.error_codes()
+
+    assert Enum.map(@fixture["crash_replay_traces"], & &1["name"]) == [
+             "after-custody-selection",
+             "after-plan-write",
+             "after-first-grant",
+             "after-all-grants",
+             "after-activation-cas"
+           ]
+
+    assert length(@fixture["race_traces"]) == 4
+    assert length(@fixture["negative_scenarios"]) == 6
+
+    # Rust guarantees erasure; the BEAM honestly cannot. The fixture records
+    # Rust's claim, and Elixir must report its own rather than echo it.
+    assert @fixture["secret_erasure_capability"] == "guaranteed"
+    assert Epoch.secret_erasure_capability() == "not_enforceable"
+
+    # Every labelled test-only secret must appear exactly once in the whole
+    # manifest. A second occurrence would mean a secret leaked into a summary, a
+    # public record, or an expected-error string.
+    Enum.each(@fixture["test_only_secrets"], fn {name, secret} ->
+      occurrences = length(String.split(@fixture_text, secret)) - 1
+      assert occurrences == 1, "secret #{name} must appear exactly once, saw #{occurrences}"
+    end)
+  end
+
+  test "exact v1 to v2 state migrations" do
+    assert Enum.map(@fixture["state_migrations"], & &1["name"]) == ["no-pending", "pending-d18h"]
+
+    Enum.each(@fixture["state_migrations"], fn vector ->
+      v1 = Profile.state_deserialize(decode(vector["d18s_v1_b64"]), @channel_id)
+      expected = decode(vector["d18s_v2_b64"])
+      v2 = Epoch.epoch_state_deserialize(expected, @channel_id)
+
+      assert v2.active_epoch == String.to_integer(vector["active_epoch"])
+      assert v2.next_sequence == String.to_integer(vector["next_sequence"])
+      assert v2.next_sequence == v1.next_sequence
+      # Migration preserves the in-flight reservation exactly; it never clears a
+      # publish that was already reserved, and never invents one.
+      assert v2.pending_header == v1.pending_header
+      assert Epoch.epoch_state_serialize(v2) == expected
+    end)
+  end
+
+  test "consumes and re-encodes the canonical activation plan" do
+    activation = @fixture["activation_case"]
+    expected = decode(activation["plan_b64"])
+    plan = Epoch.activation_plan_deserialize(expected)
+
+    assert plan.channel_id == @channel_id
+    assert {plan.base_epoch, plan.new_epoch, length(plan.receivers)} == {0, 1, 1}
+    assert Epoch.activation_plan_serialize(plan) == expected
+
+    assert Epoch.activation_plan_record_key(@channel_id, 1) == activation["plan_record_key"]
+    assert activation["plan_content_type"] == Epoch.activation_plan_content_type()
+
+    # Prospective revocation, stated as data: A is rotated out at epoch 1, so A
+    # gets no new grant and keeps only epoch 0, while B keeps both.
+    assert length(activation["grant_b64"]) == 1
+    assert activation["receiver_a_new_grant"] == nil
+    assert activation["receiver_a_retains_epochs"] == ["0"]
+    assert activation["receiver_b_retains_epochs"] == ["0", "1"]
+  end
+
+  # The strongest fixture test here. It rebuilds the candidate from the labelled
+  # test-only secrets using Elixir's own D18Q and D18T code and requires the
+  # result to equal the bytes Rust authored — plan and grant alike.
+  test "reproduces the Rust-authored plan and grant bytes" do
+    secrets = @fixture["test_only_secrets"]
+    signer = Grants.originator_signing_key_from_seed(from_hex(secrets["originator_signing_seed_hex"]))
+
+    receiver_a_key =
+      Grants.receiver_key_pair_from_private_key(from_hex(secrets["receiver_a_private_key_hex"]))
+
+    receiver_b_key =
+      Grants.receiver_key_pair_from_private_key(from_hex(secrets["receiver_b_private_key_hex"]))
+
+    receiver_a = Profile.new_receiver!("receiver-a", Grants.receiver_public_key(receiver_a_key))
+    receiver_b = Profile.new_receiver!("receiver-b", Grants.receiver_public_key(receiver_b_key))
+
+    definition =
+      Profile.new_definition!(
+        @channel_id,
+        Profile.new_originator!("originator", Grants.originator_public_key(signer)),
+        [receiver_a, receiver_b],
+        1_725_000_000_000_000_000,
+        0
+      )
+
+    rotation =
+      Grants.plan_rotation(
+        "originator",
+        @channel_id,
+        0,
+        Grants.channel_master_key_from_bytes(from_hex(secrets["next_cmk_hex"])),
+        [
+          Grants.rotation_receiver_with_material(
+            receiver_b.agent_id,
+            receiver_b.public_key,
+            from_hex(secrets["ephemeral_private_key_hex"]),
+            from_hex(secrets["wrapping_nonce_hex"])
+          )
+        ],
+        signer
+      )
+
+    prepared = EpochStore.prepare_rotation_candidate(definition, 0, [receiver_b], rotation)
+    public = prepared.public_preparation
+
+    assert public.plan_bytes == decode(@fixture["activation_case"]["plan_b64"]),
+           "Elixir produced different D18T plan bytes than the canonical Rust manifest"
+
+    assert public.grants == Enum.map(@fixture["activation_case"]["grant_b64"], &decode/1),
+           "Elixir produced different D18G bytes than the canonical Rust manifest"
+
+    # The candidate redacts under inspection.
+    assert inspect(prepared) =~ "PreparedEpoch"
+    refute inspect(prepared) =~ "cmk"
+  end
+
+  test "rejects malformed state records" do
+    canonical = decode(@fixture["state_migrations"] |> hd() |> Map.fetch!("d18s_v2_b64"))
+    size = byte_size(canonical)
+
+    [
+      {"truncated", binary_part(canonical, 0, size - 1)},
+      {"trailing-byte", canonical <> <<0>>},
+      {"wrong-version", mutate(canonical, 4, 3)},
+      {"unknown-pending-flag", mutate(canonical, size - 1, 2)},
+      {"wrong-magic", mutate(canonical, 0, ?X)}
+    ]
+    |> Enum.each(fn {name, mutated} ->
+      error =
+        assert_raise ActivationError, fn -> Epoch.epoch_state_deserialize(mutated, @channel_id) end
+
+      assert error.code == "corrupt_record", name
+    end)
+  end
+
+  test "rejects non-canonical plans" do
+    canonical = decode(@fixture["activation_case"]["plan_b64"])
+
+    assert_code("corrupt_record", fn ->
+      Epoch.activation_plan_deserialize(canonical <> <<0>>)
+    end)
+
+    # A two-receiver plan whose entries descend by receiver hash. The decoder
+    # must reject it rather than silently canonicalize — which is exactly what
+    # new_activation_plan!/4 alone would have done, since it sorts its input.
+    descending =
+      binary_part(canonical, 0, 37) <>
+        <<2::unsigned-big-32>> <>
+        :binary.copy(<<4>>, 32) <>
+        :binary.copy(<<3>>, 32) <> :binary.copy(<<2>>, 32) <> :binary.copy(<<1>>, 32)
+
+    assert_code("corrupt_record", fn -> Epoch.activation_plan_deserialize(descending) end)
+
+    entry = Epoch.new_plan_entry!(:binary.copy(<<1>>, 32), :binary.copy(<<2>>, 32))
+    other = Epoch.new_plan_entry!(:binary.copy(<<1>>, 32), :binary.copy(<<3>>, 32))
+
+    # Two distinct receivers hashing to the same value is a collision, and D18T
+    # treats a collision as invalid input rather than equal authorization.
+    assert_code("corrupt_record", fn ->
+      Epoch.new_activation_plan!(@channel_id, 0, 1, [entry, other])
+    end)
+
+    assert_code("corrupt_record", fn -> Epoch.new_activation_plan!(@channel_id, 0, 1, []) end)
+    assert_code("corrupt_record", fn -> Epoch.new_activation_plan!(@channel_id, 0, 2, [entry]) end)
+
+    # A 16-octet channel id that is not a real UUID v7 is rejected, matching
+    # Rust and Python. Accepting it would mean two conforming implementations
+    # disagreed about whether the same plan record is valid.
+    assert_code("corrupt_record", fn ->
+      Epoch.new_activation_plan!(mutate(@channel_id, 6, 0x4F), 0, 1, [entry])
+    end)
+
+    assert_code("corrupt_record", fn ->
+      Epoch.new_activation_plan!(mutate(@channel_id, 8, 0x1F), 0, 1, [entry])
+    end)
+  end
+
+  defp mutate(binary, index, byte) do
+    binary_part(binary, 0, index) <>
+      <<byte>> <> binary_part(binary, index + 1, byte_size(binary) - index - 1)
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/invariant_three_test.exs
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/invariant_three_test.exs
@@ -1,0 +1,293 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.InvariantThreeTest do
+  @moduledoc """
+  Invariant 3: "all grants before visibility".
+
+  Writing a grant successfully is not the same as being able to read it back.
+  The record a put echoes sits on the same trust boundary as the write, so
+  against a write-behind or eventually-consistent backend an echoed success
+  proves nothing. Activation must re-READ every grant and byte-compare before
+  advancing the epoch — otherwise it can make E+1 current while a receiver's
+  grant is unretrievable, locking that receiver out of a channel it was
+  authorized for.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile, as: Grants
+  alias CodingAdventures.ChiefOfStaffChannelStore, as: Profile
+  alias CodingAdventures.ChiefOfStaffChannelStore.MemoryChannelStorage
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation, as: Epoch
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.ActivationError
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody.InMemory
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Store, as: EpochStore
+
+  @channel_id Base.decode16!("018f47a09b6c7def923456789abcdef0", case: :lower)
+  @current_cmk :binary.copy(<<0x22>>, 32)
+  @next_cmk :binary.copy(<<0x33>>, 32)
+
+  defmodule GrantFaultBackend do
+    @moduledoc """
+    Accepts writes normally; diverges only on reads of one grant key.
+
+    Corrupting an already-written record would NOT test this. Activation replays
+    through put_immutable first, whose if-absent put conflicts, re-gets, and
+    returns before control ever reaches the phase-6 loop — so such a test passes
+    even with the entire invariant-3 check deleted. That is exactly how the Go
+    port's first attempt at this test went wrong. Skipping one read aims the
+    fault at phase 6.
+    """
+    use Agent
+
+    alias CodingAdventures.ChiefOfStaffChannelStore.MemoryChannelStorage
+
+    @enforce_keys [:inner, :grant_key, :pid]
+    defstruct @enforce_keys
+
+    def new!(inner, grant_key) do
+      {:ok, pid} = Agent.start_link(fn -> %{fault: :healthy, skip_reads: 1} end)
+      %__MODULE__{inner: inner, grant_key: grant_key, pid: pid}
+    end
+
+    def arm(%__MODULE__{pid: pid}, fault),
+      do: Agent.update(pid, &Map.put(&1, :fault, fault))
+
+    def reads(%__MODULE__{pid: pid}), do: Agent.get(pid, &Map.get(&1, :reads, 0))
+
+    def initialize(%__MODULE__{inner: inner}), do: MemoryChannelStorage.initialize(inner)
+
+    def get(%__MODULE__{} = backend, namespace, key) do
+      record = MemoryChannelStorage.get(backend.inner, namespace, key)
+
+      if is_nil(record) or key != backend.grant_key do
+        record
+      else
+        Agent.get_and_update(backend.pid, fn state ->
+          counted = Map.update(state, :reads, 1, &(&1 + 1))
+
+          cond do
+            counted.skip_reads > 0 ->
+              {record, %{counted | skip_reads: counted.skip_reads - 1}}
+
+            counted.fault == :vanishes ->
+              {nil, counted}
+
+            counted.fault == :mutated_body ->
+              {%{record | body: record.body <> <<0>>}, counted}
+
+            counted.fault == :mutated_content_type ->
+              {%{record | content_type: "application/vnd.wrong"}, counted}
+
+            true ->
+              {record, counted}
+          end
+        end)
+      end
+    end
+
+    def put(%__MODULE__{inner: inner}, value), do: MemoryChannelStorage.put(inner, value)
+
+    def list(%__MODULE__{inner: inner}, namespace, options),
+      do: MemoryChannelStorage.list(inner, namespace, options)
+  end
+
+  setup do
+    signer = Grants.originator_signing_key_from_seed(:binary.copy(<<0x11>>, 32))
+    receiver_a_key = Grants.receiver_key_pair_from_private_key(:binary.copy(<<0x41>>, 32))
+    receiver_b_key = Grants.receiver_key_pair_from_private_key(:binary.copy(<<0x42>>, 32))
+    receiver_a = Profile.new_receiver!("receiver-a", Grants.receiver_public_key(receiver_a_key))
+    receiver_b = Profile.new_receiver!("receiver-b", Grants.receiver_public_key(receiver_b_key))
+
+    definition =
+      Profile.new_definition!(
+        @channel_id,
+        Profile.new_originator!("originator", Grants.originator_public_key(signer)),
+        [receiver_a, receiver_b],
+        1_725_000_000_000_000_000,
+        0
+      )
+
+    %{signer: signer, receiver_b: receiver_b, definition: definition}
+  end
+
+  defp rotation(context) do
+    Grants.plan_rotation(
+      "originator",
+      @channel_id,
+      0,
+      Grants.channel_master_key_from_bytes(@next_cmk),
+      [
+        Grants.rotation_receiver_with_material(
+          context.receiver_b.agent_id,
+          context.receiver_b.public_key,
+          :binary.copy(<<0x51>>, 32),
+          :binary.copy(<<0x61>>, 24)
+        )
+      ],
+      context.signer
+    )
+  end
+
+  defp prepared_channel(context) do
+    backend = MemoryChannelStorage.new!()
+    custody = InMemory.new!()
+    store = EpochStore.open_for_testing(backend, custody, @channel_id)
+
+    EpochStore.create_epoch_channel(
+      store,
+      context.definition,
+      Grants.channel_master_key_from_bytes(@current_cmk)
+    )
+
+    EpochStore.prepare_rotation(store, context.definition, [context.receiver_b], rotation(context))
+    {backend, custody}
+  end
+
+  defp grant_key(context),
+    do: Profile.grant_key(@channel_id, 1, context.receiver_b.agent_id)
+
+  test "activation refuses when a grant is not retrievable", context do
+    Enum.each([:vanishes, :mutated_body, :mutated_content_type], fn fault ->
+      {backend, custody} = prepared_channel(context)
+      faulty = GrantFaultBackend.new!(backend, grant_key(context))
+      store = EpochStore.open_for_testing(faulty, custody, @channel_id)
+      # Arm the fault only AFTER prepare has written the grant cleanly, so the
+      # write genuinely succeeds and only the read-back diverges.
+      GrantFaultBackend.arm(faulty, fault)
+
+      error =
+        assert_raise ActivationError, fn ->
+          EpochStore.activate_prepared_epoch(store, context.definition, 1)
+        end
+
+      assert error.code == "corrupt_record", "#{fault}"
+
+      # The epoch must not have advanced.
+      GrantFaultBackend.arm(faulty, :healthy)
+      assert EpochStore.state(store).active_epoch == 0, "#{fault}"
+    end)
+  end
+
+  # Guard against the phase-6 loop being skipped entirely. Without this, a
+  # refactor that drops the read-back would leave the test above passing via
+  # some earlier check.
+  test "the grant read-back is reached at all", context do
+    {backend, custody} = prepared_channel(context)
+    counting = GrantFaultBackend.new!(backend, grant_key(context))
+    store = EpochStore.open_for_testing(counting, custody, @channel_id)
+
+    assert EpochStore.activate_prepared_epoch(store, context.definition, 1) == "activated"
+
+    # One read from put_immutable's conflict path, one from phase 6.
+    reads = GrantFaultBackend.reads(counting)
+    assert reads >= 2, "expected the grant to be re-read during replay, saw #{reads} read(s)"
+  end
+
+  # Tampered custody bundles are rejected, which is why
+  # validate_public_preparation recomputes the plan from the grants instead of
+  # trusting the stored commitment.
+  test "tampered custody bundles are rejected", context do
+    {_backend, custody} = prepared_channel(context)
+    genuine = InMemory.load_preparation(custody, @channel_id, 1)
+    assert genuine != nil
+
+    [
+      {%{genuine | plan_bytes: "not a plan"}, "corrupt_record"},
+      {%{genuine | base_epoch: 5, new_epoch: 6}, "invalid_plan"},
+      {%{genuine | grants: []}, "invalid_plan"},
+      {%{genuine | grants: ["not a grant"]}, "crypto_error"}
+    ]
+    |> Enum.each(fn {bundle, code} ->
+      error =
+        assert_raise ActivationError, fn ->
+          EpochStore.validate_public_preparation(context.definition, bundle)
+        end
+
+      assert error.code == code
+    end)
+  end
+
+  # Proves the D18T layer actually checks signatures rather than trusting
+  # whatever custody produced. This is the test that would fail if
+  # verify_grant_signature were dropped from the validation path.
+  test "a grant signed by another originator is rejected", context do
+    impostor = Grants.originator_signing_key_from_seed(:binary.copy(<<0x12>>, 32))
+
+    forged =
+      Grants.plan_rotation(
+        "originator",
+        @channel_id,
+        0,
+        Grants.channel_master_key_from_bytes(@next_cmk),
+        [
+          Grants.rotation_receiver_with_material(
+            context.receiver_b.agent_id,
+            context.receiver_b.public_key,
+            :binary.copy(<<0x57>>, 32),
+            :binary.copy(<<0x67>>, 24)
+          )
+        ],
+        impostor
+      )
+
+    error =
+      assert_raise ActivationError, fn ->
+        EpochStore.prepare_rotation_candidate(context.definition, 0, [context.receiver_b], forged)
+      end
+
+    assert error.code == "crypto_error"
+  end
+
+  test "the D18T error roster is closed", _context do
+    assert length(Epoch.error_codes()) == 19
+    assert Enum.uniq(Epoch.error_codes()) == Epoch.error_codes()
+  end
+
+  defmodule RaisingBackend do
+    @moduledoc """
+    A backend whose reads and writes fail. D18P's own dispatch turns that into a
+    ProfileError, which is a *foreign* exception to a D18T caller.
+    """
+    alias CodingAdventures.ChiefOfStaffChannelStore.MemoryChannelStorage
+
+    @enforce_keys [:inner, :mode]
+    defstruct @enforce_keys
+
+    def new!(inner, mode), do: %__MODULE__{inner: inner, mode: mode}
+
+    def initialize(%__MODULE__{inner: inner}), do: MemoryChannelStorage.initialize(inner)
+
+    def get(%__MODULE__{mode: :get} = _backend, _namespace, _key),
+      do: raise(RuntimeError, "injected backend failure")
+
+    def get(%__MODULE__{inner: inner}, namespace, key),
+      do: MemoryChannelStorage.get(inner, namespace, key)
+
+    def put(%__MODULE__{mode: :put}, _value), do: raise(RuntimeError, "injected backend failure")
+    def put(%__MODULE__{inner: inner}, value), do: MemoryChannelStorage.put(inner, value)
+
+    def list(%__MODULE__{inner: inner}, namespace, options),
+      do: MemoryChannelStorage.list(inner, namespace, options)
+  end
+
+  # Every failure this API raises must be an ActivationError carrying one of the
+  # 19 stable codes. Without translation at the backend boundary a caller
+  # rescuing ActivationError would silently miss storage failures, because D18P
+  # raises its own ProfileError there. Rust and Ruby both translate; this keeps
+  # Elixir from being the outlier.
+  test "backend failures surface as ActivationError, not a foreign exception", context do
+    {backend, custody} = prepared_channel(context)
+
+    reading = EpochStore.open_for_testing(RaisingBackend.new!(backend, :get), custody, @channel_id)
+    writing = EpochStore.open_for_testing(RaisingBackend.new!(backend, :put), custody, @channel_id)
+
+    [
+      {"state", fn -> EpochStore.state(reading) end},
+      {"activation_plan", fn -> EpochStore.activation_plan(reading, 1) end},
+      {"activate", fn -> EpochStore.activate_prepared_epoch(writing, context.definition, 1) end}
+    ]
+    |> Enum.each(fn {name, operation} ->
+      error = assert_raise ActivationError, operation
+      assert error.code in Epoch.error_codes(), "#{name} produced #{error.code}"
+    end)
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/orchestration_test.exs
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/orchestration_test.exs
@@ -1,0 +1,465 @@
+defmodule CodingAdventures.ChiefOfStaffChannelEpochActivation.OrchestrationTest do
+  @moduledoc "Crash, retry, activation, publish, race, and destruction orchestration."
+
+  use ExUnit.Case, async: true
+
+  alias CodingAdventures.ChiefOfStaffChannelCrypto.KeyGrantProfile, as: Grants
+  alias CodingAdventures.ChiefOfStaffChannelStore, as: Profile
+  alias CodingAdventures.ChiefOfStaffChannelStore.{ChannelDefinitionStore, MemoryChannelStorage}
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.ActivationError
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.ActiveEpochAppendRequest
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody.InMemory
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.EpochKeyHandle
+  alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Store, as: EpochStore
+
+  @channel_id Base.decode16!("018f47a09b6c7def923456789abcdef0", case: :lower)
+  @message_id Base.decode16!("018f47a09b6c7def923456789abcdef1", case: :lower)
+  @current_cmk :binary.copy(<<0x22>>, 32)
+  @next_cmk :binary.copy(<<0x33>>, 32)
+
+  defmodule DurableMemory do
+    @moduledoc """
+    InMemory custody that claims durability, so the production constructor
+    accepts it. Only tests may do this; the point of the durable?/1 split is
+    that a real deployment cannot.
+    """
+    alias CodingAdventures.ChiefOfStaffChannelEpochActivation.Custody.InMemory
+
+    @enforce_keys [:inner]
+    defstruct @enforce_keys
+
+    def new!, do: %__MODULE__{inner: InMemory.new!()}
+    def durable?(%__MODULE__{}), do: true
+
+    def import_active_if_absent(%__MODULE__{inner: inner}, channel_id, epoch, cmk),
+      do: InMemory.import_active_if_absent(inner, channel_id, epoch, cmk)
+
+    def resolve_handle(%__MODULE__{inner: inner}, channel_id, epoch),
+      do: InMemory.resolve_handle(inner, channel_id, epoch)
+
+    def prepare_if_absent(%__MODULE__{inner: inner}, prepared),
+      do: InMemory.prepare_if_absent(inner, prepared)
+
+    def load_preparation(%__MODULE__{inner: inner}, channel_id, new_epoch),
+      do: InMemory.load_preparation(inner, channel_id, new_epoch)
+
+    def with_key(%__MODULE__{inner: inner}, handle, operation),
+      do: InMemory.with_key(inner, handle, operation)
+
+    def destroy_channel(%__MODULE__{inner: inner}, channel_id),
+      do: InMemory.destroy_channel(inner, channel_id)
+  end
+
+  setup do
+    signer = Grants.originator_signing_key_from_seed(:binary.copy(<<0x11>>, 32))
+    receiver_a_key = Grants.receiver_key_pair_from_private_key(:binary.copy(<<0x41>>, 32))
+    receiver_b_key = Grants.receiver_key_pair_from_private_key(:binary.copy(<<0x42>>, 32))
+    receiver_a = Profile.new_receiver!("receiver-a", Grants.receiver_public_key(receiver_a_key))
+    receiver_b = Profile.new_receiver!("receiver-b", Grants.receiver_public_key(receiver_b_key))
+
+    definition =
+      Profile.new_definition!(
+        @channel_id,
+        Profile.new_originator!("originator", Grants.originator_public_key(signer)),
+        [receiver_a, receiver_b],
+        1_725_000_000_000_000_000,
+        0
+      )
+
+    backend = MemoryChannelStorage.new!()
+    custody = InMemory.new!()
+    store = EpochStore.open_for_testing(backend, custody, @channel_id)
+
+    %{
+      signer: signer,
+      receiver_a: receiver_a,
+      receiver_b: receiver_b,
+      definition: definition,
+      backend: backend,
+      custody: custody,
+      store: store
+    }
+  end
+
+  defp create(context) do
+    state =
+      EpochStore.create_epoch_channel(
+        context.store,
+        context.definition,
+        Grants.channel_master_key_from_bytes(@current_cmk)
+      )
+
+    assert state.active_epoch == 0
+    assert state.next_sequence == 0
+    assert state.pending_header == nil
+    state
+  end
+
+  defp rotation(context, cmk \\ @next_cmk, ephemeral \\ nil, nonce \\ nil) do
+    Grants.plan_rotation(
+      "originator",
+      @channel_id,
+      0,
+      Grants.channel_master_key_from_bytes(cmk),
+      [
+        Grants.rotation_receiver_with_material(
+          context.receiver_b.agent_id,
+          context.receiver_b.public_key,
+          ephemeral || :binary.copy(<<0x51>>, 32),
+          nonce || :binary.copy(<<0x61>>, 24)
+        )
+      ],
+      context.signer
+    )
+  end
+
+  defp assert_code(code, operation) do
+    error = assert_raise ActivationError, operation
+    assert error.code == code
+    # The message is exactly the code -- no channel bytes, no epoch numbers.
+    assert Exception.message(error) == code
+    error
+  end
+
+  test "production rejects non-durable custody and accepts durable", context do
+    assert_code("custody_error", fn ->
+      EpochStore.open(context.backend, InMemory.new!(), @channel_id)
+    end)
+
+    # The same custody, wrapped in a type that honestly claims durability, is
+    # accepted -- so the gate is on the declaration, not on the type.
+    durable = EpochStore.open(MemoryChannelStorage.new!(), DurableMemory.new!(), @channel_id)
+    assert durable.channel_id == @channel_id
+  end
+
+  test "custody-first creation is idempotent and conflicts fail closed", context do
+    create(context)
+
+    same =
+      EpochStore.create_epoch_channel(
+        context.store,
+        context.definition,
+        Grants.channel_master_key_from_bytes(@current_cmk)
+      )
+
+    assert same.active_epoch == 0
+
+    # A different CMK for the same epoch is a fail-closed conflict, and the
+    # error does not disclose how the stored secret differed.
+    assert_code("conflicting_active_key", fn ->
+      EpochStore.create_epoch_channel(
+        context.store,
+        context.definition,
+        Grants.channel_master_key_from_bytes(:binary.copy(<<0x99>>, 32))
+      )
+    end)
+  end
+
+  test "prepare, recover, activate, and prospective revocation", context do
+    create(context)
+
+    assert EpochStore.prepare_rotation(
+             context.store,
+             context.definition,
+             [context.receiver_b],
+             rotation(context)
+           ) == "prepared"
+
+    assert EpochStore.activation_plan(context.store, 1) != nil
+    assert EpochStore.recover_preparation(context.store, context.definition, 1) == "idempotent"
+    # Preparation must not change the active epoch.
+    assert EpochStore.state(context.store).active_epoch == 0
+
+    assert EpochStore.activate_prepared_epoch(context.store, context.definition, 1) == "activated"
+    assert EpochStore.activate_prepared_epoch(context.store, context.definition, 1) == "idempotent"
+    assert EpochStore.state(context.store).active_epoch == 1
+
+    # Prospective revocation: the originator retains BOTH epoch keys, because
+    # old messages were encrypted under epoch 0 and are never re-encrypted.
+    assert InMemory.resolve_handle(context.custody, @channel_id, 0) != nil
+    assert InMemory.resolve_handle(context.custody, @channel_id, 1) != nil
+  end
+
+  # The crash-safety core. Select a candidate in custody and do nothing else --
+  # simulating a process that died between phase 2 and phase 4 -- then require
+  # recovery to reconstruct every public record from the durable bundle alone.
+  test "crash after custody selection replays public records", context do
+    create(context)
+
+    prepared =
+      EpochStore.prepare_rotation_candidate(
+        context.definition,
+        0,
+        [context.receiver_b],
+        rotation(context)
+      )
+
+    assert InMemory.prepare_if_absent(context.custody, prepared) == Custody.selected()
+    # A byte-identical retry is idempotent, not a conflict.
+    assert InMemory.prepare_if_absent(context.custody, prepared) == Custody.idempotent()
+
+    # Crash point: custody holds the bundle, nothing is public yet.
+    assert EpochStore.activation_plan(context.store, 1) == nil
+    assert EpochStore.recover_preparation(context.store, context.definition, 1) == "idempotent"
+
+    plan = EpochStore.activation_plan(context.store, 1)
+    assert plan != nil
+    assert {plan.base_epoch, plan.new_epoch} == {0, 1}
+  end
+
+  # The race trace of the same name: two candidates compete for E+1, exactly one
+  # is selected, and the loser must not write anything public.
+  test "a different candidate loses the custody slot", context do
+    create(context)
+
+    winner =
+      EpochStore.prepare_rotation_candidate(
+        context.definition,
+        0,
+        [context.receiver_b],
+        rotation(context)
+      )
+
+    assert InMemory.prepare_if_absent(context.custody, winner) == Custody.selected()
+
+    loser =
+      EpochStore.prepare_rotation_candidate(
+        context.definition,
+        0,
+        [context.receiver_b],
+        rotation(context, :binary.copy(<<0x77>>, 32), :binary.copy(<<0x52>>, 32), :binary.copy(<<0x62>>, 24))
+      )
+
+    assert InMemory.prepare_if_absent(context.custody, loser) == Custody.conflict()
+
+    # And the store-level path reports the stable code.
+    assert_code("conflicting_preparation", fn ->
+      EpochStore.prepare_rotation(
+        context.store,
+        context.definition,
+        [context.receiver_b],
+        rotation(context, :binary.copy(<<0x88>>, 32), :binary.copy(<<0x53>>, 32), :binary.copy(<<0x63>>, 24))
+      )
+    end)
+  end
+
+  # Both directions of the shared-CAS race: a reservation in flight blocks
+  # activation, and clearing it unblocks.
+  test "a pending publish serializes rotation", context do
+    create(context)
+
+    request = %ActiveEpochAppendRequest{
+      message_id: @message_id,
+      timestamp_ns: 1_725_000_000_000_000_001,
+      originator_id: "originator",
+      content_type: "application/octet-stream",
+      key_epoch: 0
+    }
+
+    reservation =
+      EpochStore.reserve_publish_using_active_epoch(
+        context.store,
+        context.definition,
+        request,
+        "hello"
+      )
+
+    assert reservation.header.sequence == 0
+    assert reservation.key_handle.epoch == 0
+    # The handle redacts every field under inspection.
+    assert inspect(reservation.key_handle) =~ "EpochKeyHandle"
+    refute inspect(reservation.key_handle) =~ "epoch:"
+
+    # Publication won the CAS, so activation must yield rather than race it.
+    assert_code("pending_append", fn ->
+      EpochStore.prepare_rotation(
+        context.store,
+        context.definition,
+        [context.receiver_b],
+        rotation(context)
+      )
+    end)
+
+    assert EpochStore.abandon_pending(context.store) == reservation.header
+    assert EpochStore.abandon_pending(context.store) == nil
+
+    # With the reservation cleared, rotation proceeds.
+    assert EpochStore.prepare_rotation(
+             context.store,
+             context.definition,
+             [context.receiver_b],
+             rotation(context)
+           ) == "prepared"
+  end
+
+  test "an unactivated epoch is rejected before any state change", context do
+    create(context)
+
+    request = %ActiveEpochAppendRequest{
+      message_id: @message_id,
+      timestamp_ns: 1,
+      originator_id: "originator",
+      content_type: "application/octet-stream",
+      key_epoch: 1
+    }
+
+    assert_code("unactivated_epoch", fn ->
+      EpochStore.reserve_publish_using_active_epoch(
+        context.store,
+        context.definition,
+        request,
+        "hello"
+      )
+    end)
+
+    state = EpochStore.state(context.store)
+    assert state.pending_header == nil
+    assert state.next_sequence == 0
+  end
+
+  test "fail-closed preconditions and stable codes", context do
+    create(context)
+
+    assert_code("preparation_missing", fn ->
+      EpochStore.activate_prepared_epoch(context.store, context.definition, 1)
+    end)
+
+    assert_code("unexpected_epoch", fn ->
+      EpochStore.recover_preparation(context.store, context.definition, 2)
+    end)
+
+    assert_code("invalid_plan", fn ->
+      EpochStore.reserve_publish_using_active_epoch(
+        context.store,
+        context.definition,
+        %ActiveEpochAppendRequest{
+          message_id: @message_id,
+          timestamp_ns: 1,
+          originator_id: "not-originator",
+          content_type: "application/octet-stream"
+        },
+        "hello"
+      )
+    end)
+
+    assert_code("invalid_plan", fn ->
+      EpochStore.prepare_rotation(context.store, context.definition, [], rotation(context))
+    end)
+
+    isolated = EpochStore.open_for_testing(context.backend, InMemory.new!(), @channel_id)
+
+    assert_code("active_key_missing", fn ->
+      EpochStore.migrate_epoch_state(isolated, context.definition)
+    end)
+
+    assert_code("custody_error", fn ->
+      InMemory.with_key(
+        context.custody,
+        %EpochKeyHandle{channel_id: @channel_id, epoch: 99},
+        fn _ -> nil end
+      )
+    end)
+  end
+
+  test "not initialized before creation", context do
+    assert_code("not_initialized", fn -> EpochStore.state(context.store) end)
+
+    assert_code("not_initialized", fn ->
+      EpochStore.recover_preparation(context.store, context.definition, 1)
+    end)
+  end
+
+  test "corrupt public state fails closed", context do
+    create(context)
+    key = Profile.state_key(@channel_id)
+    record = MemoryChannelStorage.get(context.backend, Profile.storage_namespace(), key)
+    assert record != nil
+
+    MemoryChannelStorage.corrupt(context.backend, %{record | body: record.body <> <<0>>})
+    assert_code("corrupt_record", fn -> EpochStore.state(context.store) end)
+  end
+
+  # Invariant 6, made observable: destruction erases secrets but leaves the
+  # append-only public record exactly where it was.
+  test "destruction wipes custody but retains public history", context do
+    create(context)
+
+    EpochStore.prepare_rotation(
+      context.store,
+      context.definition,
+      [context.receiver_b],
+      rotation(context)
+    )
+
+    EpochStore.activate_prepared_epoch(context.store, context.definition, 1)
+    before_plan = EpochStore.activation_plan(context.store, 1)
+    assert before_plan != nil
+
+    destroyed =
+      ChannelDefinitionStore.destroy!(
+        ChannelDefinitionStore.new(context.backend),
+        @channel_id
+      )
+
+    assert EpochStore.apply_destruction(context.store, destroyed) == :ok
+    assert InMemory.retained_key_count(context.custody) == 0
+
+    assert EpochStore.activation_plan(context.store, 1) == before_plan
+
+    assert_code("channel_destroyed", fn ->
+      EpochStore.reserve_publish_using_active_epoch(
+        context.store,
+        destroyed,
+        %ActiveEpochAppendRequest{
+          message_id: @message_id,
+          timestamp_ns: 1,
+          originator_id: "originator",
+          content_type: "application/octet-stream"
+        },
+        "hello"
+      )
+    end)
+  end
+
+  test "apply_destruction requires a destroyed definition", context do
+    create(context)
+
+    assert_code("invalid_plan", fn ->
+      EpochStore.apply_destruction(context.store, context.definition)
+    end)
+
+    assert InMemory.retained_key_count(context.custody) > 0
+  end
+
+  test "a decreasing epoch is rejected", context do
+    create(context)
+
+    EpochStore.prepare_rotation(
+      context.store,
+      context.definition,
+      [context.receiver_b],
+      rotation(context)
+    )
+
+    EpochStore.activate_prepared_epoch(context.store, context.definition, 1)
+
+    assert_code("decreasing_epoch", fn ->
+      EpochStore.recover_preparation(context.store, context.definition, 0)
+    end)
+  end
+
+  test "the roster must match the grant receivers", context do
+    create(context)
+
+    # One-receiver rotation for B, but a roster naming A.
+    assert_code("invalid_plan", fn ->
+      EpochStore.prepare_rotation(
+        context.store,
+        context.definition,
+        [context.receiver_a],
+        rotation(context)
+      )
+    end)
+  end
+end

--- a/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/test_helper.exs
+++ b/code/packages/elixir/chief-of-staff-channel-epoch-activation/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Closes #11787. Part of #11734, #141, #128.

**This completes the six-language D18T surface.** With this merged, #11788 can add the aggregate conformance gate.

| | Rust | TypeScript | Python | Go | Ruby | Elixir |
|---|---|---|---|---|---|---|
| D18T adapter | ✅ | ✅ | ✅ | ✅ #11894 | ✅ #11928 | **this PR** |

Consumes the Rust-authored manifest at `code/fixtures/chief-of-staff-channel-epoch-activation/v1/` **directly** — no local regeneration, no shelling out to another language.

## The two ideas

**The active epoch lives in the same versioned record as the pending publish reservation.** Publication and activation contend on one revision and exactly one wins. A separate mutable "epoch head" would not be conforming — two independent CAS operations cannot exclude each other.

**Custody is claimed before anything becomes public.** The secret CMK and the complete public recovery bundle are stored together, atomically, by a single call, before the plan or any grant is written.

## Both earlier defects built in from the start

Canonical ordering is enforced on **decode**, not normalized on construction. Replay re-reads every grant and byte-compares before activation may advance the epoch (invariant 3). The definition is settled before the custody import, so a mismatched definition cannot wedge the slot.

Elixir-specific choices:

- Reports its honest **`not_enforceable`** erasure capability rather than echoing the manifest's Rust-authored `guaranteed` — immutable, garbage-collected BEAM values cannot promise physical overwrite. The fixture test asserts the difference.
- Constant-time CMK comparison **delegates to `CodingAdventures.CtCompare`** rather than being reimplemented.
- `EpochKeyHandle` and `PreparedEpoch` derive `Inspect` with an empty field list, so neither can print anything.

## Tests

**26 tests across three files.** Front door (`mix deps.get && mix test --cover`) green at **88.46%**; `mix compile --warnings-as-errors` clean.

The strongest rebuilds the rotation candidate from the manifest's labelled test-only secrets using Elixir's own D18Q and D18T code and requires byte-for-byte equality with the plan and grant Rust authored.

The invariant-3 tests use a backend that accepts writes and diverges only on **reads** of one grant key, and were **verified by mutation**: with the phase-6 loop deleted, both fail.

## Security review

Passed with **no vulnerabilities**. The reviewer fuzzed both decoders with **80,000 inputs** (zero raw exceptions, zero hangs, zero unbounded allocations), **swept every UUID-v7 bit position** to confirm the version/variant offsets are correct, and verified all eight spec invariants — including that invariant 3 runs on the idempotent activation branch, that `Agent.get_and_update` makes candidate selection genuinely atomic, and that the recursive CAS loops always decrement and cannot swallow a non-conflict error.

**Its one LOW finding is fixed here.** D18P's `Backend.get!`/`put!` map an injected-backend failure to a `ProfileError` — a *foreign* exception to a D18T caller. The direct call sites never translated it, so a caller rescuing `ActivationError` (what the stable-error contract implies, and what every test in this package does) would silently miss storage failures. Rust and Ruby both translate; Elixir was the outlier. Every backend call now routes through a `backend!/1` wrapper that maps `ProfileError` onto the D18T roster while letting `StorageConflictError` pass untouched so the CAS retry loops still work. Covered by a test with a raising backend, verified by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
