### PR TITLE
feat(semantic-ir-to-go): implement SIR22 array/matrix base cut (Phase A Slice 2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,130 @@
 # Changelog
 
+## 0.40.0 — SIR22 array/matrix base cut (second-wave backend rollout, Phase A Slice 2)
+
+Opens this backend to `Feature::NDArrays`/`Feature::MatrixOps`/
+`Feature::ArrayColumnMajor` and implements the SIR22 array/matrix "base cut"
+— `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+and `Stmt::IndexSet` (the mutating counterpart) — per
+`code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section,
+which named this backend (alongside C/Rust/Ruby) as a planned second wave
+following JS/TS's own already-shipped SIR22 codegen. The 9-node SIR22 "APL
+addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) remains explicitly OUT of
+scope for this PR — a later slice.
+
+**New `_sir_ndarray_*` runtime (`runtime.rs`)**: an inlined port of
+`semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime,
+following this backend's existing inlined-runtime convention (no `go.mod`
+dependency, pasted verbatim into every artifact, same as every other
+runtime helper here). Ported 1:1: `checkedShapeSize`, `ndarray`/`fromRows`,
+`toArrayValue`'s bare-scalar coercion, `isScalar`/`nrows`/`ncols`,
+`get`/`set` (NaN-safe AND-form bounds checks), `applyOp`'s 13-op elementwise
+dispatch table (booleans render `1.0`/`0.0`, never a native Go `bool`),
+`elementwise`'s scalar-broadcast rule, `matmul`, `transpose`, `range`
+(MATLAB-style `start:step:stop`, ULP-tolerant inclusive-stop boundary),
+`resolvePositions`/`assertValidPosition` (index-argument resolution),
+`indexGet`/`broadcastValues`/`indexSet`.
+
+**Naming**: every new helper is prefixed `_sir_ndarray_`, NOT `_sir_array_`
+— this backend's PRE-EXISTING Ruby-`Array`(`*Seq`)-method-dispatch catalog
+(C5's `_sir_array_method`/`_sir_array_responds`/`_sir_array_block_method`)
+already owns the `_sir_array_*` prefix for an entirely unrelated domain
+(Ruby's `Array` == this runtime's `*Seq`, not a SIR22 numeric matrix).
+Reusing that prefix would have collided outright with real existing
+functions of the same shape (both take a receiver + do a name-keyed
+dispatch) — a footgun worth flagging explicitly since a naive port of the
+JS reference's `Array.*` naming would have walked straight into it.
+
+**Value representation**: a `*NDArray{Shape []int; Data []float64}` — shared
++ mutable via a pointer handle, exactly like this runtime's existing
+`*Seq`/`*Map` (`Stmt::IndexSet` must mutate the very array a caller's
+binding already holds, MATLAB assignment semantics, mirroring why `*Seq`
+and `*Map` are pointer-backed too). Every element is stored as a **uniform
+`float64`** — a deliberate divergence from the sibling Ruby backend's SIR22
+port (`claude/sir22-slice2-ruby`), which preserves native Ruby
+Integer/Float propagation (Div/Pow force Float; Add/Sub/Mul don't,
+following that crate's own `div_true` precedent). MATLAB's OWN numeric
+model is "every array is a matrix of doubles" by default — there is no
+separate integer-array type in the MATLAB subset this repo's frontends
+target — so uniform `float64` storage is the semantically faithful choice
+here, not a Go-specific compromise, and it is exactly what the JS reference
+this file ports from already does (`Float64Array` throughout). Go's own
+numeric tower (`int64`/`float64` boxed into the existing `Value`
+interface{}) has no "array of numbers" precedent of its own worth
+preserving the way Ruby's native `Integer` class does, so this port stays
+byte-for-byte equivalent to the JS reference's uniform-double model instead
+of introducing a new Go-specific split. One consequence worth flagging: an
+all-integer computation (e.g. `[1 2; 3 4] * [5 6; 7 8]`) prints WITH a
+trailing `.0` on this backend (Go's own `_sir_format_float` convention),
+unlike Ruby's bare-integer output for the same computation — see
+`tests/sir22_array.rs`'s own module doc.
+
+**DoS discipline**: every constructor validates a shape/output size BEFORE
+allocating a `[]float64` from it (`_sir_ndarray_checked_shape_size`,
+called by `ndarray`/`fromRows`/`matmul`/the 2-index-argument paths of
+`indexGet`/`indexSet`), mirroring the JS reference's `MAX_ELEMENTS =
+1 << 26` cap exactly. Go-specific tightening beyond a literal JS port: the
+running shape-size product is checked for overflow ONE multiplication at a
+time (`acc > cap/d` BEFORE `acc *= d`), not after — a JS `Number` cannot
+silently wrap on overflow (only lose precision past 2^53), but Go's `int`
+is a fixed-width two's-complement type where `acc *= d` for a sufficiently
+large shape CAN wrap around to a small or negative `int`, which would slip
+straight past a naive post-hoc `> cap` check. `tests/sir22_array.rs`'s
+`matmul_output_shape_exceeding_the_element_cap_panics_cleanly` proves this
+end-to-end: two independently-under-cap `1x9000`/`9000x1` operands whose
+`9000x9000` matmul OUTPUT would exceed the cap panic cleanly (a readable
+message on stderr) instead of attempting the ~650MB allocation.
+
+**`emit.rs`**: added 6 new `Expr` match arms + 1 `Stmt` arm calling into the
+new runtime, all following this backend's existing emit style
+(`elementwise_op_go_name`/`emit_index_arg`/`emit_index_args` mirror the JS
+backend's `elementwise_op_js_name`/`emit_index_arg`/`emit_index_args`
+exactly). **Landmine avoided**: these 7 nodes previously shared ONE
+combined `panic!` match arm with the 9 SIR22-addendum nodes AND
+`Expr::Convert` (SIR26) — split carefully so `Expr::Convert`'s existing
+(untouched) panic behavior is preserved byte-for-byte in its own arm,
+while the addendum nodes' arm was updated to explain that a NEW soundness
+gate (not the capability gate) is what actually protects them now (see
+below). `cargo test -p semantic-ir-to-go` stayed 100% green throughout,
+confirming no `Expr::Convert` regression.
+
+**Addendum rejection**: the 9-node APL addendum shares
+`NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut, so — now that
+this PR adds those three flags to `ACCEPTED_FEATURES` — the ordinary
+feature-flag capability check alone can no longer distinguish "safe" base-
+cut modules from "still unimplemented" addendum ones. Unlike the JS
+backend's now-removed `find_unimplemented_sir22_addendum_node`
+(`Visitor`-based, a second separate walker) or the Ruby backend's
+`ScanHit::Sir22AddendumNode` (folded into that crate's single shared
+pre-emit scan), this backend already had its OWN pre-existing "reject a
+well-formed-but-unimplemented construct cleanly" mechanism —
+`check_exception_soundness`/`check_soundness_stmt`/`check_soundness_expr`
+(added for E3, extended for O4/MX5 since) — called once from `compile()`
+right beside the manifest gate. This PR extends THAT existing walk rather
+than adding a third parallel mechanism: nine new `check_soundness_expr`
+arms push a clean `BackendError` naming the offending node
+(`unsupported_sir22_addendum`), and the six base-cut node kinds gained
+recursion arms so nested addendum/`Const` usage inside e.g. an `ArrayLit`
+row is still caught. `Stmt::IndexSet`'s prior `panic!` placeholder arm (in
+`check_soundness_stmt`) was replaced with real recursion into its three
+sub-positions, mirroring the existing `Stmt::SeqSet`/`Stmt::MapSet` arms —
+it is a genuinely supported statement now, not a deferred one.
+
+**New `tests/sir22_array.rs`** (9 tests): real `go run` execution proof,
+hand-building `Module`s directly (no frontend targets this backend for
+SIR22 yet) — ported from the JS backend's own `tests/sir22_array.rs`
+worked examples (matmul of two 2x2 matrices against a known product,
+elementwise-mul with a bare-scalar RHS operand, `Div`'s always-true-divide,
+transpose, a MATLAB-style range read by linear index, a `Whole` (`:`)
+selector reading an entire row, `Stmt::IndexSet` mutating in place), plus
+two new tests: the shape-overflow DoS-guard proof described above, and a
+compile-time-rejection proof for `Expr::Reduce` (an addendum node) —
+`compile()` returns a clean `Err` naming the node, not a panic. Uses a
+PID + monotonic-counter temp-filename scheme (not just a per-test tag)
+to avoid the concurrent-`cargo-test` filename race this session's C-backend
+tests already guard against.
+
 ## 0.39.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
 
 Additive only — no frontend emits these names yet, bare `"/"` keeps working

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -290,6 +290,31 @@ that used to implement them were removed once every frontend finished
 migrating to `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
+### SIR22 — array/matrix base cut (`NDArrays`, `MatrixOps`, `ArrayColumnMajor`)
+
+`Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and
+`Stmt::IndexSet` (MATLAB/Octave-style dense numeric arrays and matrix ops)
+lower to calls into an inlined `_sir_ndarray_*` sub-runtime — a plain-Go
+port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
+sub-runtime, following this backend's existing "paste the runtime helpers
+inline, no `go.mod` dependency" convention. See
+[SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md) for the full
+node-by-node spec. Every array element is a `float64` (MATLAB's own
+"everything is a double" numeric model — see `runtime.rs`'s module doc for
+why this backend does NOT preserve native `int64`/`float64` propagation the
+way the sibling Ruby backend's SIR22 port does). Shape/output sizes are
+validated (with explicit multiplication-overflow guards, since Go's `int`
+can wrap where JS's `Number` cannot) BEFORE any `[]float64` allocation, an
+`_sirNdarrayMaxElements = 1 << 26` cap mirroring the JS reference's
+`MAX_ELEMENTS` exactly.
+
+The 9-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is **not yet
+supported** — it shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
+base cut above, so a plain feature-flag check can't reject it; `lib.rs`'s
+`check_exception_soundness` (extended for this PR) rejects it cleanly with
+a `BackendError` naming the offending node, before `emit` is ever reached.
+
 ## Value model
 
 ```go
@@ -300,11 +325,16 @@ type Closure  struct { Fn func(args []Value) Value }
 type Seq      struct { Items []Value }              // held by *Seq (shared, mutable)
 type MapEntry struct { Key, Val Value }
 type Map      struct { Entries []MapEntry }         // held by *Map (insertion-ordered assoc list)
+type NDArray  struct { Shape []int; Data []float64 } // held by *NDArray (shared, mutable); SIR22
 ```
 
 Single-threaded; symbol interning + globals in module-level maps.
-`*Seq` / `*Map` give sequences and maps reference (shared-mutable)
-semantics; maps key on structural value-equality (`_sir_value_eq`).
+`*Seq` / `*Map` / `*NDArray` give sequences, maps, and arrays reference
+(shared-mutable) semantics; maps key on structural value-equality
+(`_sir_value_eq`). `*NDArray`'s own helper catalog is prefixed
+`_sir_ndarray_*`, deliberately distinct from the pre-existing
+`_sir_array_*` prefix (C5's Ruby-`Array`(`*Seq`)-method-dispatch catalog,
+an unrelated domain) — see `runtime.rs`'s SIR22 section doc comment.
 
 ## Block-as-expression
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -18,7 +18,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, ParamKind, Scope, Stmt};
+use semantic_ir::{
+    Block, ElementwiseOpKind, Expr, Function, Global, IndexArg, Module, ParamKind, Scope, Stmt,
+};
 // `RescueClause` is referenced by name in `emit_try_catch`'s signature.
 use semantic_ir::RescueClause;
 
@@ -527,13 +529,84 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_try_catch(out, body, rescues, ensure_body.as_deref(), indent);
         }
         // ── SIR22 (array/matrix IR) ──────────────────────────────────
-        // `IndexSet` observes `Feature::NDArrays`/`Feature::MatrixOps`,
-        // neither of which `ACCEPTED_FEATURES` declares, so the capability
-        // gate rejects any module using it before emit is ever reached.
-        // Mirrors the `Stmt::Assign` unsupported-scope panic above.
-        Stmt::IndexSet { span, .. } => {
-            panic!("go backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
+        // `target[indices...] = value` — mutates in place via
+        // `_sir_ndarray_index_set` (see `runtime.rs`'s "SIR22 array/matrix
+        // domain" section), matching the SIR22 spec's own note that
+        // `IndexSet` is a `Stmt`, not a pure `Expr`, for exactly this
+        // in-place-mutation reason.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            out.push_str(&pad);
+            out.push_str("_sir_ndarray_index_set(");
+            emit_expr(out, target, indent);
+            out.push_str(", []_sirIndexArg{");
+            emit_index_args(out, indices, indent);
+            out.push_str("}, ");
+            emit_expr(out, value, indent);
+            out.push_str(")\n");
         }
+    }
+}
+
+/// The Go string `_sir_ndarray_apply_op`'s switch dispatches on — exact
+/// `ElementwiseOpKind` variant names, not `.name()`'s lowercase forms
+/// (`"add"`, etc.), since this string is a real runtime dispatch key.
+/// Mirrors `semantic-ir-to-javascript`'s `elementwise_op_js_name`.
+fn elementwise_op_go_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "Add",
+        ElementwiseOpKind::Sub => "Sub",
+        ElementwiseOpKind::Mul => "Mul",
+        ElementwiseOpKind::Div => "Div",
+        ElementwiseOpKind::Pow => "Pow",
+        ElementwiseOpKind::Max => "Max",
+        ElementwiseOpKind::Min => "Min",
+        ElementwiseOpKind::Eq => "Eq",
+        ElementwiseOpKind::Ne => "Ne",
+        ElementwiseOpKind::Lt => "Lt",
+        ElementwiseOpKind::Le => "Le",
+        ElementwiseOpKind::Ge => "Ge",
+        ElementwiseOpKind::Gt => "Gt",
+    }
+}
+
+/// Emit one `IndexArg` as the `_sirIndexArg{Kind: ..., ...}` struct
+/// literal `_sir_ndarray_index_get`/`index_set` expect (see
+/// `runtime.rs`'s `_sirIndexArg` doc comment). The `Range` case wraps its
+/// inner expression in `_sir_ndarray_as_ndarray(...)` rather than relying
+/// on the emitted expression's own static Go type already being
+/// `*NDArray` — that inner expression is only "typically" an
+/// `Expr::Range` node per the SIR22 spec's own doc comment on
+/// `IndexArg::Range`, not guaranteed to be one structurally, so a strict
+/// runtime assertion is safer than an implicit static-type assumption.
+fn emit_index_arg(out: &mut String, arg: &IndexArg, indent: usize) {
+    match arg {
+        IndexArg::Scalar(e) => {
+            out.push_str("_sirIndexArg{Kind: \"scalar\", Value: _sir_as_float(");
+            emit_expr(out, e, indent);
+            out.push_str(")}");
+        }
+        IndexArg::Whole => {
+            out.push_str("_sirIndexArg{Kind: \"whole\"}");
+        }
+        IndexArg::Range(e) => {
+            out.push_str("_sirIndexArg{Kind: \"range\", Indices: _sir_ndarray_as_ndarray(");
+            emit_expr(out, e, indent);
+            out.push_str(")}");
+        }
+    }
+}
+
+fn emit_index_args(out: &mut String, indices: &[IndexArg], indent: usize) {
+    for (i, arg) in indices.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        emit_index_arg(out, arg, indent);
     }
 }
 
@@ -837,24 +910,93 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::KeywordArg { span, .. } => {
             panic!("go backend reached a keyword argument outside a DirectCall at {} — indirect/closure keyword calls are deferred for the Go backend (KW6, spec §Out of scope); frontends do not emit them", span);
         }
-        // ── SIR22 (array/matrix IR) ──────────────────────────────────
-        // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
-        // all observe `Feature::NDArrays` and/or `Feature::MatrixOps`,
-        // neither of which `ACCEPTED_FEATURES` declares, so the SIR10
-        // capability gate (`Backend::check_module`) rejects any module
-        // using one of these nodes before it ever reaches emit.  Mirrors
-        // the `Expr::StrConcat`/`Expr::KeywordArg` deferred-node panics
-        // above.
-        Expr::ArrayLit { .. }
-        | Expr::Range { .. }
-        | Expr::MatMul { .. }
-        | Expr::ElementwiseOp { .. }
-        | Expr::Transpose { .. }
-        | Expr::IndexGet { .. }
-        // SIR22 addendum: APL primitive operators — same deferral rationale
-        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // features, which `ACCEPTED_FEATURES` still doesn't declare).
-        | Expr::Reduce { .. }
+        // ── SIR22 (array/matrix IR) — base cut: real codegen ──────────
+        // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+        // `IndexGet` all observe `Feature::NDArrays`/`Feature::MatrixOps`/
+        // `Feature::ArrayColumnMajor`, all three now in `ACCEPTED_FEATURES`
+        // — each lowers to a call into the `_sir_ndarray_*` sub-runtime
+        // (see `runtime.rs`'s "SIR22 array/matrix domain" section). `rows`
+        // is row-major in the literal syntax (per the SIR22 spec);
+        // `_sir_ndarray_from_rows` reconciles that with column-major
+        // storage, so the emitter just nests the row/element expressions
+        // unchanged.
+        Expr::ArrayLit { rows, .. } => {
+            out.push_str("_sir_ndarray_from_rows([][]Value{");
+            for (i, row) in rows.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('{');
+                emit_args(out, row, indent);
+                out.push('}');
+            }
+            out.push_str("})");
+        }
+        // `_sir_ndarray_range(start, stop, step)` — note the argument
+        // ORDER: the SIR node's own field order is `start, step, stop`,
+        // but `_sir_ndarray_range(startV, stopV, stepV)` takes `stop`
+        // before `step` (mirrors the JS reference's identical reordering).
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            out.push_str("_sir_ndarray_range(");
+            emit_expr(out, start, indent);
+            out.push_str(", ");
+            emit_expr(out, stop, indent);
+            out.push_str(", ");
+            match step {
+                Some(step) => emit_expr(out, step, indent),
+                None => out.push('1'),
+            }
+            out.push(')');
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            out.push_str("_sir_ndarray_matmul(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        // The op name must match `_sir_ndarray_apply_op`'s switch in
+        // `runtime.rs` exactly (`"Add"`, not `.name()`'s lowercase `"add"`).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "_sir_ndarray_elementwise({}, ",
+                quote_go_string(elementwise_op_go_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            out.push_str("_sir_ndarray_transpose(");
+            emit_expr(out, target, indent);
+            let _ = write!(out, ", {conjugate})");
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            out.push_str("_sir_ndarray_index_get(");
+            emit_expr(out, target, indent);
+            out.push_str(", []_sirIndexArg{");
+            emit_index_args(out, indices, indent);
+            out.push_str("})");
+        }
+        // ── SIR22 addendum: APL primitive operators (still deferred) ──
+        // These nine share `Feature::NDArrays`/`MatrixOps`/
+        // `ArrayColumnMajor` with the base cut just above, so the SIR10
+        // capability gate alone can no longer reject them now that this
+        // backend accepts those three features — `lib.rs`'s
+        // `check_exception_soundness` (a dedicated structural soundness
+        // gate; see its doc comment) is what actually rejects a module
+        // using one of these, with a clean `Err`, BEFORE `compile` ever
+        // calls `emit_module`. Reaching this arm at runtime would mean
+        // that gate has a bug, not a user error.
+        Expr::Reduce { .. }
         | Expr::Scan { .. }
         | Expr::OuterProduct { .. }
         | Expr::Shape { .. }
@@ -863,11 +1005,14 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::IndexOf { .. }
         | Expr::Ravel { .. }
         | Expr::Catenate { .. }
-        // SIR26 `Convert` — this backend does not accept `Conversions`, so a
-        // validated module never reaches here (capability check rejects it).
+        // SIR26 `Convert` — unrelated to SIR22; this backend still does
+        // not accept `Feature::Conversions`, so the ordinary SIR10
+        // capability gate (not the SIR22-specific soundness gate above)
+        // rejects any module using it before emit is ever reached —
+        // unaffected by this PR.
         | Expr::Convert { .. } => {
             panic!(
-                "go backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                "go backend reached a deferred SIR22-addendum/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -178,6 +178,23 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
+    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+    // (+ `Stmt::IndexSet`) route into `_sir_ndarray_*` helpers, an
+    // inlined port of the already-proven `semantic-ir-to-javascript`
+    // `ArrayRt` sub-runtime (see `runtime.rs`'s "SIR22 array/matrix
+    // domain" section). The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+    // `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) share these same three features but stay
+    // deferred to a later slice — rejected by `check_exception_soundness`
+    // below (extended for this PR to also cover SIR22, despite its
+    // E3-era name — see that function's doc comment), NOT this
+    // capability gate, since the gate alone can no longer distinguish
+    // the base cut from the addendum once these three flags are
+    // accepted.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for GoBackend {
@@ -330,6 +347,29 @@ fn check_no_keyword_rest_mix(module: &Module, errs: &mut Vec<BackendError>) {
 /// `InstanceVars`/`ClassVars`, which this backend does not accept), so this
 /// gate need only cover the const/module surface that `Classes`/`Constants`
 /// acceptance newly admits.
+///
+/// **Second job, added for the SIR22 second-wave backend rollout (still
+/// under this E3-era name — renaming was judged unnecessary churn for a
+/// crate-private function, but is flagged here for a future reader):**
+/// this same walk ALSO rejects the SIR22 "APL addendum" nodes (`Reduce`/
+/// `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+/// `Ravel`/`Catenate`).  Those nine share `Feature::NDArrays`/
+/// `Feature::MatrixOps`/`Feature::ArrayColumnMajor` with the SIR22 BASE
+/// cut this backend now implements (`ArrayLit`/`Range`/`MatMul`/
+/// `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet`) — the SIR22
+/// addendum spec gives them no feature flag of their own — so the
+/// ordinary `accepts_features()` capability check can no longer tell a
+/// module using only the base cut (real codegen, safe) from one that
+/// also uses these nine (still deferred in `emit`, would panic) now that
+/// `ACCEPTED_FEATURES` declares those three flags.  Reusing THIS
+/// existing recursive walk (rather than adding a second, separate
+/// tree-walk mechanism the way `semantic-ir-to-javascript`'s now-removed
+/// `find_unimplemented_sir22_addendum_node` or
+/// `semantic-ir-to-ruby`'s `ScanHit::Sir22AddendumNode` each did) follows
+/// this backend's OWN pre-existing idiom: one shared structural
+/// soundness gate, called once from `compile()` right beside the
+/// manifest gate, before any emission — see the doc comment above for
+/// the original (E3) rationale, which applies identically here.
 fn check_exception_soundness(module: &Module, errs: &mut Vec<BackendError>) {
     for f in &module.functions {
         for s in &f.body.stmts {
@@ -448,19 +488,35 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
             }
         }
         // ── SIR22 (array/matrix IR) ──────────────────────────────────
-        // `IndexSet` (`A(i, j) = v`) observes `Feature::NDArrays` /
-        // `Feature::MatrixOps`, neither of which this backend accepts (see
-        // `ACCEPTED_FEATURES`), so the SIR10 capability gate
-        // (`Backend::check_module`) rejects any module containing it before
-        // `check_soundness_stmt` (called only on already-gated modules) ever
-        // sees one.  Reaching this arm would be an internal bug, not a user
-        // error — mirror the `Stmt::Assign` unsupported-scope arm above.
-        Stmt::IndexSet { span, .. } => {
-            panic!(
-                "go backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
-                span
-            );
+        // `IndexSet` (`A(i, j) = v`) is now a REAL, supported statement
+        // (see `ACCEPTED_FEATURES`'s `NDArrays`/`MatrixOps`/
+        // `ArrayColumnMajor` entries and `emit.rs`'s `Stmt::IndexSet`
+        // arm) — recurse into its three sub-positions for the same
+        // residual const/addendum-node checks every other statement gets,
+        // mirroring `Stmt::SeqSet`/`Stmt::MapSet` immediately above.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            check_soundness_expr(target, errs);
+            for idx in indices {
+                check_soundness_index_arg(idx, errs);
+            }
+            check_soundness_expr(value, errs);
         }
+    }
+}
+
+/// Recurse into one `IndexArg`'s inner expression, if it has one
+/// (`Scalar`/`Range` each wrap an `Expr`; `Whole` carries none). Shared
+/// by `Stmt::IndexSet` above and `Expr::IndexGet` below.
+fn check_soundness_index_arg(arg: &semantic_ir::IndexArg, errs: &mut Vec<BackendError>) {
+    use semantic_ir::IndexArg;
+    match arg {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => check_soundness_expr(e, errs),
+        IndexArg::Whole => {}
     }
 }
 
@@ -549,9 +605,81 @@ fn check_soundness_expr(e: &semantic_ir::Expr, errs: &mut Vec<BackendError>) {
             check_soundness_expr(key, errs);
         }
         Expr::KeywordArg { value, .. } => check_soundness_expr(value, errs),
+        // ── SIR22 base cut: real, supported nodes — recurse into their
+        // sub-expressions for the same residual checks (nested `Const`
+        // usage, a nested addendum node, ...) every other composite
+        // expression gets above.
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for e in row {
+                    check_soundness_expr(e, errs);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            check_soundness_expr(start, errs);
+            if let Some(step) = step {
+                check_soundness_expr(step, errs);
+            }
+            check_soundness_expr(stop, errs);
+        }
+        Expr::MatMul { lhs, rhs, .. } | Expr::ElementwiseOp { lhs, rhs, .. } => {
+            check_soundness_expr(lhs, errs);
+            check_soundness_expr(rhs, errs);
+        }
+        Expr::Transpose { target, .. } => check_soundness_expr(target, errs),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            check_soundness_expr(target, errs);
+            for idx in indices {
+                check_soundness_index_arg(idx, errs);
+            }
+        }
+        // ── SIR22 "APL addendum": still deferred — see
+        // `check_exception_soundness`'s doc comment (this function's
+        // caller) for the full "why here, why this mechanism" rationale.
+        // These nine share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with
+        // the base cut above, so only a dedicated structural check (not
+        // the plain capability gate) can tell them apart.
+        Expr::Reduce { span, .. } => errs.push(unsupported_sir22_addendum("Reduce", span.clone())),
+        Expr::Scan { span, .. } => errs.push(unsupported_sir22_addendum("Scan", span.clone())),
+        Expr::OuterProduct { span, .. } => {
+            errs.push(unsupported_sir22_addendum("OuterProduct", span.clone()))
+        }
+        Expr::Shape { span, .. } => errs.push(unsupported_sir22_addendum("Shape", span.clone())),
+        Expr::Reshape { span, .. } => {
+            errs.push(unsupported_sir22_addendum("Reshape", span.clone()))
+        }
+        Expr::IndexGenerator { span, .. } => {
+            errs.push(unsupported_sir22_addendum("IndexGenerator", span.clone()))
+        }
+        Expr::IndexOf { span, .. } => {
+            errs.push(unsupported_sir22_addendum("IndexOf", span.clone()))
+        }
+        Expr::Ravel { span, .. } => errs.push(unsupported_sir22_addendum("Ravel", span.clone())),
+        Expr::Catenate { span, .. } => {
+            errs.push(unsupported_sir22_addendum("Catenate", span.clone()))
+        }
         // Leaves / nodes with no sub-exprs of interest.
         _ => {}
     }
+}
+
+/// One `BackendError` for a SIR22 "APL addendum" node — see
+/// `check_exception_soundness`'s doc comment for the full rationale.
+fn unsupported_sir22_addendum(kind: &str, span: semantic_ir::Span) -> BackendError {
+    unsupported(
+        &format!(
+            "go backend does not yet implement the SIR22 addendum node `{kind}` (deferred to \
+             a later slice; it shares Feature::NDArrays/MatrixOps/ArrayColumnMajor with the \
+             SIR22 base cut this backend now accepts, so the feature-flag capability gate \
+             alone cannot reject it — this dedicated structural check does instead)"
+        ),
+        span,
+    )
 }
 
 fn check_soundness_block(b: &semantic_ir::Block, errs: &mut Vec<BackendError>) {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -4743,6 +4743,623 @@ func _sir_call_super(method string, cls string, args ...Value) Value {
 	return nil
 }
 
+// ── SIR22 array/matrix domain (base cut, second-wave backend rollout) ──
+//
+// Ported from `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
+// IIFE (see that crate's `runtime.rs`, "SIR22 array/matrix base cut"
+// section) — the BASE CUT only (`ArrayLit`/`Range`/`MatMul`/
+// `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet`), NOT the
+// 9-node "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+// `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — see the
+// SIR22 spec's "Backend impact" section for why the addendum is a
+// separate, later slice; `lib.rs`'s `check_exception_soundness` rejects
+// those nine cleanly before this backend's emit is ever reached.
+//
+// Naming: every helper below is prefixed `_sir_ndarray_`, NOT
+// `_sir_array_` — this backend's pre-existing Ruby-Array(`*Seq`)-method-
+// dispatch catalog (see `_sir_array_method`/`_sir_array_responds`/
+// `_sir_array_block_method` above, C5) already owns the `_sir_array_*`
+// prefix for an entirely unrelated domain (Ruby's `Array` == this
+// runtime's `*Seq`, not a SIR22 numeric matrix). Reusing that prefix
+// here would either collide outright or, worse, silently shadow/confuse
+// two unrelated concepts that both happen to be called "array" in their
+// respective source languages. `_sir_ndarray_*` (matching the SIR22
+// spec's own `SirType::NDArray`) keeps the two domains textually
+// distinct.
+//
+// Value representation: an `*NDArray` — shared + mutable via a pointer
+// handle, exactly like `*Seq`/`*Map` above (`Stmt::IndexSet`, i.e.
+// `A(i,j) = v`, must mutate the very array a caller's binding already
+// holds — MATLAB assignment semantics — so the same pointer-handle
+// pattern this runtime already uses for `Seq`/`Map` applies here too).
+//
+// Storage: dense, COLUMN-MAJOR (Fortran/MATLAB order — `Feature::
+// ArrayColumnMajor`), every element a `float64`, uniformly. This is a
+// DELIBERATE divergence from the sibling Ruby backend's SIR22 port,
+// which preserves native Ruby Integer/Float propagation (Div/Pow force
+// Float; Add/Sub/Mul don't) — worth calling out explicitly since the
+// brief for this rollout flagged it as a design decision to make
+// consciously, not copy blindly. MATLAB's OWN numeric model is "every
+// array is a matrix of doubles" by default (there is no separate
+// integer-array type in the MATLAB subset this repo's frontends target)
+// — so uniform float64 storage is not a Go-specific compromise, it is
+// the semantically faithful choice, and it is exactly what the JS
+// reference this file ports from already does (`Float64Array`
+// throughout). Go's own numeric tower (`int64`/`float64` boxed
+// `Value`s, see `_sir_as_float` above) has no "array of numbers"
+// precedent of its own to preserve the way Ruby's native `Integer`
+// class does, so there is no reason to introduce a Go-specific
+// int/float split the JS reference doesn't have; this port stays
+// byte-for-byte equivalent to the JS reference's uniform-double model.
+//
+// SECURITY: every factory below validates a shape/output size BEFORE
+// allocating a `[]float64` from it — shape sizes here can be
+// attacker/input-influenced runtime values (loop counts, index-range
+// widths, ...), not fixed compile-time constants, so an unbounded or
+// malformed shape must fail with a controlled `panic` (crashing the
+// program cleanly with a message, or caught by the nearest `recover` in
+// a `TryCatch`) rather than let `make([]float64, n)` attempt a huge or
+// negative-wrapped allocation. Mirrors `semantic-ir-to-javascript`'s
+// `MAX_ELEMENTS` bound exactly.
+const _sirNdarrayMaxElements = 1 << 26 // 67,108,864
+
+type NDArray struct {
+	Shape []int
+	Data  []float64
+}
+
+// One resolved `IndexArg` (see the SIR22 spec's `IndexArg` — `Scalar` /
+// `Whole` / `Range`), mirroring the JS reference's
+// `{kind, value/indices}` tagged object as a small Go struct instead.
+// `end`-relative indices are never seen here — per SIR10 discipline the
+// frontend resolves `end` to a concrete 0-based `scalar` index before
+// emitting `IndexGet`/`IndexSet` (see `nodes.rs`'s `Expr::IndexGet` doc).
+type _sirIndexArg struct {
+	Kind    string // "scalar" | "whole" | "range"
+	Value   float64
+	Indices *NDArray
+}
+
+// _sir_ndarray_checked_shape_size validates `shape` (every dimension
+// must be >= 0) and returns the total element count, panicking if any
+// dimension is negative or if the product exceeds
+// `_sirNdarrayMaxElements`.
+//
+// SECURITY: the running product is checked for overflow ONE
+// multiplication at a time (`acc > _sirNdarrayMaxElements/d` BEFORE
+// `acc *= d`), not after the fact. This matters more here than in the
+// JS reference: a JS `Number` cannot silently wrap on overflow (only
+// lose precision past 2^53, which the `Number.isFinite`-style check
+// there still catches), but Go's `int` is a fixed-width two's-complement
+// type — `acc *= d` for a sufficiently large shape CAN wrap around to a
+// small or even negative `int`, which would then slip straight past a
+// naive post-hoc `acc > cap` check. Validating before every multiply
+// closes that gap; `make([]float64, n)` is never reached with an
+// unvalidated `n`.
+func _sir_ndarray_checked_shape_size(shape []int) int {
+	acc := 1
+	for _, d := range shape {
+		if d < 0 {
+			panic(fmt.Sprintf("checkedShapeSize: shape %v has a negative dimension", shape))
+		}
+		if d != 0 && acc > _sirNdarrayMaxElements/d {
+			panic(fmt.Sprintf("checkedShapeSize: shape %v exceeds the %d-element cap", shape, _sirNdarrayMaxElements))
+		}
+		acc *= d
+	}
+	if acc > _sirNdarrayMaxElements {
+		panic(fmt.Sprintf("checkedShapeSize: shape %v (%d elements) exceeds the %d-element cap", shape, acc, _sirNdarrayMaxElements))
+	}
+	return acc
+}
+
+// _sir_ndarray_new is the base constructor: validates `shape` (via
+// `_sir_ndarray_checked_shape_size`) and that `data` has exactly the
+// implied element count, BEFORE returning the handle.
+func _sir_ndarray_new(shape []int, data []float64) *NDArray {
+	n := _sir_ndarray_checked_shape_size(shape)
+	if n != len(data) {
+		panic(fmt.Sprintf("ndarray: shape %v implies %d elements, got %d", shape, n, len(data)))
+	}
+	return &NDArray{Shape: shape, Data: data}
+}
+
+// `[1 2; 3 4]` — build an `*NDArray` from row-major literal syntax
+// (`rows[r][c]`), storing it column-major (`data[c*nrowsIn+r]`) per
+// `Feature::ArrayColumnMajor`. Each element is coerced through
+// `_sir_as_float` (this backend's existing int64/float64 numeric-tower
+// coercion, see above) since an `ArrayLit` element can be any numeric
+// `Value` the ordinary emit path produces (an `IntLit`, a `FloatLit`, or
+// an arbitrary arithmetic sub-expression's result).
+func _sir_ndarray_from_rows(rows [][]Value) *NDArray {
+	nrowsIn := len(rows)
+	if nrowsIn == 0 {
+		return _sir_ndarray_new([]int{0, 0}, []float64{})
+	}
+	ncolsIn := len(rows[0])
+	for _, r := range rows {
+		if len(r) != ncolsIn {
+			panic("fromRows: ragged rows")
+		}
+	}
+	n := _sir_ndarray_checked_shape_size([]int{nrowsIn, ncolsIn})
+	data := make([]float64, n)
+	for r := 0; r < nrowsIn; r++ {
+		for c := 0; c < ncolsIn; c++ {
+			data[c*nrowsIn+r] = _sir_as_float(rows[r][c]) // column-major store
+		}
+	}
+	return _sir_ndarray_new([]int{nrowsIn, ncolsIn}, data)
+}
+
+// Coerce a bare numeric `Value` into a rank-0 (scalar) `*NDArray`; an
+// already-`*NDArray` value passes through unchanged. Needed because
+// `matlab-to-semantic-ir`'s lowerer emits a MIXED operand pair for
+// `.* ./ .\` and for `* /` when exactly one side is scalar (e.g.
+// `A .* 2`) — the bare scalar sub-expression is passed through
+// `ElementwiseOp`/`MatMul` unwrapped (a plain numeric `Value`, not
+// wrapped in an `ArrayLit`/scalar-array constructor first). Every
+// function below that accepts an "array-or-scalar" operand normalizes
+// through this first, mirroring the JS reference's `toArrayValue` fix
+// exactly (a prior regression there: reading `.shape` off an
+// un-normalized number threw before this coercion was added).
+func _sir_ndarray_to_array_value(v Value) *NDArray {
+	if a, ok := v.(*NDArray); ok {
+		return a
+	}
+	return _sir_ndarray_new([]int{}, []float64{_sir_as_float(v)})
+}
+
+// Strict variant of the coercion above: asserts `v` is ALREADY an
+// `*NDArray`, panicking with a clean message otherwise, rather than
+// coercing a bare scalar. Used exactly where the JS reference's own
+// `transpose`/`indexGet`/`indexSet` do NOT call `toArrayValue` (their
+// `target` operand is always already an array by construction — a
+// MATLAB frontend never transposes/indexes a provably-scalar
+// expression) — kept as a dedicated function (rather than an inline
+// type assertion at each call site) purely so the failure message is
+// controlled and readable, matching this runtime's existing
+// `_sir_seq_index`/`_sir_map_get`-style "panic with a formatted message
+// on the wrong dynamic type" discipline instead of a raw, less legible
+// Go interface-conversion panic.
+func _sir_ndarray_as_ndarray(v Value) *NDArray {
+	a, ok := v.(*NDArray)
+	if !ok {
+		panic(fmt.Sprintf("expected an array, got %T", v))
+	}
+	return a
+}
+
+func _sir_ndarray_is_scalar(a *NDArray) bool { return len(a.Data) == 1 }
+
+// Rows, treating a scalar as `1×1` and a vector `[n]` as `n×1`.
+func _sir_ndarray_nrows(a *NDArray) int {
+	if len(a.Shape) == 0 {
+		return 1
+	}
+	return a.Shape[0]
+}
+
+// Columns, treating a scalar as `1×1` and a vector `[n]` as `n×1`.
+func _sir_ndarray_ncols(a *NDArray) int {
+	if len(a.Shape) <= 1 {
+		return 1
+	}
+	return a.Shape[1]
+}
+
+// Element `(r, c)` (column-major); the second return is `false` when out
+// of bounds (mirrors the JS reference's `undefined` sentinel without
+// needing a separate sentinel value in Go's numeric tower).
+func _sir_ndarray_get(a *NDArray, r int, c int) (float64, bool) {
+	if r >= 0 && c >= 0 && r < _sir_ndarray_nrows(a) && c < _sir_ndarray_ncols(a) {
+		return a.Data[c*_sir_ndarray_nrows(a)+r], true
+	}
+	return 0, false
+}
+
+// Set element `(r, c)` in place (column-major) — mutates `a.Data`
+// directly, matching MATLAB assignment semantics (`A(i,j) = v` rebinds
+// one element of the EXISTING array, it does not produce a new one).
+// This is why `Stmt::IndexSet` is a statement, not a pure expression,
+// in the SIR22 spec.
+//
+// SECURITY: written as the AND-form `r >= 0 && c >= 0 && r < nrows &&
+// c < ncols`, negated once (`!(...)`), NOT as a De Morgan'd OR-form
+// (`r < 0 || c < 0 || ...`) — this mirrors the JS reference's own `set`
+// exactly, whose doc comment explains the IEEE-754 hazard this form
+// avoids (a NaN in an OR-form check silently defeats every branch, so
+// the "out of bounds" guard never fires). `r`/`c` here are already
+// validated, truncated `int`s (see `_sir_ndarray_assert_valid_position`
+// below) by the time they reach this function, so the NaN hazard itself
+// cannot recur at THIS call site in Go the way it can in JS — but the
+// AND-form is kept anyway, both for exact structural parity with the
+// ported reference and because `_sir_ndarray_set` is part of this
+// file's own re-usable surface, not something every future caller
+// should have to re-derive the invariant for.
+func _sir_ndarray_set(a *NDArray, r int, c int, value float64) {
+	if !(r >= 0 && c >= 0 && r < _sir_ndarray_nrows(a) && c < _sir_ndarray_ncols(a)) {
+		panic(fmt.Sprintf("set: index (%d, %d) out of bounds for shape %v", r, c, a.Shape))
+	}
+	a.Data[c*_sir_ndarray_nrows(a)+r] = value
+}
+
+// ── elementwise binary ops ──────────────────────────────────────
+// Comparisons follow the same APL-style boolean convention
+// `array_runtime::BinOp` uses (and the JS reference mirrors): `1.0` for
+// true, `0.0` for false (never a native Go `bool`), since the result
+// must stay a plain `float64` array element like every other value here.
+func _sir_ndarray_apply_op(op string, a float64, b float64) float64 {
+	b2f := func(cond bool) float64 {
+		if cond {
+			return 1
+		}
+		return 0
+	}
+	switch op {
+	case "Add":
+		return a + b
+	case "Sub":
+		return a - b
+	case "Mul":
+		return a * b
+	case "Div":
+		return a / b
+	case "Pow":
+		return math.Pow(a, b)
+	case "Max":
+		return math.Max(a, b)
+	case "Min":
+		return math.Min(a, b)
+	case "Eq":
+		return b2f(a == b)
+	case "Ne":
+		return b2f(a != b)
+	case "Lt":
+		return b2f(a < b)
+	case "Le":
+		return b2f(a <= b)
+	case "Ge":
+		return b2f(a >= b)
+	case "Gt":
+		return b2f(a > b)
+	default:
+		// An unrecognised `op` string crosses an emitter/runtime boundary
+		// the emitter itself can't enforce at the call site — fail loudly
+		// here rather than silently falling through to a zero value.
+		panic(fmt.Sprintf("applyOp: unrecognised ElementwiseOpKind %q", op))
+	}
+}
+
+func _sir_ndarray_same_shape(a []int, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Elementwise binary op with scalar broadcasting. Either operand may be
+// a scalar; otherwise the shapes must match exactly (full NumPy/MATLAB
+// broadcasting is out of scope, same as the Rust `array-runtime`
+// reference). Result takes the non-scalar operand's shape (or the
+// scalar's, if both are).
+func _sir_ndarray_elementwise(op string, av Value, bv Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	b := _sir_ndarray_to_array_value(bv)
+	var data []float64
+	var shape []int
+	switch {
+	case _sir_ndarray_is_scalar(a):
+		data = make([]float64, len(b.Data))
+		for i, y := range b.Data {
+			data[i] = _sir_ndarray_apply_op(op, a.Data[0], y)
+		}
+		shape = b.Shape
+	case _sir_ndarray_is_scalar(b):
+		data = make([]float64, len(a.Data))
+		for i, x := range a.Data {
+			data[i] = _sir_ndarray_apply_op(op, x, b.Data[0])
+		}
+		shape = a.Shape
+	default:
+		if !_sir_ndarray_same_shape(a.Shape, b.Shape) {
+			panic(fmt.Sprintf("elementwise: non-conformable arrays: %v vs %v", a.Shape, b.Shape))
+		}
+		data = make([]float64, len(a.Data))
+		for i := range data {
+			data[i] = _sir_ndarray_apply_op(op, a.Data[i], b.Data[i])
+		}
+		shape = a.Shape
+	}
+	return _sir_ndarray_new(shape, data)
+}
+
+// Matrix product `[m, k] · [k, n] → [m, n]` (column-major throughout).
+// `m` and `n` come from two INDEPENDENT operands (each individually
+// under `_sirNdarrayMaxElements`, but their product isn't bounded by
+// that alone), so `_sir_ndarray_checked_shape_size` validates `[m, n]`
+// BEFORE allocating `out`, not after.
+//
+// Like `_sir_ndarray_elementwise`, normalizes both operands through
+// `_sir_ndarray_to_array_value` first: a provably-scalar `x * y` between
+// two non-literal operands can still lower to `Expr::MatMul` (the
+// frontend's scalar/array disambiguation heuristic can't see through a
+// bare variable reference), so a bare boxed number can reach here on
+// either side.
+func _sir_ndarray_matmul(av Value, bv Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	b := _sir_ndarray_to_array_value(bv)
+	m := _sir_ndarray_nrows(a)
+	ka := _sir_ndarray_ncols(a)
+	kb := _sir_ndarray_nrows(b)
+	n := _sir_ndarray_ncols(b)
+	if ka != kb {
+		panic(fmt.Sprintf("matmul: inner dimensions disagree (%dx%d . %dx%d)", m, ka, kb, n))
+	}
+	outLen := _sir_ndarray_checked_shape_size([]int{m, n})
+	out := make([]float64, outLen)
+	for j := 0; j < n; j++ {
+		for i := 0; i < m; i++ {
+			acc := 0.0
+			for p := 0; p < ka; p++ {
+				acc += a.Data[p*m+i] * b.Data[j*kb+p] // column-major indexing
+			}
+			out[j*m+i] = acc
+		}
+	}
+	return _sir_ndarray_new([]int{m, n}, out)
+}
+
+// Matrix transpose. `conjugate` distinguishes MATLAB `'` (`true`) from
+// `.'` (`false`) — this runtime has no `Complex` value type yet
+// (matching `array-runtime`'s own real-only scope today, and the JS
+// reference's identical stance), so a conjugate transpose of real data
+// is identical to a plain transpose; `conjugate` is accepted for
+// call-shape parity with the SIR spec only.
+//
+// Deliberately does NOT coerce `av` through `_sir_ndarray_to_array_value`
+// — mirrors the JS reference's `transpose` exactly, which also takes its
+// operand un-coerced (a MATLAB frontend never transposes a
+// provably-scalar expression). Uses the strict `_sir_ndarray_as_ndarray`
+// instead, so a genuinely-wrong-typed operand still fails with a clean
+// message rather than a raw Go interface-conversion panic.
+func _sir_ndarray_transpose(av Value, conjugate bool) *NDArray {
+	_ = conjugate
+	a := _sir_ndarray_as_ndarray(av)
+	m := _sir_ndarray_nrows(a)
+	n := _sir_ndarray_ncols(a)
+	out := make([]float64, len(a.Data))
+	for j := 0; j < n; j++ {
+		for i := 0; i < m; i++ {
+			out[i*n+j] = a.Data[j*m+i]
+		}
+	}
+	return _sir_ndarray_new([]int{n, m}, out)
+}
+
+// Tolerance for the inclusive-stop boundary check, matching
+// `matlab-runtime`'s own `eval_colon` (and the JS reference's
+// `RANGE_EPSILON`) exactly — a floating step (e.g. `1:0.1:2`) can drift
+// a few ULPs short of `stop` by the final iteration, and MATLAB's
+// `a:step:b` is inclusive of `b`.
+const _sirNdarrayRangeEpsilon = 1e-9
+
+// Materialize a MATLAB-style range `start:step:stop` (default `step =
+// 1`) as a `1×n` row vector — MATLAB's `:` always produces a row, never
+// a column. Bounded by `_sirNdarrayMaxElements` so a compiled program's
+// `1:1e18`-style range can't exhaust memory before this function ever
+// gets to materialize anything.
+func _sir_ndarray_range(startV Value, stopV Value, stepV Value) *NDArray {
+	start := _sir_as_float(startV)
+	stop := _sir_as_float(stopV)
+	step := _sir_as_float(stepV)
+	if step == 0 {
+		panic("range: step cannot be zero")
+	}
+	// SECURITY: the loop condition below would be false on its very
+	// first check whenever start/stop/step is NaN (every relational
+	// comparison with NaN is false) or +-Inf drives it there — an
+	// unguarded non-finite bound would silently produce an empty range
+	// instead of erroring. Reject non-finite bounds up front instead of
+	// letting them fall through to a quietly-wrong empty result.
+	if math.IsNaN(start) || math.IsInf(start, 0) ||
+		math.IsNaN(stop) || math.IsInf(stop, 0) ||
+		math.IsNaN(step) || math.IsInf(step, 0) {
+		panic(fmt.Sprintf("range: start/stop/step must be finite numbers, got (%v, %v, %v)", start, stop, step))
+	}
+	var values []float64
+	x := start
+	for (step > 0 && x <= stop+_sirNdarrayRangeEpsilon) || (step < 0 && x >= stop-_sirNdarrayRangeEpsilon) {
+		if len(values) >= _sirNdarrayMaxElements {
+			panic(fmt.Sprintf("range: produces more than %d elements", _sirNdarrayMaxElements))
+		}
+		values = append(values, x)
+		x += step
+	}
+	if len(values) == 0 {
+		return _sir_ndarray_new([]int{1, 0}, []float64{})
+	}
+	return _sir_ndarray_new([]int{1, len(values)}, values)
+}
+
+// ── indexing ────────────────────────────────────────────────────
+// One MATLAB-style index-position argument, mirroring the SIR22 spec's
+// `IndexArg` exactly via `_sirIndexArg{Kind: "scalar"|"whole"|"range",
+// ...}` — see that type's doc comment above.
+
+// Validate that `x` is a finite integer (after truncation for the
+// "range" case — see `_sir_ndarray_resolve_positions`), returning it as
+// an `int` position.
+//
+// SECURITY: mirrors the JS reference's `assertValidPosition` exactly —
+// under IEEE-754, `NaN`/`+-Inf` fail or defeat naive relational bounds
+// checks downstream (`i < 0 || i >= len` lets a NaN through both
+// branches, since every NaN comparison is false), so a malformed index
+// must be rejected at THIS single choke point — the one place both
+// `_sir_ndarray_index_get` and `_sir_ndarray_index_set` resolve every
+// position through (via `_sir_ndarray_resolve_positions`) — rather than
+// re-deriving a NaN-safe bounds check at every call site.
+func _sir_ndarray_assert_valid_position(x float64) int {
+	if math.IsNaN(x) || math.IsInf(x, 0) || x != math.Trunc(x) {
+		panic(fmt.Sprintf("resolvePositions: index %v is not a finite integer", x))
+	}
+	return int(x)
+}
+
+// Resolve one `_sirIndexArg` against a dimension of size `dimSize` into
+// a flat list of 0-based positions along that dimension.
+func _sir_ndarray_resolve_positions(arg _sirIndexArg, dimSize int) []int {
+	switch arg.Kind {
+	case "scalar":
+		return []int{_sir_ndarray_assert_valid_position(arg.Value)}
+	case "whole":
+		out := make([]int, dimSize)
+		for i := range out {
+			out[i] = i
+		}
+		return out
+	case "range":
+		out := make([]int, len(arg.Indices.Data))
+		for i, x := range arg.Indices.Data {
+			out[i] = _sir_ndarray_assert_valid_position(math.Trunc(x))
+		}
+		return out
+	default:
+		// Emitted code crosses a Go runtime boundary the emitter can't
+		// enforce at the actual call site — a malformed `Kind` must fail
+		// cleanly here, not fall through to a zero-value slice.
+		panic(fmt.Sprintf("resolvePositions: unrecognised IndexArg kind %q", arg.Kind))
+	}
+}
+
+// `A(i)` / `A(i, j)` — read one element or a sub-array. Scoped to 1 or 2
+// index arguments (rank <= 2): a single argument indexes `a`'s
+// underlying column-major data linearly (MATLAB's own single-subscript
+// convention, which is column-major too); two arguments index `(row,
+// col)`. Returns a bare `float64` (boxed into the returned `Value`) when
+// every argument is `"scalar"` (a single element), otherwise an
+// `*NDArray`.
+func _sir_ndarray_index_get(av Value, indices []_sirIndexArg) Value {
+	a := _sir_ndarray_as_ndarray(av)
+	switch len(indices) {
+	case 1:
+		arg := indices[0]
+		positions := _sir_ndarray_resolve_positions(arg, len(a.Data))
+		read := func(i int) float64 {
+			if i < 0 || i >= len(a.Data) {
+				panic(fmt.Sprintf("indexGet: linear index %d out of bounds", i))
+			}
+			return a.Data[i]
+		}
+		if arg.Kind == "scalar" {
+			return read(positions[0])
+		}
+		out := make([]float64, len(positions))
+		for i, p := range positions {
+			out[i] = read(p)
+		}
+		return _sir_ndarray_new([]int{1, len(positions)}, out)
+	case 2:
+		rowArg, colArg := indices[0], indices[1]
+		rows := _sir_ndarray_resolve_positions(rowArg, _sir_ndarray_nrows(a))
+		cols := _sir_ndarray_resolve_positions(colArg, _sir_ndarray_ncols(a))
+		read := func(r int, c int) float64 {
+			v, ok := _sir_ndarray_get(a, r, c)
+			if !ok {
+				panic(fmt.Sprintf("indexGet: (%d, %d) out of bounds for shape %v", r, c, a.Shape))
+			}
+			return v
+		}
+		if rowArg.Kind == "scalar" && colArg.Kind == "scalar" {
+			return read(rows[0], cols[0])
+		}
+		// `len(rows)`/`len(cols)` are each individually bounded by `a`'s
+		// own dimensions (`"whole"`) or by a `"range"` NDArray's own
+		// `_sirNdarrayMaxElements` cap — but nothing bounds their PRODUCT
+		// on its own, so this is the exact outer-product-shaped
+		// allocation `_sir_ndarray_matmul` guards against, one level up.
+		// Validate before allocating, not after.
+		outLen := _sir_ndarray_checked_shape_size([]int{len(rows), len(cols)})
+		data := make([]float64, outLen)
+		for ci, c := range cols {
+			for ri, r := range rows {
+				data[ci*len(rows)+ri] = read(r, c)
+			}
+		}
+		return _sir_ndarray_new([]int{len(rows), len(cols)}, data)
+	default:
+		panic(fmt.Sprintf("indexGet: only 1 or 2 index arguments are supported (rank <= 2 scope), got %d", len(indices)))
+	}
+}
+
+// Broadcast a scalar-or-`*NDArray` right-hand side to exactly `count`
+// values (mirrors `_sir_ndarray_elementwise`'s scalar-broadcast rule).
+func _sir_ndarray_broadcast_values(value Value, count int) []float64 {
+	if a, ok := value.(*NDArray); ok {
+		if len(a.Data) == 1 {
+			out := make([]float64, count)
+			for i := range out {
+				out[i] = a.Data[0]
+			}
+			return out
+		}
+		if len(a.Data) != count {
+			panic(fmt.Sprintf("indexSet: value has %d elements, expected %d", len(a.Data), count))
+		}
+		return a.Data
+	}
+	f := _sir_as_float(value)
+	out := make([]float64, count)
+	for i := range out {
+		out[i] = f
+	}
+	return out
+}
+
+// `A(i) = v` / `A(i, j) = v` — write one element or a sub-array, IN
+// PLACE (see `_sir_ndarray_set`'s doc comment above for why this
+// mutates rather than returns a new array). `value` may be a scalar
+// (broadcast to every selected position) or an `*NDArray` with exactly
+// as many elements as positions are selected.
+func _sir_ndarray_index_set(av Value, indices []_sirIndexArg, value Value) {
+	a := _sir_ndarray_as_ndarray(av)
+	switch len(indices) {
+	case 1:
+		arg := indices[0]
+		positions := _sir_ndarray_resolve_positions(arg, len(a.Data))
+		values := _sir_ndarray_broadcast_values(value, len(positions))
+		for k, i := range positions {
+			if i < 0 || i >= len(a.Data) {
+				panic(fmt.Sprintf("indexSet: linear index %d out of bounds", i))
+			}
+			a.Data[i] = values[k]
+		}
+	case 2:
+		rowArg, colArg := indices[0], indices[1]
+		rows := _sir_ndarray_resolve_positions(rowArg, _sir_ndarray_nrows(a))
+		cols := _sir_ndarray_resolve_positions(colArg, _sir_ndarray_ncols(a))
+		// Same product-of-two-independent-selections gap
+		// `_sir_ndarray_index_get` closes above — validate before
+		// `_sir_ndarray_broadcast_values` allocates.
+		count := _sir_ndarray_checked_shape_size([]int{len(rows), len(cols)})
+		values := _sir_ndarray_broadcast_values(value, count)
+		k := 0
+		for _, c := range cols {
+			for _, r := range rows {
+				_sir_ndarray_set(a, r, c, values[k])
+				k++
+			}
+		}
+	default:
+		panic(fmt.Sprintf("indexSet: only 1 or 2 index arguments are supported (rank <= 2 scope), got %d", len(indices)))
+	}
+}
+
 "##;
 
 #[cfg(test)]

--- a/code/packages/rust/semantic-ir-to-go/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/sir22_array.rs
@@ -1,0 +1,346 @@
+//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/`MatMul`/
+//! `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the Go
+//! backend — hand-builds `Module`s directly (bypassing any frontend,
+//! since none targets this backend for SIR22 yet), emits Go, runs it
+//! with a real `go run`, and asserts stdout. Mirrors
+//! `compile_and_run_division_ops.rs`'s pattern; skips (does not fail)
+//! when no `go` is on `PATH`.
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir22_array.rs` (and cross-checked against the sibling Ruby
+//! backend's own port on `claude/sir22-slice2-ruby`) — same worked
+//! examples, adapted to this backend's own value-type convention: EVERY
+//! `_sir_ndarray_*` element is a `float64` (see `runtime.rs`'s own
+//! module doc for why this backend, unlike Ruby's sibling port, does NOT
+//! preserve native Integer/Float propagation), so an all-integer
+//! computation here prints WITH a trailing `.0` (Go's own
+//! `_sir_format_float` convention) rather than Ruby's bare integer form.
+//!
+//! Every test constructs `Module`s directly via `print_stmt`'s scalar
+//! `IndexGet` reads (top-left/bottom-right element, etc.) — sidesteps
+//! needing an NDArray display/format story, which is out of this
+//! slice's scope, exactly as the JS/Ruby references' own tests do.
+
+use semantic_ir::{
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    IndexArg, Metadata, Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn array_lit(rows: Vec<Vec<Expr>>) -> Expr {
+    Expr::ArrayLit { rows, span: s() }
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+fn scalar(i: i64) -> IndexArg {
+    IndexArg::Scalar(Box::new(ilit(i)))
+}
+fn index_get(target: Expr, indices: Vec<IndexArg>) -> Expr {
+    Expr::IndexGet { target: Box::new(target), indices, span: s() }
+}
+
+const ARRAY_FEATURES: &[Feature] =
+    &[Feature::NDArrays, Feature::MatrixOps, Feature::ArrayColumnMajor];
+
+fn array_module(stmts: Vec<Stmt>) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings, Feature::Floats];
+    features.extend_from_slice(ARRAY_FEATURES);
+    Module {
+        name: "sir22array".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    std::process::Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile, write to a unique temp file, `go run` it. Returns `None` if
+/// `go` is unavailable (caller should skip, not fail). Unique temp-file
+/// names per call (PID + a monotonic counter, not just a per-test
+/// `tag`) — a name collision would let concurrently-running `cargo test`
+/// threads race on the same path, the same class of race this session's
+/// `sir-conformance` division tests hit and fixed earlier in this arc
+/// (see the C backend's `tests/compile_and_run_array_methods.rs` for the
+/// identical PID+counter precedent).
+fn run_raw(module: &Module, tag: &str) -> Option<std::process::Output> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    if !go_available() {
+        return None;
+    }
+    let artifact = compile(module).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let src_path = dir.join(format!("sir_go_array_{tag}_{nonce}_{seq}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let out = std::process::Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    Some(out)
+}
+
+fn run(module: &Module, tag: &str) -> Option<String> {
+    let out = run_raw(module, tag)?;
+    assert!(
+        out.status.success(),
+        "emitted Go failed to compile/run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+// ── base cut: real codegen ────────────────────────────────────────────
+
+#[test]
+fn matmul_of_two_by_two_matrices_computes_the_right_product() {
+    // [1 2; 3 4] * [5 6; 7 8] = [19 22; 43 50] (standard matrix product).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5), ilit(6)], vec![ilit(7), ilit(8)]]);
+    let product = Expr::MatMul { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("p", product),
+        print_stmt(index_get(local("p"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("p"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m, "matmul") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["19.0", "50.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
+    // MATLAB `A .* 2` -- matlab-to-semantic-ir emits the `2` as a bare
+    // IntLit operand, unwrapped (not an ArrayLit), when exactly one side
+    // is scalar. This is the exact shape `_sir_ndarray_to_array_value`'s
+    // coercion in runtime.rs exists for; a regression there panics with
+    // a Go interface-conversion error instead of computing [2 4; 6 8].
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let scaled = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("sc", scaled),
+        print_stmt(index_get(local("sc"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("sc"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m, "elemwise_scalar") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["2.0", "8.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_div_always_true_divides_even_on_integer_operands() {
+    // 7 ./ 2 = 3.5 -- Div always real-divides (matches MATLAB `./`); this
+    // backend's array elements are uniformly `float64` regardless, so
+    // this mainly proves the `Div` dispatch arm is wired to `/`, not a
+    // truncating integer division.
+    let a = array_lit(vec![vec![ilit(7)]]);
+    let divided = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Div,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("d", divided),
+        print_stmt(index_get(local("d"), vec![scalar(0), scalar(0)])),
+    ]);
+    match run(&m, "div_true") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3.5"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn transpose_of_a_two_by_three_matrix_swaps_rows_and_columns() {
+    // [1 2 3; 4 5 6]' = [1 4; 2 5; 3 6]
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let t = Expr::Transpose { target: Box::new(a), conjugate: true, span: s() };
+    let m = array_module(vec![
+        let_binding("t", t),
+        print_stmt(index_get(local("t"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("t"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run(&m, "transpose") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["4.0", "6.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn range_materializes_a_row_vector_read_by_linear_index() {
+    // 1:2:9 -> [1 3 5 7 9], a 1x5 row vector. A single index argument
+    // reads linearly (rank-1 IndexGet).
+    let r = Expr::Range {
+        start: Box::new(ilit(1)),
+        step: Some(Box::new(ilit(2))),
+        stop: Box::new(ilit(9)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(4)])),
+    ]);
+    match run(&m, "range") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "9.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn whole_selector_reads_an_entire_row() {
+    // A(2, :) on [1 2; 3 4] (0-based: row 1) reads the whole second row
+    // [3 4], then a scalar linear IndexGet reads its second element.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let row = index_get(a, vec![scalar(1), IndexArg::Whole]);
+    let m = array_module(vec![
+        let_binding("row", row),
+        print_stmt(index_get(local("row"), vec![scalar(1)])),
+    ]);
+    match run(&m, "whole") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["4.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn index_set_mutates_in_place() {
+    // A(1, 1) = 99 (0-based) on [1 2; 3 4] -- IndexSet is a Stmt
+    // (in-place mutation), not a pure Expr, per the SIR22 spec.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let m = array_module(vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![scalar(1), scalar(1)],
+            value: Box::new(ilit(99)),
+            span: s(),
+        },
+        print_stmt(index_get(local("a"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m, "index_set") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["99.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+// ── DoS guard: shape-size cap enforced BEFORE allocation ───────────────
+
+#[test]
+fn matmul_output_shape_exceeding_the_element_cap_panics_cleanly() {
+    // Two INDEPENDENT 1x9000 / 9000x1 operands (each individually far
+    // under the 2^26 = 67,108,864-element cap) whose matmul OUTPUT shape
+    // (9000x9000 = 81,000,000 elements) exceeds it -- exactly the
+    // "product of two independently-bounded dimensions isn't itself
+    // bounded" gap `_sir_ndarray_checked_shape_size` exists to close
+    // BEFORE `make([]float64, outLen)` ever runs. A regression here
+    // would either panic with a Go runtime OOM/negative-length-slice
+    // crash (uncontrolled) instead of this controlled, readable message,
+    // or (worse, if the overflow check were removed entirely) attempt
+    // the huge allocation.
+    let r = Expr::Range {
+        start: Box::new(ilit(1)),
+        step: None,
+        stop: Box::new(ilit(9000)),
+        span: s(),
+    };
+    let rt = Expr::Transpose { target: Box::new(r.clone()), conjugate: true, span: s() };
+    let product = Expr::MatMul { lhs: Box::new(rt), rhs: Box::new(r), span: s() };
+    let m = array_module(vec![Stmt::ExprStmt { expr: product, span: s() }]);
+    match run_raw(&m, "matmul_overflow") {
+        Some(out) => {
+            assert!(
+                !out.status.success(),
+                "expected a clean panic (nonzero exit) for an over-cap shape, got success"
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("exceeds the 67108864-element cap"),
+                "expected the checkedShapeSize cap message on stderr, got:\n{stderr}"
+            );
+        }
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+
+#[test]
+fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
+    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
+    // cut, so the ordinary feature-flag check alone can't reject it --
+    // proves the dedicated structural soundness check (`lib.rs`'s
+    // `check_exception_soundness`, extended for SIR22) does, with a
+    // clean `Err`, not an `emit_expr` `panic!`.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
+    let m = array_module(vec![print_stmt(Expr::Reduce {
+        op: ElementwiseOpKind::Add,
+        target: Box::new(target),
+        span: s(),
+    })]);
+    let err = compile(&m).expect_err("Reduce must be rejected, not emitted");
+    assert!(
+        err.message.contains("Reduce"),
+        "error should name the rejected node: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary
- Opens the Go backend (`semantic-ir-to-go`) to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and implements the SIR22 array/matrix "base cut" -- `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and `Stmt::IndexSet` -- per `code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section. One of 5 parallel, independent per-backend PRs for this slice (see `claude/sir22-slice2-ruby` for the sibling Ruby port).
- New inlined `_sir_ndarray_*` runtime (`runtime.rs`): a plain-Go port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime, following this backend's existing "paste the runtime inline, no `go.mod` dependency" convention. Prefixed `_sir_ndarray_*` (not `_sir_array_*`) deliberately -- this backend's pre-existing Ruby-`Array`(`*Seq`)-method-dispatch catalog already owns that prefix for an unrelated domain, and reusing it would collide.
- Value representation: `*NDArray{Shape []int; Data []float64}`, shared + mutable via a pointer handle like the existing `*Seq`/`*Map`. Every element stored as a uniform `float64` (MATLAB's own "everything is a double" numeric model, matching the JS reference's `Float64Array`) -- a deliberate divergence from the sibling Ruby backend's port, which preserves native Integer/Float propagation; documented in the CHANGELOG.
- DoS discipline: every shape/output size is validated (`_sir_ndarray_checked_shape_size`) BEFORE any `[]float64` allocation, with an explicit per-multiplication overflow guard -- Go's `int` can wrap on a large-shape product where JS's `Number` cannot, so a naive post-hoc `> cap` check would not be sufficient here.
- Split a previously-combined `emit.rs` match arm that panicked for the SIR22 base cut, the 9-node SIR22 "APL addendum", and SIR26's `Expr::Convert` all together. The base cut now gets real codegen; the addendum + `Convert` stay in an updated panic arm, with `Convert`'s existing behavior left untouched byte-for-byte.
- The 9-node APL addendum shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut, so the feature-flag gate alone can no longer distinguish them. Extended this backend's own pre-existing structural soundness gate (`check_exception_soundness`/`check_soundness_stmt`/`check_soundness_expr`, originally added for E3) with nine new rejection arms, rather than adding a second parallel mechanism the way the JS/Ruby sibling ports each did.

## Test plan
- [x] `cargo test -p semantic-ir-to-go` -- 100% green (full existing suite + new tests), confirming no regression to `Expr::Convert` or anything else
- [x] `cargo clippy -p semantic-ir-to-go --all-targets -- -D warnings` -- clean
- [x] `go vet` on a representative emitted `.go` file (matmul/range/whole-selector/transpose/elementwise/indexSet in one program) -- clean
- [x] New `tests/sir22_array.rs` (9 tests, real `go run` execution proof against the actual Go toolchain, hand-built `Module`s since no frontend targets this backend for SIR22 yet): matmul of two 2x2 matrices against a known product, elementwise-mul with a bare-scalar RHS operand (the `toArrayValue`-coercion regression case), `Div`'s always-true-divide, transpose, a MATLAB-style range read by linear index, a `Whole` (`:`) selector reading an entire row, `Stmt::IndexSet` mutating in place, a shape-overflow DoS-guard proof (two independently-under-cap operands whose matmul output exceeds the cap panics cleanly), and a compile-time-rejection proof for `Expr::Reduce` (an addendum node) returning a clean `Err`, not a panic
- [x] `cargo build -p sir-conformance -p sir-bench` -- both downstream consumers of this crate build clean against the new API
- [x] Security review (`/security-review`, sub-agent with the diff inline): **PASSED**, no findings -- reviewer specifically verified the shape-overflow guard closes before every allocation, the NaN-safe AND-form bounds checks, and that `Expr::Convert`'s behavior is byte-for-byte unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)