### PR TITLE
feat(semantic-ir-to-rust): implement SIR22 array/matrix base cut (Phase A Slice 2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,116 @@
 # Changelog
 
+## 0.42.0 — SIR22 array/matrix base cut (Phase A Slice 2, second-wave backend rollout)
+
+Opens this backend to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and
+implements the SIR22 array/matrix "base cut": `Expr::ArrayLit`/`Range`/
+`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and `Stmt::IndexSet` (the
+9-node "APL addendum" — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` — stays out of scope for this
+slice; see below). Part of the SIR22/SIR23 second-wave backend-expansion
+initiative (see the SIR22 spec's "Backend impact" section, amended for this
+exact rollout).
+
+**Runtime port** (`runtime.rs`, new "SIR22 array/matrix domain" section):
+an inlined port of `semantic-ir-to-javascript`'s already-proven `ArrayRt`
+sub-runtime, following this backend's existing "self-contained, no external
+crate" convention (the same reason `seq_*`/`map_*` are inlined rather than
+imported — this backend shells out to bare `rustc` on a single generated
+`.rs` file, with no `Cargo.toml`/dependency graph for the generated
+program, so a real crate dependency on a hypothetical `array-runtime` was
+never an option). New `Value::NDArray(Rc<RefCell<SirNDArray>>)` variant and
+`SirNDArray { shape: Vec<usize>, data: Vec<f64> }` struct, plus
+`array_checked_shape_size`/`array_ndarray`/`array_from_rows`/`array_coerce`/
+`array_get`/`array_set`/`array_apply_op`/`array_elementwise`/`array_matmul`/
+`array_transpose`/`array_range`/`array_assert_valid_position`/
+`array_resolve_positions`/`array_index_get`/`array_broadcast_values`/
+`array_index_set` — a 1:1 port of the JS reference's `checkedShapeSize`/
+`ndarray`/`fromRows`/`toArrayValue`/`get`/`set`/`applyOp`/`elementwise`/
+`matmul`/`transpose`/`range`/`assertValidPosition`/`resolvePositions`/
+`indexGet`/`broadcastValues`/`indexSet`.
+
+**Value-model decision**: array data is stored uniformly as `f64` (mirroring
+the JS backend's `Float64Array`), NOT `semantic-ir-to-ruby`'s deliberate
+Int/Float-preserving choice — a considered divergence from that sibling PR,
+not an oversight. This backend's `Value` already distinguishes `Int`/
+`Float` at the scalar level, but threading that distinction element-by-
+element through every array op would multiply the arithmetic-dispatch
+surface for a domain whose own spec maps 1:1 onto `array_runtime::execute()`
+(itself f64-only) — not worth it for a slice whose own reference
+implementation (JS) is f64-only to begin with. A consequence: `Expr::IndexGet`
+on a scalar position always yields `Value::Float`, so an all-integer `matmul`
+prints with a trailing `.0` (`"19.0"`, not `"19"`) — documented in
+`tests/sir22_array.rs` and expected in its assertions, not a bug.
+
+**IndexSet / ownership decision** (the one place this port is genuinely
+harder than JS's or Ruby's — see `runtime.rs`'s own doc for the long-form
+version): `Value::NDArray` reuses the EXACT `Rc<RefCell<…>>` shared-mutable-
+handle shape `Value::Seq`/`Value::Map` already establish in this same file.
+`Stmt::IndexSet` mutates through `RefCell::borrow_mut()`, so every alias of
+an array binding observes an in-place write — exactly the same mechanism
+`Stmt::SeqSet`/`Stmt::MapSet` already use for sequences/maps. No new
+ownership strategy was needed; SIR16 sequences had already forced this
+backend to solve "mutate the very value the caller's binding holds, visible
+through every alias" once, and this slice just applies that same answer to
+a new variant.
+
+**Security discipline**: every allocation (`array_checked_shape_size`) uses
+`checked_mul` so a shape product can never silently wrap on overflow before
+an unvalidated size reaches `Vec::with_capacity`-shaped allocations, mirroring
+the DoS discipline every other backend in this slice uses. Every index
+position is funneled through `array_assert_valid_position` before it is
+allowed to become a `usize` — the one place a NaN could otherwise defeat a
+bounds check (every IEEE-754 relational comparison with NaN is `false`, so an
+OR-negated bounds check's every branch would go `false` too). This backend
+gets a *stronger* guarantee than JS/Ruby's own "written defensively" AND-form
+checks: because `usize` cannot represent NaN or a negative value at all, once
+a position clears `array_assert_valid_position` every downstream bounds check
+(`array_get`/`array_set`) is NaN-safe *by construction*, not merely by
+comparison order — though they are still written in AND-form
+(`r < nrows && c < ncols`) for readability and consistency with every other
+backend's port of this same runtime. Every array/matrix error raises a
+catchable `RuntimeError` (via this backend's existing `raise`/`catch_unwind`
+machinery), never a bare, uncatchable Rust panic.
+
+**Addendum rejection** (`lib.rs`, new `reject_sir22_addendum`): the 9-node
+APL addendum shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base
+cut, so the ordinary feature-flag capability check alone cannot reject a
+module using one of those nine. Mirrors `semantic-ir-to-ruby`'s own
+`ScanHit::Sir22AddendumNode` (implemented for this same rollout wave), but
+uses `semantic_ir`'s shared `Visitor`/`walk_expr_default` walker rather than
+a hand-rolled recursive match — with ~40 `Expr` variants, a hand-picked-
+subset walk (this crate's existing style for `reject_stateful_class`/
+`reject_const_ref`) is exactly the kind of check that can silently drift out
+of sync with the emitter as new node kinds are added; the shared walker
+guarantees every position the validator itself visits is covered here too.
+
+**Emitter** (`emit.rs`): six new `Expr` arms plus `Stmt::IndexSet`, each
+emitting a call into the new `__sir::array_*` helpers; new
+`elementwise_op_rs_name`/`emit_index_arg`/`emit_index_args` helpers
+(the `IndexArg` → `__sir::SirIndexArg` translation). `collect_stmt_assigned`/
+`collect_expr_assigned` (used to pre-declare `let mut` locals) now recurse
+into the base cut's real sub-expressions instead of the previous
+"nothing reachable, rejected before emit" no-op — the addendum's 9 nodes
+keep that no-op treatment (still rejected before emit, by
+`reject_sir22_addendum`).
+
+**Tests**: new `tests/sir22_array.rs` (8 tests, ported from the JS backend's
+own `tests/sir22_array.rs`, cross-checked against `semantic-ir-to-ruby`'s
+port of the same suite) — hand-builds `Module`s directly (no frontend
+targets this backend for SIR22 yet), compiles with a real `rustc`, and
+asserts stdout: 2×2 `matmul` against a known product, an `ElementwiseOp`
+with a bare-scalar operand (the `array_coerce`/`toArrayValue`-coercion
+regression case — MATLAB's `.* / .\` lowering can hand a raw scalar, not an
+`ArrayLit`, on one side), `Div`'s always-true-divide behavior, `transpose`,
+`range`, a `Whole`-selector `IndexGet` (reads a whole row), `Stmt::IndexSet`
+mutating in place, and a compile-time-rejection test proving `Expr::Reduce`
+(an addendum node) is cleanly rejected with a real `Err`, not a panic.
+Skips (does not fail) when no `rustc`/usable linker is on the host, matching
+every other `compile_and_run_*` test in this crate; unique temp-file names
+per test run (PID + a monotonic `AtomicUsize` counter), avoiding the
+same-path collision race this crate's test suite has hit before when a
+temp-file name was not unique across concurrently-running test threads.
+
 ## 0.41.0 — SIR21 T3b-2 Slice 2: `div_floor`/`div_trunc`/`udiv_trunc`/`div_true`
 
 Additive-only: adds the four new division builtin names from SIR21 T3b-2

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -298,10 +298,31 @@ backend emits — bare `"print"`/`"puts"` `BuiltinCall`s and the `print`/
 every frontend finished migrating to `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
+**`NDArrays` / `MatrixOps` / `ArrayColumnMajor`** (SIR22 array/matrix base
+cut, Phase A Slice 2): `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+`Transpose`/`IndexGet` and `Stmt::IndexSet` route into a new `__sir::array_*`
+sub-runtime — an inlined port of `semantic-ir-to-javascript`'s own
+already-proven `ArrayRt` sub-runtime (this backend inlines its runtime
+helpers, same as `seq_*`/`map_*`, since the generated program has no
+`Cargo.toml`/dependency graph to hang a real crate dependency off). Array
+data is stored uniformly as `f64` (mirroring the JS backend's
+`Float64Array`), so `IndexGet` on a scalar position always yields a
+`Value::Float`. `Stmt::IndexSet` mutates through the new
+`Value::NDArray(Rc<RefCell<SirNDArray>>)` handle — the same shared-mutable
+pattern `Seq`/`Map` already use, so every alias of an array binding
+observes the write. The 9-node SIR22 "APL addendum"
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+`IndexOf`/`Ravel`/`Catenate`) shares these same three features with the
+base cut but stays deferred to a later slice — rejected cleanly by a
+dedicated pre-emit scan (`reject_sir22_addendum` in `lib.rs`) rather than
+this capability gate, since the gate alone can't tell the two groups
+apart. See [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
-(empty whitelist in v0), `StringInterpolation`, and a stateful (non-empty
+(empty whitelist in v0), `StringInterpolation`, a stateful (non-empty
 body) `Class`/`Module` or a non-name-slot `Const` reference (rejected
-cleanly by the soundness gates).
+cleanly by the soundness gates), and the SIR22 "APL addendum" nodes above
+(rejected cleanly by `reject_sir22_addendum`, not this capability gate).
 
 ## Value model
 
@@ -316,7 +337,10 @@ enum Value {
     Seq(Rc<RefCell<Vec<Value>>>),            // SIR16 Sequences
     Map(Rc<RefCell<Vec<(Value, Value)>>>),   // SIR16 Maps (insertion-ordered)
     Instance(u64),                           // SIR17 O5 user-object handle
+    NDArray(Rc<RefCell<SirNDArray>>),        // SIR22 array/matrix base cut
 }
+
+struct SirNDArray { shape: Vec<usize>, data: Vec<f64> }  // rank <= 2, column-major
 ```
 
 - Single-threaded (`Rc`, not `Arc`).
@@ -336,6 +360,10 @@ enum Value {
 - Sequences and maps are `Rc<RefCell<…>>` so `SeqSet`/`MapSet` mutate the
   shared value in place; maps key by `value_eq` (linear lookup) and keep
   insertion order.
+- `NDArray` is `Rc<RefCell<…>>` for the identical reason: `Stmt::IndexSet`
+  must mutate the very array a caller's binding holds, visible through
+  every alias — the same requirement `Seq`/`Map` already solve, applied to
+  a new variant rather than inventing a second ownership strategy.
 
 ## `main` collision
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -20,7 +20,10 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt};
+use semantic_ir::{
+    Block, ElementwiseOpKind, Expr, Function, Global, IndexArg, Module, Param, ParamKind, Scope,
+    Stmt,
+};
 
 use crate::runtime::RUNTIME;
 
@@ -428,12 +431,32 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
         | Stmt::ModuleDef { .. }
         | Stmt::SingletonClassDef { .. }
         | Stmt::TryCatch { .. } => {}
-        // SIR22 array/matrix indexed assignment: `Feature::NDArrays` /
-        // `Feature::MatrixOps` are not in this backend's accepted-features
-        // list, so `check_module` rejects any module using `IndexSet`
-        // before it ever reaches this pure collection helper. Nothing
-        // reachable to collect.
-        Stmt::IndexSet { .. } => {}
+        // SIR22 array/matrix indexed assignment: `target`, each index
+        // argument, and `value` can each nest an `Assign` (e.g.
+        // `A(i) = (foo := 1)`), so recurse into all three — same
+        // treatment as `SeqSet`/`MapSet` above.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            collect_expr_assigned(target, out);
+            for arg in indices {
+                collect_index_arg_assigned(arg, out);
+            }
+            collect_expr_assigned(value, out);
+        }
+    }
+}
+
+/// Recurse into an `IndexArg`'s nested expression(s), if any — shared by
+/// `collect_stmt_assigned`'s `IndexSet` arm and `collect_expr_assigned`'s
+/// `IndexGet` arm.
+fn collect_index_arg_assigned(arg: &IndexArg, out: &mut HashSet<String>) {
+    match arg {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => collect_expr_assigned(e, out),
+        IndexArg::Whole => {}
     }
 }
 
@@ -510,19 +533,43 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::VarRef { .. }
         | Expr::Intrinsic { .. }
         | Expr::StrConcat { .. } => {}
-        // SIR22 array/matrix nodes (rejected before emit — see
-        // `collect_stmt_assigned`'s `IndexSet` arm): none of these carry a
-        // reachable `Assign` for THIS backend, since a validated module can
-        // never contain them in the first place.
-        Expr::ArrayLit { .. }
-        | Expr::Range { .. }
-        | Expr::MatMul { .. }
-        | Expr::ElementwiseOp { .. }
-        | Expr::Transpose { .. }
-        | Expr::IndexGet { .. }
-        // SIR22 addendum: APL primitive operators — same rationale as the
-        // base SIR22 nodes above.
-        | Expr::Reduce { .. }
+        // SIR22 array/matrix nodes (base cut) — real recursion, since this
+        // backend now accepts them: each sub-expression can nest an
+        // `Assign` the same as any other operand position.
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for item in row {
+                    collect_expr_assigned(item, out);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            collect_expr_assigned(start, out);
+            if let Some(step) = step {
+                collect_expr_assigned(step, out);
+            }
+            collect_expr_assigned(stop, out);
+        }
+        Expr::MatMul { lhs, rhs, .. } | Expr::ElementwiseOp { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::Transpose { target, .. } => collect_expr_assigned(target, out),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            collect_expr_assigned(target, out);
+            for arg in indices {
+                collect_index_arg_assigned(arg, out);
+            }
+        }
+        // SIR22 addendum: APL primitive operators — rejected before emit
+        // (`reject_sir22_addendum` in `lib.rs`), so none of these carry a
+        // reachable `Assign` for THIS backend: a validated, accepted
+        // module can never contain them.
+        Expr::Reduce { .. }
         | Expr::Scan { .. }
         | Expr::OuterProduct { .. }
         | Expr::Shape { .. }
@@ -787,13 +834,26 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         } => {
             emit_try_catch(out, body, rescues, ensure_body, indent);
         }
-        // SIR22 array/matrix indexed assignment — `Feature::NDArrays` /
-        // `Feature::MatrixOps` are not in this backend's accepted-features
-        // list, so `check_module` rejects any module using `IndexSet`
-        // before it ever reaches emit.  Defensive panic covers internal
-        // bugs only (matches the `SingletonClassDef` arm above).
-        Stmt::IndexSet { span, .. } => {
-            panic!("rust backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
+        // ── SIR22: array/matrix indexed assignment ───────────────────
+        // `target[indices...] = value;` — mutates in place via
+        // `__sir::array_index_set` (see `runtime.rs`'s "SIR22
+        // array/matrix domain" section), matching the SIR22 spec's own
+        // note that `IndexSet` is a `Stmt`, not a pure `Expr`, for
+        // exactly this in-place-mutation reason.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            out.push_str(&pad);
+            out.push_str("__sir::array_index_set(&(");
+            emit_expr(out, target, indent);
+            out.push_str("), vec![");
+            emit_index_args(out, indices, indent);
+            out.push_str("], ");
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
     }
 }
@@ -1116,22 +1176,93 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::KeywordArg { span, .. } => {
             panic!("rust backend reached a stand-alone keyword-arg expression at {} — indirect/closure keyword calls are out of scope for v0 (see sir-keyword-params.md)", span);
         }
-        // SIR22 array/matrix expressions (`ArrayLit`/`Range`/`MatMul`/
-        // `ElementwiseOp`/`Transpose`/`IndexGet`) — `Feature::NDArrays` /
-        // `Feature::MatrixOps` are not in this backend's accepted-features
-        // list, so `check_module` rejects any module using them before it
-        // ever reaches emit.  Defensive panic covers internal bugs only
-        // (matches the `StrConcat`/`Intrinsic` arms above).
-        Expr::ArrayLit { span, .. }
-        | Expr::Range { span, .. }
-        | Expr::MatMul { span, .. }
-        | Expr::ElementwiseOp { span, .. }
-        | Expr::Transpose { span, .. }
-        | Expr::IndexGet { span, .. }
+        // ── SIR22: array/matrix expressions (base cut) ────────────────
+        // Real codegen: calls into the inlined `__sir::array_*` sub-
+        // runtime (see `runtime.rs`'s "SIR22 array/matrix domain"
+        // section) — a Rust port of `semantic-ir-to-javascript`'s own
+        // already-proven `ArrayRt` sub-runtime, mirroring how the SIR16
+        // `Expr::SeqLit`/`Expr::SeqIndex` arms above call into
+        // `__sir::seq_*`. `rows` is row-major in the literal syntax (per
+        // the SIR22 spec); `__sir::array_from_rows` reconciles that with
+        // column-major storage, so the emitter just nests the row/element
+        // expressions unchanged.
+        Expr::ArrayLit { rows, .. } => {
+            out.push_str("__sir::array_from_rows(vec![");
+            for (i, row) in rows.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str("vec![");
+                emit_args(out, row, indent);
+                out.push(']');
+            }
+            out.push_str("])");
+        }
+        // `__sir::array_range(start, stop, step)` — note the argument
+        // ORDER: the SIR node's own field order is `start, step, stop`,
+        // but `array_range(start, stop, step)` (mirroring the JS
+        // reference's own `range(start, stop, step = 1)`) takes `stop`
+        // before `step`.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            out.push_str("__sir::array_range(");
+            emit_expr(out, start, indent);
+            out.push_str(", ");
+            emit_expr(out, stop, indent);
+            out.push_str(", ");
+            match step {
+                Some(step) => emit_expr(out, step, indent),
+                None => out.push_str("__sir::Value::Int(1i64)"),
+            }
+            out.push(')');
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            out.push_str("__sir::array_matmul(&(");
+            emit_expr(out, lhs, indent);
+            out.push_str("), &(");
+            emit_expr(out, rhs, indent);
+            out.push_str("))");
+        }
+        // The op name must match `array_apply_op`'s `match` in
+        // `runtime.rs` exactly (`"Add"`, not `.name()`'s lowercase
+        // `"add"`).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__sir::array_elementwise({}, &(",
+                quote_rs_string(elementwise_op_rs_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str("), &(");
+            emit_expr(out, rhs, indent);
+            out.push_str("))");
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            out.push_str("__sir::array_transpose(&(");
+            emit_expr(out, target, indent);
+            let _ = write!(out, "), {conjugate})");
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            out.push_str("__sir::array_index_get(&(");
+            emit_expr(out, target, indent);
+            out.push_str("), vec![");
+            emit_index_args(out, indices, indent);
+            out.push_str("])");
+        }
         // SIR22 addendum: APL primitive operators — same deferral rationale
         // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // features, not in this backend's accepted-features list either).
-        | Expr::Reduce { span, .. }
+        // features the base cut above now accepts; a dedicated pre-emit
+        // scan, `reject_sir22_addendum` in `lib.rs`, rejects a module
+        // using one of these nine BEFORE it ever reaches emit — see that
+        // function's doc for why the feature gate alone can't tell the
+        // two groups apart). Defensive panic below covers internal bugs
+        // only (matches the `StrConcat`/`Intrinsic` arms above).
+        Expr::Reduce { span, .. }
         | Expr::Scan { span, .. }
         | Expr::OuterProduct { span, .. }
         | Expr::Shape { span, .. }
@@ -1144,7 +1275,7 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // validated module.
         | Expr::Convert { span, .. } => {
             panic!(
-                "rust backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                "rust backend reached a deferred SIR22-addendum/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 span
             );
@@ -1207,6 +1338,63 @@ fn emit_args(out: &mut String, args: &[Expr], indent: usize) {
             out.push_str(", ");
         }
         emit_expr(out, a, indent);
+    }
+}
+
+/// The Rust string `__sir::array_apply_op`'s `match` switches on — exact
+/// `ElementwiseOpKind` variant names, not `.name()`'s lowercase forms
+/// (`"add"`, etc., used elsewhere for e.g. debug/display), since this
+/// string is a real runtime dispatch key, not a cosmetic label.  Mirrors
+/// `semantic-ir-to-javascript`'s own `elementwise_op_js_name` exactly.
+fn elementwise_op_rs_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "Add",
+        ElementwiseOpKind::Sub => "Sub",
+        ElementwiseOpKind::Mul => "Mul",
+        ElementwiseOpKind::Div => "Div",
+        ElementwiseOpKind::Pow => "Pow",
+        ElementwiseOpKind::Max => "Max",
+        ElementwiseOpKind::Min => "Min",
+        ElementwiseOpKind::Eq => "Eq",
+        ElementwiseOpKind::Ne => "Ne",
+        ElementwiseOpKind::Lt => "Lt",
+        ElementwiseOpKind::Le => "Le",
+        ElementwiseOpKind::Ge => "Ge",
+        ElementwiseOpKind::Gt => "Gt",
+    }
+}
+
+/// Emit one `IndexArg` as the `__sir::SirIndexArg` variant `array_index_get`/
+/// `array_index_set` expect: `Scalar(<expr>)` / `Whole` / `Range(<expr>)`.
+/// The `Range` case reuses `emit_expr` on the inner `Expr::Range` node
+/// directly — that node's own `Expr::Range` arm already emits a call into
+/// `__sir::array_range(...)`, which returns exactly the `Value::NDArray`
+/// shape `SirIndexArg::Range` expects, so no separate handling is needed
+/// here.  Mirrors `semantic-ir-to-javascript`'s own `emit_index_arg`.
+fn emit_index_arg(out: &mut String, arg: &IndexArg, indent: usize) {
+    match arg {
+        IndexArg::Scalar(e) => {
+            out.push_str("__sir::SirIndexArg::Scalar(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        IndexArg::Whole => {
+            out.push_str("__sir::SirIndexArg::Whole");
+        }
+        IndexArg::Range(e) => {
+            out.push_str("__sir::SirIndexArg::Range(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+    }
+}
+
+fn emit_index_args(out: &mut String, indices: &[IndexArg], indent: usize) {
+    for (i, arg) in indices.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        emit_index_arg(out, arg, indent);
     }
 }
 
@@ -2327,11 +2515,22 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         } => {
             emit_try_catch(out, body, rescues, ensure_body, indent);
         }
-        // SIR22 array/matrix indexed assignment (inline) — see the
-        // `IndexSet` arm in `emit_stmt` above; same reasoning applies here
-        // (matches the `SingletonClassDef` (inline) arm above).
-        Stmt::IndexSet { span, .. } => {
-            panic!("rust backend (inline) reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
+        // SIR22 array/matrix indexed assignment (inline) — same
+        // `array_index_set` helper as the statement path in `emit_stmt`,
+        // with a trailing space instead of a newline.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            out.push_str("{ __sir::array_index_set(&(");
+            emit_expr(out, target, indent);
+            out.push_str("), vec![");
+            emit_index_args(out, indices, indent);
+            out.push_str("], ");
+            emit_expr(out, value, indent);
+            out.push_str("); } ");
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -29,7 +29,7 @@ mod runtime;
 
 use semantic_ir::{
     Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr, Feature, IndexArg,
-    Module, ParamKind, Scope, Stmt,
+    Module, ParamKind, Scope, Stmt, Visitor, walk_expr_default,
 };
 
 pub use emit::sanitize_ident;
@@ -212,6 +212,21 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
+    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+    // (+ `Stmt::IndexSet`) route into `__sir::array_*` helpers, an
+    // inlined port of the already-proven `semantic-ir-to-javascript`
+    // `ArrayRt` sub-runtime (see `runtime.rs`'s "SIR22 array/matrix
+    // domain" section) — this backend's existing "self-contained, no
+    // external crate" convention, same as `seq_*`/`map_*`.  The SIR22
+    // "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share these
+    // same three features but stay deferred — rejected by a dedicated
+    // pre-emit scan (`reject_sir22_addendum`, below), not this capability
+    // gate, since the gate alone can't distinguish them.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for RustBackend {
@@ -267,6 +282,15 @@ impl Backend for RustBackend {
             return Err(e);
         }
         if let Some(e) = reject_const_ref(module) {
+            return Err(e);
+        }
+
+        // 2d. SIR22 "APL addendum" soundness gate — shares
+        //     `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the SIR22
+        //     base cut this backend now implements, so the feature-flag
+        //     capability check above cannot tell the two groups apart.
+        //     See `reject_sir22_addendum`'s doc.
+        if let Some(e) = reject_sir22_addendum(module) {
             return Err(e);
         }
 
@@ -734,6 +758,75 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
         // Leaf / already-supported expressions carry no nested Const.
         _ => None,
     }
+}
+
+/// Reject a module containing any of the nine SIR22 "APL addendum" nodes
+/// (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+/// `IndexOf`/`Ravel`/`Catenate`).
+///
+/// These share `Feature::NDArrays`/`Feature::MatrixOps`/
+/// `Feature::ArrayColumnMajor` with the SIR22 **base cut** this backend now
+/// implements (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+/// `IndexGet`/`Stmt::IndexSet`) — see the SIR22 spec's "Backend impact"
+/// section. That means `check_module`'s ordinary feature-flag capability
+/// check cannot tell a module using one of these nine apart from a safe
+/// base-cut-only module: both declare the identical three features. A
+/// dedicated pre-emit scan is the only way to reject them cleanly, mirroring
+/// `semantic-ir-to-ruby`'s own `ScanHit::Sir22AddendumNode` (implemented for
+/// this exact rollout wave) and `semantic-ir-to-javascript`'s (since-removed,
+/// once that backend's own addendum codegen shipped)
+/// `find_unimplemented_sir22_addendum_node`.
+///
+/// Unlike `reject_stateful_class`/`reject_const_ref` above (hand-rolled
+/// recursive walks over a hand-picked subset of `Stmt`/`Expr` positions),
+/// this uses `semantic_ir`'s shared [`semantic_ir::Visitor`] walker: with
+/// ~40 `Expr` variants and growing, a hand-picked-subset walk is exactly the
+/// kind of check that can silently drift out of sync with the emitter as new
+/// node kinds are added — the shared walker's `walk_expr_default`/
+/// `walk_stmt_default` guarantee every position the validator itself visits
+/// is covered here too, so this check can never miss a nested occurrence
+/// (inside a closure capture, a `TryCatch` body, a parameter default, …).
+///
+/// Returns `Some(err)` for the FIRST offending node found (fail-fast, like
+/// the other capability checks), or `None` if the module is clean.
+fn reject_sir22_addendum(module: &Module) -> Option<BackendError> {
+    struct Finder(Option<(&'static str, semantic_ir::Span)>);
+
+    impl Visitor for Finder {
+        fn visit_expr(&mut self, e: &Expr, depth: usize) {
+            if self.0.is_some() {
+                return;
+            }
+            let hit = match e {
+                Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
+                Expr::Scan { span, .. } => Some(("Scan", span.clone())),
+                Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
+                Expr::Shape { span, .. } => Some(("Shape", span.clone())),
+                Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
+                Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
+                Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
+                Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
+                Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
+                _ => None,
+            };
+            if hit.is_some() {
+                self.0 = hit;
+                return;
+            }
+            walk_expr_default(self, e, depth);
+        }
+    }
+
+    let mut finder = Finder(None);
+    finder.visit_module(module);
+    finder.0.map(|(kind, span)| BackendError {
+        kind: BackendErrorKind::UnsupportedFeature,
+        message: format!(
+            "the rust backend does not yet implement the SIR22 addendum node `{kind}` \
+             (deferred to a later slice)"
+        ),
+        span,
+    })
 }
 
 fn unsupported_const(span: semantic_ir::Span) -> BackendError {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -116,6 +116,17 @@ pub const RUNTIME: &str = r##"mod __sir {
         // (`format_d`, and an identity arm in `value_eq_d`); every other
         // `match` already has a `_`/`matches!` fallback.
         Instance(u64),
+        // ── SIR22 array/matrix domain ──────────────────────────────
+        // A dense, rectangular, column-major numeric array (see the
+        // "SIR22 array/matrix domain" section further down this file for
+        // the full value-model / ownership rationale). `Rc<RefCell<…>>`
+        // is the SAME shared-mutable-handle shape `Seq`/`Map` above
+        // already use — `Stmt::IndexSet` must mutate the very array the
+        // caller's binding already holds, and two bindings that alias the
+        // same literal must see each other's writes, exactly like
+        // `SeqSet`/`MapSet`. Cloning a `Value::NDArray` clones the `Rc`,
+        // not the backing storage.
+        NDArray(Rc<RefCell<SirNDArray>>),
     }
 
     pub struct Pair {
@@ -948,6 +959,29 @@ pub const RUNTIME: &str = r##"mod __sir {
             // needed here.  A program wanting a richer form defines its
             // own `to_s`, which dispatches through `call_method` first.
             Value::Instance(id) => format!("#<{}>", instance_class(*id)),
+            // An `NDArray` prints its shape and flattened (column-major)
+            // data — a defensive rendering only: every test/consumer of
+            // this SIR22 slice reads a SCALAR back out via `IndexGet`
+            // (see `array_index_get`'s doc), so this path is not the
+            // primary display story for this domain (matching the JS/
+            // Ruby/TS backends' own base-cut slices, which likewise defer
+            // a real NDArray display convention). No cycle risk — `data`
+            // is a flat `Vec<f64>`, never another `Value` — so no
+            // `visited` handling is needed here, same as `Instance` above.
+            Value::NDArray(a) => {
+                let a = a.borrow();
+                let mut s = String::from("NDArray");
+                s.push_str(&format!("{:?}", a.shape));
+                s.push('[');
+                for (i, x) in a.data.iter().enumerate() {
+                    if i > 0 {
+                        s.push_str(", ");
+                    }
+                    s.push_str(&format_float(*x));
+                }
+                s.push(']');
+                s
+            }
         }
     }
 
@@ -1212,6 +1246,634 @@ pub const RUNTIME: &str = r##"mod __sir {
                 value
             }
             other => panic!("map-set on non-map: {}", format(other)),
+        }
+    }
+
+    // ── SIR22 array/matrix domain ────────────────────────────────────
+    //
+    // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+    // (and `Stmt::IndexSet`) lower to calls into the `array_*` helpers
+    // below — an inlined port of `semantic-ir-to-javascript`'s own
+    // already-proven `ArrayRt` sub-runtime, following this backend's
+    // existing "self-contained, no external crate" discipline (same as
+    // `seq_*`/`map_*` above).
+    //
+    // ## Value model
+    //
+    // `SirNDArray { shape: Vec<usize>, data: Vec<f64> }` — dense,
+    // rectangular, COLUMN-MAJOR storage (Fortran/MATLAB order), mirroring
+    // `array_runtime::value::Array` field-for-field. `shape == []` is a
+    // scalar, `[n]` a vector (an `n×1` column for row/column purposes),
+    // `[r, c]` a matrix — this port's whole scope, like the JS/TS/Ruby
+    // references, is rank <= 2. `data` is uniformly `f64` (mirroring the
+    // JS backend's `Float64Array`, NOT `semantic-ir-to-ruby`'s
+    // Int/Float-preserving choice) — a deliberate simplification: this
+    // backend's `Value` already distinguishes `Int`/`Float` at the SCALAR
+    // level, but threading that distinction element-by-element through an
+    // array would multiply the arithmetic-dispatch surface (every
+    // `array_apply_op` call would need `any_float`-style promotion logic)
+    // for a domain whose own spec ("Motivation") maps 1:1 onto
+    // `array_runtime::execute()`, which is itself f64-only. A value read
+    // back out of an array via `IndexGet` is always `Value::Float`,
+    // documented at `array_index_get`.
+    //
+    // ## Ownership / `IndexSet` mutation (the one place this port is
+    // genuinely harder than the other backends')
+    //
+    // `Value::NDArray(Rc<RefCell<SirNDArray>>)` reuses EXACTLY the shared-
+    // mutable-handle pattern `Value::Seq`/`Value::Map` above already
+    // establish for this backend: cloning a `Value::NDArray` clones the
+    // `Rc` (a shared handle), not the backing storage, and `Stmt::IndexSet`
+    // (`array_index_set` below) mutates through `RefCell::borrow_mut()` —
+    // exactly the same shape `seq_set`/`map_set` use for `Stmt::SeqSet`/
+    // `Stmt::MapSet`. This was a genuine design question unique to this
+    // backend (JS/Ruby have no ownership model to satisfy — every value is
+    // implicitly a shared, mutable heap reference there), but it has an
+    // exact precedent already sitting in this same file: SIR16 sequences
+    // hit the identical "must mutate the very value the caller's binding
+    // already holds, and every alias must observe the write" requirement,
+    // and `Rc<RefCell<…>>` is how this backend already answers it. No new
+    // ownership strategy was needed — just the same one, applied to a new
+    // variant.
+    //
+    // ## Security discipline
+    //
+    // Every factory below validates a shape/output size *before*
+    // allocating a `Vec` from it (via `array_checked_shape_size`, using
+    // `checked_mul` so a shape product can never silently wrap on
+    // overflow) — a compiled program's array sizes come from potentially
+    // attacker-influenced runtime values (loop counts, parsed input, …),
+    // not fixed compile-time constants. Every *position* (an index
+    // resolved from a `Value`, itself ultimately `f64`-backed for a
+    // `Float` operand) is validated by `array_assert_valid_position`
+    // BEFORE it is allowed to become a `usize` — this is the one place a
+    // literal IEEE-754 NaN could otherwise defeat a bounds check (every
+    // relational comparison with NaN is `false`, so an unguarded NaN
+    // index could make an OR-negated bounds check's every branch `false`
+    // and slip through). Note this backend gets a STRONGER guarantee than
+    // JS/Ruby's own "written defensively" AND-form checks: because
+    // `array_assert_valid_position` is the ONLY path from an arbitrary
+    // `Value`/`f64` into a `usize` position, and Rust's `usize` cannot
+    // represent NaN or a negative value at all, every downstream bounds
+    // check (`array_get`/`array_set`) is NaN-safe *by construction*, not
+    // merely by writing the comparison in AND-form — though they are
+    // still written that way (`r < nrows && c < ncols`), both for
+    // readability and so the discipline reads consistently with every
+    // other backend's port of this same runtime.
+    //
+    // The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is
+    // deferred — these nine share `NDArrays`/`MatrixOps`/
+    // `ArrayColumnMajor` with the base cut above, so `lib.rs`'s `compile`
+    // adds a dedicated pre-emit scan (`reject_sir22_addendum`) rejecting
+    // them cleanly, beyond the ordinary feature-flag capability check.
+
+    /// Element cap for any array/matrix allocation in this domain —
+    /// mirrors the JS/TS/Ruby backends' identical `MAX_ELEMENTS`/
+    /// `SIR_ARRAY_MAX_ELEMENTS` bound exactly, so behaviour (and the DoS
+    /// ceiling) is identical across every backend implementing this slice.
+    pub const ARRAY_MAX_ELEMENTS: usize = 1 << 26; // 67,108,864
+
+    /// Tolerance for `array_range`'s inclusive-stop boundary check — a
+    /// floating step (e.g. `1:0.1:2`) can drift a few ULPs short of `stop`
+    /// by the final iteration, and MATLAB's `a:step:b` is inclusive of `b`.
+    const ARRAY_RANGE_EPSILON: f64 = 1e-9;
+
+    /// A dense, rectangular, column-major numeric array (rank <= 2 in this
+    /// slice's scope). See this section's module doc for the full value-
+    /// model rationale.
+    #[derive(Clone, Debug)]
+    pub struct SirNDArray {
+        pub shape: Vec<usize>,
+        pub data: Vec<f64>,
+    }
+
+    /// One resolved `IndexArg`, mirroring the SIR22 spec's `IndexArg`
+    /// exactly: `Scalar(v)` / `Whole` / `Range(v)` (`v` for `Range` is the
+    /// `Value::NDArray` an `Expr::Range` sub-expression evaluates to — see
+    /// the SIR22 spec's note that an index-position `Range` reuses
+    /// `Expr::Range` rather than duplicating its operand slots). `end`-
+    /// relative indices are never seen here — per SIR10 discipline, the
+    /// frontend resolves `end` to a concrete 0-based `Scalar` index before
+    /// emitting `IndexGet`/`IndexSet`.
+    pub enum SirIndexArg {
+        Scalar(Value),
+        Whole,
+        Range(Value),
+    }
+
+    /// Raise a catchable `RuntimeError` from this domain — every array/
+    /// matrix error is reported this way (a `raise`, not a bare Rust
+    /// panic), so a malformed shape/index/operand fails with a clean,
+    /// `TryCatch`-rescuable error instead of an uncatchable process abort.
+    fn array_raise(msg: String) -> ! {
+        raise("RuntimeError", Value::Str(Rc::from(msg.as_str())))
+    }
+
+    /// Validate `shape` and return its total element count — SECURITY:
+    /// called BEFORE every allocation in this domain, using `checked_mul`
+    /// so a shape product can never silently wrap around on overflow
+    /// (mirrors the JS/Ruby backends' own `Number.isFinite`/no-overflow
+    /// checks, adapted to Rust's checked-arithmetic idiom). Unlike JS/Ruby,
+    /// there is no "negative or non-integer dimension" case to check here
+    /// — `shape: &[usize]` already rules that out at the type level.
+    fn array_checked_shape_size(shape: &[usize]) -> usize {
+        let mut n: usize = 1;
+        for &d in shape {
+            n = match n.checked_mul(d) {
+                Some(v) => v,
+                None => array_raise(format!(
+                    "array_checked_shape_size: shape {:?} overflows while computing element count",
+                    shape
+                )),
+            };
+        }
+        if n > ARRAY_MAX_ELEMENTS {
+            array_raise(format!(
+                "array_checked_shape_size: shape {:?} ({} elements) exceeds the {} element cap",
+                shape, n, ARRAY_MAX_ELEMENTS
+            ));
+        }
+        n
+    }
+
+    /// Construct a `Value::NDArray`, validating `data.len()` against
+    /// `shape`'s own implied element count.
+    fn array_ndarray(shape: Vec<usize>, data: Vec<f64>) -> Value {
+        let n = array_checked_shape_size(&shape);
+        if n != data.len() {
+            array_raise(format!(
+                "array_ndarray: shape {:?} implies {} elements, got {}",
+                shape,
+                n,
+                data.len()
+            ));
+        }
+        Value::NDArray(Rc::new(RefCell::new(SirNDArray { shape, data })))
+    }
+
+    /// `[1 2; 3 4]` — build an `NDArray` from a row-major literal (per the
+    /// SIR22 spec, `rows` is row-major in the literal syntax; this
+    /// reconciles that with column-major storage). Each element is an
+    /// already-evaluated `Value` (an `IntLit`/`FloatLit`/arithmetic
+    /// result); `as_f64` widens it, matching the well-typed-input
+    /// assumption every other numeric builtin in this file already makes.
+    pub fn array_from_rows(rows: Vec<Vec<Value>>) -> Value {
+        let nrows_in = rows.len();
+        if nrows_in == 0 {
+            return array_ndarray(vec![0, 0], vec![]);
+        }
+        let ncols_in = rows[0].len();
+        if rows.iter().any(|r| r.len() != ncols_in) {
+            array_raise("array_from_rows: ragged rows".to_string());
+        }
+        let n = array_checked_shape_size(&[nrows_in, ncols_in]);
+        let mut data = vec![0.0f64; n];
+        for (r, row) in rows.iter().enumerate() {
+            for (c, v) in row.iter().enumerate() {
+                data[c * nrows_in + r] = as_f64(v); // column-major store
+            }
+        }
+        array_ndarray(vec![nrows_in, ncols_in], data)
+    }
+
+    /// Coerce a `Value` into an owned `SirNDArray` — the "toArrayValue"
+    /// bare-scalar coercion the JS/Ruby references perform. Needed because
+    /// `matlab-to-semantic-ir`'s lowerer emits a mixed operand pair for
+    /// `.* ./ .\` and for `* /` when exactly one side is scalar (e.g.
+    /// `A .* 2`) — the *bare* scalar sub-expression is passed through
+    /// `ElementwiseOp` unwrapped (a plain `Value::Int`/`Value::Float`), not
+    /// wrapped in an `ArrayLit`/scalar-array constructor first. Every
+    /// function below that accepts an "array" operand normalizes through
+    /// this first. Clones the backing `Vec`s for an already-`NDArray`
+    /// value — a deliberate simplicity/read-path trade-off (this domain's
+    /// element cap already bounds the cost; nothing here is a hot loop).
+    fn array_coerce(v: &Value) -> SirNDArray {
+        match v {
+            Value::NDArray(a) => a.borrow().clone(),
+            other => SirNDArray {
+                shape: vec![],
+                data: vec![as_f64(other)],
+            },
+        }
+    }
+
+    fn array_is_scalar(a: &SirNDArray) -> bool {
+        a.data.len() == 1
+    }
+
+    /// Rows, treating a scalar as `1×1` and a vector `[n]` as `n×1`.
+    fn array_nrows_of(shape: &[usize]) -> usize {
+        if shape.is_empty() {
+            1
+        } else {
+            shape[0]
+        }
+    }
+
+    /// Columns, treating a scalar as `1×1` and a vector `[n]` as `n×1`.
+    fn array_ncols_of(shape: &[usize]) -> usize {
+        if shape.len() <= 1 {
+            1
+        } else {
+            shape[1]
+        }
+    }
+
+    fn array_nrows(a: &SirNDArray) -> usize {
+        array_nrows_of(&a.shape)
+    }
+
+    fn array_ncols(a: &SirNDArray) -> usize {
+        array_ncols_of(&a.shape)
+    }
+
+    /// Element `(r, c)` (column-major), or `None` if out of bounds.
+    ///
+    /// `r`/`c` are `usize` — see this section's module doc on why that
+    /// already makes this AND-form check (`r < nrows && c < ncols`)
+    /// NaN-safe by construction, not merely by comparison order.
+    fn array_get(a: &SirNDArray, r: usize, c: usize) -> Option<f64> {
+        let (nrows, ncols) = (array_nrows(a), array_ncols(a));
+        if r < nrows && c < ncols {
+            Some(a.data[c * nrows + r])
+        } else {
+            None
+        }
+    }
+
+    /// Set element `(r, c)` IN PLACE (column-major) — mutates `a.data`
+    /// directly, matching MATLAB assignment semantics (`A(i,j) = v`
+    /// rebinds one element of the existing array, it does not produce a
+    /// new one). This is why `Stmt::IndexSet` is a statement, not a pure
+    /// expression, in the SIR22 spec. Same NaN-safe-by-construction
+    /// bounds check as `array_get`.
+    fn array_set(a: &mut SirNDArray, r: usize, c: usize, value: f64) {
+        let (nrows, ncols) = (array_nrows(a), array_ncols(a));
+        if !(r < nrows && c < ncols) {
+            array_raise(format!(
+                "array_set: index ({}, {}) out of bounds for shape {:?}",
+                r, c, a.shape
+            ));
+        }
+        let idx = c * nrows + r;
+        a.data[idx] = value;
+    }
+
+    /// Comparisons follow the same APL-style boolean convention
+    /// `array_runtime::BinOp` uses: `1.0` for true, `0.0` for false (never
+    /// a native `bool`), since the result must stay a plain `f64` array
+    /// element like every other value here. `Max`/`Min` use `f64::max`/
+    /// `f64::min`, whose IEEE-754-2008 minNum/maxNum semantics return the
+    /// non-NaN operand when exactly one side is NaN — a harmless, spec-
+    /// sanctioned divergence from JS's `Math.max`/`Math.min` (which
+    /// propagate NaN), noted here rather than silently diverging.
+    fn array_apply_op(op: &str, a: f64, b: f64) -> f64 {
+        let b2f = |cond: bool| if cond { 1.0 } else { 0.0 };
+        match op {
+            "Add" => a + b,
+            "Sub" => a - b,
+            "Mul" => a * b,
+            "Div" => a / b,
+            "Pow" => a.powf(b),
+            "Max" => a.max(b),
+            "Min" => a.min(b),
+            "Eq" => b2f(a == b),
+            "Ne" => b2f(a != b),
+            "Lt" => b2f(a < b),
+            "Le" => b2f(a <= b),
+            "Ge" => b2f(a >= b),
+            "Gt" => b2f(a > b),
+            _ => array_raise(format!("array_apply_op: unrecognised ElementwiseOpKind {:?}", op)),
+        }
+    }
+
+    fn array_same_shape(a: &[usize], b: &[usize]) -> bool {
+        a == b
+    }
+
+    /// Elementwise binary op with scalar broadcasting. Either operand may
+    /// be a scalar; otherwise the shapes must match exactly (full
+    /// NumPy/MATLAB broadcasting is out of scope, same as the JS/Ruby
+    /// references). Result takes the non-scalar operand's shape (or the
+    /// scalar's, if both are).
+    pub fn array_elementwise(op: &str, a: &Value, b: &Value) -> Value {
+        let a = array_coerce(a);
+        let b = array_coerce(b);
+        let (shape, data) = if array_is_scalar(&a) {
+            (
+                b.shape.clone(),
+                b.data.iter().map(|&y| array_apply_op(op, a.data[0], y)).collect(),
+            )
+        } else if array_is_scalar(&b) {
+            (
+                a.shape.clone(),
+                a.data.iter().map(|&x| array_apply_op(op, x, b.data[0])).collect(),
+            )
+        } else {
+            if !array_same_shape(&a.shape, &b.shape) {
+                array_raise(format!(
+                    "array_elementwise: non-conformable arrays: {:?} vs {:?}",
+                    a.shape, b.shape
+                ));
+            }
+            let data = a
+                .data
+                .iter()
+                .zip(b.data.iter())
+                .map(|(&x, &y)| array_apply_op(op, x, y))
+                .collect();
+            (a.shape.clone(), data)
+        };
+        array_ndarray(shape, data)
+    }
+
+    /// Matrix product `[m, k] · [k, n] → [m, n]` (column-major
+    /// throughout). `m`/`n` come from two INDEPENDENT operands (each
+    /// individually under `ARRAY_MAX_ELEMENTS`, but their product isn't
+    /// bounded by that alone — an outer-product-shaped call could still
+    /// ask for a huge output), so `array_checked_shape_size` validates
+    /// `[m, n]` BEFORE allocating `out`, not after.
+    pub fn array_matmul(a: &Value, b: &Value) -> Value {
+        let a = array_coerce(a);
+        let b = array_coerce(b);
+        let m = array_nrows(&a);
+        let ka = array_ncols(&a);
+        let kb = array_nrows(&b);
+        let n = array_ncols(&b);
+        if ka != kb {
+            array_raise(format!(
+                "array_matmul: inner dimensions disagree ({}x{} . {}x{})",
+                m, ka, kb, n
+            ));
+        }
+        let out_len = array_checked_shape_size(&[m, n]);
+        let mut out = vec![0.0f64; out_len];
+        for j in 0..n {
+            for i in 0..m {
+                let mut acc = 0.0f64;
+                for p in 0..ka {
+                    acc += a.data[p * m + i] * b.data[j * kb + p]; // column-major indexing
+                }
+                out[j * m + i] = acc;
+            }
+        }
+        array_ndarray(vec![m, n], out)
+    }
+
+    /// Matrix transpose. `conjugate` distinguishes MATLAB `'` (`true`)
+    /// from `.'` (`false`) — this runtime has no `Complex` value type yet
+    /// (matching `array-runtime`'s own real-only scope today), so a
+    /// conjugate transpose of real data is identical to a plain
+    /// transpose; `conjugate` is accepted for call-shape parity with the
+    /// SIR spec only.
+    pub fn array_transpose(a: &Value, _conjugate: bool) -> Value {
+        let a = array_coerce(a);
+        let m = array_nrows(&a);
+        let n = array_ncols(&a);
+        let mut out = vec![0.0f64; a.data.len()];
+        for j in 0..n {
+            for i in 0..m {
+                out[i * n + j] = a.data[j * m + i];
+            }
+        }
+        array_ndarray(vec![n, m], out)
+    }
+
+    /// Materialize a MATLAB-style range `start:step:stop` (default
+    /// `step = 1`) as a `1×n` row vector — MATLAB's `:` always produces a
+    /// row, never a column. Bounded by `ARRAY_MAX_ELEMENTS` so a compiled
+    /// program's `1:1e18`-style range can't exhaust memory before this
+    /// function ever gets to materialize anything.
+    ///
+    /// SECURITY: rejects a non-finite `start`/`stop`/`step` up front — the
+    /// loop condition below is `false` on its very first check whenever a
+    /// bound is NaN (every relational comparison with NaN is `false`), so
+    /// an unguarded NaN bound would silently produce an empty range
+    /// instead of erroring, the same "NaN defeats a comparison-based
+    /// check" class `array_assert_valid_position` closes for index
+    /// resolution below.
+    pub fn array_range(start: Value, stop: Value, step: Value) -> Value {
+        let start = as_f64(&start);
+        let stop = as_f64(&stop);
+        let step = as_f64(&step);
+        if step == 0.0 {
+            array_raise("array_range: step cannot be zero".to_string());
+        }
+        if !start.is_finite() || !stop.is_finite() || !step.is_finite() {
+            array_raise(format!(
+                "array_range: start/stop/step must be finite numbers, got ({}, {}, {})",
+                start, stop, step
+            ));
+        }
+        let mut values: Vec<f64> = Vec::new();
+        let mut x = start;
+        while (step > 0.0 && x <= stop + ARRAY_RANGE_EPSILON)
+            || (step < 0.0 && x >= stop - ARRAY_RANGE_EPSILON)
+        {
+            if values.len() >= ARRAY_MAX_ELEMENTS {
+                array_raise(format!(
+                    "array_range: produces more than {} elements",
+                    ARRAY_MAX_ELEMENTS
+                ));
+            }
+            values.push(x);
+            x += step;
+        }
+        let shape = if values.is_empty() {
+            vec![1, 0]
+        } else {
+            vec![1, values.len()]
+        };
+        array_ndarray(shape, values)
+    }
+
+    /// Validate one resolved position is a real, finite, non-negative
+    /// integer, and return it as a genuine `usize`.
+    ///
+    /// SECURITY: this is the single choke point `array_resolve_positions`
+    /// (and therefore `array_index_get`/`array_index_set`) sends every
+    /// position through — an unvalidated NaN/negative/fractional value is
+    /// rejected here with a catchable `raise`, not silently coerced. Once
+    /// this returns, the position is a genuine `usize`: Rust's type system
+    /// then makes a NaN/negative position impossible to reintroduce for
+    /// every downstream bounds check (see `array_get`/`array_set`).
+    fn array_assert_valid_position(x: f64) -> usize {
+        if !x.is_finite() || x != x.trunc() || x < 0.0 {
+            array_raise(format!(
+                "array_resolve_positions: index {} is not a finite non-negative integer",
+                x
+            ));
+        }
+        x as usize
+    }
+
+    /// Resolve one `SirIndexArg` against a dimension of size `dim_size`
+    /// into a flat list of 0-based positions along that dimension.
+    fn array_resolve_positions(arg: &SirIndexArg, dim_size: usize) -> Vec<usize> {
+        match arg {
+            SirIndexArg::Scalar(v) => vec![array_assert_valid_position(as_f64(v))],
+            SirIndexArg::Whole => (0..dim_size).collect(),
+            SirIndexArg::Range(v) => {
+                let a = array_coerce(v);
+                a.data
+                    .iter()
+                    .map(|&x| array_assert_valid_position(if x.is_finite() { x.trunc() } else { x }))
+                    .collect()
+            }
+        }
+    }
+
+    /// `A(i)` / `A(i, j)` — read one element or a sub-array. Scoped to 1
+    /// or 2 index arguments (rank <= 2): a single argument indexes `a`'s
+    /// underlying column-major data linearly (MATLAB's own single-
+    /// subscript convention, which is column-major too); two arguments
+    /// index `(row, col)`. Returns `Value::Float` when every argument is
+    /// `Scalar` (a single element), otherwise a `Value::NDArray`.
+    pub fn array_index_get(target: &Value, indices: Vec<SirIndexArg>) -> Value {
+        let a = array_coerce(target);
+        match indices.len() {
+            1 => {
+                let arg = &indices[0];
+                let positions = array_resolve_positions(arg, a.data.len());
+                let read = |i: usize| -> f64 {
+                    if i >= a.data.len() {
+                        array_raise(format!("array_index_get: linear index {} out of bounds", i));
+                    }
+                    a.data[i]
+                };
+                if matches!(arg, SirIndexArg::Scalar(_)) {
+                    Value::Float(read(positions[0]))
+                } else {
+                    let data: Vec<f64> = positions.iter().map(|&i| read(i)).collect();
+                    array_ndarray(vec![1, data.len()], data)
+                }
+            }
+            2 => {
+                let row_arg = &indices[0];
+                let col_arg = &indices[1];
+                let rows = array_resolve_positions(row_arg, array_nrows(&a));
+                let cols = array_resolve_positions(col_arg, array_ncols(&a));
+                let read = |r: usize, c: usize| -> f64 {
+                    match array_get(&a, r, c) {
+                        Some(v) => v,
+                        None => array_raise(format!(
+                            "array_index_get: ({}, {}) out of bounds for shape {:?}",
+                            r, c, a.shape
+                        )),
+                    }
+                };
+                if matches!(row_arg, SirIndexArg::Scalar(_)) && matches!(col_arg, SirIndexArg::Scalar(_))
+                {
+                    Value::Float(read(rows[0], cols[0]))
+                } else {
+                    // `rows.len()`/`cols.len()` are each individually
+                    // bounded by `a`'s own dimensions (`Whole`) or by a
+                    // `Range` NDArray's own `ARRAY_MAX_ELEMENTS` cap — but
+                    // nothing bounds their PRODUCT on its own, so this is
+                    // the exact outer-product-shaped allocation
+                    // `array_matmul` guards against, one level up.
+                    // Validate before allocating, not after.
+                    let out_len = array_checked_shape_size(&[rows.len(), cols.len()]);
+                    let mut data = vec![0.0f64; out_len];
+                    for (ci, &c) in cols.iter().enumerate() {
+                        for (ri, &r) in rows.iter().enumerate() {
+                            data[ci * rows.len() + ri] = read(r, c);
+                        }
+                    }
+                    array_ndarray(vec![rows.len(), cols.len()], data)
+                }
+            }
+            n => array_raise(format!(
+                "array_index_get: only 1 or 2 index arguments are supported (rank <= 2 scope), got {}",
+                n
+            )),
+        }
+    }
+
+    /// Broadcast a scalar-or-`NDArray` right-hand side to exactly `count`
+    /// values (mirrors `array_elementwise`'s scalar-broadcast rule).
+    fn array_broadcast_values(value: &Value, count: usize) -> Vec<f64> {
+        match value {
+            Value::NDArray(h) => {
+                let a = h.borrow();
+                if a.data.len() == 1 {
+                    vec![a.data[0]; count]
+                } else if a.data.len() != count {
+                    array_raise(format!(
+                        "array_index_set: value has {} elements, expected {}",
+                        a.data.len(),
+                        count
+                    ))
+                } else {
+                    a.data.clone()
+                }
+            }
+            other => vec![as_f64(other); count],
+        }
+    }
+
+    /// `A(i) = v` / `A(i, j) = v` — write one element or a sub-array, IN
+    /// PLACE (see `array_set`'s doc comment above for why this mutates
+    /// rather than returns a new array; see this section's module doc for
+    /// why `Value::NDArray`'s `Rc<RefCell<…>>` handle is what makes this
+    /// mutation visible through every alias of `target`). `value` may be
+    /// a scalar (broadcast to every selected position) or an `NDArray`
+    /// with exactly as many elements as positions are selected.
+    ///
+    /// `target` must already be a `Value::NDArray` (an `IndexSet` whose
+    /// target is a bare scalar is malformed input from a well-typed
+    /// frontend — same "internal bug, not a DoS surface" class as
+    /// `as_i64`/`as_f64`'s own panics elsewhere in this file).
+    pub fn array_index_set(target: &Value, indices: Vec<SirIndexArg>, value: Value) {
+        let handle = match target {
+            Value::NDArray(h) => h.clone(),
+            other => panic!("array_index_set: target is not an array: {}", format(other)),
+        };
+        // Snapshot shape/length under a short shared borrow, dropped
+        // before resolving positions (which may itself coerce a `Range`
+        // index argument — no reachable re-entrancy into THIS handle
+        // today, but scoping the borrow keeps that invariant free rather
+        // than assumed, matching `map_set`'s own borrow-scoping care).
+        let (shape, data_len) = {
+            let a = handle.borrow();
+            (a.shape.clone(), a.data.len())
+        };
+        match indices.len() {
+            1 => {
+                let positions = array_resolve_positions(&indices[0], data_len);
+                let values = array_broadcast_values(&value, positions.len());
+                let mut a = handle.borrow_mut();
+                for (k, &i) in positions.iter().enumerate() {
+                    if i >= a.data.len() {
+                        array_raise(format!("array_index_set: linear index {} out of bounds", i));
+                    }
+                    a.data[i] = values[k];
+                }
+            }
+            2 => {
+                let nrows = array_nrows_of(&shape);
+                let ncols = array_ncols_of(&shape);
+                let rows = array_resolve_positions(&indices[0], nrows);
+                let cols = array_resolve_positions(&indices[1], ncols);
+                // Same product-of-two-independent-selections gap
+                // `array_index_get` closes above — validate before
+                // `array_broadcast_values` allocates.
+                let count = array_checked_shape_size(&[rows.len(), cols.len()]);
+                let values = array_broadcast_values(&value, count);
+                let mut a = handle.borrow_mut();
+                let mut k = 0;
+                for &c in &cols {
+                    for &r in &rows {
+                        array_set(&mut a, r, c, values[k]);
+                        k += 1;
+                    }
+                }
+            }
+            n => array_raise(format!(
+                "array_index_set: only 1 or 2 index arguments are supported (rank <= 2 scope), got {}",
+                n
+            )),
         }
     }
 
@@ -1533,6 +2195,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Closure(_) => "Proc".to_string(),
             Value::Instance(id) => instance_class(*id),
             Value::Missing => "Object".to_string(),
+            Value::NDArray(_) => "NDArray".to_string(),
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/sir22_array.rs
@@ -1,0 +1,327 @@
+//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/`MatMul`/
+//! `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the Rust
+//! backend — hand-builds a module calling each node directly (bypassing
+//! the frontend, since no frontend targets this backend for SIR22 yet),
+//! emits Rust, compiles it with a real `rustc`, runs the binary, and
+//! asserts stdout. Mirrors `compile_and_run_floats.rs`'s pattern; skips
+//! (does not fail) when no `rustc` is on `PATH` or no usable linker is
+//! present, exactly like every other `compile_and_run_*` test in this
+//! crate.
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir22_array.rs` (and cross-checked against
+//! `semantic-ir-to-ruby`'s own port of the same suite) — same worked
+//! examples, adapted to this backend's own value-type convention: this
+//! port's `array_*` runtime (`runtime.rs`) stores every element as `f64`
+//! (mirroring the JS backend's `Float64Array`, not Ruby's Int/Float-
+//! preserving choice — see `runtime.rs`'s own module doc for why), so
+//! `Expr::IndexGet` on a scalar position always yields a `Value::Float`.
+//! Every printed assertion below therefore expects the `.0`-suffixed
+//! float rendering (`format_float` in `runtime.rs`), e.g. `"19.0"` rather
+//! than `"19"` — a deliberate, documented divergence from the Ruby
+//! reference's Integer-preserving output, not a bug.
+//!
+//! Every test constructs `Module`s directly via `print_stmt`'s scalar
+//! `IndexGet` reads (top-left/bottom-right element, etc.) — sidesteps
+//! needing an NDArray display/format story, which is out of this slice's
+//! scope, exactly as the JS/Ruby references' own tests do.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use semantic_ir::{
+    Block, Effect, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function,
+    IndexArg, Metadata, Module, Scope, Span, Stmt,
+};
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn array_lit(rows: Vec<Vec<Expr>>) -> Expr {
+    Expr::ArrayLit { rows, span: s() }
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+fn scalar(i: i64) -> IndexArg {
+    IndexArg::Scalar(Box::new(ilit(i)))
+}
+fn index_get(target: Expr, indices: Vec<IndexArg>) -> Expr {
+    Expr::IndexGet { target: Box::new(target), indices, span: s() }
+}
+
+const ARRAY_FEATURES: &[Feature] =
+    &[Feature::NDArrays, Feature::MatrixOps, Feature::ArrayColumnMajor];
+
+fn array_module(stmts: Vec<Stmt>) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings];
+    features.extend_from_slice(ARRAY_FEATURES);
+    Module {
+        name: "sir22array".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile `m` to Rust, run it with a real `rustc`, and return stdout — or
+/// `None` to skip when no `rustc`/usable linker is on the host, matching
+/// every other `compile_and_run_*` test in this crate exactly. Unique
+/// temp-file names per call (PID + a monotonic counter) — a constant name
+/// would let concurrently-running `cargo test` threads collide on the same
+/// path, the exact race this crate's own test suite has hit and fixed
+/// before (see e.g. `compile_and_run_array_aggregates.rs`'s sibling test
+/// functions, each with their own literal filename prefix).
+fn run_array_program(m: &Module) -> Option<String> {
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    if !rustc_available() {
+        return None;
+    }
+
+    let artifact = semantic_ir_to_rust::compile(m).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed));
+    let src_path = dir.join(format!("sir_rust_array_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_rust_array_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr)
+    );
+    Some(String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn matmul_of_two_by_two_matrices_computes_the_right_product() {
+    // [1 2; 3 4] * [5 6; 7 8] = [19 22; 43 50] (standard matrix product).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5), ilit(6)], vec![ilit(7), ilit(8)]]);
+    let product = Expr::MatMul { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("p", product),
+        print_stmt(index_get(local("p"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("p"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "19.0\n50.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
+    // MATLAB `A .* 2` -- matlab-to-semantic-ir emits the `2` as a bare
+    // IntLit operand, unwrapped (not an ArrayLit), when exactly one side
+    // is scalar. This is the exact shape `array_coerce`'s
+    // (`toArrayValue`) coercion in runtime.rs exists for; a regression
+    // there panics instead of computing [2 4; 6 8].
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let scaled = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("sc", scaled),
+        print_stmt(index_get(local("sc"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("sc"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2.0\n8.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn elementwise_div_always_true_divides_even_on_integer_operands() {
+    // `Div` always real-divides (7 / 2 = 3.5) -- never an integer floor,
+    // matching MATLAB's `./` (and this backend's own `true_div`
+    // precedent for the plain `/` builtin).
+    let a = array_lit(vec![vec![ilit(7)]]);
+    let divided = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Div,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("d", divided),
+        print_stmt(index_get(local("d"), vec![scalar(0), scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "3.5\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn transpose_of_a_two_by_three_matrix_swaps_rows_and_columns() {
+    // [1 2 3; 4 5 6]' = [1 4; 2 5; 3 6]
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let t = Expr::Transpose { target: Box::new(a), conjugate: true, span: s() };
+    let m = array_module(vec![
+        let_binding("t", t),
+        print_stmt(index_get(local("t"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("t"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "4.0\n6.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn range_materializes_a_row_vector_read_by_linear_index() {
+    // 1:2:9 -> [1 3 5 7 9], a 1x5 row vector. A single index argument
+    // reads linearly (rank-1 IndexGet).
+    let r = Expr::Range {
+        start: Box::new(ilit(1)),
+        step: Some(Box::new(ilit(2))),
+        stop: Box::new(ilit(9)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(4)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n9.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn whole_selector_reads_an_entire_row() {
+    // A(1, :) on [1 2; 3 4] reads the whole second row [3 4], then a
+    // scalar linear IndexGet reads its second element.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let row = index_get(a, vec![scalar(1), IndexArg::Whole]);
+    let m = array_module(vec![
+        let_binding("row", row),
+        print_stmt(index_get(local("row"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "4.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn index_set_mutates_in_place() {
+    // A(1, 1) = 99 on [1 2; 3 4] -- IndexSet is a Stmt (in-place
+    // mutation), not a pure Expr, per the SIR22 spec. Proves this
+    // backend's `Value::NDArray(Rc<RefCell<SirNDArray>>)` handle mutates
+    // through the SAME binding the caller already holds (`a`), exactly
+    // like `Stmt::SeqSet` already does for `Value::Seq`.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let m = array_module(vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![scalar(1), scalar(1)],
+            value: Box::new(ilit(99)),
+            span: s(),
+        },
+        print_stmt(index_get(local("a"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "99.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+
+#[test]
+fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
+    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
+    // cut, so the ordinary feature-flag check alone can't reject it --
+    // proves the dedicated `reject_sir22_addendum` pre-emit scan does,
+    // with a clean `Err`, not an `emit_expr` internal-bug panic.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
+    let m = array_module(vec![print_stmt(Expr::Reduce {
+        op: ElementwiseOpKind::Add,
+        target: Box::new(target),
+        span: s(),
+    })]);
+    let err = semantic_ir_to_rust::compile(&m).expect_err("Reduce must be rejected, not emitted");
+    assert!(
+        err.message.contains("Reduce"),
+        "error should name the rejected node: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary
- Opens the Rust backend (`semantic-ir-to-rust`) to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and implements the SIR22 array/matrix "base cut" -- `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and `Stmt::IndexSet` -- per `code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section. One of 5 parallel, independent per-backend PRs for this slice (see `claude/sir22-slice2-ruby` and PR #11952 for the sibling Ruby/Go ports).
- New inlined `__sir::array_*` runtime (`runtime.rs`, new "SIR22 array/matrix domain" section): a Rust port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime, following this backend's existing "paste the runtime inline as generated-Rust-source text, no `Cargo.toml`/dependency graph for the generated program" convention -- this backend shells out directly to bare `rustc`, never `cargo build`, on a single self-contained `.rs` file, so a real crate dependency on a hypothetical `array-runtime` crate was never an option.
- **Value representation**: new `Value::NDArray(Rc<RefCell<SirNDArray>>)` variant, `SirNDArray { shape: Vec<usize>, data: Vec<f64> }`. Every element stored as a uniform `f64` (mirroring the JS reference's `Float64Array`) -- a deliberate divergence from the sibling Ruby backend's port, which preserves native Integer/Float propagation; this backend's `Value` already distinguishes `Int`/`Float` at the scalar level, but threading that distinction element-by-element through every array op would multiply the arithmetic-dispatch surface for a domain whose own spec maps 1:1 onto `array_runtime::execute()` (itself f64-only). Documented in the CHANGELOG.
- **`IndexSet` / ownership decision** (this backend's own unique design question -- JS/Ruby have no ownership model to satisfy, every value there is implicitly a shared mutable heap reference): `Value::NDArray` reuses the *exact* `Rc<RefCell<...>>` shared-mutable-handle pattern `Value::Seq`/`Value::Map` already establish in this same runtime. `Stmt::IndexSet` mutates through `RefCell::borrow_mut()`, so every alias of an array binding observes the write -- exactly the same mechanism `Stmt::SeqSet`/`Stmt::MapSet` already use. No new ownership strategy was needed; SIR16 sequences had already forced this backend to solve "mutate the value every alias holds" once, and this slice just applies that same answer to a new variant.
- **DoS discipline**: every shape/output size is validated (`array_checked_shape_size`, using `checked_mul` so a shape product can never silently wrap on overflow) *before* any `Vec` allocation -- including the two-independent-operand cases (`matmul`'s `[m, n]`, `IndexGet`/`IndexSet`'s `[rows.len(), cols.len()]`) that aren't bounded by either operand's own cap alone.
- **NaN-safety**: every index position is funneled through `array_assert_valid_position` before it is allowed to become a `usize` -- the one place a NaN could otherwise defeat a comparison-based bounds check. Rust's `usize` cannot represent NaN or a negative value at all, so once a position clears that function, every downstream bounds check (`array_get`/`array_set`) is NaN-safe *by construction*, a strictly stronger guarantee than the JS/Ruby references' own "written defensively" AND-form checks (still written in AND-form here too, for readability and cross-backend consistency).
- The 9-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) shares these same three features with the base cut, so the feature-flag gate alone can't distinguish them. Added a dedicated pre-emit scan (`reject_sir22_addendum` in `lib.rs`) using `semantic_ir`'s shared `Visitor`/`walk_expr_default` walker -- rather than this crate's existing hand-rolled-recursive-match style (`reject_stateful_class`/`reject_const_ref`), since a hand-picked-subset walk over ~40 `Expr` variants is exactly the kind of check that can silently drift out of sync with the emitter as new node kinds are added. Mirrors `semantic-ir-to-ruby`'s own `ScanHit::Sir22AddendumNode` for this same rollout wave.

## Test plan
- [x] `cargo build -p semantic-ir-to-rust` -- clean
- [x] `cargo test -p semantic-ir-to-rust` -- 100% green (full existing suite + new tests), no regressions
- [x] `cargo clippy -p semantic-ir-to-rust --all-targets -- -D warnings` -- clean
- [x] New `tests/sir22_array.rs` (8 tests, ported from the JS backend's own `tests/sir22_array.rs`, real `rustc`-compile-and-execute proof, hand-built `Module`s since no frontend targets this backend for SIR22 yet): matmul of two 2x2 matrices against a known product, elementwise-mul with a bare-scalar RHS operand (the `array_coerce`/`toArrayValue`-coercion regression case -- MATLAB's `.* / .\` lowering can hand a raw scalar, not an `ArrayLit`, on one side), `Div`'s always-true-divide, transpose, a MATLAB-style range read by linear index, a `Whole` (`:`) selector reading an entire row, `Stmt::IndexSet` mutating in place, and a compile-time-rejection proof for `Expr::Reduce` (an addendum node) returning a clean `Err`, not a panic. Skips (does not fail) when no `rustc`/usable linker is on the host, matching every other `compile_and_run_*` test in this crate; unique temp-file names per run (PID + a monotonic `AtomicUsize` counter).
- [x] Also independently sanity-checked the generated runtime text compiles standalone (`rustc --crate-type lib`) before wiring it into the emitter, since `RUNTIME` is a raw string constant `cargo build` does not type-check on its own.
- [x] Security review (`/security-review`, sub-agent with the diff inline): **PASSED** -- no CRITICAL/HIGH/MEDIUM findings. Reviewer specifically verified the shape-overflow guards close before every allocation (including the two-independent-operand cases), the NaN-safe-by-construction bounds checks, the `Rc<RefCell<...>>` two-phase-borrow pattern in `array_index_set` for TOCTOU/reentrancy, and confirmed no `unsafe` blocks were introduced anywhere in the diff. Two non-blocking INFO notes (an internal-bug-class `panic!` consistent with this file's existing `as_f64`/`as_i64` convention, and `array_range`'s bounded-but-large worst-case iteration count) -- neither required a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)