### PR TITLE
fix(d18t): settle the definition before importing custody in TypeScript

### DIFF
--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Validate the channel definition before importing the caller's CMK in
+  `createEpochChannel`. Custody slots are keyed by `(channelId, epoch)` and the
+  first writer wins permanently, so importing first let a caller presenting a
+  mismatched definition claim an unclaimed slot and then fail -- leaving the
+  legitimate import to hit `conflicting_active_key` forever. Fail closed, but
+  permanently unrecoverable. D18T only requires custody before *state*, and the
+  D18S write still follows the import. A `try`/`finally` with a `consumed` flag
+  keeps the CMK erased exactly once on every path.
+
+  Found by the security review of the Go port (#11894) and fixed there and in
+  Python (#11898), Ruby (#11928), and Elixir (#11935); TypeScript was the last
+  carrier.
+
 ## [0.1.0] - 2026-08-14
 
 ### Added

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/index.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/src/index.ts
@@ -138,31 +138,49 @@ export class EpochActivationStore {
     return new EpochActivationStore(backend, custody, channelId);
   }
 
-  /** Custody-first creation of a D18T-aware channel and its initial v2 state. */
+  /**
+   * Custody-first creation of a D18T-aware channel and its initial v2 state.
+   *
+   * The definition is settled *before* the custody import, and that ordering
+   * matters. Custody slots are keyed by (channelId, epoch) and the first writer
+   * wins permanently, so importing first would let a caller presenting a
+   * mismatched definition claim an unclaimed slot and then fail -- leaving the
+   * legitimate import to hit conflicting_active_key forever. Fail closed, but
+   * permanently wedged. D18T only requires custody before *state*, so
+   * validating the definition first costs nothing and removes the wedge.
+   */
   async createEpochChannel(
     definition: ChannelDefinition,
     initialCmk: ChannelMasterKey,
   ): Promise<EpochState> {
-    if (!bytesEqual(definition.channelId, this.#channelId) || definition.lifecycle !== "active") {
-      initialCmk.destroy();
-      fail("invalid_plan");
-    }
-    await this.#importInitialKey(definition.keyEpoch, initialCmk);
-    const definitions = new ChannelDefinitionStore(this.#backend);
+    let consumed = false;
     try {
-      const existing = await definitions.load(this.#channelId);
-      if (existing === undefined) await definitions.create(definition);
-      else if (existing.lifecycle === "destroyed") fail("channel_destroyed");
-      else if (!existing.equals(definition)) fail("invalid_plan");
-    }
-    catch (error) {
-      if (error instanceof EpochActivationError) throw error;
-      if (error instanceof ChannelProfileError) {
-        if (error.code === "channel_destroyed") fail("channel_destroyed");
-        if (error.code === "conflicting_definition") fail("invalid_plan");
-        fail("corrupt_record");
+      if (!bytesEqual(definition.channelId, this.#channelId) || definition.lifecycle !== "active") {
+        fail("invalid_plan");
       }
-      throw storageError(error);
+      const definitions = new ChannelDefinitionStore(this.#backend);
+      try {
+        const existing = await definitions.load(this.#channelId);
+        if (existing === undefined) await definitions.create(definition);
+        else if (existing.lifecycle === "destroyed") fail("channel_destroyed");
+        else if (!existing.equals(definition)) fail("invalid_plan");
+      }
+      catch (error) {
+        if (error instanceof EpochActivationError) throw error;
+        if (error instanceof ChannelProfileError) {
+          if (error.code === "channel_destroyed") fail("channel_destroyed");
+          if (error.code === "conflicting_definition") fail("invalid_plan");
+          fail("corrupt_record");
+        }
+        throw storageError(error);
+      }
+      consumed = true;
+      await this.#importInitialKey(definition.keyEpoch, initialCmk);
+    }
+    finally {
+      // #importInitialKey owns the erase once it runs; every earlier exit must
+      // still erase, so an unused secret never outlives the call.
+      if (!consumed) initialCmk.destroy();
     }
     return this.migrateEpochState(definition);
   }

--- a/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/orchestration.test.ts
+++ b/code/packages/typescript/chief-of-staff-channel-epoch-activation/tests/orchestration.test.ts
@@ -295,6 +295,61 @@ describe("D18T orchestration", () => {
     await expect(store.prepareRotation(definition, [fixture.receiverB], fixture.rotation()))
       .rejects.toMatchObject({ code: "epoch_exhausted" });
   });
+
+  // Custody slots are keyed by (channelId, epoch) and the first writer wins
+  // permanently. If the import ran before the definition were validated, a
+  // caller presenting a mismatched definition could claim an unclaimed slot and
+  // then fail -- after which the legitimate create hits conflicting_active_key
+  // forever. Fail closed, but unrecoverable.
+  //
+  // The reachable state is a channel whose definition is durable but whose D18T
+  // custody import never completed: a crash between the two, or a D18P channel
+  // awaiting migration.
+  it("a mismatched definition cannot wedge the custody slot", async () => {
+    const fixture = await new Fixture().initialize();
+    const store = await fixture.store();
+    expect(fixture.custody.retainedKeyCount).toBe(0);
+
+    // Same channel and epoch, different membership, and crucially a DIFFERENT
+    // CMK -- reusing the real one would make the pre-fix import merely
+    // idempotent and this would pass either way.
+    const impostor = new ChannelDefinition({
+      channelId: channelId(),
+      originator: { agentId: utf8("originator"), publicKey: fixture.signer.publicKey },
+      receivers: [fixture.receiverA],
+      createdAtNs: 1_725_000_000_000_000_000n,
+      keyEpoch: 0n,
+    });
+    await expect(
+      store.createEpochChannel(impostor, ChannelMasterKey.fromBytes(new Uint8Array(32).fill(0x99))),
+    ).rejects.toMatchObject({ code: "invalid_plan" });
+
+    // The slot was never claimed, so the legitimate owner can still open it.
+    expect(fixture.custody.retainedKeyCount).toBe(0);
+    const state = await store.createEpochChannel(
+      fixture.definition, ChannelMasterKey.fromBytes(CURRENT_CMK),
+    );
+    expect(state.activeEpoch).toBe(0n);
+  });
+
+  it("a refused create still erases the caller's key", async () => {
+    const fixture = await new Fixture().initialize();
+    const store = await fixture.store();
+    const foreign = new ChannelDefinition({
+      channelId: messageId(0x09),
+      originator: { agentId: utf8("originator"), publicKey: fixture.signer.publicKey },
+      receivers: [fixture.receiverA],
+      createdAtNs: 1_725_000_000_000_000_000n,
+      keyEpoch: 0n,
+    });
+    const cmk = ChannelMasterKey.fromBytes(CURRENT_CMK);
+    await expect(store.createEpochChannel(foreign, cmk)).rejects.toMatchObject({
+      code: "invalid_plan",
+    });
+    // A destroyed key refuses to hand its bytes back.
+    expect(() => cmk.bytes).toThrow();
+  });
+
 });
 
 class StateCasConflictBackend implements ChannelStorageBackend {


### PR DESCRIPTION
Part of #11734, #141, #128.

`createEpochChannel` imported the caller's CMK **before** validating the channel definition. Custody slots are keyed by `(channelId, epoch)` and the first writer wins permanently, so a caller presenting a mismatched definition could claim an unclaimed slot and then fail — after which the legitimate create hits `conflicting_active_key` **forever**. Fail closed, but permanently unrecoverable.

The reachable state is a channel whose definition is durable but whose D18T custody import never completed: a crash between the two, or a D18P channel awaiting migration.

**TypeScript was the last carrier of this defect.**

| Rust | Go | Python | Ruby | Elixir | TypeScript |
|---|---|---|---|---|---|
| n/a¹ | ✅ #11894 | ✅ #11898 | ✅ #11928 | ✅ #11935² | ❌ → **this PR** |

¹ Rust has no `create_epoch_channel` — that API is a port-level addition.
² Built correct from the start, once the pattern was known.

## The fix

The definition is settled first. D18T only requires custody before **state**, and the D18S write still follows the import — so the crash-safety ordering that actually matters is untouched. A `try`/`finally` with a `consumed` flag keeps the CMK erased exactly once on every path, including the ones where `#importInitialKey` erases it itself.

## The test is not vacuous

The impostor uses a **different** CMK. Reusing the real one would make the pre-fix import merely `idempotent` and the test would pass either way — which is the trap a naive version of this test falls into. It also asserts the custody slot is still unclaimed afterwards, so the legitimate owner can open the channel.

**Verified by mutation:** with the ordering reverted, the test fails.

17 tests pass, coverage 93.12%, package front door green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)