### PR TITLE
feat(semantic-ir-to-c): implement SIR22 array/matrix base cut (Phase A Slice 2)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,125 @@
 # Changelog
 
+## 0.40.0 — SIR22 array/matrix base cut (Phase A Slice 2, second-wave backend rollout)
+
+Opens this backend to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and
+implements the SIR22 "base cut": `Expr::ArrayLit`/`Range`/`MatMul`/
+`ElementwiseOp`/`Transpose`/`IndexGet` and `Stmt::IndexSet` (the mutating
+counterpart — a statement, not an expression, per the SIR22 spec's
+"Effects" section). One of five parallel, independent backend PRs for this
+slice (C/Go/Rust/Ruby follow JS's inlined-runtime model; Python follows
+TS's imported-package model — see the SIR22 spec's "Backend impact"
+section, amended for this rollout in #11946).
+
+**New `_sir_array_*` runtime** (`runtime.rs`, appended as a new "SIR22
+array/matrix domain" section): an inlined port of
+`semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime,
+following this crate's existing inlined-runtime convention (this backend
+always inlines its runtime helpers into the emitted `.c` file — it never
+imports a package, unlike the TS/Python model). A new `SirNDArray` struct
+(`{ rank, rows, cols, data, data_len }`, `rank` always 0 or 2 — a rank-1
+shape is never actually produced by any base-cut constructor, see the
+runtime's own module doc) and a new `SIR_ARRAY` `SirTag` variant carry the
+value; `_sir_fmt`/`_sir_display_str`/`_sir_value_eq_d`/`_sir_object_equal_p`
+each gained a minimal `SIR_ARRAY` case (a `#<Array>` placeholder for
+display, pointer identity for equality — a full `[1 2; 3 4]`-style
+rendering is out of this slice's scope, matching every reference backend's
+own test suite, which reads a scalar element back out via `IndexGet`
+instead of printing the array itself).
+
+**Value-model divergence from the Ruby port (documented, deliberate)**: the
+sibling `semantic-ir-to-ruby` 0.x SIR22 slice (merged the same day) chose
+to preserve native Ruby `Integer`/`Float` propagation through `+`/`-`/`*`,
+forcing `Float` only for `Div`/`Pow`. This C port instead follows the JS
+reference's ACTUAL internal representation: every `SirNDArray` element is
+an unconditional `double`, and an element read back out is always
+`_sir_float(d)` — not JS's cosmetic integer-display shortcut (`19` instead
+of `19.0`), just its real `Float64Array` storage. Given C's `SirValue` is
+statically tagged (`SIR_INT` xor `SIR_FLOAT`, no dynamic `Numeric`
+hierarchy the way Ruby has), this is the simplest correct choice: it
+avoids a second int/float dispatch path through `_sir_array_apply_op`
+(which the Ruby port needs precisely because Ruby's numeric tower isn't
+statically tracked), at the cost of a cosmetic trailing ".0" that no
+reference backend's tests need to match — each backend's own
+`tests/sir22_array.rs` asserts against its own emitted output only.
+
+**The C-specific overflow hazard neither JS nor Ruby has**: JS `Number`s
+are IEEE doubles (lose precision past 2^53, but never wrap) and Ruby
+`Integer` is arbitrary-precision (never overflows) — `rows * cols`
+computing an element count is safe in both references with no explicit
+overflow check. C's `int64_t` has neither property: `rows * cols` can
+silently wrap (undefined behaviour, for a signed overflow) before it is
+ever compared against the `SIR_ARRAY_MAX_ELEMENTS` (2^26) cap, turning a
+huge requested shape into a small/negative/UB computed size and then
+`malloc`ing too little for what the caller believes it got — a classic
+heap-overflow setup. `_sir_array_checked_size` checks `rows >
+SIR_ARRAY_MAX_ELEMENTS / cols` (rejecting) **before** ever computing
+`rows * cols`, not after; every allocation in this file routes through it
+(directly, or via a caller — `_sir_array_new_matrix` — that always calls
+it) before ever calling `_sir_alloc`. Index-position resolution has its
+own, distinct NaN/overflow hazard: casting a NaN or out-of-`int64_t`-range
+`double` to `int64_t` is undefined behaviour in C (unlike JS's
+`Number.isInteger` guard or Ruby's `Float#to_i`, which both fail cleanly
+instead) — `_sir_array_assert_valid_position` bounds-checks the `double`
+**before** the `(int64_t)` cast, not after, and every index position in
+this domain funnels through that one choke point.
+
+**Two compile-time structural checks, added specifically because C's
+static AST shape makes them possible where the JS/Ruby ports could only
+check at runtime**: (1) an `ArrayLit` with ragged rows is rejected by
+`emit.rs`'s pre-emit scan (raggedness is knowable from the SIR AST alone —
+`rows: Vec<Vec<Expr>>`'s row lengths are fixed at parse/lowering time, not
+a runtime-computed shape); (2) an `IndexGet`/`IndexSet` with other than 1
+or 2 index arguments (the "rank <= 2" scope boundary) is likewise rejected
+at compile time (`indices.len()` is static too). The runtime
+(`_sir_array_index_get`/`_sir_array_index_set`) repeats the arg-count
+check anyway, as defense-in-depth for a hand-built `Module` that bypassed
+the scan — consistent with this file's existing "don't rely on every
+future caller re-deriving an invariant" discipline.
+
+**SIR22 "APL addendum" rejected cleanly, using this crate's EXISTING
+mechanism, not a new one**: `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` share
+`NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut above, so the
+ordinary feature-flag capability check alone cannot distinguish "safe"
+modules from "still unimplemented" ones. Nine new arms were added directly
+to `emit.rs`'s existing `scan_expr_for_builtin` — the SAME structural
+pre-emit scan `first_unsupported_builtin` already uses for every other
+"well-formed but not yet lowered" construct in this crate (malformed
+`__new__`/`__def_method__`/etc. shapes) — rather than inventing a parallel
+mechanism (contrast the sibling Ruby backend, which added a dedicated
+`ScanHit::Sir22AddendumNode` variant to its own differently-shaped single
+shared scan; this crate's scan already returns a plain `Option<(String,
+Span)>`, so no new enum variant was needed). Without this, a module using
+e.g. `Reduce` would pass the capability check and panic inside
+`emit_assign`'s `unreachable!` catch-all.
+
+**New `tests/sir22_array.rs`** (13 tests, ported from the JS backend's own
+`sir22_array.rs`, cross-checked against the sibling Ruby backend's port):
+`matmul` of two 2x2 matrices (verified against a known-correct product),
+elementwise `Mul` with a bare-scalar operand (the `_sir_array_coerce`
+bare-scalar-operand regression case — MATLAB's `.* / .\` lowering can hand
+a raw scalar, not an `ArrayLit`, on one side), elementwise `Div`'s
+always-true-divide behaviour (distinguished from this backend's own bare
+`/`, which floors on two `SIR_INT`s), `transpose`, `range` (both explicit
+and default `step`), an `IndexGet` with a `Whole` selector (whole-row
+read), `Stmt::IndexSet` mutating in place (both a `Scalar` position and an
+`IndexArg::Range` sub-range overwrite), plus five compile-time-rejection
+tests: two APL-addendum nodes (`Reduce`, `Catenate` — proving the
+rejection is a real per-variant scan arm, not a fluke that only catches
+one), a ragged `ArrayLit`, and a rank-3 `IndexGet`. Every execution test
+runs against a real `cc`/`clang`/`gcc` toolchain (`SIR_CC` env var, then
+PATH probing, matching `compile_and_run_division_ops.rs`'s exact
+`find_cc`/`compile_and_link` pattern, copied verbatim including its
+unique per-process-and-atomic-counter temp filenames), skipping gracefully
+when none is present.
+
+Verified via the full `semantic-ir-to-c` test suite (all pre-existing
+integration tests still green) and `cargo clippy --all-targets -- -D
+warnings` (clean).
+
+`semantic-ir-to-c` 0.39.0 -> 0.40.0.
+
 ## 0.39.0 — SIR21 T3b-2 Slice 7: cleanup — remove dead `tdiv`/`utdiv`
 
 Part of the SIR21 T3b-2 arc's final slice. `c-to-semantic-ir` — the only

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -290,8 +290,31 @@ validator before this backend ever sees them) baked in as C int constants —
 never source-derived text reaching a dynamic file-handle lookup. See
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
+And the SIR22 array/matrix **base cut** — `NDArrays`/`MatrixOps`/
+`ArrayColumnMajor` — `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+`Transpose`/`IndexGet` (+ `Stmt::IndexSet`, the mutating counterpart) route
+into a new `_sir_array_*` sub-runtime (a `SirNDArray` — dense, rank <= 2,
+column-major — behind a new `SIR_ARRAY` tag), an inlined port of
+`semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime.
+Every element is stored as a plain `double` (this backend's `SirValue` is
+statically tagged, unlike Ruby's dynamic numeric tower, so an NDArray read
+always comes back `_sir_float`); every shape-size computation is checked
+for `int64_t` overflow BEFORE multiplying, not after — the one hazard
+class neither the JS (`Number`) nor Ruby (`Integer`) ports had to guard
+against — and every index position is bounds-checked before the
+`(double)`→`int64_t` cast that would otherwise be undefined behaviour on a
+NaN or out-of-range value. The 9-node SIR22 "APL addendum" (`Reduce`/
+`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+`Ravel`/`Catenate`) shares these same three features but stays deferred to
+a later slice — rejected cleanly by the SAME structural pre-emit scan
+`first_unsupported_builtin` already uses for every other well-formed-but-
+unimplemented construct, not a new mechanism. See
+[SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
+
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, a `class << self` singleton, and
+`Intrinsics`, a `class << self` singleton, the SIR22 "APL addendum" nodes
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+`IndexOf`/`Ravel`/`Catenate`), and
 every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -14,7 +14,10 @@ use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, IntSpec, IntWidth, Module, Scope, Span, Stmt};
+use semantic_ir::{
+    Block, ElementwiseOpKind, Expr, Function, Global, IndexArg, IntSpec, IntWidth, Module, Scope,
+    Span, Stmt,
+};
 
 use crate::runtime::RUNTIME;
 
@@ -821,6 +824,60 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         Stmt::ModuleDef { .. } => {
             let _ = writeln!(out, "{pad}/* module declaration (no module object) */");
         }
+        // ── SIR22: array/matrix indexed assignment ────────────────────
+        // `target[indices...] = value;` — mutates the shared `SirNDArray`
+        // box IN PLACE via `_sir_array_index_set` (see `runtime.rs`'s
+        // "SIR22 array/matrix domain" section), matching the SIR22 spec's
+        // own note that `IndexSet` is a `Stmt`, not a pure `Expr`, for
+        // exactly this in-place-mutation reason. Operands (target, value,
+        // and each index arg's inner expression) are hoisted so
+        // left-to-right evaluation order holds even when one is compound —
+        // mirrors `SeqSet`/`MapSet` above. `value` is emitted BEFORE the
+        // index-argument pack (`_sir_array_index_set`'s C signature puts it
+        // there, since C requires `...` to be the LAST parameter — see that
+        // function's own doc comment for why the field order isn't
+        // `target, indices, value` at the call site).
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let mut ops: Vec<&Expr> = vec![target.as_ref(), value.as_ref()];
+            for arg in indices {
+                match arg {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => ops.push(e.as_ref()),
+                    IndexArg::Whole => {}
+                }
+            }
+            let names = hoist_operands(out, &ops, inner);
+            let mut it = names.into_iter();
+            let target_name = it.next().expect("target operand");
+            let value_name = it.next().expect("value operand");
+            let _ = write!(
+                out,
+                "{ipad}_sir_array_index_set({target_name}, {value_name}, {}",
+                indices.len()
+            );
+            for arg in indices {
+                match arg {
+                    IndexArg::Scalar(_) => {
+                        let _ = write!(out, ", _sir_array_idx_scalar({})", it.next().unwrap());
+                    }
+                    IndexArg::Whole => {
+                        out.push_str(", _sir_array_idx_whole()");
+                    }
+                    IndexArg::Range(_) => {
+                        let _ = write!(out, ", _sir_array_idx_range({})", it.next().unwrap());
+                    }
+                }
+            }
+            out.push_str(");\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
 }
@@ -1022,9 +1079,168 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
             );
             let _ = writeln!(out, "{pad}}}");
         }
+        // ── SIR22 array/matrix base cut ────────────────────────────────
+        // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+        // route into the `_sir_array_*` helpers ported from
+        // `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
+        // sub-runtime (see `runtime.rs`'s "SIR22 array/matrix domain"
+        // section). Every operand is hoisted (`hoist_operands`) so
+        // left-to-right evaluation order holds even when compound —
+        // mirrors `SeqLit`/`MapLit` above; none of these six nodes has a
+        // "simple" fast path (`is_simple` returns `false` for all of them
+        // via its catch-all), so they only ever reach the emitter here.
+        Expr::ArrayLit { rows, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let ncols = rows.first().map_or(0, |r| r.len());
+            let ops: Vec<&Expr> = rows.iter().flatten().collect();
+            let names = hoist_operands(out, &ops, inner);
+            let _ = write!(
+                out,
+                "{ipad}{dst} = _sir_array_from_rows({}, {ncols}, {}",
+                rows.len(),
+                names.len()
+            );
+            for n in &names {
+                let _ = write!(out, ", {n}");
+            }
+            out.push_str(");\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // Argument ORDER: the SIR node's own field order is `start, step,
+        // stop`, but `_sir_array_range(start, stop, step)` (matching the
+        // JS/Ruby references' `range(start, stop, step = 1)`) takes `stop`
+        // before `step`.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = match step {
+                Some(step) => hoist_operands(out, &[start.as_ref(), stop.as_ref(), step.as_ref()], inner),
+                None => {
+                    let mut names = hoist_operands(out, &[start.as_ref(), stop.as_ref()], inner);
+                    let one = format!("_sir_a{}", fresh_id());
+                    let _ = writeln!(out, "{ipad}SirValue {one} = _sir_int(1LL);");
+                    names.push(one);
+                    names
+                }
+            };
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_range({}, {}, {});",
+                names[0], names[1], names[2]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[lhs.as_ref(), rhs.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_matmul({}, {});",
+                names[0], names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // The enum constant must match `_sir_array_apply_op`'s `switch` in
+        // `runtime.rs` exactly (see `elementwise_op_c_name`).
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[lhs.as_ref(), rhs.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_elementwise({}, {}, {});",
+                elementwise_op_c_name(*op),
+                names[0],
+                names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[target.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_transpose({}, {});",
+                names[0],
+                if *conjugate { 1 } else { 0 }
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let mut ops: Vec<&Expr> = vec![target.as_ref()];
+            for arg in indices {
+                match arg {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => ops.push(e.as_ref()),
+                    IndexArg::Whole => {}
+                }
+            }
+            let names = hoist_operands(out, &ops, inner);
+            let mut it = names.into_iter();
+            let target_name = it.next().expect("target operand");
+            let _ = write!(
+                out,
+                "{ipad}{dst} = _sir_array_index_get({target_name}, {}",
+                indices.len()
+            );
+            for arg in indices {
+                match arg {
+                    IndexArg::Scalar(_) => {
+                        let _ = write!(out, ", _sir_array_idx_scalar({})", it.next().unwrap());
+                    }
+                    IndexArg::Whole => {
+                        out.push_str(", _sir_array_idx_whole()");
+                    }
+                    IndexArg::Range(_) => {
+                        let _ = write!(out, ", _sir_array_idx_range({})", it.next().unwrap());
+                    }
+                }
+            }
+            out.push_str(");\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
         // A call whose arguments contain control flow: hoist every argument
         // into a temp (left-to-right), then make the call.
         _ => emit_compound_call(out, dst, e, indent),
+    }
+}
+
+/// The C enum constant `_sir_array_apply_op`'s `switch` in `runtime.rs`
+/// dispatches on — exact `SirElementwiseOp` variant names (`SIR_EW_ADD`,
+/// not `.name()`'s lowercase `"add"`, used elsewhere for e.g. debug/display),
+/// since this is a real runtime dispatch key, mirroring the JS backend's
+/// `elementwise_op_js_name` / the Ruby backend's `elementwise_op_ruby_name`.
+fn elementwise_op_c_name(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Add => "SIR_EW_ADD",
+        ElementwiseOpKind::Sub => "SIR_EW_SUB",
+        ElementwiseOpKind::Mul => "SIR_EW_MUL",
+        ElementwiseOpKind::Div => "SIR_EW_DIV",
+        ElementwiseOpKind::Pow => "SIR_EW_POW",
+        ElementwiseOpKind::Max => "SIR_EW_MAX",
+        ElementwiseOpKind::Min => "SIR_EW_MIN",
+        ElementwiseOpKind::Eq => "SIR_EW_EQ",
+        ElementwiseOpKind::Ne => "SIR_EW_NE",
+        ElementwiseOpKind::Lt => "SIR_EW_LT",
+        ElementwiseOpKind::Le => "SIR_EW_LE",
+        ElementwiseOpKind::Ge => "SIR_EW_GE",
+        ElementwiseOpKind::Gt => "SIR_EW_GT",
     }
 }
 
@@ -2357,7 +2573,45 @@ fn scan_stmt_for_builtin(s: &Stmt) -> Option<(String, Span)> {
             }
             None
         }
+        // ── SIR22: array/matrix indexed assignment ────────────────────
+        // `target[indices...] = value` — a compound statement whose
+        // sub-expressions (target, value, and each `Scalar`/`Range` index
+        // arg's inner expression) may themselves hide a deferred builtin,
+        // matching the pattern every other compound stmt above follows
+        // (`SeqSet`/`MapSet`, ...). Also enforces the "rank <= 2" scope
+        // structurally: an `indices` list of any length other than 1 or 2
+        // is rejected here at COMPILE time (the runtime's own
+        // `_sir_array_index_set` repeats this check only as
+        // defense-in-depth for a hand-built `Module` that bypassed this
+        // scan — see that function's doc comment).
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            span,
+        } => {
+            if indices.len() != 1 && indices.len() != 2 {
+                return Some((
+                    "an IndexSet with other than 1 or 2 index arguments (rank <= 2 scope)"
+                        .to_string(),
+                    span.clone(),
+                ));
+            }
+            scan_expr_for_builtin(target)
+                .or_else(|| indices.iter().find_map(scan_index_arg_for_builtin))
+                .or_else(|| scan_expr_for_builtin(value))
+        }
         _ => None,
+    }
+}
+
+/// Scan one `IndexArg`'s inner expression (`Scalar`/`Range`; `Whole` carries
+/// none) for a deferred builtin — shared by the `IndexGet`/`IndexSet` scan
+/// arms below.
+fn scan_index_arg_for_builtin(arg: &IndexArg) -> Option<(String, Span)> {
+    match arg {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => scan_expr_for_builtin(e),
+        IndexArg::Whole => None,
     }
 }
 
@@ -2540,6 +2794,81 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
         }
         Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
             scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
+        }
+        // ── SIR22 array/matrix base cut ────────────────────────────────
+        // Sub-expressions may themselves hide a deferred builtin — scan
+        // them, matching every other composite expr arm above. `ArrayLit`
+        // additionally enforces non-raggedness structurally: `emit.rs`'s
+        // `_sir_array_from_rows` call trusts `rows[0].len()` as every
+        // row's width (see that arm's own comment), so a ragged literal
+        // must be rejected here, before it can reach that trust.
+        Expr::ArrayLit { rows, span } => {
+            let ncols = rows.first().map_or(0, |r| r.len());
+            if rows.iter().any(|r| r.len() != ncols) {
+                return Some(("an ArrayLit with ragged rows".to_string(), span.clone()));
+            }
+            rows.iter().flatten().find_map(scan_expr_for_builtin)
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => scan_expr_for_builtin(start)
+            .or_else(|| step.as_deref().and_then(scan_expr_for_builtin))
+            .or_else(|| scan_expr_for_builtin(stop)),
+        Expr::MatMul { lhs, rhs, .. } => {
+            scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
+        }
+        Expr::Transpose { target, .. } => scan_expr_for_builtin(target),
+        // Same "rank <= 2 scope, enforced structurally at compile time" as
+        // `Stmt::IndexSet` above — see that arm's comment.
+        Expr::IndexGet {
+            target,
+            indices,
+            span,
+        } => {
+            if indices.len() != 1 && indices.len() != 2 {
+                return Some((
+                    "an IndexGet with other than 1 or 2 index arguments (rank <= 2 scope)"
+                        .to_string(),
+                    span.clone(),
+                ));
+            }
+            scan_expr_for_builtin(target).or_else(|| indices.iter().find_map(scan_index_arg_for_builtin))
+        }
+        // ── SIR22 "APL addendum" — deferred, rejected cleanly ────────────
+        // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+        // `IndexOf`/`Ravel`/`Catenate` share `NDArrays`/`MatrixOps`/
+        // `ArrayColumnMajor` with the base cut above, so they pass the
+        // ordinary feature-flag capability check — this dedicated scan arm
+        // (folded into this crate's existing single shared pre-emit scan,
+        // the SAME mechanism `first_unsupported_builtin` already uses for
+        // every other "well-formed but not yet lowered" construct, not a
+        // new one) is what actually rejects them, cleanly, until their own
+        // later rollout slice. Mirrors JS/TS's own (since-removed once
+        // THEIR addendum shipped) `find_unimplemented_sir22_addendum_node`
+        // and the sibling Ruby backend's `ScanHit::Sir22AddendumNode`.
+        Expr::Reduce { span, .. } => Some(("SIR22 addendum node Reduce".to_string(), span.clone())),
+        Expr::Scan { span, .. } => Some(("SIR22 addendum node Scan".to_string(), span.clone())),
+        Expr::OuterProduct { span, .. } => Some((
+            "SIR22 addendum node OuterProduct".to_string(),
+            span.clone(),
+        )),
+        Expr::Shape { span, .. } => Some(("SIR22 addendum node Shape".to_string(), span.clone())),
+        Expr::Reshape { span, .. } => {
+            Some(("SIR22 addendum node Reshape".to_string(), span.clone()))
+        }
+        Expr::IndexGenerator { span, .. } => Some((
+            "SIR22 addendum node IndexGenerator".to_string(),
+            span.clone(),
+        )),
+        Expr::IndexOf { span, .. } => {
+            Some(("SIR22 addendum node IndexOf".to_string(), span.clone()))
+        }
+        Expr::Ravel { span, .. } => Some(("SIR22 addendum node Ravel".to_string(), span.clone())),
+        Expr::Catenate { span, .. } => {
+            Some(("SIR22 addendum node Catenate".to_string(), span.clone()))
         }
         _ => None,
     }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -202,6 +202,23 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // console-output primitive every frontend now emits in place of the
     // old bare `print`/`puts` (SIR28 §7 removed the dead bare-name path).
     Feature::ConsoleIO,
+    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+    // (+ `Stmt::IndexSet`) route into the `_sir_array_*` helpers appended
+    // to `runtime.rs`'s "SIR22 array/matrix domain" section — an inlined
+    // port of the already-proven `semantic-ir-to-javascript` `ArrayRt`
+    // sub-runtime, following this crate's existing inlined-runtime
+    // convention (this backend always inlines, unlike the TS/Python
+    // imported-package model). The SIR22 "APL addendum" nodes (`Reduce`/
+    // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+    // `Ravel`/`Catenate`) share these same three features but stay
+    // deferred to a later slice — rejected cleanly by `emit.rs`'s
+    // `scan_expr_for_builtin` (folded into this crate's existing
+    // structural pre-emit scan, not a new mechanism), since the
+    // feature-flag gate alone can't distinguish them from the base cut.
+    Feature::NDArrays,
+    Feature::MatrixOps,
+    Feature::ArrayColumnMajor,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -57,7 +57,14 @@ typedef enum {
      * because their value type is `Copy`), C stores the `SirInstance *` INLINE in
      * the union: the pointer IS the handle, so pointer-identity is object
      * identity.  A dedicated tag means no built-in-type helper mis-handles it. */
-    SIR_INSTANCE
+    SIR_INSTANCE,
+    /* SIR22: a dense, rank <= 2, COLUMN-MAJOR numeric array (`SirNDArray`) —
+     * see the "SIR22 array/matrix domain" section near the end of this file
+     * for the full value model and every `_sir_array_*` op. A dedicated tag
+     * (rather than reusing `SIR_SEQ`) mirrors `SIR_INSTANCE`'s own reasoning:
+     * no built-in Sequence helper should ever mis-handle an NDArray, and the
+     * two have different storage (a flat `double*` here, not a `SirValue*`). */
+    SIR_ARRAY
 } SirTag;
 
 typedef struct SirValue SirValue;
@@ -67,6 +74,7 @@ typedef struct SirSeq SirSeq;
 typedef struct SirMap SirMap;
 typedef struct SirError SirError;
 typedef struct SirInstance SirInstance;
+typedef struct SirNDArray SirNDArray;
 
 struct SirValue {
     SirTag tag;
@@ -81,6 +89,7 @@ struct SirValue {
         SirMap *map;      /* SIR_MAP */
         SirError *err;    /* SIR_ERROR */
         SirInstance *inst;/* SIR_INSTANCE */
+        SirNDArray *arr;  /* SIR_ARRAY */
     } as;
 };
 
@@ -576,6 +585,11 @@ int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
          * default `==` on a user object is identity) — the inline pointer IS the
          * identity, so this is a plain pointer compare. */
         case SIR_INSTANCE: return a.as.inst == b.as.inst;
+        /* Reference identity only (like `SIR_CLOSURE`/`SIR_ERROR` above) —
+         * a full element-wise structural comparison is out of this slice's
+         * scope; this at least makes `a == a` true rather than silently
+         * falling to the `default: return 0` below. */
+        case SIR_ARRAY:   return a.as.arr == b.as.arr;
         default:          return 0;
     }
 }
@@ -977,6 +991,12 @@ void _sir_fmt(FILE *out, SirValue v) {
          * embed a non-reproducible pointer). */
         case SIR_INSTANCE:
             fputs("#<", out); fputs(v.as.inst->sir_class, out); fputc('>', out); break;
+        /* A full `[1 2; 3 4]`-style rendering is out of this slice's scope
+         * (see the "SIR22 array/matrix domain" section below) — every base-
+         * cut test reads a SCALAR element back out via `IndexGet` instead,
+         * exactly like the JS/Ruby references' own test suites. This
+         * placeholder mirrors `SIR_CLOSURE`'s `#<closure>` precedent. */
+        case SIR_ARRAY: fputs("#<Array>", out); break;
         default: break;
     }
     _sir_fmt_depth--;
@@ -1081,6 +1101,9 @@ char *_sir_display_str(SirValue v) {
         case SIR_INSTANCE:
             result = _sir_cat(_sir_cat("#<", v.as.inst->sir_class), ">");
             break;
+        /* See `_sir_fmt`'s matching `SIR_ARRAY` case above for why this is a
+         * placeholder, not a full `[1 2; 3 4]` rendering. */
+        case SIR_ARRAY: result = _sir_dup("#<Array>"); break;
         default: result = _sir_dup("");
     }
     _sir_display_depth--;
@@ -3127,6 +3150,7 @@ static SirValue _sir_object_equal_p(SirValue a, SirValue b) {
         case SIR_MAP:      return _sir_bool(a.as.map == b.as.map);
         case SIR_ERROR:    return _sir_bool(a.as.err == b.as.err);
         case SIR_INSTANCE: return _sir_bool(a.as.inst == b.as.inst);
+        case SIR_ARRAY:    return _sir_bool(a.as.arr == b.as.arr);
         default:           return _sir_bool(0);  /* SIR_MISSING: never user-observed */
     }
 }
@@ -3941,5 +3965,750 @@ SirValue _sir_builtin_closure(const char *name) {
 SirValue _sir_unknown_builtin(const char *name) {
     fprintf(stderr, "sir: unsupported builtin '%s'\n", name);
     exit(1);
+}
+
+/* ============================================================
+ * SIR22 array/matrix domain (Phase A Slice 2, second-wave backend
+ * rollout — see the SIR22 spec's "Backend impact" section)
+ * ============================================================
+ *
+ * `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` (and
+ * `Stmt::IndexSet`) — the SIR22 "base cut" — lower to calls into the
+ * `_sir_array_*` helpers below: an inlined port of
+ * `semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime
+ * (itself a plain-JS port of the published `@coding-adventures/
+ * sir-runtime-array` package), following this crate's existing
+ * inlined-runtime convention (this backend always inlines, unlike the
+ * TS/Python imported-package model). The 9-node SIR22 "APL addendum"
+ * (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+ * `IndexOf`/`Ravel`/`Catenate`) is a SEPARATE, later rollout slice — see
+ * `emit.rs`'s `scan_expr_for_builtin`, which rejects those nine cleanly
+ * (a compile-time error, not a reachable `unreachable!` panic) even
+ * though they share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
+ * base cut this file implements.
+ *
+ * ## Value model
+ *
+ * `SirNDArray { rank, rows, cols, data, data_len }` — dense, rectangular,
+ * COLUMN-MAJOR storage (Fortran/MATLAB order), mirroring
+ * `array_runtime::value::Array` field-for-field. `rank == 0` is a scalar
+ * (`data_len == 1`, `rows`/`cols` unused); `rank == 2` is a matrix
+ * (`rows` x `cols`, `data_len == rows * cols`) — this port's whole scope,
+ * like the JS/TS/Ruby references, is rank <= 2. (A JS/Ruby-style
+ * "rank-1 vector" shape is never actually produced by any base-cut
+ * constructor here: `range`/`indexGet`'s 1-argument form both return a
+ * `1 x n` RANK-2 row, and `fromRows` is always 2-D — so this port omits a
+ * rank-1 representation entirely rather than carrying dead code for a
+ * shape nothing constructs.)
+ *
+ * Unlike the Ruby port (which preserves native Integer/Float propagation
+ * through `+`/`-`/`*`, only forcing Float for `Div`/`Pow`), this C port
+ * follows the JS reference's ACTUAL internal representation: every
+ * element is a plain C `double`, unconditionally — not JS's cosmetic
+ * integer-display shortcut (`19` instead of `19.0`), just its real
+ * `Float64Array` storage. `SirValue` here is statically tagged
+ * (`SIR_INT` xor `SIR_FLOAT`), so an element read off an NDArray always
+ * becomes `_sir_float(d)`, and an all-integer computation like a 2x2
+ * `matmul` therefore prints WITH a trailing ".0" (`_sir_fmt_float`'s
+ * existing convention for every other Float in this backend), unlike the
+ * Ruby port's int-preserving `19`. This is the simplest correct choice
+ * for C's statically-tagged value model: it avoids a second int/float
+ * dispatch path through `_sir_array_apply_op` (which the Ruby port needs
+ * precisely because Ruby's `Numeric` types aren't statically tracked),
+ * at the cost of a cosmetic ".0" no reference backend's tests need to
+ * match (each backend's own `tests/sir22_array.rs` asserts against ITS
+ * OWN emitted output).
+ *
+ * ## The C-specific overflow hazard neither JS nor Ruby has
+ *
+ * JS `Number`s are IEEE doubles (lose precision silently past 2^53, but
+ * never WRAP), and Ruby `Integer` is arbitrary-precision (never wraps,
+ * never overflows) — so `rows * cols` computing an element count is safe
+ * in both references without an explicit overflow check. C's `int64_t`
+ * has neither property: `rows * cols` can silently wrap (undefined
+ * behaviour, in fact, for a signed overflow) BEFORE it is ever compared
+ * against the `SIR_ARRAY_MAX_ELEMENTS` cap, turning a huge requested
+ * shape into a small (or negative, or UB) computed size and then
+ * `malloc`ing too little for what the caller believes it got — a classic
+ * heap-overflow setup. `_sir_array_checked_size` below therefore checks
+ * `rows > SIR_ARRAY_MAX_ELEMENTS / cols` (rejecting) BEFORE ever
+ * computing `rows * cols`, not after — every allocation in this file
+ * routes through it (or a caller that already routed its own inputs
+ * through it) before calling `_sir_alloc`.
+ */
+
+/* SECURITY: every constructor below validates a shape/output size BEFORE
+ * allocating — a compiled program's array sizes come from potentially
+ * attacker-influenced runtime values (loop counts, parsed input, ...), not
+ * fixed compile-time constants, so an unbounded or malformed shape must fail
+ * cleanly (a `stderr` message + `exit(1)`, matching this file's existing
+ * `_sir_seq_set`/`_sir_divide_v` "trap" convention) rather than let a huge or
+ * wrapped `malloc` size corrupt the heap or exhaust memory. Mirrors the JS
+ * backend's own `MAX_ELEMENTS` bound exactly, so the cap is identical across
+ * every backend that ports this runtime. */
+#define SIR_ARRAY_MAX_ELEMENTS ((int64_t)1 << 26) /* 67,108,864 */
+
+/* Tolerance for the inclusive-stop boundary check in `_sir_array_range`,
+ * matching `matlab-runtime`'s own `eval_colon` and the JS/Ruby ports exactly
+ * — a floating step (e.g. `1:0.1:2`) can drift a few ULPs short of `stop` by
+ * the final iteration, and MATLAB's `a:step:b` is inclusive of `b`. */
+#define SIR_ARRAY_RANGE_EPSILON 1e-9
+
+struct SirNDArray {
+    int rank;            /* 0 (scalar) or 2 (matrix) — see the module doc above */
+    int64_t rows, cols;  /* valid only when rank == 2 */
+    double *data;        /* `data_len` doubles, column-major when rank == 2 */
+    int64_t data_len;
+};
+
+/* Extract a `double` out of a numeric `SirValue`, failing loudly (not
+ * silently coercing to 0.0 the way this file's general-purpose `_sir_as_num`
+ * does) on a non-numeric value — an ArrayLit element or Range bound that
+ * turns out to be, say, a String is a genuine program error in this domain,
+ * not a value this runtime should silently zero out. */
+double _sir_array_num_of(SirValue v, const char *ctx) {
+    if (v.tag == SIR_INT)   return (double)v.as.i;
+    if (v.tag == SIR_FLOAT) return v.as.f;
+    fprintf(stderr, "sir: %s: expected a number, got a non-numeric value\n", ctx);
+    exit(1);
+    return 0.0; /* unreachable; silences -Wreturn-type on toolchains that don't know exit() is noreturn */
+}
+
+/* Checked shape-size computation for a `rows` x `cols` matrix — see the
+ * module doc's "C-specific overflow hazard" section for why the overflow
+ * check happens BEFORE the multiply, not after. `rows`/`cols` are also
+ * range-checked non-negative (a negative dimension is nonsensical and would
+ * otherwise defeat the overflow check's own division). */
+int64_t _sir_array_checked_size(int64_t rows, int64_t cols, const char *ctx) {
+    if (rows < 0 || cols < 0) {
+        fprintf(stderr, "sir: %s: shape (%lld, %lld) has a negative dimension\n",
+                ctx, (long long)rows, (long long)cols);
+        exit(1);
+    }
+    if (cols != 0 && rows > SIR_ARRAY_MAX_ELEMENTS / cols) {
+        fprintf(stderr, "sir: %s: shape (%lld, %lld) exceeds the %lld-element cap\n",
+                ctx, (long long)rows, (long long)cols, (long long)SIR_ARRAY_MAX_ELEMENTS);
+        exit(1);
+    }
+    {
+        int64_t n = rows * cols;
+        if (n > SIR_ARRAY_MAX_ELEMENTS) {
+            fprintf(stderr, "sir: %s: shape (%lld, %lld) (%lld elements) exceeds the %lld-element cap\n",
+                    ctx, (long long)rows, (long long)cols, (long long)n, (long long)SIR_ARRAY_MAX_ELEMENTS);
+            exit(1);
+        }
+        return n;
+    }
+}
+
+/* Construct a rank-2 `rows` x `cols` NDArray from an already-populated
+ * `data` buffer of exactly `rows * cols` doubles (the caller's
+ * responsibility — every call site below allocates `data` via
+ * `_sir_array_checked_size`'s own return value first). Re-validates the
+ * shape (cheap, and keeps "every NDArray that exists passed validation" a
+ * true invariant regardless of which constructor built it, not just the
+ * ones that remembered to check). */
+SirValue _sir_array_new_matrix(int64_t rows, int64_t cols, double *data, const char *ctx) {
+    SirNDArray *a;
+    (void)_sir_array_checked_size(rows, cols, ctx);
+    a = (SirNDArray *)_sir_alloc(sizeof(SirNDArray));
+    a->rank = 2; a->rows = rows; a->cols = cols; a->data = data; a->data_len = rows * cols;
+    { SirValue v; v.tag = SIR_ARRAY; v.as.arr = a; return v; }
+}
+
+/* Construct a rank-0 scalar NDArray wrapping one `double`. */
+SirValue _sir_array_scalar(double x) {
+    SirNDArray *a = (SirNDArray *)_sir_alloc(sizeof(SirNDArray));
+    double *data = (double *)_sir_alloc(sizeof(double));
+    data[0] = x;
+    a->rank = 0; a->rows = 0; a->cols = 0; a->data = data; a->data_len = 1;
+    { SirValue v; v.tag = SIR_ARRAY; v.as.arr = a; return v; }
+}
+
+/* Construct a new NDArray with the SAME shape as `shape_src` but a fresh
+ * `data` buffer (already populated by the caller with `shape_src->data_len`
+ * doubles) — used by `_sir_array_elementwise`'s scalar-broadcast branches,
+ * whose result shape is whichever operand was non-scalar. */
+SirValue _sir_array_new_like(const SirNDArray *shape_src, double *data) {
+    SirNDArray *a = (SirNDArray *)_sir_alloc(sizeof(SirNDArray));
+    a->rank = shape_src->rank; a->rows = shape_src->rows; a->cols = shape_src->cols;
+    a->data = data; a->data_len = shape_src->data_len;
+    { SirValue v; v.tag = SIR_ARRAY; v.as.arr = a; return v; }
+}
+
+/* Rows, treating a scalar as `1x1`. */
+int64_t _sir_array_nrows(const SirNDArray *a) { return a->rank == 0 ? 1 : a->rows; }
+/* Columns, treating a scalar as `1x1`. */
+int64_t _sir_array_ncols(const SirNDArray *a) { return a->rank == 0 ? 1 : a->cols; }
+
+/* Coerce a `SirValue` operand that must ALREADY be an NDArray (`transpose`,
+ * `indexGet`/`indexSet`'s `target`) — unlike `_sir_array_coerce` below,
+ * there is no bare-scalar fallback here, matching the JS/Ruby references
+ * (neither calls `toArrayValue` on these operands either). */
+SirNDArray *_sir_array_require(SirValue v, const char *ctx) {
+    if (v.tag != SIR_ARRAY) {
+        fprintf(stderr, "sir: %s: expected an NDArray\n", ctx);
+        exit(1);
+    }
+    return v.as.arr;
+}
+
+/* Coerce a bare numeric `SirValue` into a rank-0 scalar NDArray; an
+ * already-NDArray value passes through unchanged. Needed because
+ * `matlab-to-semantic-ir`'s lowerer emits a mixed operand pair for
+ * `.* ./ .\` and for `* /` when exactly one side is scalar (e.g. `A .* 2`)
+ * — the BARE scalar sub-expression is passed through `ElementwiseOp`/
+ * `MatMul` unwrapped (a plain `IntLit`/`FloatLit`/arithmetic result), not
+ * wrapped in an `ArrayLit` first. `_sir_array_elementwise`/`_sir_array_matmul`
+ * both normalize through this first, so a raw `SirValue` never reaches
+ * `->data`/`->rows` and fails loudly (via `_sir_array_require`'s cousin
+ * check below) instead of dereferencing a non-`SIR_ARRAY` union member. */
+SirNDArray *_sir_array_coerce(SirValue v, const char *ctx) {
+    if (v.tag == SIR_ARRAY) return v.as.arr;
+    return _sir_array_scalar(_sir_array_num_of(v, ctx)).as.arr;
+}
+
+int _sir_array_is_scalar(const SirNDArray *a) { return a->data_len == 1; }
+
+/* Element `(r, c)` (column-major). Returns 1 and writes `*out` on success, 0
+ * (leaving `*out` untouched) if out of bounds.
+ *
+ * SECURITY: written in AND-form (`r >= 0 && c >= 0 && r < nrows && c <
+ * ncols`), matching the JS/Ruby references' own explicit warning: the
+ * negated OR-form (`r < 0 || c < 0 || ...`) is NOT equivalent under
+ * IEEE-754 if `r`/`c` ever carried a NaN (every relational comparison with
+ * NaN is false, so an OR-form check would have every branch evaluate false,
+ * silently skipping the bounds check). `r`/`c` are always already-validated
+ * `int64_t` positions by the time they reach this function (never a raw
+ * `double`), so integers can't be NaN and this specific call path is not
+ * actually reachable with one — kept in AND-form anyway for the same
+ * "don't rely on every future caller re-deriving the invariant" discipline
+ * the JS `set` doc comment states, at zero extra cost either way. */
+int _sir_array_get(const SirNDArray *a, int64_t r, int64_t c, double *out) {
+    int64_t nr = _sir_array_nrows(a), nc = _sir_array_ncols(a);
+    if (r >= 0 && c >= 0 && r < nr && c < nc) {
+        *out = a->data[c * nr + r];
+        return 1;
+    }
+    return 0;
+}
+
+/* Set element `(r, c)` IN PLACE (column-major) — mutates `a->data` directly,
+ * matching MATLAB assignment semantics (`A(i,j) = v` rebinds one element of
+ * the existing array, it does not produce a new one). This is why
+ * `Stmt::IndexSet` is a statement, not a pure expression, in the SIR22 spec.
+ * Returns 1 on success, 0 (no mutation) if out of bounds. Same AND-form
+ * bounds check as `_sir_array_get`. */
+int _sir_array_set(SirNDArray *a, int64_t r, int64_t c, double value) {
+    int64_t nr = _sir_array_nrows(a), nc = _sir_array_ncols(a);
+    if (r >= 0 && c >= 0 && r < nr && c < nc) {
+        a->data[c * nr + r] = value;
+        return 1;
+    }
+    return 0;
+}
+
+/* ── elementwise binary ops ─────────────────────────────────────────── */
+
+/* Mirrors `ElementwiseOpKind` — `emit.rs`'s `elementwise_op_c_name` emits
+ * exactly these constant names, so the two stay in lockstep by construction
+ * (a Rust `match` over the same source enum, not a hand-maintained string
+ * table the way the JS/Ruby ports' string-keyed dispatch needs). */
+typedef enum {
+    SIR_EW_ADD, SIR_EW_SUB, SIR_EW_MUL, SIR_EW_DIV, SIR_EW_POW,
+    SIR_EW_MAX, SIR_EW_MIN, SIR_EW_EQ, SIR_EW_NE,
+    SIR_EW_LT, SIR_EW_LE, SIR_EW_GE, SIR_EW_GT
+} SirElementwiseOp;
+
+/* Comparisons follow the same APL-style boolean convention
+ * `array_runtime::BinOp` uses: `1.0` for true, `0.0` for false (never a
+ * native C `_Bool`/`SIR_BOOL`), since the result must stay a plain array
+ * element like every other value here. `Div` is ALWAYS a true float divide
+ * (`a / b` over `double`s) — unlike this backend's OWN `_sir_divide_v`
+ * (bare `/`), which FLOORS when both operands happen to be `SIR_INT`; that
+ * integer-floor behaviour belongs to Ruby's `/`, not MATLAB's `./`, which
+ * always real-divides. A zero divisor here silently produces IEEE
+ * inf/nan (matching the JS/Ruby references' `applyOp` exactly), NOT this
+ * file's OWN `_sir_true_div`, which fails loudly — that divergence is
+ * deliberate: `_sir_true_div` models Python's `/` (raises), this models
+ * MATLAB's `./` over `double`s (never raises, produces `Inf`/`NaN`, which
+ * MATLAB itself does too). */
+double _sir_array_apply_op(SirElementwiseOp op, double a, double b) {
+    switch (op) {
+        case SIR_EW_ADD: return a + b;
+        case SIR_EW_SUB: return a - b;
+        case SIR_EW_MUL: return a * b;
+        case SIR_EW_DIV: return a / b;
+        case SIR_EW_POW: return pow(a, b);
+        case SIR_EW_MAX: return a > b ? a : b;
+        case SIR_EW_MIN: return a < b ? a : b;
+        case SIR_EW_EQ:  return a == b ? 1.0 : 0.0;
+        case SIR_EW_NE:  return a != b ? 1.0 : 0.0;
+        case SIR_EW_LT:  return a < b  ? 1.0 : 0.0;
+        case SIR_EW_LE:  return a <= b ? 1.0 : 0.0;
+        case SIR_EW_GE:  return a >= b ? 1.0 : 0.0;
+        case SIR_EW_GT:  return a > b  ? 1.0 : 0.0;
+    }
+    fprintf(stderr, "sir: _sir_array_apply_op: unrecognised op %d\n", (int)op);
+    exit(1);
+    return 0.0; /* unreachable */
+}
+
+/* Elementwise binary op with scalar broadcasting. Either operand may be a
+ * scalar; otherwise the shapes must match exactly (full NumPy/MATLAB
+ * broadcasting is out of scope, same as the Rust/JS/Ruby references).
+ * Result takes the non-scalar operand's shape (or the scalar's, if both
+ * are). Normalizes both operands through `_sir_array_coerce` first — see
+ * that function's doc for the bare-scalar-operand regression this guards. */
+SirValue _sir_array_elementwise(SirElementwiseOp op, SirValue av, SirValue bv) {
+    SirNDArray *a = _sir_array_coerce(av, "elementwise");
+    SirNDArray *b = _sir_array_coerce(bv, "elementwise");
+    if (_sir_array_is_scalar(a)) {
+        int64_t n = b->data_len, i;
+        double *data = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (i = 0; i < n; i++) data[i] = _sir_array_apply_op(op, a->data[0], b->data[i]);
+        return _sir_array_new_like(b, data);
+    }
+    if (_sir_array_is_scalar(b)) {
+        int64_t n = a->data_len, i;
+        double *data = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (i = 0; i < n; i++) data[i] = _sir_array_apply_op(op, a->data[i], b->data[0]);
+        return _sir_array_new_like(a, data);
+    }
+    if (a->rank != b->rank || a->rows != b->rows || a->cols != b->cols) {
+        fprintf(stderr, "sir: elementwise: non-conformable arrays: (%lld, %lld) vs (%lld, %lld)\n",
+                (long long)_sir_array_nrows(a), (long long)_sir_array_ncols(a),
+                (long long)_sir_array_nrows(b), (long long)_sir_array_ncols(b));
+        exit(1);
+    }
+    {
+        int64_t n = a->data_len, i;
+        double *data = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (i = 0; i < n; i++) data[i] = _sir_array_apply_op(op, a->data[i], b->data[i]);
+        return _sir_array_new_like(a, data);
+    }
+}
+
+/* Matrix product `[m, k] . [k, n] -> [m, n]` (column-major throughout). `m`
+ * and `n` come from two INDEPENDENT operands (each individually under
+ * `SIR_ARRAY_MAX_ELEMENTS`, but their product isn't bounded by that alone —
+ * an outer-product-shaped call could still ask for a huge output), so
+ * `_sir_array_checked_size` (inside `_sir_array_new_matrix`, via the
+ * pre-check below) validates `[m, n]` BEFORE allocating `out`, not after.
+ * Normalizes both operands through `_sir_array_coerce` first, same
+ * reasoning as `_sir_array_elementwise`. */
+SirValue _sir_array_matmul(SirValue av, SirValue bv) {
+    SirNDArray *a = _sir_array_coerce(av, "matmul");
+    SirNDArray *b = _sir_array_coerce(bv, "matmul");
+    int64_t m = _sir_array_nrows(a), ka = _sir_array_ncols(a);
+    int64_t kb = _sir_array_nrows(b), n = _sir_array_ncols(b);
+    int64_t out_len;
+    double *out;
+    if (ka != kb) {
+        fprintf(stderr, "sir: matmul: inner dimensions disagree (%lldx%lld . %lldx%lld)\n",
+                (long long)m, (long long)ka, (long long)kb, (long long)n);
+        exit(1);
+    }
+    out_len = _sir_array_checked_size(m, n, "matmul");
+    out = (out_len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)out_len) : NULL;
+    {
+        int64_t j, i, p;
+        for (j = 0; j < n; j++) {
+            for (i = 0; i < m; i++) {
+                double acc = 0.0;
+                for (p = 0; p < ka; p++) {
+                    acc += a->data[p * m + i] * b->data[j * kb + p]; /* column-major indexing */
+                }
+                out[j * m + i] = acc;
+            }
+        }
+    }
+    return _sir_array_new_matrix(m, n, out, "matmul");
+}
+
+/* Matrix transpose. `conjugate` distinguishes MATLAB `'` (`1`) from `.'`
+ * (`0`) — this runtime has no `Complex` value type yet (matching
+ * `array-runtime`'s own real-only scope today), so a conjugate transpose of
+ * real data is identical to a plain transpose; `conjugate` is accepted only
+ * for call-shape parity with the SIR spec. `target` must already be an
+ * NDArray (`_sir_array_require`, no bare-scalar coercion — matching the
+ * JS/Ruby references, neither of which calls `toArrayValue` here either). */
+SirValue _sir_array_transpose(SirValue targetv, int conjugate) {
+    SirNDArray *a = _sir_array_require(targetv, "transpose");
+    int64_t m = _sir_array_nrows(a), n = _sir_array_ncols(a);
+    int64_t len = a->data_len;
+    double *out = (len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)len) : NULL;
+    int64_t i, j;
+    (void)conjugate;
+    for (j = 0; j < n; j++) {
+        for (i = 0; i < m; i++) {
+            out[i * n + j] = a->data[j * m + i];
+        }
+    }
+    return _sir_array_new_matrix(n, m, out, "transpose");
+}
+
+/* Materialize a MATLAB-style range `start:step:stop` (default `step = 1`)
+ * as a `1 x n` row vector — MATLAB's `:` always produces a row, never a
+ * column. Bounded by `SIR_ARRAY_MAX_ELEMENTS` so a compiled program's
+ * `1:1e18`-style range can't exhaust memory before this function ever gets
+ * to materialize anything: a first COUNTING pass establishes exactly how
+ * many elements the range needs (failing loudly past the cap) before any
+ * allocation happens, then a second pass fills a buffer sized to that exact
+ * count — no realloc-and-grow, and no risk of the two passes disagreeing,
+ * since both walk the identical deterministic `x += step` sequence from the
+ * same `start`. */
+SirValue _sir_array_range(SirValue startv, SirValue stopv, SirValue stepv) {
+    double start = _sir_array_num_of(startv, "range");
+    double stop  = _sir_array_num_of(stopv, "range");
+    double step  = _sir_array_num_of(stepv, "range");
+    int64_t count;
+    double x;
+    double *data;
+    if (step == 0.0) {
+        fprintf(stderr, "sir: range: step cannot be zero\n");
+        exit(1);
+    }
+    /* SECURITY: reject non-finite bounds up front — the loop condition below
+     * is false on its very first check whenever start/stop/step is NaN
+     * (every relational comparison with NaN is false), so an unguarded NaN
+     * bound would silently produce an empty range instead of erroring, the
+     * same "NaN defeats a comparison-based check" hazard class the index
+     * resolution functions below also guard against. An unguarded
+     * Infinity bound would instead loop until the element cap trips, which
+     * is merely slow, not wrong — but is rejected here too for the same
+     * "fail loudly, don't fall through to a confusing downstream state"
+     * discipline the JS/Ruby references both apply uniformly to all three
+     * bounds. */
+    if (!isfinite(start) || !isfinite(stop) || !isfinite(step)) {
+        fprintf(stderr, "sir: range: start/stop/step must be finite numbers, got (%.17g, %.17g, %.17g)\n",
+                start, stop, step);
+        exit(1);
+    }
+    count = 0;
+    x = start;
+    while ((step > 0 && x <= stop + SIR_ARRAY_RANGE_EPSILON) ||
+           (step < 0 && x >= stop - SIR_ARRAY_RANGE_EPSILON)) {
+        if (count >= SIR_ARRAY_MAX_ELEMENTS) {
+            fprintf(stderr, "sir: range: produces more than %lld elements\n",
+                    (long long)SIR_ARRAY_MAX_ELEMENTS);
+            exit(1);
+        }
+        count++;
+        x += step;
+    }
+    data = (count > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)count) : NULL;
+    x = start;
+    { int64_t i; for (i = 0; i < count; i++) { data[i] = x; x += step; } }
+    return _sir_array_new_matrix(1, count, data, "range");
+}
+
+/* ── ArrayLit ────────────────────────────────────────────────────────── */
+
+/* `[1 2; 3 4]` (`Expr::ArrayLit`) — `rows_in`/`cols_in` are the literal's
+ * dimensions (known at COMPILE time from the SIR `rows: Vec<Vec<Expr>>`
+ * shape; `emit.rs`'s pre-emit scan rejects a ragged literal cleanly before
+ * this function is ever emitted, so `rows_in * cols_in` always equals the
+ * `total` varargs actually passed). Elements arrive ROW-MAJOR (matching the
+ * literal syntax and the SIR node's own field order) and are stored
+ * COLUMN-MAJOR (`Feature::ArrayColumnMajor`, per the SIR22 spec's "Storage
+ * convention"). `rows_in == 0` is the empty literal `[]` -> a `0x0` array,
+ * matching the JS/Ruby references' own special case. */
+SirValue _sir_array_from_rows(int64_t rows_in, int64_t cols_in, int total, ...) {
+    int64_t n, r, c;
+    double *data;
+    va_list ap;
+    (void)total;
+    if (rows_in == 0) {
+        return _sir_array_new_matrix(0, 0, NULL, "fromRows");
+    }
+    n = _sir_array_checked_size(rows_in, cols_in, "fromRows");
+    data = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+    va_start(ap, total);
+    for (r = 0; r < rows_in; r++) {
+        for (c = 0; c < cols_in; c++) {
+            SirValue e = va_arg(ap, SirValue);
+            data[c * rows_in + r] = _sir_array_num_of(e, "fromRows"); /* column-major store */
+        }
+    }
+    va_end(ap);
+    return _sir_array_new_matrix(rows_in, cols_in, data, "fromRows");
+}
+
+/* ── indexing ────────────────────────────────────────────────────────── */
+/* One MATLAB-style index-position argument, mirroring the SIR22 spec's
+ * `IndexArg` exactly: `Scalar(value)` / `Whole` / `Range(indices)`. `end`-
+ * relative indices are never seen here — per SIR10 discipline, the
+ * frontend resolves `end` to a concrete 0-based `Scalar` index before
+ * emitting `IndexGet`/`IndexSet`. */
+typedef enum { SIR_IDXARG_SCALAR, SIR_IDXARG_WHOLE, SIR_IDXARG_RANGE } SirIndexArgKind;
+typedef struct {
+    SirIndexArgKind kind;
+    SirValue value; /* SCALAR: the index value. RANGE: the NDArray of indices. WHOLE: unused (nil). */
+} SirIndexArg;
+
+SirIndexArg _sir_array_idx_scalar(SirValue v) { SirIndexArg a; a.kind = SIR_IDXARG_SCALAR; a.value = v; return a; }
+SirIndexArg _sir_array_idx_whole(void)        { SirIndexArg a; a.kind = SIR_IDXARG_WHOLE;  a.value = _sir_nil(); return a; }
+SirIndexArg _sir_array_idx_range(SirValue v)  { SirIndexArg a; a.kind = SIR_IDXARG_RANGE;  a.value = v; return a; }
+
+typedef struct { int64_t *pos; int64_t n; } SirArrayPositions;
+
+/* Validate one resolved position is a real, finite integer, and return it
+ * as an `int64_t`.
+ *
+ * SECURITY: unlike this file's general-purpose `_sir_as_int` (used e.g. by
+ * `ForRange`'s loop counters), which casts a `SIR_FLOAT`'s `double` to
+ * `int64_t` UNCONDITIONALLY, this function validates BEFORE ever casting —
+ * casting a NaN, or a finite-but-out-of-`int64_t`-range, `double` to
+ * `int64_t` is UNDEFINED BEHAVIOUR in C (unlike JS's `Number.isInteger`
+ * guard or Ruby's `Float#to_i`, which both fail cleanly instead). The
+ * magnitude bound (+-9.2e18, comfortably inside `int64_t`'s actual range but
+ * far enough from the exact boundary that the comparison itself can't be
+ * fooled by `double`'s limited precision at that magnitude) is checked
+ * FIRST, so the subsequent `(int64_t)d` cast only ever runs on a value
+ * already known to be in range. Every index position this array domain
+ * resolves funnels through this single choke point (mirroring the JS
+ * reference's `assertValidPosition`), so this NaN-safety fix, once made
+ * here, covers `indexGet`/`indexSet`/range-selector resolution uniformly. */
+int64_t _sir_array_assert_valid_position(SirValue v, const char *ctx) {
+    double d = _sir_array_num_of(v, ctx);
+    if (!(d == d) || d < -9.2e18 || d > 9.2e18 || d != (double)(int64_t)d) {
+        fprintf(stderr, "sir: %s: index %.17g is not a finite integer\n", ctx, d);
+        exit(1);
+    }
+    return (int64_t)d;
+}
+
+/* Resolve one `SirIndexArg` against a dimension of size `dim_size` into a
+ * flat list of 0-based positions along that dimension (arena-allocated,
+ * never freed, like every heap value in this file). */
+SirArrayPositions _sir_array_resolve_positions(SirIndexArg arg, int64_t dim_size) {
+    SirArrayPositions r;
+    switch (arg.kind) {
+        case SIR_IDXARG_SCALAR: {
+            int64_t *p = (int64_t *)_sir_alloc(sizeof(int64_t));
+            p[0] = _sir_array_assert_valid_position(arg.value, "resolvePositions");
+            r.pos = p; r.n = 1;
+            return r;
+        }
+        case SIR_IDXARG_WHOLE: {
+            int64_t *p = (dim_size > 0) ? (int64_t *)_sir_alloc(sizeof(int64_t) * (size_t)dim_size) : NULL;
+            int64_t i;
+            for (i = 0; i < dim_size; i++) p[i] = i;
+            r.pos = p; r.n = dim_size;
+            return r;
+        }
+        case SIR_IDXARG_RANGE: {
+            SirNDArray *ra;
+            int64_t n, i;
+            int64_t *p;
+            if (arg.value.tag != SIR_ARRAY) {
+                fprintf(stderr, "sir: resolvePositions: a range index argument must be an NDArray\n");
+                exit(1);
+            }
+            ra = arg.value.as.arr;
+            n = ra->data_len;
+            p = (n > 0) ? (int64_t *)_sir_alloc(sizeof(int64_t) * (size_t)n) : NULL;
+            for (i = 0; i < n; i++) {
+                /* `trunc` toward zero (matching JS's `Math.trunc` / Ruby's
+                 * `Float#truncate`); safe to call on any double (IEEE `trunc`
+                 * of NaN/Infinity is defined to yield NaN/Infinity back, no
+                 * UB) — `_sir_array_assert_valid_position` below is what
+                 * actually rejects a non-finite/non-integral result. */
+                p[i] = _sir_array_assert_valid_position(_sir_float(trunc(ra->data[i])), "resolvePositions");
+            }
+            r.pos = p; r.n = n;
+            return r;
+        }
+    }
+    fprintf(stderr, "sir: resolvePositions: unrecognised IndexArg kind %d\n", (int)arg.kind);
+    exit(1);
+    r.pos = NULL; r.n = 0; /* unreachable */
+    return r;
+}
+
+/* `A(i)` / `A(i, j)` (`Expr::IndexGet`) — read one element or a sub-array.
+ * `n` (the argument count) is a COMPILE-TIME constant baked in by
+ * `emit.rs` (`indices.len()`, from the SIR AST — never attacker-influenced
+ * at runtime) — `emit.rs`'s pre-emit scan already rejects any module whose
+ * `IndexGet`/`IndexSet` has other than 1 or 2 `IndexArg`s, so the `n != 1 &&
+ * n != 2` check below is defense-in-depth for a hand-built `Module` that
+ * bypassed that scan, not a path any compiled program can reach.
+ *
+ * A single argument indexes `target`'s underlying column-major data
+ * LINEARLY (MATLAB's own single-subscript convention, which is
+ * column-major too); two arguments index `(row, col)`. Returns a SCALAR
+ * `SirValue` (`_sir_float`) when every argument is `Scalar` (a single
+ * element), otherwise a fresh `SIR_ARRAY`. */
+SirValue _sir_array_index_get(SirValue targetv, int n, ...) {
+    SirNDArray *a = _sir_array_require(targetv, "indexGet");
+    SirIndexArg args[2];
+    va_list ap;
+    if (n != 1 && n != 2) {
+        fprintf(stderr, "sir: indexGet: only 1 or 2 index arguments are supported (rank <= 2 scope), got %d\n", n);
+        exit(1);
+    }
+    va_start(ap, n);
+    { int i; for (i = 0; i < n; i++) args[i] = va_arg(ap, SirIndexArg); }
+    va_end(ap);
+
+    if (n == 1) {
+        SirArrayPositions ps = _sir_array_resolve_positions(args[0], a->data_len);
+        if (args[0].kind == SIR_IDXARG_SCALAR) {
+            int64_t i = ps.pos[0];
+            if (i < 0 || i >= a->data_len) {
+                fprintf(stderr, "sir: indexGet: linear index %lld out of bounds\n", (long long)i);
+                exit(1);
+            }
+            return _sir_float(a->data[i]);
+        }
+        {
+            int64_t out_len = _sir_array_checked_size(1, ps.n, "indexGet");
+            double *data = (out_len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)out_len) : NULL;
+            int64_t k;
+            for (k = 0; k < ps.n; k++) {
+                int64_t i = ps.pos[k];
+                if (i < 0 || i >= a->data_len) {
+                    fprintf(stderr, "sir: indexGet: linear index %lld out of bounds\n", (long long)i);
+                    exit(1);
+                }
+                data[k] = a->data[i];
+            }
+            return _sir_array_new_matrix(1, ps.n, data, "indexGet");
+        }
+    }
+    {
+        SirArrayPositions rows = _sir_array_resolve_positions(args[0], _sir_array_nrows(a));
+        SirArrayPositions cols = _sir_array_resolve_positions(args[1], _sir_array_ncols(a));
+        if (args[0].kind == SIR_IDXARG_SCALAR && args[1].kind == SIR_IDXARG_SCALAR) {
+            double v;
+            if (!_sir_array_get(a, rows.pos[0], cols.pos[0], &v)) {
+                fprintf(stderr, "sir: indexGet: (%lld, %lld) out of bounds for shape (%lld, %lld)\n",
+                        (long long)rows.pos[0], (long long)cols.pos[0],
+                        (long long)_sir_array_nrows(a), (long long)_sir_array_ncols(a));
+                exit(1);
+            }
+            return _sir_float(v);
+        }
+        /* SECURITY: `rows.n`/`cols.n` are each individually bounded by `a`'s
+         * own dimensions (a `Whole` selector) or by a `Range` NDArray's own
+         * `SIR_ARRAY_MAX_ELEMENTS`-checked construction — but nothing bounds
+         * their PRODUCT on its own, the exact outer-product-shaped
+         * allocation `_sir_array_matmul` guards against, one level up.
+         * Validate before allocating, not after. */
+        {
+            int64_t out_len = _sir_array_checked_size(rows.n, cols.n, "indexGet");
+            double *data = (out_len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)out_len) : NULL;
+            int64_t ci, ri;
+            for (ci = 0; ci < cols.n; ci++) {
+                for (ri = 0; ri < rows.n; ri++) {
+                    double v;
+                    if (!_sir_array_get(a, rows.pos[ri], cols.pos[ci], &v)) {
+                        fprintf(stderr, "sir: indexGet: (%lld, %lld) out of bounds for shape (%lld, %lld)\n",
+                                (long long)rows.pos[ri], (long long)cols.pos[ci],
+                                (long long)_sir_array_nrows(a), (long long)_sir_array_ncols(a));
+                        exit(1);
+                    }
+                    data[ci * rows.n + ri] = v;
+                }
+            }
+            return _sir_array_new_matrix(rows.n, cols.n, data, "indexGet");
+        }
+    }
+}
+
+/* Broadcast a scalar-or-NDArray right-hand side to exactly `count` values
+ * (mirrors `_sir_array_elementwise`'s scalar-broadcast rule). Returns a
+ * buffer of `count` doubles — either a fresh fill (scalar / 1-element
+ * NDArray source) or, when `value` already has exactly `count` elements,
+ * the SAME buffer `value` owns (shared, not copied — matching the JS/Ruby
+ * references' identical `return value.data`; safe here because every
+ * caller only READS the returned buffer before the statement ends, never
+ * retains it). */
+double *_sir_array_broadcast_values(SirValue value, int64_t count, const char *ctx) {
+    if (value.tag == SIR_INT || value.tag == SIR_FLOAT) {
+        double x = _sir_array_num_of(value, ctx);
+        double *out = (count > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)count) : NULL;
+        int64_t i;
+        for (i = 0; i < count; i++) out[i] = x;
+        return out;
+    }
+    if (value.tag == SIR_ARRAY) {
+        SirNDArray *v = value.as.arr;
+        if (v->data_len == 1) {
+            double x = v->data[0];
+            double *out = (count > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)count) : NULL;
+            int64_t i;
+            for (i = 0; i < count; i++) out[i] = x;
+            return out;
+        }
+        if (v->data_len != count) {
+            fprintf(stderr, "sir: %s: value has %lld elements, expected %lld\n",
+                    ctx, (long long)v->data_len, (long long)count);
+            exit(1);
+        }
+        return v->data;
+    }
+    fprintf(stderr, "sir: %s: value must be a number or NDArray\n", ctx);
+    exit(1);
+    return NULL; /* unreachable */
+}
+
+/* `A(i) = v` / `A(i, j) = v` (`Stmt::IndexSet`) — write one element or a
+ * sub-array, IN PLACE (see `_sir_array_set`'s doc comment above for why
+ * this mutates rather than returns a new array). `value` may be a scalar
+ * (broadcast to every selected position) or an NDArray with exactly as
+ * many elements as positions are selected. `value` is passed BEFORE the
+ * variadic index-argument pack (C requires `...` to be the LAST parameter,
+ * so it can't sit between `target` and the indices the way the SIR node's
+ * own `target, indices, value` field order would suggest) — `emit.rs`
+ * documents this reordering at its one call site. Same `n != 1 && n != 2`
+ * defense-in-depth as `_sir_array_index_get`. */
+void _sir_array_index_set(SirValue targetv, SirValue value, int n, ...) {
+    SirNDArray *a = _sir_array_require(targetv, "indexSet");
+    SirIndexArg args[2];
+    va_list ap;
+    if (n != 1 && n != 2) {
+        fprintf(stderr, "sir: indexSet: only 1 or 2 index arguments are supported (rank <= 2 scope), got %d\n", n);
+        exit(1);
+    }
+    va_start(ap, n);
+    { int i; for (i = 0; i < n; i++) args[i] = va_arg(ap, SirIndexArg); }
+    va_end(ap);
+
+    if (n == 1) {
+        SirArrayPositions ps = _sir_array_resolve_positions(args[0], a->data_len);
+        double *values = _sir_array_broadcast_values(value, ps.n, "indexSet");
+        int64_t k;
+        for (k = 0; k < ps.n; k++) {
+            int64_t i = ps.pos[k];
+            if (i < 0 || i >= a->data_len) {
+                fprintf(stderr, "sir: indexSet: linear index %lld out of bounds\n", (long long)i);
+                exit(1);
+            }
+            a->data[i] = values[k];
+        }
+        return;
+    }
+    {
+        SirArrayPositions rows = _sir_array_resolve_positions(args[0], _sir_array_nrows(a));
+        SirArrayPositions cols = _sir_array_resolve_positions(args[1], _sir_array_ncols(a));
+        /* Same product-of-two-independent-selections gap `indexGet` closes
+         * above — validate before `_sir_array_broadcast_values` allocates. */
+        int64_t count = _sir_array_checked_size(rows.n, cols.n, "indexSet");
+        double *values = _sir_array_broadcast_values(value, count, "indexSet");
+        int64_t k = 0, ci, ri;
+        for (ci = 0; ci < cols.n; ci++) {
+            for (ri = 0; ri < rows.n; ri++) {
+                if (!_sir_array_set(a, rows.pos[ri], cols.pos[ci], values[k])) {
+                    fprintf(stderr, "sir: indexSet: (%lld, %lld) out of bounds for shape (%lld, %lld)\n",
+                            (long long)rows.pos[ri], (long long)cols.pos[ci],
+                            (long long)_sir_array_nrows(a), (long long)_sir_array_ncols(a));
+                    exit(1);
+                }
+                k++;
+            }
+        }
+    }
 }
 "####;

--- a/code/packages/rust/semantic-ir-to-c/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/sir22_array.rs
@@ -1,0 +1,421 @@
+//! SIR22 array/matrix base-cut execution proof: `ArrayLit`/`Range`/
+//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the C
+//! backend — hand-builds a module calling each node directly (bypassing the
+//! frontend, since no frontend targets this backend for SIR22 yet), emits
+//! C, compiles with a real gcc/clang-style compiler, runs, asserts stdout.
+//! Skips gracefully when no `cc` is present, mirroring
+//! `compile_and_run_division_ops.rs`'s identical `find_cc`/`compile_and_link`
+//! pattern (copied verbatim below, including its unique-per-process-and-
+//! counter temp filenames — the exact race this session's own sibling test
+//! files hit and fixed earlier in this arc).
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir22_array.rs` (same worked examples as the sibling Ruby port's
+//! `tests/sir22_array.rs`), adapted to THIS backend's own value-type
+//! convention: unlike the Ruby port (which preserves native Integer/Float
+//! propagation) this C port stores every `SirNDArray` element as a plain
+//! `double` and always reads one back out as `_sir_float` — see
+//! `runtime.rs`'s "SIR22 array/matrix domain" module doc for why — so an
+//! all-integer computation here prints WITH a trailing ".0"
+//! (`_sir_fmt_float`'s existing convention for every Float in this
+//! backend), unlike the Ruby port's int-preserving bare `19`.
+//!
+//! Every test reads back a SCALAR element via `IndexGet` (top-left/
+//! bottom-right, etc.) — sidesteps needing a full `[1 2; 3 4]`-style
+//! `SirNDArray` display/format story, out of this slice's scope, exactly
+//! like the JS/Ruby references' own test suites.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
+    Metadata, Module, Scope, Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+// ── compile/run harness — copied from `compile_and_run_division_ops.rs` ──
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn compile_and_link(module: &Module) -> Option<(PathBuf, String)> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_array_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .arg("-lm")
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    Some((exe, artifact.source))
+}
+
+fn run(module: &Module) -> Option<String> {
+    let (exe, _src) = compile_and_link(module)?;
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+// ── module-building helpers ──────────────────────────────────────────────
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn array_lit(rows: Vec<Vec<Expr>>) -> Expr {
+    Expr::ArrayLit { rows, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+/// `puts(arg)` — prints `arg` followed by a newline, via `__sys_write__`
+/// (`"per_value"` terminator, `unpack_arrays: true`), mirroring
+/// `compile_and_run_division_ops.rs`'s identical helper.
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc(
+            "__sys_write__",
+            vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "per_value".into(), span: s() },
+                Expr::BoolLit { value: true, span: s() },
+                arg,
+            ],
+        ),
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+fn scalar(i: i64) -> IndexArg {
+    IndexArg::Scalar(Box::new(ilit(i)))
+}
+fn index_get(target: Expr, indices: Vec<IndexArg>) -> Expr {
+    Expr::IndexGet { target: Box::new(target), indices, span: s() }
+}
+
+const ARRAY_FEATURES: &[Feature] =
+    &[Feature::NDArrays, Feature::MatrixOps, Feature::ArrayColumnMajor];
+
+fn array_module(stmts: Vec<Stmt>) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings];
+    features.extend_from_slice(ARRAY_FEATURES);
+    Module {
+        name: "sir22array".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+// ── base cut: real compile-and-run proof ─────────────────────────────────
+
+#[test]
+fn matmul_of_two_by_two_matrices_computes_the_right_product() {
+    // [1 2; 3 4] * [5 6; 7 8] = [19 22; 43 50] (standard matrix product).
+    // Every NDArray element is a `double` in this port (see the module doc
+    // above), so the printed result carries a trailing ".0".
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5), ilit(6)], vec![ilit(7), ilit(8)]]);
+    let product = Expr::MatMul { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("p", product),
+        puts(index_get(local("p"), vec![scalar(0), scalar(0)])),
+        puts(index_get(local("p"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "19.0\n50.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
+    // MATLAB `A .* 2` -- matlab-to-semantic-ir emits the `2` as a bare
+    // IntLit operand, unwrapped (not an ArrayLit), when exactly one side is
+    // scalar. This is the exact shape `_sir_array_coerce`'s coercion in
+    // runtime.rs exists for; a regression there fails loudly (dereferencing
+    // a non-`SIR_ARRAY` union member) instead of computing [2 4; 6 8].
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let scaled = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("sc", scaled),
+        puts(index_get(local("sc"), vec![scalar(0), scalar(0)])),
+        puts(index_get(local("sc"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "2.0\n8.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn elementwise_div_always_true_divides_even_on_integer_operands() {
+    // `ElementwiseOp(Div, ...)` always real-divides over `double`s
+    // (`_sir_array_apply_op`'s `SIR_EW_DIV` case) -- distinct from this
+    // backend's OWN bare `/` (`_sir_divide_v`), which FLOORS toward
+    // negative infinity when both operands happen to be `SIR_INT`. A
+    // regression that routed this op through `_sir_divide_v` instead would
+    // print "3" (floored), not "3.5".
+    let a = array_lit(vec![vec![ilit(7)]]);
+    let divided = Expr::ElementwiseOp {
+        op: ElementwiseOpKind::Div,
+        lhs: Box::new(a),
+        rhs: Box::new(ilit(2)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("d", divided),
+        puts(index_get(local("d"), vec![scalar(0), scalar(0)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "3.5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn transpose_of_a_two_by_three_matrix_swaps_rows_and_columns() {
+    // [1 2 3; 4 5 6]' = [1 4; 2 5; 3 6]
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let t = Expr::Transpose { target: Box::new(a), conjugate: true, span: s() };
+    let m = array_module(vec![
+        let_binding("t", t),
+        puts(index_get(local("t"), vec![scalar(0), scalar(1)])),
+        puts(index_get(local("t"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "4.0\n6.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn range_materializes_a_row_vector_read_by_linear_index() {
+    // 1:2:9 -> [1 3 5 7 9], a 1x5 row vector. A single index argument reads
+    // linearly (rank-1 IndexGet).
+    let r = Expr::Range {
+        start: Box::new(ilit(1)),
+        step: Some(Box::new(ilit(2))),
+        stop: Box::new(ilit(9)),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("r", r),
+        puts(index_get(local("r"), vec![scalar(0)])),
+        puts(index_get(local("r"), vec![scalar(4)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n9.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn range_with_default_step_materializes_a_unit_stride_row() {
+    // 3:6 (no `step` field, None -> default 1) -> [3 4 5 6].
+    let r = Expr::Range { start: Box::new(ilit(3)), step: None, stop: Box::new(ilit(6)), span: s() };
+    let m = array_module(vec![
+        let_binding("r", r),
+        puts(index_get(local("r"), vec![scalar(0)])),
+        puts(index_get(local("r"), vec![scalar(3)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "3.0\n6.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn whole_selector_reads_an_entire_row() {
+    // A(1, :) on [1 2; 3 4] reads the whole second row [3 4], then a scalar
+    // linear IndexGet reads its second element.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let row = index_get(a, vec![scalar(1), IndexArg::Whole]);
+    let m = array_module(vec![
+        let_binding("row", row),
+        puts(index_get(local("row"), vec![scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "4.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn index_set_mutates_in_place() {
+    // A(1, 1) = 99 on [1 2; 3 4] -- IndexSet is a Stmt (in-place mutation),
+    // not a pure Expr, per the SIR22 spec.
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let m = array_module(vec![
+        let_binding("a", a),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![scalar(1), scalar(1)],
+            value: Box::new(ilit(99)),
+            span: s(),
+        },
+        puts(index_get(local("a"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "99.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn index_set_with_a_range_selector_overwrites_a_sub_range_linearly() {
+    // A row vector 1:4 ([1 2 3 4]); A([1 2]) = [50 60] (a Range index arg
+    // reusing an Expr::Range, resolved to positions [1, 2]) overwrites the
+    // middle two elements in place -- exercises the `IndexArg::Range`
+    // resolution path (`_sir_array_resolve_positions`'s `SIR_IDXARG_RANGE`
+    // case), not just `Scalar`/`Whole`.
+    let r = Expr::Range { start: Box::new(ilit(1)), step: None, stop: Box::new(ilit(4)), span: s() };
+    let sel = Expr::Range { start: Box::new(ilit(1)), step: None, stop: Box::new(ilit(2)), span: s() };
+    let replacement = array_lit(vec![vec![ilit(50), ilit(60)]]);
+    let m = array_module(vec![
+        let_binding("a", r),
+        Stmt::IndexSet {
+            target: Box::new(local("a")),
+            indices: vec![IndexArg::Range(Box::new(sel))],
+            value: Box::new(replacement),
+            span: s(),
+        },
+        puts(index_get(local("a"), vec![scalar(0)])),
+        puts(index_get(local("a"), vec![scalar(1)])),
+        puts(index_get(local("a"), vec![scalar(2)])),
+        puts(index_get(local("a"), vec![scalar(3)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n50.0\n60.0\n4.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ──────
+
+#[test]
+fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
+    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
+    // cut, so the ordinary feature-flag check alone can't reject it --
+    // proves the dedicated pre-emit scan arm in `scan_expr_for_builtin`
+    // does, with a clean `Err`, not an `emit_expr`/`emit_assign`
+    // `unreachable!` panic.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
+    let m = array_module(vec![puts(Expr::Reduce {
+        op: ElementwiseOpKind::Add,
+        target: Box::new(target),
+        span: s(),
+    })]);
+    let err = semantic_ir_to_c::compile(&m).expect_err("Reduce must be rejected, not emitted");
+    assert!(
+        err.message.contains("Reduce"),
+        "error should name the rejected node: {}",
+        err.message
+    );
+}
+
+#[test]
+fn catenate_node_is_rejected_cleanly_not_a_compile_time_panic() {
+    // A second addendum node, to prove the rejection is a real per-variant
+    // scan arm (all nine), not a fluke that only happens to catch `Reduce`.
+    let a = array_lit(vec![vec![ilit(1)]]);
+    let b = array_lit(vec![vec![ilit(2)]]);
+    let m = array_module(vec![puts(Expr::Catenate {
+        lhs: Box::new(a),
+        rhs: Box::new(b),
+        span: s(),
+    })]);
+    let err = semantic_ir_to_c::compile(&m).expect_err("Catenate must be rejected, not emitted");
+    assert!(
+        err.message.contains("Catenate"),
+        "error should name the rejected node: {}",
+        err.message
+    );
+}
+
+// ── malformed hand-built shapes: rejected cleanly, not a runtime panic ───
+
+#[test]
+fn ragged_array_lit_is_rejected_cleanly_at_compile_time() {
+    let ragged = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3)]]);
+    let m = array_module(vec![puts(ragged)]);
+    let err = semantic_ir_to_c::compile(&m).expect_err("a ragged ArrayLit must be rejected");
+    assert!(
+        err.message.contains("ragged"),
+        "error should mention raggedness: {}",
+        err.message
+    );
+}
+
+#[test]
+fn index_get_with_three_indices_is_rejected_cleanly_at_compile_time() {
+    let a = array_lit(vec![vec![ilit(1)]]);
+    let m = array_module(vec![puts(index_get(a, vec![scalar(0), scalar(0), scalar(0)]))]);
+    let err = semantic_ir_to_c::compile(&m).expect_err("a rank-3 IndexGet must be rejected");
+    assert!(
+        err.message.contains("IndexGet"),
+        "error should name the rejected construct: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary
- Phase A Slice 2 of the SIR22/SIR23 backend-expansion initiative — opens the C backend (`semantic-ir-to-c`) to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and implements the SIR22 array/matrix "base cut": `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and `Stmt::IndexSet` (the mutating counterpart). One of five parallel, independent backend PRs for this slice (C/Go/Rust/Ruby follow JS's inlined-runtime model; Python follows TS's imported-package model — see the SIR22 spec's "Backend impact" section).
- New `_sir_array_*` runtime (`runtime.rs`): an inlined port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime, behind a new `SIR_ARRAY` `SirValue` tag / `SirNDArray` struct (rank <= 2, column-major, plain-`double` storage — a deliberate, documented divergence from the sibling Ruby port, which preserves native Integer/Float propagation; C's statically-tagged `SirValue` makes uniform-double the simpler correct choice).
- Two hazard classes unique to C's static/unmanaged value model, absent from the JS/Ruby ports: shape-size multiplication (`rows * cols`) is checked for `int64_t` overflow **before** multiplying, not after (JS `Number`/Ruby `Integer` can't silently wrap the way C's fixed-width int can); and every index position is bounds-checked before the `(double)`→`int64_t` cast that would otherwise be undefined behaviour on a NaN or out-of-range value.
- The 9-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) shares these same three feature flags with the base cut, so a bare capability check can't tell them apart — extended this crate's **existing** structural pre-emit scan (`scan_expr_for_builtin`, folded into `first_unsupported_builtin`), not a new mechanism, to reject all nine cleanly until their own later slice.
- The same scan also rejects a ragged `ArrayLit` and an `IndexGet`/`IndexSet` with other than 1 or 2 index arguments at **compile time** — checks only possible because C's SIR AST shape (`rows: Vec<Vec<Expr>>`, `indices.len()`) is fully static, where the JS/Ruby ports could only validate these at runtime.
- New `tests/sir22_array.rs` (13 tests, ported from the JS backend's own `sir22_array.rs`): `matmul` of two 2x2 matrices, elementwise `Mul` with a bare-scalar operand (the `_sir_array_coerce` regression case), elementwise `Div`'s always-true-divide behaviour (vs. this backend's own bare `/`, which floors on two ints), `transpose`, `range` (explicit and default step), a `Whole` selector, `Stmt::IndexSet` (both `Scalar` and `IndexArg::Range` sub-range), plus 5 compile-time-rejection tests (2 APL-addendum nodes, a ragged literal, a rank-3 `IndexGet`).
- Cargo.toml 0.39.0 → 0.40.0; CHANGELOG.md and README.md updated (README's capability-declaration and "Rejects" sections now document the SIR22 base cut and the addendum's clean rejection).

## Test plan
- [x] Full `semantic-ir-to-c` test suite: 39 integration test binaries, all green (verified via exit code + per-binary `test result: ok` lines, not a summary grep)
- [x] New `tests/sir22_array.rs`: 13/13 passing against a real `cc` toolchain (real compile-and-run proof, not stubbed)
- [x] `cargo clippy -p semantic-ir-to-c --all-targets -- -D warnings` — clean
- [x] `/security-review` — PASSED, no vulnerabilities found (sub-agent traced the overflow-checked-size discipline, NaN-safe bounds checks, and the `va_arg`-count-is-a-compile-time-constant invariant end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)