### PR TITLE
feat(ct-compare): add the Ruby port, completing the eleven-language set

### DIFF
--- a/code/packages/ruby/chief-of-staff-channel-epoch-activation/CHANGELOG.md
+++ b/code/packages/ruby/chief-of-staff-channel-epoch-activation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Delegate the custody CMK comparison to `CodingAdventures::CtCompare.ct_eq_fixed`
+  instead of hand-rolling the loop. The D18T spec requires using "the platform's
+  constant-time primitive where one exists"; `ruby/ct-compare` did not exist
+  until now, which is the only reason this package carried its own copy. The
+  other five ports already delegate.
+
 ## 0.1.0
 
 - Add the Ruby D18T durable epoch-activation adapter, consuming the canonical

--- a/code/packages/ruby/chief-of-staff-channel-epoch-activation/Gemfile
+++ b/code/packages/ruby/chief-of-staff-channel-epoch-activation/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem "coding_adventures_chacha20_poly1305", path: "../chacha20-poly1305"
 gem "coding_adventures_chief_of_staff_channel_crypto", path: "../chief-of-staff-channel-crypto"
+gem "coding_adventures_ct_compare", path: "../ct-compare"
 gem "coding_adventures_chief_of_staff_channel_store", path: "../chief-of-staff-channel-store"
 gem "coding_adventures_ed25519", path: "../ed25519"
 gem "coding_adventures_hkdf", path: "../hkdf"

--- a/code/packages/ruby/chief-of-staff-channel-epoch-activation/coding_adventures_chief_of_staff_channel_epoch_activation.gemspec
+++ b/code/packages/ruby/chief-of-staff-channel-epoch-activation/coding_adventures_chief_of_staff_channel_epoch_activation.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   }
   spec.add_dependency "coding_adventures_chief_of_staff_channel_crypto", ">= 0.1.0"
   spec.add_dependency "coding_adventures_chief_of_staff_channel_store", ">= 0.1.0"
+  spec.add_dependency "coding_adventures_ct_compare", ">= 0.1.0"
   spec.add_dependency "coding_adventures_sha256", ">= 0.1.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/code/packages/ruby/chief-of-staff-channel-epoch-activation/lib/coding_adventures_chief_of_staff_channel_epoch_activation.rb
+++ b/code/packages/ruby/chief-of-staff-channel-epoch-activation/lib/coding_adventures_chief_of_staff_channel_epoch_activation.rb
@@ -2,6 +2,7 @@
 
 require "coding_adventures_chief_of_staff_channel_crypto"
 require "coding_adventures_chief_of_staff_channel_store"
+require "coding_adventures_ct_compare"
 require "coding_adventures_sha256"
 
 module CodingAdventures

--- a/code/packages/ruby/chief-of-staff-channel-epoch-activation/lib/coding_adventures_chief_of_staff_channel_epoch_activation/custody.rb
+++ b/code/packages/ruby/chief-of-staff-channel-epoch-activation/lib/coding_adventures_chief_of_staff_channel_epoch_activation/custody.rb
@@ -191,16 +191,15 @@ module CodingAdventures
       module_function
 
       # Constant-time comparison. Both operands are secrets, so a
-      # length-or-content early exit would leak information about the stored
-      # key to a caller who controls the candidate.
+      # length-or-content early exit would leak information about the stored key
+      # to a caller who controls the candidate.
+      #
+      # Delegates to the repository's audited primitive rather than
+      # reimplementing the loop here -- which is what the other five D18T ports
+      # do, and what the D18T spec asks for ("MUST use the platform's
+      # constant-time primitive where one exists").
       def same_cmk?(left, right)
-        left_bytes = left.bytes
-        right_bytes = right.bytes
-        return false unless left_bytes.bytesize == right_bytes.bytesize
-
-        difference = 0
-        left_bytes.bytes.zip(right_bytes.bytes) { |a, b| difference |= a ^ b }
-        difference.zero?
+        CodingAdventures::CtCompare.ct_eq_fixed(left.bytes, right.bytes)
       end
     end
   end

--- a/code/packages/ruby/ct-compare/BUILD
+++ b/code/packages/ruby/ct-compare/BUILD
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/ct-compare/BUILD_windows
+++ b/code/packages/ruby/ct-compare/BUILD_windows
@@ -1,0 +1,3 @@
+bundle config set path vendor/bundle
+bundle install --quiet --full-index
+bundle exec rake test

--- a/code/packages/ruby/ct-compare/CHANGELOG.md
+++ b/code/packages/ruby/ct-compare/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.1.0
+
+- Add the Ruby port of `ct-compare`, completing the eleven-language set. Ruby
+  was the only language missing it, which is why the D18T durable
+  epoch-activation profile was hand-rolling its own constant-time loop.
+- Add `ct_eq`, `ct_eq_fixed`, `ct_select_bytes`, and `ct_eq_u64`, matching the
+  behaviour of the existing C, C++, C#, Elixir, F#, Go, Java, Kotlin, Python,
+  Rust, and TypeScript ports.
+- No data-dependent branches and no early exits: work depends only on input
+  length, never on content. Length is deliberately not hidden, since operand
+  lengths are public.
+- Accept both byte strings and arrays of byte values, and compare by bytes
+  rather than by encoding.

--- a/code/packages/ruby/ct-compare/Gemfile
+++ b/code/packages/ruby/ct-compare/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/ct-compare/README.md
+++ b/code/packages/ruby/ct-compare/README.md
@@ -1,0 +1,68 @@
+# coding_adventures_ct_compare
+
+Constant-time comparison helpers for byte strings and unsigned counters.
+
+## Why this is a package and not three lines at each call site
+
+A secret comparison that returns early on the first differing byte leaks how far
+the match got. An attacker who controls one operand can recover the other a byte
+at a time by measuring how long the comparison takes. The defence is to look at
+every byte regardless, accumulating differences rather than branching on them.
+
+That is a small amount of code and an easy thing to get subtly wrong — which is
+exactly why it belongs in one audited place. Ten other languages in this
+repository already have this package; Ruby was the gap, and the D18T durable
+epoch-activation profile was hand-rolling its own loop as a result.
+
+## What "constant time" does and does not mean here
+
+These functions have **no data-dependent branches and no early exits**: the work
+depends only on the *length* of the inputs, never on their contents. That is the
+property callers need.
+
+It is **not** a claim about the machine. Ruby is a managed runtime with a garbage
+collector and a JIT, and `String#getbyte` is not a constant-time primitive in the
+hardware sense. What this package guarantees is that the *algorithm* leaks
+nothing through control flow. Timing that varies because the GC ran is noise an
+attacker cannot steer; timing that varies because byte 3 differed is a signal
+they can.
+
+Length is deliberately not hidden. `ct_eq` returns `false` immediately for
+mismatched lengths, because operand lengths are almost always public — a 32-byte
+key is 32 bytes whether or not you know its value — and pretending otherwise
+would cost work without buying secrecy.
+
+## Usage
+
+```ruby
+require "coding_adventures_ct_compare"
+
+CT = CodingAdventures::CtCompare
+
+CT.ct_eq(stored_mac, computed_mac)          # => true / false, no early exit
+CT.ct_eq_fixed(stored_key, candidate_key)   # fixed-width companion
+CT.ct_select_bytes(left, right, choice)     # branchless select
+CT.ct_eq_u64(stored_counter, seen_counter)  # unsigned 64-bit compare
+```
+
+`ct_eq_fixed` is an alias in Ruby. In the statically typed ports it takes
+fixed-width arrays, which lets the compiler drop the length check entirely; the
+name is kept so the six-language call sites read identically and a reader moving
+between them is not left wondering what the difference is.
+
+`ct_select_bytes` avoids branching on `choice` with arithmetic rather than
+control flow:
+
+```
+result = right ^ ((left ^ right) & mask)
+```
+
+With `mask = 0xFF` that reduces to `left`; with `mask = 0x00` it reduces to
+`right`. Both inputs are read and the same instructions run either way.
+
+## Development
+
+```sh
+bundle install
+bundle exec rake test
+```

--- a/code/packages/ruby/ct-compare/Rakefile
+++ b/code/packages/ruby/ct-compare/Rakefile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new do |task|
+  task.libs << "lib"
+  task.pattern = "test/test_*.rb"
+  task.verbose = true
+end
+
+task default: :test

--- a/code/packages/ruby/ct-compare/coding_adventures_ct_compare.gemspec
+++ b/code/packages/ruby/ct-compare/coding_adventures_ct_compare.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_ct_compare"
+  spec.version       = "0.1.0"
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "Constant-time comparison helpers for byte strings and unsigned counters"
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
+
+  spec.files         = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/ct-compare/lib/coding_adventures_ct_compare.rb
+++ b/code/packages/ruby/ct-compare/lib/coding_adventures_ct_compare.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  # Constant-time comparison helpers for byte strings and unsigned counters.
+  #
+  # == Why this exists as its own package
+  #
+  # A secret comparison that returns early on the first differing byte leaks how
+  # far the match got. An attacker who controls one operand can recover the other
+  # a byte at a time by measuring how long the comparison takes. The defence is
+  # to look at every byte regardless, accumulating differences rather than
+  # branching on them.
+  #
+  # That is a small amount of code and an easy thing to get subtly wrong, which
+  # is exactly why it belongs in one audited place rather than being rewritten at
+  # each call site. Ten other languages in this repository already have this
+  # package; Ruby was the gap.
+  #
+  # == What "constant time" does and does not mean here
+  #
+  # These functions have no data-dependent branches and no early exits: the work
+  # depends only on the *length* of the inputs, never on their contents. That is
+  # the property callers need.
+  #
+  # It is not a claim about the machine. Ruby is a managed runtime with a
+  # garbage collector and a JIT, and +String#getbyte+ is not a constant-time
+  # primitive in the hardware sense. What this package guarantees is that the
+  # *algorithm* leaks nothing through control flow. Timing that varies because
+  # the GC ran is noise an attacker cannot steer; timing that varies because
+  # byte 3 differed is a signal they can.
+  #
+  # Length is deliberately not hidden. +ct_eq+ returns false immediately for
+  # mismatched lengths, because the lengths of the operands are almost always
+  # public (a 32-byte key is 32 bytes whether or not you know its value), and
+  # pretending otherwise would cost work without buying secrecy.
+  module CtCompare
+    U64_MAX = (1 << 64) - 1
+
+    module_function
+
+    # Return whether two byte strings are equal, without early exit.
+    #
+    # Every byte of both operands is read exactly once. Differences accumulate
+    # into a single value that is compared to zero at the end, so the loop takes
+    # the same path whether the strings match on byte 0 or byte 31.
+    def ct_eq(left, right)
+      left_bytes = as_bytes(left)
+      right_bytes = as_bytes(right)
+      return false unless left_bytes.bytesize == right_bytes.bytesize
+
+      accumulator = 0
+      index = 0
+      while index < left_bytes.bytesize
+        accumulator |= left_bytes.getbyte(index) ^ right_bytes.getbyte(index)
+        index += 1
+      end
+      accumulator.zero?
+    end
+
+    # Fixed-size companion to ct_eq.
+    #
+    # In statically typed ports this takes fixed-width arrays, which lets the
+    # compiler drop the length check entirely. Ruby has no such type, so this is
+    # an alias -- kept so the six-language call sites read identically and a
+    # reader moving between them is not left wondering what the difference is.
+    def ct_eq_fixed(left, right) = ct_eq(left, right)
+
+    # Select +left+ when +choice+ is true, otherwise +right+, without branching
+    # on +choice+.
+    #
+    # The trick is arithmetic rather than control flow: a mask of all-ones or
+    # all-zeros turns the selection into XOR, so both inputs are read and the
+    # same instructions run either way.
+    #
+    #   result = right ^ ((left ^ right) & mask)
+    #
+    # With mask = 0xFF that reduces to +left+; with mask = 0x00 it reduces to
+    # +right+. Nothing observable distinguishes the two cases.
+    def ct_select_bytes(left, right, choice)
+      left_bytes = as_bytes(left)
+      right_bytes = as_bytes(right)
+      unless left_bytes.bytesize == right_bytes.bytesize
+        raise ArgumentError, "ct_select_bytes requires equal-length byte strings"
+      end
+
+      # Reject non-boolean choice rather than leaning on Ruby truthiness. In
+      # Ruby `0` is truthy and would select LEFT; in Python it is falsy and
+      # selects RIGHT. A call site ported from another language passing 0/1
+      # would silently take the opposite branch -- which, in a constant-time
+      # select, means the wrong key. Elixir guards with is_boolean; so do we.
+      unless [true, false].include?(choice)
+        raise ArgumentError, "ct_select_bytes requires choice to be true or false"
+      end
+
+      mask = choice ? 0xFF : 0x00
+      output = +"".b
+      index = 0
+      while index < left_bytes.bytesize
+        left_byte = left_bytes.getbyte(index)
+        right_byte = right_bytes.getbyte(index)
+        output << (right_byte ^ ((left_byte ^ right_byte) & mask))
+        index += 1
+      end
+      output
+    end
+
+    # Return whether two unsigned 64-bit integers are equal, without branching
+    # on their values.
+    #
+    # Folding the XOR down to its sign bit avoids a comparison against zero that
+    # a compiler might turn into a branch. Ruby would not, but the ports share
+    # this shape so the reasoning transfers.
+    def ct_eq_u64(left, right)
+      validate_u64!(left, "left")
+      validate_u64!(right, "right")
+      difference = (left ^ right) & U64_MAX
+      folded = (difference | (-difference & U64_MAX)) >> 63
+      folded.zero?
+    end
+
+    def as_bytes(value)
+      case value
+      when String
+        value.b
+      when Array
+        # pack("C*") silently reduces mod 256 and truncates Floats, so an
+        # unvalidated array would make an EQUALITY primitive answer true for
+        # unequal inputs -- ct_eq([256], "\x00") and ct_eq([97.9], "a") both
+        # would. That is the worst failure this function can have. The typed
+        # ports cannot express it at all and Python raises; validate instead.
+        unless value.all? { |byte| byte.is_a?(Integer) && byte.between?(0, 255) }
+          raise ArgumentError, "byte values must be integers in 0..255"
+        end
+
+        value.pack("C*")
+      else
+        raise ArgumentError, "expected a String or an Array of byte values"
+      end
+    end
+
+    def validate_u64!(value, name)
+      return if value.is_a?(Integer) && !value.negative? && value <= U64_MAX
+
+      raise ArgumentError, "#{name} must be an unsigned 64-bit integer"
+    end
+
+    private_class_method :as_bytes, :validate_u64!
+  end
+end

--- a/code/packages/ruby/ct-compare/required_capabilities.json
+++ b/code/packages/ruby/ct-compare/required_capabilities.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "package": "ruby/ct-compare",
+  "capabilities": [],
+  "justification": "Pure arithmetic over caller-supplied byte strings and integers. Reads no files, opens no sockets, and consults no clock or randomness."
+}

--- a/code/packages/ruby/ct-compare/test/test_ct_compare.rb
+++ b/code/packages/ruby/ct-compare/test/test_ct_compare.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "coding_adventures_ct_compare"
+
+class TestCtCompare < Minitest::Test
+  CT = CodingAdventures::CtCompare
+
+  def test_ct_eq_matches_only_identical_byte_strings
+    assert CT.ct_eq("", "")
+    assert CT.ct_eq("abc".b, "abc".b)
+    assert CT.ct_eq(("\x00".b * 32), ("\x00".b * 32))
+    refute CT.ct_eq("abc".b, "abd".b)
+    refute CT.ct_eq("abc".b, "abc ".b)
+    refute CT.ct_eq("".b, "a".b)
+  end
+
+  # The point of the accumulator is that a difference anywhere is caught. A
+  # naive loop that forgot to OR would report equality whenever the LAST byte
+  # matched, so differences are exercised at the first, middle, and last
+  # positions rather than only at one end.
+  def test_a_difference_at_any_position_is_detected
+    base = ("\x41".b * 32)
+    [0, 15, 31].each do |index|
+      mutated = base.dup
+      mutated.setbyte(index, 0x42)
+      refute CT.ct_eq(base, mutated), "difference at byte #{index} must be detected"
+      refute CT.ct_eq(mutated, base), "difference at byte #{index} must be symmetric"
+    end
+  end
+
+  def test_ct_eq_accepts_byte_arrays_and_rejects_other_types
+    assert CT.ct_eq([0x61, 0x62], "ab".b)
+    assert CT.ct_eq([1, 2, 3], [1, 2, 3])
+    assert_raises(ArgumentError) { CT.ct_eq(nil, "a".b) }
+    assert_raises(ArgumentError) { CT.ct_eq(42, "a".b) }
+  end
+
+  def test_ct_eq_ignores_encoding_and_compares_bytes
+    # Same bytes, different encodings, must compare equal: these are byte
+    # strings, not text.
+    utf8 = "abc"
+    binary = "abc".b
+    assert CT.ct_eq(utf8, binary)
+  end
+
+  def test_ct_eq_fixed_agrees_with_ct_eq_everywhere
+    [
+      ["", ""],
+      ["abc".b, "abc".b],
+      ["abc".b, "abd".b],
+      ["abc".b, "ab".b]
+    ].each do |left, right|
+      assert_equal CT.ct_eq(left, right), CT.ct_eq_fixed(left, right),
+        "ct_eq_fixed must not diverge from ct_eq"
+    end
+  end
+
+  def test_ct_select_bytes_picks_a_side_without_branching
+    left = "\x01\x02\x03".b
+    right = "\xfd\xfe\xff".b
+    assert_equal left, CT.ct_select_bytes(left, right, true)
+    assert_equal right, CT.ct_select_bytes(left, right, false)
+    assert_equal Encoding::BINARY, CT.ct_select_bytes(left, right, true).encoding
+  end
+
+  def test_ct_select_bytes_requires_equal_lengths
+    assert_raises(ArgumentError) { CT.ct_select_bytes("ab".b, "abc".b, true) }
+    assert_equal "".b, CT.ct_select_bytes("".b, "".b, true)
+  end
+
+  def test_ct_select_bytes_covers_every_byte_value
+    # The XOR-mask identity must hold across the full 0..255 range, not just the
+    # low bytes -- an implementation using a signed mask would break near 0x80.
+    left = (0..255).to_a.pack("C*")
+    right = (0..255).to_a.reverse.pack("C*")
+    assert_equal left, CT.ct_select_bytes(left, right, true)
+    assert_equal right, CT.ct_select_bytes(left, right, false)
+  end
+
+  def test_ct_eq_u64_compares_unsigned_counters
+    assert CT.ct_eq_u64(0, 0)
+    assert CT.ct_eq_u64(CT::U64_MAX, CT::U64_MAX)
+    refute CT.ct_eq_u64(0, 1)
+    refute CT.ct_eq_u64(CT::U64_MAX, CT::U64_MAX - 1)
+    # A difference confined to the high bit must still be caught -- the fold
+    # shifts by 63, so an off-by-one there would report equality here.
+    refute CT.ct_eq_u64(1 << 63, 0)
+    assert CT.ct_eq_u64(1 << 63, 1 << 63)
+  end
+
+  def test_ct_eq_u64_rejects_out_of_range_and_non_integers
+    [-1, CT::U64_MAX + 1, 1.0, "1", nil].each do |bad|
+      assert_raises(ArgumentError, "#{bad.inspect} must be rejected") { CT.ct_eq_u64(bad, 0) }
+      assert_raises(ArgumentError, "#{bad.inspect} must be rejected") { CT.ct_eq_u64(0, bad) }
+    end
+  end
+
+  # An equality primitive that answers true for unequal inputs is the worst
+  # failure it can have. pack("C*") reduces mod 256 and truncates Floats, so
+  # without validation ct_eq([256], "\x00") would be true. The typed ports
+  # cannot express these inputs at all and Python raises; match that.
+  def test_out_of_range_array_elements_are_rejected_not_truncated
+    [[256], [257, 258], [-1], [97.9], [nil], ["a"], [1 << 64]].each do |bad|
+      assert_raises(ArgumentError, "#{bad.inspect} must be rejected") { CT.ct_eq(bad, "\x00".b) }
+      assert_raises(ArgumentError, "#{bad.inspect} must be rejected") { CT.ct_eq("\x00".b, bad) }
+    end
+    # The boundary values themselves remain valid.
+    assert CT.ct_eq([0, 255], "\x00\xff".b)
+  end
+
+  # Ruby truthiness would make 0 select LEFT; Python treats 0 as falsy and
+  # selects RIGHT. A call site ported across languages would silently take the
+  # opposite branch, which in a constant-time select means the wrong key.
+  def test_ct_select_bytes_requires_a_real_boolean
+    left = "\x01".b
+    right = "\x02".b
+    [0, 1, nil, "true", :true].each do |bad|
+      assert_raises(ArgumentError, "#{bad.inspect} must be rejected") do
+        CT.ct_select_bytes(left, right, bad)
+      end
+    end
+    assert_equal left, CT.ct_select_bytes(left, right, true)
+    assert_equal right, CT.ct_select_bytes(left, right, false)
+  end
+
+  def test_internal_helpers_are_not_public
+    refute_respond_to CT, :as_bytes
+    refute_respond_to CT, :validate_u64!
+  end
+end


### PR DESCRIPTION
Ruby was the **only** language missing `ct-compare` — c, cpp, csharp, elixir, fsharp, go, java, kotlin, python, rust, and typescript all had it.

That gap is why the D18T durable epoch-activation profile was hand-rolling its own constant-time loop, which the spec explicitly asks implementations not to do: it requires *"the platform's constant-time primitive where one exists"*. Found by the security review of the Ruby D18T adapter (#11928), which flagged it as a spec deviation while noting it wasn't exploitable as written.

## What this adds

`ct_eq`, `ct_eq_fixed`, `ct_select_bytes`, `ct_eq_u64` — matching the eleven existing ports. No data-dependent branches, no early exits: work depends only on input *length*, never on content.

`chief-of-staff-channel-epoch-activation` now delegates its custody CMK comparison here instead of carrying its own copy.

## Honest about what Ruby can promise

Length is **deliberately not hidden**. `ct_eq` returns `false` immediately on a length mismatch, because operand lengths are almost always public — a 32-byte key is 32 bytes whether or not you know its value — and pretending otherwise costs work without buying secrecy.

The README states this is a claim about the **algorithm's control flow**, not about the machine. Ruby is a managed runtime with a GC and a JIT; `String#getbyte` is not a hardware constant-time primitive. Timing that varies because the GC ran is noise an attacker can't steer; timing that varies because byte 3 differed is a signal they can. Only the second is in scope.

## Security review — two LOW findings, both fixed

Both were divergences from the sibling ports rather than logic errors, and both now have tests:

**`as_bytes` truncated instead of rejecting.** `pack("C*")` silently reduces mod 256 and truncates Floats, so an *equality* primitive answered `true` for unequal inputs:

```ruby
CT.ct_eq([256, 257], "\x00\x01")  # => true
CT.ct_eq([97.9],     "a")         # => true
```

That's the worst failure this function can have. The typed ports can't express those inputs at all and Python raises. Now validated before packing. Unreachable from the in-repo consumer, which passes Strings — but this is a published gem.

**`ct_select_bytes` leaned on Ruby truthiness.** `choice = 0` selected **left**; Python's falsy `0` selects **right**. A call site ported across languages would silently take the opposite branch — in a constant-time select, the wrong key. Now rejects non-booleans, matching Elixir's `is_boolean` guard.

## Verification

The reviewer fuzzed against a naive reference: **250k** `ct_eq`, **200k** `ct_select_bytes` plus **exhaustive 256×256×2 byte-pair coverage**, and **300k+** `ct_eq_u64` including all edge values and every single-bit difference. Zero divergences — the XOR-mask identity holds across the full 0..255 range with no signed-mask bug, and the u64 fold is correct despite Ruby's arbitrary-precision integers.

It also ran the pre-change and post-change custody comparison **side by side over 20k CMK pairs** including single-bit flips, confirming the delegation is exactly equivalent and copies no secret anywhere new.

`ct-compare` 13 runs / 68 assertions · `epoch-activation` 24 runs / 209 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
