### PR TITLE
fix(d18t): validate the plan channel_id as a real UUID v7 in Go

### DIFF
--- a/code/packages/go/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/go/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Validate that a plan's `channel_id` is a real UUID v7 — version nibble 7 in
+  byte 6, variant bits `0b10` in byte 8 — not merely 16 octets. The Rust
+  reference, Python, Ruby, and Elixir all check this; Go checked only the
+  length, so a plan record with a malformed channel identifier decoded here but
+  was `corrupt_record` everywhere else. Two conforming implementations
+  disagreed about whether the same bytes were valid, which the six-language
+  conformance gate (#11788) would have surfaced as a CI failure rather than a
+  decision.
 - Add the Go D18T durable epoch-activation adapter, consuming the canonical
   Rust-authored manifest at `code/fixtures/chief-of-staff-channel-epoch-activation/v1/`
   directly. Go reproduces the canonical D18T plan bytes and every D18G grant

--- a/code/packages/go/chief-of-staff-channel-epoch-activation/fixtures_test.go
+++ b/code/packages/go/chief-of-staff-channel-epoch-activation/fixtures_test.go
@@ -430,6 +430,42 @@ func TestRejectsNonCanonicalPlans(t *testing.T) {
 		}
 	})
 
+	// A 16-octet channel id that is not a real UUID v7 is rejected, matching
+	// Rust, Python, Ruby, and Elixir. Accepting it would mean two conforming
+	// implementations disagreed about whether the same plan record is valid.
+	t.Run("channel-id-is-not-uuid-v7", func(t *testing.T) {
+		for _, testCase := range []struct {
+			name  string
+			index int
+			value byte
+		}{
+			{"wrong-version-nibble", 6, 0x4f},
+			{"wrong-variant-bits", 8, 0x1f},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				bad := append([]byte(nil), channelID...)
+				bad[testCase.index] = testCase.value
+				entry, err := NewActivationPlanEntry(repeatByte(0x01, 32), repeatByte(0x02, 32))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := NewActivationPlan(bad, 0, 1, []ActivationPlanEntry{entry}); !IsCode(err, ErrCorruptRecord) {
+					t.Fatalf("expected corrupt_record, got %v", err)
+				}
+			})
+		}
+
+		// The canonical fixture identifier must still be accepted, so the check
+		// cannot be satisfied by rejecting everything.
+		entry, err := NewActivationPlanEntry(repeatByte(0x01, 32), repeatByte(0x02, 32))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewActivationPlan(channelID, 0, 1, []ActivationPlanEntry{entry}); err != nil {
+			t.Fatalf("the canonical channel id must remain valid: %v", err)
+		}
+	})
+
 	t.Run("empty-receiver-set", func(t *testing.T) {
 		if _, err := NewActivationPlan(channelID, 0, 1, nil); !IsCode(err, ErrCorruptRecord) {
 			t.Fatalf("expected corrupt_record, got %v", err)

--- a/code/packages/go/chief-of-staff-channel-epoch-activation/wire.go
+++ b/code/packages/go/chief-of-staff-channel-epoch-activation/wire.go
@@ -167,6 +167,26 @@ type ActivationPlanEntry struct {
 	grantHash      [32]byte
 }
 
+// requireUUIDv7 checks that a channel identifier is a real UUID v7 -- version
+// nibble 7 in the high half of byte 6, and variant bits 0b10 in the top two
+// bits of byte 8 -- not merely 16 octets.
+//
+// The Rust reference, Python, Ruby, and Elixir all validate this; Go checked
+// only the length. That divergence meant a plan record with a malformed channel
+// identifier decoded here but was corrupt_record everywhere else, so two
+// conforming implementations disagreed about whether the same bytes were valid.
+// The six-language conformance gate (#11788) would have surfaced it as a CI
+// failure rather than a decision.
+func requireUUIDv7(channelID []byte) error {
+	if len(channelID) != 16 {
+		return wireFail()
+	}
+	if channelID[6]>>4 != 7 || channelID[8]&0xc0 != 0x80 {
+		return wireFail()
+	}
+	return nil
+}
+
 // NewActivationPlanEntry builds one commitment pair from 32-octet hashes.
 func NewActivationPlanEntry(receiverIDHash, grantHash []byte) (ActivationPlanEntry, error) {
 	if len(receiverIDHash) != 32 || len(grantHash) != 32 {
@@ -216,8 +236,8 @@ type ActivationPlan struct {
 // treat a collision as equal authorization, it treats it as invalid input.
 // Rejecting rather than merging is the fail-closed choice.
 func NewActivationPlan(channelID []byte, baseEpoch, newEpoch uint64, receivers []ActivationPlanEntry) (ActivationPlan, error) {
-	if len(channelID) != 16 {
-		return ActivationPlan{}, wireFail()
+	if err := requireUUIDv7(channelID); err != nil {
+		return ActivationPlan{}, err
 	}
 	if baseEpoch == MaxU64 || newEpoch != baseEpoch+1 {
 		return ActivationPlan{}, wireFail()


### PR DESCRIPTION
Part of #11788. Also #11734, #141, #128.

`NewActivationPlan` checked only that `channel_id` was 16 octets. The Rust reference, Python, Ruby, and Elixir all additionally verify the UUID v7 shape — version nibble 7 in the high half of byte 6, variant bits `0b10` in the top two bits of byte 8.

| Rust | TypeScript | Python | Ruby | Elixir | Go |
|---|---|---|---|---|---|
| ✅ | n/a¹ | ✅ | ✅ | ✅ | ❌ → **fixed** |

¹ TypeScript's plan constructor takes an already-validated channel id from its store layer.

## Why it matters

A D18T plan record carrying a malformed channel identifier decoded successfully in Go while being `corrupt_record` in the other implementations — two conforming ports disagreeing about whether the same bytes are valid.

Not exploitable: every consumption path (`ActivationPlanRecord`, `validatePublicPreparation`) compares the plan's `channel_id` against the store's own. But it is a byte-level conformance break, and **#11788's aggregate validator would have surfaced it as a CI failure rather than as a decision.** Better to converge now, while the gate is still being written.

Found by the security review of the Ruby port (#11928), which fixed the same gap there and flagged Go as still carrying it.

## Tests

Both malformed shapes are rejected, **and** the canonical fixture identifier is still accepted — so the check cannot be satisfied by rejecting everything. Coverage 83.2%, package front door green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)