### PR TITLE
feat(semantic-ir-to-ruby): implement SIR22 array/matrix base cut (Phase A Slice 2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.25.0 — SIR22 array/matrix base cut (second-wave backend rollout, Phase A Slice 2)
+
+Part of the SIR22/SIR23 backend-expansion initiative (opening
+C/Go/Rust/Python/Ruby to array/matrix and symbolic/pattern support — see
+`code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section).
+This backend now accepts `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}`
+and implements the SIR22 base cut: `ArrayLit`/`Range`/`MatMul`/
+`ElementwiseOp`/`Transpose`/`IndexGet` (+ `Stmt::IndexSet`).
+
+**New runtime** (`runtime.rs`): `sir_array_*` — an inlined port of
+`semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime
+(itself a port of the published `@coding-adventures/sir-runtime-array`
+package), following this crate's existing inlined-runtime convention
+(unlike Python/TypeScript's imported-package model). Column-major dense
+storage (`SirNDArray(shape, data)`), same value model as the Rust/JS/TS
+references.
+
+**A deliberate divergence from the JS/TS references, not a bug**: `data`
+holds whatever Numeric type the source arithmetic naturally produces
+(Integer stays Integer through `+`/`-`/`*`; only `Div`/`Pow` force a Float
+result) rather than JS's `Float64Array`-forced uniform-double storage —
+Ruby distinguishes Integer/Float in its own display convention (this
+crate's `sir_fmt_float` already deliberately keeps a trailing `.0` on a
+real Float), so an all-integer computation like a 2x2 `matmul` prints its
+result without a spurious `.0`, matching this crate's own `div_true`
+precedent for exactly the same class of decision.
+
+**SIR22 "APL addendum" nodes** (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share
+`NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut above, so a
+bare feature-flag check can't tell a module using one of these nine apart
+from a safe base-cut-only module. Added a dedicated pre-emit scan arm
+(`ScanHit::Sir22AddendumNode`, folded into this crate's existing single
+shared `Scan`/`first_scan_issue` traversal rather than a second,
+JS-style, separate walker) that rejects them cleanly — mirrors JS/TS's
+own `find_unimplemented_sir22_addendum_node` (since removed there, once
+their own addendum shipped in a later PR — see the SIR22 spec's
+now-corrected "Backend impact" section). Real codegen for these nine is
+Phase A Slice 3, a separate later PR.
+
+**Security**: every NaN-safe AND-form bounds check the JS reference
+documents (`sir_array_get`/`sir_array_set`'s `r >= 0 && c >= 0 && ...`,
+never the OR-form negation) is replicated exactly — Ruby's `Float::NAN`
+follows the same IEEE-754 "every relational comparison is false" rule, so
+the identical hazard class applies. Every shape/output size is validated
+via `sir_array_checked_shape_size` *before* allocating, matching the JS
+reference's own DoS-safety discipline (an attacker-influenced shape must
+fail cleanly, not exhaust memory or crash on an unvalidated `Array.new`).
+
+New `tests/sir22_array.rs` (8 tests, ported from
+`semantic-ir-to-javascript/tests/sir22_array.rs`'s own worked examples,
+adapted for this backend's numeric-type-propagation divergence noted
+above): hand-built `Module`s exercising `matmul`/scalar-broadcast
+`elementwise`/`Div`'s forced-float behavior/`transpose`/`range`/a `Whole`
+selector/`IndexSet` mutation, each compiled and run through a real `ruby`
+interpreter (skips gracefully when absent), plus a compile-time rejection
+test proving `Reduce` is cleanly rejected rather than reaching an
+`emit_expr` panic.
+
+`semantic-ir-to-ruby` 0.24.0 -> 0.25.0.
+
 ## 0.24.0 — SIR21 T3b-2 Slice 7: cleanup — remove dead `tdiv`/`utdiv`
 
 Part of the SIR21 T3b-2 arc's final slice. `c-to-semantic-ir` was the only

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -114,11 +114,23 @@ ONLY console-output primitive the backend emits — bare `"print"`/`"puts"`
 to implement them were removed once every frontend finished migrating to
 `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
-Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
-indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-built-in collection methods; plus a namespaced class/constant definition or a
-non-`@@x`-init class/module body) until its slice lands — each a clean,
-source-positioned `UnsupportedFeature`.
+**SIR22 array/matrix base cut**: `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+`Transpose`/`IndexGet` (+ `Stmt::IndexSet`) route into `sir_array_*` — an
+inlined port of `semantic-ir-to-javascript`'s own `ArrayRt` sub-runtime.
+Dense column-major storage (`SirNDArray(shape, data)`); `data` preserves
+native Ruby Integer/Float type propagation rather than JS's uniform-double
+storage (`Div`/`Pow` force a Float result; `Add`/`Sub`/`Mul` don't), so an
+all-integer computation prints without a spurious `.0` — see
+`runtime.rs`'s own module doc and the CHANGELOG for the full reasoning.
+The nine-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/etc.)
+shares these same three features with the base cut, so a dedicated
+pre-emit scan (`ScanHit::Sir22AddendumNode`) rejects it cleanly until its
+own later slice lands.
+Rejects `TailCalls`, `Intrinsics`, and every other not-yet-wired feature
+(array-pattern destructuring; built-in collection methods; plus a
+namespaced class/constant definition or a non-`@@x`-init class/module
+body) until its slice lands — each a clean, source-positioned
+`UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -11,7 +11,10 @@ use std::collections::HashSet;
 use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use semantic_ir::{Block, Expr, Function, Global, IntWidth, Module, ParamKind, Scope, Stmt};
+use semantic_ir::{
+    Block, ElementwiseOpKind, Expr, Function, Global, IndexArg, IntWidth, Module, ParamKind,
+    Scope, Stmt,
+};
 
 use crate::runtime::RUNTIME;
 
@@ -232,6 +235,15 @@ pub enum ScanHit {
     /// A `Scope::ClassVar` name (`@@x`) that is not a valid Ruby class-variable
     /// name (`@@<identifier>`) — injection guard at the class-variable positions.
     ClassVarName(String, semantic_ir::Span),
+    /// SIR22 "APL addendum" node (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    /// `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — shares
+    /// `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut this
+    /// slice implements, so a bare feature-flag check cannot tell a module
+    /// using one of these nine apart from a safe base-cut-only module.
+    /// Rejected cleanly here rather than reaching `emit_expr`'s
+    /// `unreachable!` — mirrors JS/TS's own (since-removed, once the
+    /// addendum shipped there) `find_unimplemented_sir22_addendum_node`.
+    Sir22AddendumNode(&'static str, semantic_ir::Span),
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
@@ -640,7 +652,23 @@ impl Scan {
                 None
             }
         }
-        _ => None,
+        // SIR22 indexed-write — sub-expressions may hide a deferred
+        // builtin, matching the pattern every other compound stmt above
+        // follows (`SeqSet`/`MapSet`, ...).
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => self
+            .expr(target)
+            .or_else(|| {
+                indices.iter().find_map(|arg| match arg {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => self.expr(e),
+                    IndexArg::Whole => None,
+                })
+            })
+            .or_else(|| self.expr(value)),
     }
     }
 }
@@ -906,6 +934,45 @@ impl Scan {
         } if !is_valid_classvar_name(name) => {
             Some(ScanHit::ClassVarName(name.clone(), span.clone()))
         }
+        // ── SIR22 array/matrix base cut ──────────────────────────────
+        // Sub-expressions may themselves hide a deferred builtin or
+        // injectable name — scan them, matching every other composite
+        // expr arm above.
+        Expr::ArrayLit { rows, .. } => rows.iter().flatten().find_map(|e| self.expr(e)),
+        Expr::Range {
+            start, step, stop, ..
+        } => self
+            .expr(start)
+            .or_else(|| step.as_deref().and_then(|s| self.expr(s)))
+            .or_else(|| self.expr(stop)),
+        Expr::MatMul { lhs, rhs, .. } => self.expr(lhs).or_else(|| self.expr(rhs)),
+        Expr::ElementwiseOp { lhs, rhs, .. } => self.expr(lhs).or_else(|| self.expr(rhs)),
+        Expr::Transpose { target, .. } => self.expr(target),
+        Expr::IndexGet {
+            target, indices, ..
+        } => self.expr(target).or_else(|| {
+            indices.iter().find_map(|arg| match arg {
+                IndexArg::Scalar(e) | IndexArg::Range(e) => self.expr(e),
+                IndexArg::Whole => None,
+            })
+        }),
+        // ── SIR22 "APL addendum" — deferred, rejected cleanly ────────
+        // Shares NDArrays/MatrixOps/ArrayColumnMajor with the base cut
+        // above, so it must be checked explicitly here (not just at the
+        // feature-flag gate) — see `ScanHit::Sir22AddendumNode`'s doc.
+        Expr::Reduce { span, .. } => Some(ScanHit::Sir22AddendumNode("Reduce", span.clone())),
+        Expr::Scan { span, .. } => Some(ScanHit::Sir22AddendumNode("Scan", span.clone())),
+        Expr::OuterProduct { span, .. } => {
+            Some(ScanHit::Sir22AddendumNode("OuterProduct", span.clone()))
+        }
+        Expr::Shape { span, .. } => Some(ScanHit::Sir22AddendumNode("Shape", span.clone())),
+        Expr::Reshape { span, .. } => Some(ScanHit::Sir22AddendumNode("Reshape", span.clone())),
+        Expr::IndexGenerator { span, .. } => {
+            Some(ScanHit::Sir22AddendumNode("IndexGenerator", span.clone()))
+        }
+        Expr::IndexOf { span, .. } => Some(ScanHit::Sir22AddendumNode("IndexOf", span.clone())),
+        Expr::Ravel { span, .. } => Some(ScanHit::Sir22AddendumNode("Ravel", span.clone())),
+        Expr::Catenate { span, .. } => Some(ScanHit::Sir22AddendumNode("Catenate", span.clone())),
         _ => None,
     }
     }
@@ -1244,7 +1311,25 @@ fn emit_stmt(s: &Stmt) -> String {
         // registered separately with `__def_method__` (reusing slice-2 machinery),
         // and a class mixes it in with the native `include`/`extend` below.
         Stmt::ModuleDef { name, .. } => format!("Object.const_set(:{name}, Module.new)"),
-        // Other not-yet-supported statements (e.g. index-set, singleton defs) are
+        // ── SIR22: array/matrix indexed assignment ──────────────────
+        // `target[indices...] = value` — mutates IN PLACE via
+        // `sir_array_index_set` (see `runtime.rs`), matching the SIR22
+        // spec's own note that `IndexSet` is a `Stmt`, not a pure `Expr`,
+        // for exactly this in-place-mutation reason.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            format!(
+                "sir_array_index_set({}, [{}], {})",
+                emit_expr(target),
+                emit_index_args(indices),
+                emit_expr(value)
+            )
+        }
+        // Other not-yet-supported statements (e.g. singleton defs) are
         // rejected by the capability check / scan before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
@@ -1415,12 +1500,124 @@ fn emit_expr(e: &Expr) -> String {
         Expr::KeywordArg { name, value, .. } => {
             format!("{}: {}", sanitize_ident(name), emit_expr(value))
         }
+        // ── SIR22 array/matrix base cut ──────────────────────────────
+        // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+        // (and `Stmt::IndexSet` below) route into `sir_array_*` helpers
+        // ported from `semantic-ir-to-javascript`'s own already-proven
+        // `ArrayRt` sub-runtime (see `runtime.rs`'s "SIR22 array/matrix
+        // domain" section for the value model and the full port). This
+        // backend inlines its runtime like the JS/C/Go/Rust backends
+        // (not an imported package, unlike Python/TS) — consistent with
+        // this crate's existing precedent for every other feature batch.
+        Expr::ArrayLit { rows, .. } => {
+            let row_strs: Vec<String> = rows
+                .iter()
+                .map(|row| {
+                    let elems: Vec<String> = row.iter().map(emit_expr).collect();
+                    format!("[{}]", elems.join(", "))
+                })
+                .collect();
+            format!("sir_array_from_rows([{}])", row_strs.join(", "))
+        }
+        // Argument ORDER: the SIR node's own field order is `start, step,
+        // stop`, but `sir_array_range(start, stop, step = 1)` (matching
+        // the JS/TS reference's `range(start, stop, step)`) takes `stop`
+        // before `step`.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            let step_str = step
+                .as_ref()
+                .map(|s| emit_expr(s))
+                .unwrap_or_else(|| "1".to_string());
+            format!(
+                "sir_array_range({}, {}, {})",
+                emit_expr(start),
+                emit_expr(stop),
+                step_str
+            )
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            format!("sir_array_matmul({}, {})", emit_expr(lhs), emit_expr(rhs))
+        }
+        // The op name must match `sir_array_apply_op`'s `case` in
+        // `runtime.rs` exactly (`"Add"`, not `.name()`'s lowercase form).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            format!(
+                "sir_array_elementwise({}, {}, {})",
+                elementwise_op_ruby_name(*op),
+                emit_expr(lhs),
+                emit_expr(rhs)
+            )
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            format!(
+                "sir_array_transpose({}, {})",
+                emit_expr(target),
+                conjugate
+            )
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            format!(
+                "sir_array_index_get({}, [{}])",
+                emit_expr(target),
+                emit_index_args(indices)
+            )
+        }
         other => unreachable!("Ruby backend reached unsupported expr: {other:?}"),
     }
 }
 
 fn emit_args(args: &[Expr]) -> String {
     args.iter().map(emit_expr).collect::<Vec<_>>().join(", ")
+}
+
+/// The Ruby string `sir_array_apply_op`'s `case` switches on — exact
+/// `ElementwiseOpKind` variant names, not `.name()`'s lowercase forms
+/// (`"add"`, used elsewhere for display), since this string is a real
+/// runtime dispatch key, matching the JS backend's `elementwise_op_js_name`.
+fn elementwise_op_ruby_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "\"Add\"",
+        ElementwiseOpKind::Sub => "\"Sub\"",
+        ElementwiseOpKind::Mul => "\"Mul\"",
+        ElementwiseOpKind::Div => "\"Div\"",
+        ElementwiseOpKind::Pow => "\"Pow\"",
+        ElementwiseOpKind::Max => "\"Max\"",
+        ElementwiseOpKind::Min => "\"Min\"",
+        ElementwiseOpKind::Eq => "\"Eq\"",
+        ElementwiseOpKind::Ne => "\"Ne\"",
+        ElementwiseOpKind::Lt => "\"Lt\"",
+        ElementwiseOpKind::Le => "\"Le\"",
+        ElementwiseOpKind::Ge => "\"Ge\"",
+        ElementwiseOpKind::Gt => "\"Gt\"",
+    }
+}
+
+/// Emit one `IndexArg` as the Ruby Hash literal `sir_array_index_get`/
+/// `sir_array_index_set` expect: `{ kind: "scalar", value: <expr> }` /
+/// `{ kind: "whole" }` / `{ kind: "range", indices: <NDArray> }`. The
+/// `Range` case reuses `emit_expr` on the inner `Expr::Range` node
+/// directly — that node's own `Expr::Range` arm already emits a call
+/// into `sir_array_range(...)`.
+fn emit_index_arg(arg: &IndexArg) -> String {
+    match arg {
+        IndexArg::Scalar(e) => format!("{{ kind: \"scalar\", value: {} }}", emit_expr(e)),
+        IndexArg::Whole => "{ kind: \"whole\" }".to_string(),
+        IndexArg::Range(e) => format!("{{ kind: \"range\", indices: {} }}", emit_expr(e)),
+    }
+}
+
+fn emit_index_args(indices: &[IndexArg]) -> String {
+    indices
+        .iter()
+        .map(emit_index_arg)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn emit_var_ref(name: &str, scope: Scope) -> String {

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -232,6 +232,17 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
+    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+    // (+ `Stmt::IndexSet`) route into `sir_array_*` helpers, an inlined
+    // port of the already-proven `semantic-ir-to-javascript` `ArrayRt`
+    // sub-runtime (see `runtime.rs`). The SIR22 "APL addendum" nodes
+    // share these same three features but stay deferred — rejected by a
+    // dedicated pre-emit scan (`ScanHit::Sir22AddendumNode`), not this
+    // capability gate, since the gate alone can't distinguish them.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for RubyBackend {
@@ -346,6 +357,16 @@ impl Backend for RubyBackend {
                     message: format!(
                         "the Ruby backend cannot emit the class variable `{name}` \
                          (not a valid `@@identifier`)"
+                    ),
+                    span,
+                });
+            }
+            Some(emit::ScanHit::Sir22AddendumNode(kind, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend does not yet implement the SIR22 addendum node `{kind}` \
+                         (deferred to a later slice)"
                     ),
                     span,
                 });

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -316,4 +316,406 @@ end
 def sir_builtin_closure(name)
   ->(*args) { sir_builtin_dispatch(name, args) }
 end
+
+# ── SIR22 array/matrix domain ──
+#
+# `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` (and
+# `Stmt::IndexSet`) lower to calls into `sir_array_*` below — an inlined
+# port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
+# sub-runtime (itself a plain-JS port of the published
+# `@coding-adventures/sir-runtime-array` package), so the Ruby artifact
+# stays self-contained like every other feature batch in this file.
+#
+# ## Value model
+#
+# `SirNDArray(shape, data)` — dense, rectangular, COLUMN-MAJOR storage
+# (Fortran/MATLAB order), mirroring `array_runtime::value::Array`
+# field-for-field. `shape == []` is a scalar, `[n]` a vector (an `n×1`
+# column for row/column purposes), `[r, c]` a matrix — this port's whole
+# scope, like the JS/TS references, is rank <= 2. Unlike JS (whose
+# `Float64Array` forces every element to an IEEE double), `data` here is a
+# plain Ruby Array holding whatever Numeric type the source arithmetic
+# naturally produces (Integer stays Integer through `+`/`-`/`*`; only
+# `Div`/`Pow` force a Float result, matching this crate's own `div_true`
+# precedent) — so an all-integer computation like a 2x2 `matmul` prints
+# its result without a spurious ".0", matching this backend's existing
+# `sir_fmt_float` display convention (which deliberately keeps ".0" on a
+# REAL Float, e.g. from `Div`).
+#
+# The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+# `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is deferred —
+# these nine share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base
+# cut above, so `lib.rs`'s `compile` adds a dedicated pre-emit scan
+# (`ScanHit::Sir22AddendumNode`) rejecting them cleanly, beyond the
+# ordinary feature-flag capability check.
+SirNDArray = Struct.new(:shape, :data)
+
+# SECURITY: every factory below validates a shape/output size *before*
+# allocating a Ruby Array from it — a compiled program's array sizes come
+# from potentially attacker-influenced runtime values (loop counts, parsed
+# input, ...), not fixed compile-time constants, so an unbounded or
+# malformed shape must fail cleanly with a catchable exception rather than
+# let `Array.new(n)` itself exhaust memory. Mirrors the JS backend's own
+# `MAX_ELEMENTS` bound exactly, so behaviour is identical across both.
+SIR_ARRAY_MAX_ELEMENTS = 1 << 26 # 67,108,864
+SIR_ARRAY_RANGE_EPSILON = 1e-9
+
+# `Number.isInteger`-equivalent: true for a Ruby Integer, or a finite Float
+# equal to its own truncation (e.g. `2.0`, not `2.5`/NaN/Infinity).
+def sir_array_integer_dim?(d)
+  d.is_a?(Integer) || (d.is_a?(Float) && d.finite? && d == d.to_i)
+end
+
+# `Number.isFinite`-equivalent over this domain's numeric literals (always
+# Integer or Float): every Ruby Integer is finite; a Float is finite only
+# when neither NaN nor +/-Infinity.
+def sir_array_finite?(x)
+  x.is_a?(Integer) || (x.is_a?(Float) && x.finite?)
+end
+
+def sir_array_checked_shape_size(shape)
+  unless shape.all? { |d| sir_array_integer_dim?(d) && d >= 0 }
+    raise "sir_array_checked_shape_size: shape #{shape} has a negative or non-integer dimension"
+  end
+  n = shape.reduce(1) { |acc, d| acc * d }
+  if n > SIR_ARRAY_MAX_ELEMENTS
+    raise "sir_array_checked_shape_size: shape #{shape} (#{n} elements) exceeds the #{SIR_ARRAY_MAX_ELEMENTS}-element cap"
+  end
+  n
+end
+
+def sir_array_ndarray(shape, data)
+  raise "sir_array_ndarray: data must be an Array" unless data.is_a?(Array)
+  n = sir_array_checked_shape_size(shape)
+  if n != data.length
+    raise "sir_array_ndarray: shape #{shape} implies #{n} elements, got #{data.length}"
+  end
+  SirNDArray.new(shape, data)
+end
+
+def sir_array_from_rows(rows)
+  nrows_in = rows.length
+  return sir_array_ndarray([0, 0], []) if nrows_in == 0
+  ncols_in = rows[0].length
+  raise "sir_array_from_rows: ragged rows" if rows.any? { |r| r.length != ncols_in }
+  n = sir_array_checked_shape_size([nrows_in, ncols_in])
+  data = Array.new(n)
+  (0...nrows_in).each do |r|
+    (0...ncols_in).each do |c|
+      data[c * nrows_in + r] = rows[r][c] # column-major store
+    end
+  end
+  sir_array_ndarray([nrows_in, ncols_in], data)
+end
+
+# Coerce a bare Ruby Numeric into a rank-0 (scalar) SirNDArray; an
+# already-SirNDArray value passes through unchanged. Needed because
+# `matlab-to-semantic-ir`'s lowerer emits a mixed operand pair for `.* ./
+# .\` and for `* /` when exactly one side is scalar (e.g. `A .* 2`) — the
+# BARE scalar sub-expression is passed through `ElementwiseOp` unwrapped
+# (a plain Integer/Float), not wrapped in an `ArrayLit` first. Every
+# function below that accepts an "array" operand normalizes through this
+# first, so a raw number never reaches `.data`/`.shape` and raises
+# `NoMethodError` instead of behaving correctly.
+def sir_array_to_array_value(v)
+  v.is_a?(SirNDArray) ? v : SirNDArray.new([], [v])
+end
+
+def sir_array_is_scalar(a) = a.data.length == 1
+
+# Rows, treating a scalar as `1x1` and a vector `[n]` as `nx1`.
+def sir_array_nrows(a) = a.shape.empty? ? 1 : a.shape[0]
+
+# Columns, treating a scalar as `1x1` and a vector `[n]` as `nx1`.
+def sir_array_ncols(a) = a.shape.length <= 1 ? 1 : a.shape[1]
+
+# Element `(r, c)` (column-major), or `nil` if out of bounds.
+#
+# SECURITY: written as the AND-form `r >= 0 && c >= 0 && r < nrows && c <
+# ncols`, NOT the negation `r < 0 || c < 0 || ...` — under IEEE-754 those
+# are NOT equivalent for NaN: every relational comparison with NaN is
+# false, so a NaN `r`/`c` would make every branch of the OR-form false too,
+# silently skipping the bounds check (mirrors the JS backend's own
+# `resolvePositions`/`assertValidPosition` fix for the identical hazard).
+def sir_array_get(a, r, c)
+  if r >= 0 && c >= 0 && r < sir_array_nrows(a) && c < sir_array_ncols(a)
+    a.data[c * sir_array_nrows(a) + r]
+  end
+end
+
+# Set element `(r, c)` IN PLACE (column-major) — mutates `a.data`
+# directly, matching MATLAB assignment semantics (`A(i,j) = v` rebinds one
+# element of the existing array, it does not produce a new one). This is
+# why `Stmt::IndexSet` is a statement, not a pure expression, in the SIR22
+# spec. Same NaN-safe AND-form bounds check as `sir_array_get`.
+def sir_array_set(a, r, c, value)
+  unless r >= 0 && c >= 0 && r < sir_array_nrows(a) && c < sir_array_ncols(a)
+    raise "sir_array_set: index (#{r}, #{c}) out of bounds for shape #{a.shape}"
+  end
+  a.data[c * sir_array_nrows(a) + r] = value
+end
+
+# Comparisons follow the same APL-style boolean convention
+# `array_runtime::BinOp` uses: `1` for true, `0` for false (never a native
+# `true`/`false`), since the result must stay a plain array element like
+# every other value here. `Div`/`Pow` force a Float result (Ruby's native
+# Integer `/` floors and `**` can promote to Rational for a negative
+# exponent — neither matches this domain's always-real-division /
+# always-real-power semantics), matching JS's `Float64Array`-backed
+# `Math.pow`/`/` exactly; `Add`/`Sub`/`Mul`/`Max`/`Min` preserve whatever
+# Numeric type the operands already are.
+def sir_array_apply_op(op, a, b)
+  case op
+  when "Add" then a + b
+  when "Sub" then a - b
+  when "Mul" then a * b
+  when "Div" then a.to_f / b.to_f
+  when "Pow" then a.to_f**b.to_f
+  when "Max" then [a, b].max
+  when "Min" then [a, b].min
+  when "Eq" then a == b ? 1 : 0
+  when "Ne" then a != b ? 1 : 0
+  when "Lt" then a < b ? 1 : 0
+  when "Le" then a <= b ? 1 : 0
+  when "Ge" then a >= b ? 1 : 0
+  when "Gt" then a > b ? 1 : 0
+  else
+    raise "sir_array_apply_op: unrecognised ElementwiseOpKind #{op.inspect}"
+  end
+end
+
+def sir_array_same_shape(a, b)
+  a.length == b.length && a.each_with_index.all? { |d, i| d == b[i] }
+end
+
+# Elementwise binary op with scalar broadcasting. Either operand may be a
+# scalar; otherwise the shapes must match exactly (full NumPy/MATLAB
+# broadcasting is out of scope, same as the Rust reference). Result takes
+# the non-scalar operand's shape (or the scalar's, if both are).
+def sir_array_elementwise(op, a, b)
+  a = sir_array_to_array_value(a)
+  b = sir_array_to_array_value(b)
+  ad = a.data
+  bd = b.data
+  if sir_array_is_scalar(a)
+    data = bd.map { |y| sir_array_apply_op(op, ad[0], y) }
+  elsif sir_array_is_scalar(b)
+    data = ad.map { |x| sir_array_apply_op(op, x, bd[0]) }
+  else
+    unless sir_array_same_shape(a.shape, b.shape)
+      raise "sir_array_elementwise: non-conformable arrays: #{a.shape} vs #{b.shape}"
+    end
+    data = ad.each_with_index.map { |x, i| sir_array_apply_op(op, x, bd[i]) }
+  end
+  shape = sir_array_is_scalar(a) ? b.shape : a.shape
+  sir_array_ndarray(shape, data)
+end
+
+# Matrix product `[m, k] . [k, n] -> [m, n]` (column-major throughout).
+# `m`/`n` come from two INDEPENDENT operands (each individually under
+# `SIR_ARRAY_MAX_ELEMENTS`, but their product isn't bounded by that alone
+# — an outer-product-shaped call could still ask for a huge output), so
+# `sir_array_checked_shape_size` validates `[m, n]` BEFORE allocating
+# `out`, not after. Normalizes both operands through
+# `sir_array_to_array_value` first, same reasoning as `sir_array_elementwise`.
+def sir_array_matmul(a, b)
+  a = sir_array_to_array_value(a)
+  b = sir_array_to_array_value(b)
+  m = sir_array_nrows(a)
+  ka = sir_array_ncols(a)
+  kb = sir_array_nrows(b)
+  n = sir_array_ncols(b)
+  if ka != kb
+    raise "sir_array_matmul: inner dimensions disagree (#{m}x#{ka} . #{kb}x#{n})"
+  end
+  out_len = sir_array_checked_shape_size([m, n])
+  ad = a.data
+  bd = b.data
+  out = Array.new(out_len, 0)
+  (0...n).each do |j|
+    (0...m).each do |i|
+      acc = 0
+      (0...ka).each do |p|
+        acc += ad[p * m + i] * bd[j * kb + p] # column-major indexing
+      end
+      out[j * m + i] = acc
+    end
+  end
+  sir_array_ndarray([m, n], out)
+end
+
+# Matrix transpose. `conjugate` distinguishes MATLAB `'` (`true`) from `.'`
+# (`false`) — this runtime has no Complex value type yet (matching
+# `array-runtime`'s own real-only scope today), so a conjugate transpose
+# of real data is identical to a plain transpose; `conjugate` is accepted
+# for call-shape parity with the SIR spec only.
+def sir_array_transpose(a, _conjugate)
+  m = sir_array_nrows(a)
+  n = sir_array_ncols(a)
+  ad = a.data
+  out = Array.new(ad.length)
+  (0...n).each do |j|
+    (0...m).each do |i|
+      out[i * n + j] = ad[j * m + i]
+    end
+  end
+  sir_array_ndarray([n, m], out)
+end
+
+# Materialize a MATLAB-style range `start:step:stop` (default `step = 1`)
+# as a `1xn` row vector — MATLAB's `:` always produces a row, never a
+# column. Bounded by `SIR_ARRAY_MAX_ELEMENTS` so a compiled program's
+# `1:1e18`-style range can't exhaust memory before this function ever gets
+# to materialize anything. `SIR_ARRAY_RANGE_EPSILON` tolerates the
+# inclusive-stop boundary (a floating step, e.g. `1:0.1:2`, can drift a
+# few ULPs short of `stop` by the final iteration).
+def sir_array_range(start, stop, step = 1)
+  raise "sir_array_range: step cannot be zero" if step == 0
+  unless sir_array_finite?(start) && sir_array_finite?(stop) && sir_array_finite?(step)
+    raise "sir_array_range: start/stop/step must be finite numbers, got (#{start}, #{stop}, #{step})"
+  end
+  values = []
+  x = start
+  while (step > 0 && x <= stop + SIR_ARRAY_RANGE_EPSILON) || (step < 0 && x >= stop - SIR_ARRAY_RANGE_EPSILON)
+    if values.length >= SIR_ARRAY_MAX_ELEMENTS
+      raise "sir_array_range: produces more than #{SIR_ARRAY_MAX_ELEMENTS} elements"
+    end
+    values << x
+    x += step
+  end
+  sir_array_ndarray(values.empty? ? [1, 0] : [1, values.length], values)
+end
+
+# One MATLAB-style index-position argument, mirroring the SIR22 spec's
+# `IndexArg` exactly: `{kind: "scalar", value:}` / `{kind: "whole"}` /
+# `{kind: "range", indices:}`. `end`-relative indices are never seen here
+# — per SIR10 discipline, the frontend resolves `end` to a concrete
+# 0-based `scalar` index before emitting `IndexGet`/`IndexSet`.
+
+# Validate one resolved position is a real, finite integer, and return it
+# as a genuine Ruby Integer (JS can index a typed array with a
+# float-valued-but-integer number like `3.0` directly; Ruby's `Array#[]`
+# cannot, so this coerces after validating, unlike the JS reference).
+#
+# SECURITY: the caller resolves EVERY position through this single choke
+# point before it ever reaches `sir_array_get`/`sir_array_set`'s own
+# NaN-safe bounds checks below — an unvalidated Float::NAN/Infinity index
+# must fail loudly here (a clean, catchable exception), not silently
+# produce a bogus position that then defeats a downstream comparison.
+def sir_array_assert_valid_position(i)
+  unless sir_array_integer_dim?(i)
+    raise "sir_array_resolve_positions: index #{i} is not a finite integer"
+  end
+  i.to_i
+end
+
+def sir_array_resolve_positions(arg, dim_size)
+  case arg[:kind]
+  when "scalar" then [sir_array_assert_valid_position(arg[:value])]
+  when "whole" then (0...dim_size).to_a
+  when "range"
+    arg[:indices].data.map do |x|
+      # `Float#truncate` raises FloatDomainError on NaN/Infinity in Ruby
+      # (unlike JS's `Math.trunc`, which returns NaN/Infinity unchanged) —
+      # only truncate a value already known finite; a non-finite x is
+      # passed through as-is so `sir_array_assert_valid_position` reports
+      # its own clean error instead of a raw FloatDomainError escaping.
+      sir_array_assert_valid_position(sir_array_finite?(x) ? x.truncate : x)
+    end
+  else
+    raise "sir_array_resolve_positions: unrecognised IndexArg #{arg.inspect}"
+  end
+end
+
+# `A(i)` / `A(i, j)` — read one element or a sub-array. Scoped to 1 or 2
+# index arguments (rank <= 2): a single argument indexes `a`'s underlying
+# column-major data linearly (MATLAB's own single-subscript convention,
+# which is column-major too); two arguments index `(row, col)`. Returns a
+# bare Numeric when every argument is `scalar` (a single element),
+# otherwise a SirNDArray.
+def sir_array_index_get(a, indices)
+  if indices.length == 1
+    arg = indices[0]
+    positions = sir_array_resolve_positions(arg, a.data.length)
+    read = lambda do |i|
+      raise "sir_array_index_get: linear index #{i} out of bounds" if i < 0 || i >= a.data.length
+      a.data[i]
+    end
+    return read.call(positions[0]) if arg[:kind] == "scalar"
+    return sir_array_ndarray([1, positions.length], positions.map { |i| read.call(i) })
+  end
+  if indices.length == 2
+    row_arg, col_arg = indices
+    rows = sir_array_resolve_positions(row_arg, sir_array_nrows(a))
+    cols = sir_array_resolve_positions(col_arg, sir_array_ncols(a))
+    read = lambda do |r, c|
+      v = sir_array_get(a, r, c)
+      raise "sir_array_index_get: (#{r}, #{c}) out of bounds for shape #{a.shape}" if v.nil?
+      v
+    end
+    return read.call(rows[0], cols[0]) if row_arg[:kind] == "scalar" && col_arg[:kind] == "scalar"
+    # `rows.length`/`cols.length` are each individually bounded by `a`'s
+    # own dimensions (`whole`) or by a `range` NDArray's own
+    # SIR_ARRAY_MAX_ELEMENTS cap — but nothing bounds their PRODUCT on its
+    # own, so this is the exact outer-product-shaped allocation
+    # `sir_array_matmul` guards against, one level up. Validate before
+    # allocating, not after.
+    out_len = sir_array_checked_shape_size([rows.length, cols.length])
+    data = Array.new(out_len)
+    cols.each_with_index do |c, ci|
+      rows.each_with_index do |r, ri|
+        data[ci * rows.length + ri] = read.call(r, c)
+      end
+    end
+    return sir_array_ndarray([rows.length, cols.length], data)
+  end
+  raise "sir_array_index_get: only 1 or 2 index arguments are supported (rank <= 2 scope), got #{indices.length}"
+end
+
+# Broadcast a scalar-or-SirNDArray right-hand side to exactly `count`
+# values (mirrors `sir_array_elementwise`'s scalar-broadcast rule).
+def sir_array_broadcast_values(value, count)
+  return Array.new(count, value) if value.is_a?(Numeric)
+  return Array.new(count, value.data[0]) if value.data.length == 1
+  if value.data.length != count
+    raise "sir_array_index_set: value has #{value.data.length} elements, expected #{count}"
+  end
+  value.data
+end
+
+# `A(i) = v` / `A(i, j) = v` — write one element or a sub-array, IN PLACE
+# (see `sir_array_set`'s doc comment above for why this mutates rather
+# than returns a new array). `value` may be a scalar (broadcast to every
+# selected position) or a SirNDArray with exactly as many elements as
+# positions are selected.
+def sir_array_index_set(a, indices, value)
+  if indices.length == 1
+    arg = indices[0]
+    positions = sir_array_resolve_positions(arg, a.data.length)
+    values = sir_array_broadcast_values(value, positions.length)
+    positions.each_with_index do |i, k|
+      raise "sir_array_index_set: linear index #{i} out of bounds" if i < 0 || i >= a.data.length
+      a.data[i] = values[k]
+    end
+    return
+  end
+  if indices.length == 2
+    row_arg, col_arg = indices
+    rows = sir_array_resolve_positions(row_arg, sir_array_nrows(a))
+    cols = sir_array_resolve_positions(col_arg, sir_array_ncols(a))
+    # Same product-of-two-independent-selections gap `sir_array_index_get`
+    # closes above — validate before `sir_array_broadcast_values` allocates.
+    count = sir_array_checked_shape_size([rows.length, cols.length])
+    values = sir_array_broadcast_values(value, count)
+    k = 0
+    cols.each do |c|
+      rows.each do |r|
+        sir_array_set(a, r, c, values[k])
+        k += 1
+      end
+    end
+    return
+  end
+  raise "sir_array_index_set: only 1 or 2 index arguments are supported (rank <= 2 scope), got #{indices.length}"
+end
 "####;

--- a/code/packages/rust/semantic-ir-to-ruby/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/sir22_array.rs
@@ -1,0 +1,279 @@
+//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/
+//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the
+//! Ruby backend — hand-builds a module calling each node directly
+//! (bypassing the frontend, since no frontend targets this backend for
+//! SIR22 yet), emits Ruby, runs it with a real `ruby` interpreter, and
+//! asserts stdout. Mirrors `division_ops_tests.rs`'s pattern; skips (does
+//! not fail) when no `ruby` is on `PATH`.
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir22_array.rs` — same worked examples, adapted to this
+//! backend's own value-type conventions (Ruby preserves native
+//! Integer/Float type propagation rather than JS's uniform-double
+//! storage; see `runtime.rs`'s own module doc for why an all-integer
+//! computation here prints without a spurious `.0`).
+//!
+//! Every test constructs `Module`s directly via `print_stmt`'s scalar
+//! `IndexGet` reads (top-left/bottom-right element, etc.) — sidesteps
+//! needing an NDArray display/format story, which is out of this slice's
+//! scope, exactly as the JS reference's own tests do.
+
+use semantic_ir::{
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    IndexArg, Metadata, Module, Scope, Span, Stmt,
+};
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn array_lit(rows: Vec<Vec<Expr>>) -> Expr {
+    Expr::ArrayLit { rows, span: s() }
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+fn scalar(i: i64) -> IndexArg {
+    IndexArg::Scalar(Box::new(ilit(i)))
+}
+fn index_get(target: Expr, indices: Vec<IndexArg>) -> Expr {
+    Expr::IndexGet { target: Box::new(target), indices, span: s() }
+}
+
+const ARRAY_FEATURES: &[Feature] =
+    &[Feature::NDArrays, Feature::MatrixOps, Feature::ArrayColumnMajor];
+
+fn array_module(stmts: Vec<Stmt>) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings];
+    features.extend_from_slice(ARRAY_FEATURES);
+    Module {
+        name: "sir22array".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Run emitted Ruby, returning stdout, or `None` to skip when no `ruby` is
+/// on `PATH`. Unique temp-file names per call (PID + a monotonic counter)
+/// — a constant name would let concurrently-running `cargo test` threads
+/// collide on the same path, the exact race this session's own
+/// `sir-conformance` division tests hit and fixed earlier in this arc.
+fn run_array_program(m: &Module) -> Option<String> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    let source = semantic_ir_to_ruby::compile(m).expect("ruby emit").source;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "sir_ruby_array_{}_{}.rb",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::File::create(&path).ok()?.write_all(source.as_bytes()).ok()?;
+    let out = std::process::Command::new("ruby").arg(&path).output().ok()?;
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "emitted ruby exited non-zero:\n{}\n--- source ---\n{source}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn matmul_of_two_by_two_matrices_computes_the_right_product() {
+    // [1 2; 3 4] * [5 6; 7 8] = [19 22; 43 50] (standard matrix product).
+    // All-integer inputs stay Integer through Ruby's native `+`/`*`, so
+    // the printed result has no spurious ".0" (see runtime.rs's own doc).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5), ilit(6)], vec![ilit(7), ilit(8)]]);
+    let product = Expr::MatMul { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("p", product),
+        print_stmt(index_get(local("p"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("p"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "19\n50\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
+    // MATLAB `A .* 2` -- matlab-to-semantic-ir emits the `2` as a bare
+    // IntLit operand, unwrapped (not an ArrayLit), when exactly one side
+    // is scalar. This is the exact shape `sir_array_to_array_value`'s
+    // coercion in runtime.rs exists for; a regression there raises
+    // NoMethodError instead of computing [2 4; 6 8].
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let scaled = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("sc", scaled),
+        print_stmt(index_get(local("sc"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("sc"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n8\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_div_always_true_divides_even_on_integer_operands() {
+    // Unlike Add/Sub/Mul (which preserve Integer), Div forces a Float
+    // result -- Ruby's native Integer#/ floors, which would silently
+    // disagree with MATLAB's `./` (always real division).
+    let a = array_lit(vec![vec![ilit(7)]]);
+    let divided = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Div,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("d", divided),
+        print_stmt(index_get(local("d"), vec![scalar(0), scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "3.5\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn transpose_of_a_two_by_three_matrix_swaps_rows_and_columns() {
+    // [1 2 3; 4 5 6]' = [1 4; 2 5; 3 6]
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let t = Expr::Transpose { target: Box::new(a), conjugate: true, span: s() };
+    let m = array_module(vec![
+        let_binding("t", t),
+        print_stmt(index_get(local("t"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("t"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "4\n6\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn range_materializes_a_row_vector_read_by_linear_index() {
+    // 1:2:9 -> [1 3 5 7 9], a 1x5 row vector. A single index argument
+    // reads linearly (rank-1 IndexGet).
+    let r = Expr::Range {
+        start: Box::new(ilit(1)),
+        step: Some(Box::new(ilit(2))),
+        stop: Box::new(ilit(9)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(4)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n9\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn whole_selector_reads_an_entire_row() {
+    // A(1, :) on [1 2; 3 4] reads the whole second row [3 4], then a
+    // scalar linear IndexGet reads its second element.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let row = index_get(a, vec![scalar(1), IndexArg::Whole]);
+    let m = array_module(vec![
+        let_binding("row", row),
+        print_stmt(index_get(local("row"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "4\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn index_set_mutates_in_place() {
+    // A(1, 1) = 99 on [1 2; 3 4] -- IndexSet is a Stmt (in-place
+    // mutation), not a pure Expr, per the SIR22 spec.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let m = array_module(vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![scalar(1), scalar(1)],
+            value: Box::new(ilit(99)),
+            span: s(),
+        },
+        print_stmt(index_get(local("a"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "99\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+
+#[test]
+fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
+    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
+    // cut, so the ordinary feature-flag check alone can't reject it --
+    // proves the dedicated `ScanHit::Sir22AddendumNode` pre-emit scan
+    // does, with a clean `Err`, not an `emit_expr` `unreachable!` panic.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
+    let m = array_module(vec![print_stmt(Expr::Reduce {
+        op: ElementwiseOpKind::Add,
+        target: Box::new(target),
+        span: s(),
+    })]);
+    let err = semantic_ir_to_ruby::compile(&m).expect_err("Reduce must be rejected, not emitted");
+    assert!(
+        err.message.contains("Reduce"),
+        "error should name the rejected node: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary
- Part of the SIR22/SIR23 backend-expansion initiative (opening C/Go/Rust/Python/Ruby to array/matrix and symbolic/pattern support — see `code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section, amended in a prior PR).
- This backend now accepts `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and implements the SIR22 base cut: `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` (+ `Stmt::IndexSet`).
- New `sir_array_*` runtime (`runtime.rs`): an inlined port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime, following this crate's existing inlined-runtime convention (unlike Python/TypeScript's imported-package model).
- **A deliberate divergence from the JS/TS references, documented in the CHANGELOG**: array data preserves native Ruby Integer/Float type propagation (`Add`/`Sub`/`Mul` stay Integer; only `Div`/`Pow` force Float) rather than JS's uniform-double storage — matches this crate's own `div_true` precedent and its existing `sir_fmt_float` display convention.
- The 9-node SIR22 "APL addendum" shares feature flags with the base cut, so a bare capability check can't distinguish it — added a dedicated `ScanHit::Sir22AddendumNode` arm folded into this crate's existing single shared pre-emit scan (not a second, JS-style separate walker), rejecting it cleanly until its own later slice (Phase A Slice 3).
- Every shape/index-position validation happens before allocation, and every bounds check follows the NaN-safe AND-form the JS reference documents (verified explicitly by security review, including the two OR-form checks that are safe because their inputs are already funneled through a NaN-rejecting validator first).

## Test plan
- [x] `cargo test -p semantic-ir-to-ruby` — full suite, 145 tests total (124 pre-existing + 8 new SIR22 tests + 6 division + 7 sys_write), 0 failures
- [x] New `tests/sir22_array.rs` (8 tests, ported from the JS backend's own `sir22_array.rs` worked examples): `matmul`, scalar-broadcast `elementwise`, `Div`'s forced-float behavior, `transpose`, `range`, a `Whole` selector, `IndexSet` mutation — each compiled and run through a real `ruby` interpreter — plus a compile-time rejection test proving `Reduce` is cleanly rejected rather than reaching an `emit_expr` panic
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `/security-review` — PASSED, no vulnerabilities found (DoS-safety and NaN-bounds-check discipline explicitly verified line-by-line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)