### PR TITLE
docs(specs): amend SIR22/SIR23 for the planned second-wave backend rollout

### DIFF
--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -261,12 +261,15 @@ Emit logic gates each import on the module's manifest exactly like the
 existing `uses_oop`/`uses_exceptions` checks: a pure-numeric MATLAB module
 never imports the symbolic runtime and vice versa.
 
-Other backends (Rust/Go/Python) are **not required** to support SIR22/SIR23
-in this first wave — per SIR10's backend-capability model, a backend that
-doesn't declare a feature in `accepts_features()` cleanly rejects a module
-that needs it, rather than emitting wrong code. JS/TS is the first target
-because it's what motivated this work; other backends can add support later
-without any change to the IR or the frontends.
+Other backends (C/Go/Rust/Python/Ruby) were not required to support SIR22/
+SIR23 in the first wave — per SIR10's backend-capability model, a backend
+that doesn't declare a feature in `accepts_features()` cleanly rejects a
+module that needs it, rather than emitting wrong code. JS/TS was the first
+target because it's what motivated this work. That second wave is now
+planned (see `SIR22-array-matrix-semantic-ir.md`/
+`SIR23-symbolic-pattern-semantic-ir.md`'s own "Backend impact" sections
+for the per-backend rollout) — no change to the IR or the frontends is
+needed either way, exactly as this section always said.
 
 ## §5 Rollout — two parallel streams, one shared serialization point
 

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -277,12 +277,15 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
   inlines its runtime helpers, unlike the TS backend's imported-package
   model) for the base cut (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
   `Transpose`/`IndexGet`/`IndexSet`). `NDArrays`/`MatrixOps`/
-  `ArrayColumnMajor` are in `ACCEPTED_FEATURES`. The SIR22 "APL addendum"
-  nodes below share these same three features but remain deferred — this
-  backend adds a dedicated tree-walk check inside `compile()` (beyond the
-  ordinary feature-flag capability check) so a module using one of the
-  nine still fails cleanly rather than reaching an emit-time panic; see
-  that crate's `find_unimplemented_sir22_addendum_node`.
+  `ArrayColumnMajor` are in `ACCEPTED_FEATURES`. **Update, since
+  superseded:** the SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+  `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/
+  `Catenate`) originally shared these same three features but stayed
+  deferred behind a dedicated tree-walk rejection check
+  (`find_unimplemented_sir22_addendum_node`) — real codegen for all nine
+  landed in a later PR and that check was removed once it became dead
+  code (see `compiles_reduce_node_instead_of_rejecting_it`-style
+  regression tests in `semantic-ir-to-javascript/src/lib.rs`).
 - **TS** (`semantic-ir-to-typescript`) — **done**: new `match` arms emit
   calls into the *imported* `@coding-adventures/sir-runtime-array` package
   (`import * as __SirArray from "@coding-adventures/sir-runtime-array"`,
@@ -324,10 +327,24 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
   hands it a bare number (fixed in `sir-runtime-array` 0.4.0, reusing the
   `elementwise.ts` module's existing `toArrayValue` bare-scalar
   normaliser rather than re-solving the same problem a third time).
-- **Rust/Go/Python backends**: not required to support this in the first
-  wave; they reject modules declaring `NDArrays`/`MatrixOps` per the existing
-  capability-rejection path. No code changes required to these backends for
-  this spec to land safely.
+- **C/Go/Rust/Python/Ruby backends** — **second wave, planned**: the
+  original text here named only Rust/Go/Python as declining this domain
+  "in the first wave... no code changes required" — C and Ruby decline
+  identically today (same capability-rejection path, same panic-stub
+  match arms forced by Rust's exhaustiveness checking) but were never
+  actually named, an omission fixed here since all five behave the same
+  way. This is now a planned second wave, not a permanent scope boundary:
+  **C/Go/Rust/Ruby** will
+  follow JS's *inlined* runtime-port model (new source text ported from
+  `semantic-ir-to-javascript`'s own `ArrayRt` sub-runtime, appended to
+  each backend's own `RUNTIME` constant); **Python** will follow TS's
+  *imported-package* model (a new `code/packages/python/sir-runtime-array`
+  pip package, ported from `code/packages/typescript/sir-runtime-array`,
+  wired via Python's existing gated-import pattern). The base cut
+  (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
+  `IndexSet`) and the nine-node APL addendum are separate rollout slices
+  on each backend, mirroring how JS/TS themselves shipped the addendum
+  as a later, separate PR rather than bundled with the base cut.
 
 ## Versioning
 

--- a/code/specs/SIR23-symbolic-pattern-semantic-ir.md
+++ b/code/specs/SIR23-symbolic-pattern-semantic-ir.md
@@ -191,10 +191,28 @@ isn't SIR" boundary the native runtimes already draw.)
   runtime via `sir-runtime-symbolic` (`__SirSym.apply(head, args)`,
   `__SirSym.replaceAll(expr, rules)`, `__SirSym.replaceRepeated(expr, rules,
   cap)`), imported only when `Feature::SymbolicExpr`/`PatternMatching` is in
-  the manifest.
-- **Rust/Go/Python backends**: not required in this first wave; they reject
-  modules declaring `SymbolicExpr`/`PatternMatching` per the existing
-  capability-rejection path.
+  the manifest. Per this spec's own Addendum below, this is the **matcher
+  only** (Tier A) — `SymApply` compiles to a pure, inert term constructor;
+  no backend has an evaluator (Tier B) as of this writing.
+- **C/Go/Rust/Python/Ruby backends** — **second wave, planned**: the
+  original text here named only Rust/Go/Python as declining this domain
+  "in this first wave" — C and Ruby decline identically today but were
+  never actually named, an omission fixed here since all five behave the
+  same way. This is now a planned second wave, scoped explicitly
+  to **Tier A (the matcher) only** — the evaluator remains out of scope
+  for every backend, including JS/TS, and is its own later, per-backend
+  arc. **C/Go/Rust/Ruby** will port the matcher subset only of JS's
+  `Symbolic` IIFE (`matchPattern`/`substituteTerm`/`applyRuleTerm`/
+  `replaceAllTerm`/`replaceRepeatedTerm` — explicitly excluding
+  `evalTerm` and the environment/held-form/function-dispatch machinery)
+  into each backend's own runtime; **Python** will get a new
+  `code/packages/python/sir-runtime-symbolic` package ported from
+  `code/packages/typescript/sir-runtime-symbolic`, which per this spec's
+  own scope boundary already re-exports the matcher only — already
+  exactly Tier A, the ideal minimal port source. Each backend's
+  `SymReplaceAll` depth cap must be its own empirically-measured constant
+  (this spec's own CWE-674 methodology below) — JS's `512` does not
+  transfer to a different language's stack-frame cost.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- Phase A Slice 1 of the SIR22/SIR23 backend-expansion initiative — opening C/Go/Rust/Python/Ruby to array/matrix (SIR22) and symbolic/pattern (SIR23) support, following the same additive-rollout discipline as the SIR21 T3b-2 and SIR28 arcs.
- `SIR22-array-matrix-semantic-ir.md`/`SIR23-symbolic-pattern-semantic-ir.md`'s "Backend impact" sections: replace the stale "not required in the first wave, no code changes needed" text (which also only ever named Rust/Go/Python, omitting C and Ruby despite identical behavior) with this second wave's actual decisions — which five backends, the runtime-architecture split (C/Go/Rust/Ruby inline-port JS's runtime; Python imports a new package mirroring TS's model), and SIR23's explicit Tier A (matcher, in scope) / Tier B (evaluator, deferred everywhere including JS/TS) split.
- SIR22 also fixes a genuinely stale claim found during this review: JS and TS have both already shipped the 9-node APL addendum in a later PR (real codegen, dedicated rejection checks removed as dead code), but the spec's JS paragraph still said "remain deferred". Corrected to match current code.
- `HML01-math-to-semantic-ir.md`: updates its own backend-capability aside to point at the SIR22/SIR23 specs' now-current Backend impact sections instead of repeating the same stale first-wave claim.
- No `semantic-ir` core-IR/validator change — every `Feature` flag already exists in `manifest.rs`.

## Test plan
- [x] Docs-only change (spec markdown) — no code, no tests to run
- [x] Verified the "JS addendum still deferred" claim was stale by grepping `semantic-ir-to-javascript/src/emit.rs`/`lib.rs` directly (real `Reduce`/`Scan`/`OuterProduct`/etc. match arms exist, the rejection-check comment says "since removed")
- [x] `/security-review` — PASSED, no vulnerabilities found (pure documentation change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)