### PR TITLE
fix(brainfuck): eliminate runtime grammar-file disk reads via build.rs

### DIFF
--- a/code/packages/rust/brainfuck/CHANGELOG.md
+++ b/code/packages/rust/brainfuck/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.0 — 2026-08-17
+
+### Changed
+
+- `lexer.rs`/`parser.rs` no longer read `brainfuck.tokens`/`brainfuck.grammar`
+  off disk at runtime via `env!("CARGO_MANIFEST_DIR")` path-climbing. Added
+  `build.rs`, which compiles both grammar files into Rust source (via
+  `grammar_tools::compiler`) at build time, embedded with `include!` and
+  cached in a `OnceLock` — the same pattern already used by `twig-lexer`/
+  `twig-parser`. This was the last Rust crate in the repo with runtime
+  grammar-file disk I/O; fixes a real gap (a published crate would not ship
+  `code/grammars/`) and restores Miri-sandbox compatibility (Miri's default
+  isolation mode blocks filesystem access).
+
 ## 0.3.0 — 2026-04-10
 
 ### Added

--- a/code/packages/rust/brainfuck/Cargo.toml
+++ b/code/packages/rust/brainfuck/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "brainfuck"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 virtual-machine = { path = "../virtual-machine" }
 grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
 parser = { path = "../parser" }
+
+[build-dependencies]
+grammar-tools = { path = "../grammar-tools" }

--- a/code/packages/rust/brainfuck/build.rs
+++ b/code/packages/rust/brainfuck/build.rs
@@ -1,0 +1,84 @@
+//! # brainfuck build script — compile brainfuck.tokens/.grammar into Rust at build time.
+//!
+//! Reads `code/grammars/brainfuck/brainfuck.tokens` and
+//! `code/grammars/brainfuck/brainfuck.grammar`, parses them via
+//! `grammar_tools::token_grammar::parse_token_grammar` /
+//! `grammar_tools::parser_grammar::parse_parser_grammar`, runs
+//! `grammar_tools::compiler::compile_token_grammar` /
+//! `compile_parser_grammar` to emit Rust source code that reconstructs
+//! the parsed grammars, and writes the results to `$OUT_DIR`.
+//!
+//! `src/lexer.rs` and `src/parser.rs` each `include!` their generated file
+//! inside a private module and wrap the generated constructor in a
+//! `OnceLock` so the struct is materialised exactly once per process.
+//!
+//! ## Why a build.rs
+//!
+//! Mirrors `twig-lexer/build.rs` / `twig-parser/build.rs` (the established
+//! pattern in this repo — see those files for the full rationale). In
+//! short: no runtime file I/O (works under Miri's default FS isolation,
+//! works in a published crate with no `code/grammars/` tree on disk),
+//! build-time validation, and one construction per process instead of one
+//! per lexer/parser call.
+//!
+//! ## Cargo rerun signals
+//!
+//! `cargo:rerun-if-changed` tells Cargo to re-run this build script
+//! whenever `build.rs` itself or either grammar file changes.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::{compile_parser_grammar, compile_token_grammar};
+use grammar_tools::parser_grammar::parse_parser_grammar;
+use grammar_tools::token_grammar::parse_token_grammar;
+
+fn main() {
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR must be set by cargo");
+
+    let grammars_dir = PathBuf::from(&manifest_dir)
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("grammars")
+        .join("brainfuck");
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // --- brainfuck.tokens -> OUT_DIR/brainfuck_token_grammar.rs ---
+    let tokens_path = grammars_dir.join("brainfuck.tokens");
+    let tokens_path = tokens_path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("Failed to resolve brainfuck.tokens path {tokens_path:?}: {e}"));
+    println!("cargo:rerun-if-changed={}", tokens_path.display());
+
+    let tokens_text = fs::read_to_string(&tokens_path)
+        .unwrap_or_else(|e| panic!("Failed to read {tokens_path:?}: {e}"));
+    let token_grammar = parse_token_grammar(&tokens_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {tokens_path:?}: {e}"));
+
+    let token_rust = compile_token_grammar(&token_grammar, "brainfuck.tokens");
+    let token_out_path = PathBuf::from(&out_dir).join("brainfuck_token_grammar.rs");
+    fs::write(&token_out_path, token_rust)
+        .unwrap_or_else(|e| panic!("Failed to write {token_out_path:?}: {e}"));
+
+    // --- brainfuck.grammar -> OUT_DIR/brainfuck_parser_grammar.rs ---
+    let grammar_path = grammars_dir.join("brainfuck.grammar");
+    let grammar_path = grammar_path.canonicalize().unwrap_or_else(|e| {
+        panic!("Failed to resolve brainfuck.grammar path {grammar_path:?}: {e}")
+    });
+    println!("cargo:rerun-if-changed={}", grammar_path.display());
+
+    let grammar_text = fs::read_to_string(&grammar_path)
+        .unwrap_or_else(|e| panic!("Failed to read {grammar_path:?}: {e}"));
+    let parser_grammar = parse_parser_grammar(&grammar_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {grammar_path:?}: {e}"));
+
+    let parser_rust = compile_parser_grammar(&parser_grammar, "brainfuck.grammar");
+    let parser_out_path = PathBuf::from(&out_dir).join("brainfuck_parser_grammar.rs");
+    fs::write(&parser_out_path, parser_rust)
+        .unwrap_or_else(|e| panic!("Failed to write {parser_out_path:?}: {e}"));
+}

--- a/code/packages/rust/brainfuck/src/lexer.rs
+++ b/code/packages/rust/brainfuck/src/lexer.rs
@@ -4,10 +4,10 @@
 // This module is the tokenization layer for Brainfuck source code. It is one
 // of three layers in the Brainfuck front-end pipeline:
 //
-//   brainfuck.tokens    (grammar file on disk — declarative token definitions)
-//          |
+//   brainfuck.tokens    (grammar file — declarative token definitions)
+//          |             compiled to Rust at BUILD time (see build.rs)
 //          v
-//   grammar-tools       (parses .tokens → TokenGrammar struct)
+//   grammar-tools       (compile_token_grammar embeds a TokenGrammar literal)
 //          |
 //          v
 //   lexer::GrammarLexer (tokenizes source using TokenGrammar)
@@ -40,48 +40,35 @@
 // character, so those never appear in the token stream. The parser sees
 // only the eight command tokens plus EOF.
 //
-// # Path navigation
+// # Grammar source
 //
-// This module lives inside the `brainfuck` crate. The crate's Cargo.toml
-// is at `code/packages/rust/brainfuck/Cargo.toml`, so CARGO_MANIFEST_DIR
-// points to `code/packages/rust/brainfuck/`. From there, the grammar file
-// is at `../../../grammars/brainfuck.tokens`.
+// The grammar is compiled ahead of time by `build.rs` (via
+// `grammar_tools::compiler::compile_token_grammar`) into Rust source
+// embedded at `$OUT_DIR/brainfuck_token_grammar.rs`, `include!`d below and
+// cached in a `OnceLock`. See `build.rs` for the full rationale (no
+// runtime file I/O, Miri-sandbox compatibility, one construction per
+// process). This mirrors `twig-lexer`/`twig-parser`, the canonical
+// reference for this pattern in the repo.
 
-use std::fs;
+use std::sync::OnceLock;
 
-use grammar_tools::token_grammar::parse_token_grammar;
+use grammar_tools::token_grammar::TokenGrammar;
 use lexer::grammar_lexer::GrammarLexer;
 use lexer::token::Token;
 
 // ===========================================================================
-// Grammar file location
+// Generated grammar (build.rs -> grammar-tools::compiler -> Rust)
 // ===========================================================================
 
-/// Build the path to the `brainfuck.tokens` grammar file.
-///
-/// We use `env!("CARGO_MANIFEST_DIR")` to get the directory containing this
-/// crate's `Cargo.toml` at compile time. From there, we navigate up to the
-/// `grammars/` directory at the repository root.
-///
-/// The directory structure looks like:
-///
-/// ```text
-/// code/
-///   grammars/
-///     brainfuck.tokens           <-- this is what we want
-///   packages/
-///     rust/
-///       brainfuck/
-///         Cargo.toml             <-- CARGO_MANIFEST_DIR points here
-///         src/
-///           lexer.rs             <-- we are here
-/// ```
-///
-/// So the relative path from CARGO_MANIFEST_DIR to the grammar file is:
-/// `../../../grammars/brainfuck.tokens`
-fn grammar_path() -> String {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest_dir}/../../../grammars/brainfuck/brainfuck.tokens")
+mod generated_grammar {
+    // build.rs writes this file; it defines `pub fn token_grammar() -> TokenGrammar`.
+    include!(concat!(env!("OUT_DIR"), "/brainfuck_token_grammar.rs"));
+}
+
+static BRAINFUCK_TOKEN_GRAMMAR: OnceLock<TokenGrammar> = OnceLock::new();
+
+fn brainfuck_token_grammar() -> &'static TokenGrammar {
+    BRAINFUCK_TOKEN_GRAMMAR.get_or_init(generated_grammar::token_grammar)
 }
 
 // ===========================================================================
@@ -90,10 +77,9 @@ fn grammar_path() -> String {
 
 /// Create a `GrammarLexer` configured for Brainfuck source text.
 ///
-/// This function:
-/// 1. Reads the `brainfuck.tokens` grammar file from disk.
-/// 2. Parses it into a `TokenGrammar` using `grammar-tools`.
-/// 3. Constructs a `GrammarLexer` with the grammar and the given source.
+/// This function looks up the build-time-compiled `TokenGrammar` (see
+/// "Generated grammar" above) and constructs a `GrammarLexer` with it and
+/// the given source.
 ///
 /// The returned lexer is ready to call `.tokenize()` on. Use this when you
 /// need access to the lexer object itself (e.g., for incremental tokenization
@@ -111,13 +97,6 @@ fn grammar_path() -> String {
 /// is discarded before the command characters are matched. The token stream
 /// the parser receives is clean: only the 8 commands and EOF.
 ///
-/// # Panics
-///
-/// Panics if the grammar file cannot be read or parsed. This should never
-/// happen in a correctly cloned repository — the grammar file is checked in
-/// and validated by grammar-tools tests. A panic here indicates a broken
-/// build or missing file.
-///
 /// # Example
 ///
 /// ```no_run
@@ -130,30 +109,7 @@ fn grammar_path() -> String {
 /// }
 /// ```
 pub fn create_brainfuck_lexer(source: &str) -> GrammarLexer<'_> {
-    // Step 1: Read the grammar file from disk.
-    //
-    // We read at runtime (not compile time via include_str!) because grammar
-    // files may be updated independently of Rust source. This also avoids
-    // embedding grammar text in the binary.
-    let grammar_text = fs::read_to_string(grammar_path())
-        .unwrap_or_else(|e| panic!("Failed to read brainfuck.tokens: {e}"));
-
-    // Step 2: Parse the grammar text into a structured TokenGrammar.
-    //
-    // The TokenGrammar for Brainfuck contains:
-    //   - 8 token definitions (one per command character)
-    //   - 2 skip patterns (WHITESPACE and COMMENT)
-    //   - No keywords (Brainfuck has none — all tokens are punctuation)
-    //   - Mode: default (no indentation tracking)
-    let grammar = parse_token_grammar(&grammar_text)
-        .unwrap_or_else(|e| panic!("Failed to parse brainfuck.tokens: {e}"));
-
-    // Step 3: Create and return the lexer.
-    //
-    // The GrammarLexer compiles all token patterns into anchored regexes
-    // and is ready to tokenize the source string. Because skip patterns
-    // consume comments, the caller only ever sees command tokens and EOF.
-    GrammarLexer::new(source, &grammar)
+    GrammarLexer::new(source, brainfuck_token_grammar())
 }
 
 /// Tokenize Brainfuck source text into a vector of tokens.
@@ -168,9 +124,9 @@ pub fn create_brainfuck_lexer(source: &str) -> GrammarLexer<'_> {
 ///
 /// # Panics
 ///
-/// Panics if the grammar file cannot be read/parsed. Brainfuck source
-/// never causes a tokenization error because every non-command character
-/// is treated as a comment — there is no "unexpected character" case.
+/// Brainfuck source never causes a tokenization error because every
+/// non-command character is treated as a comment — there is no
+/// "unexpected character" case.
 ///
 /// # Example
 ///
@@ -353,7 +309,19 @@ mod tests {
         // The '{' is a comment (not a command), so it is silently skipped.
         // We expect 8 command tokens.
         let n = names(&tokens);
-        assert_eq!(n, vec!["RIGHT", "LEFT", "INC", "DEC", "OUTPUT", "INPUT", "LOOP_START", "LOOP_END"]);
+        assert_eq!(
+            n,
+            vec![
+                "RIGHT",
+                "LEFT",
+                "INC",
+                "DEC",
+                "OUTPUT",
+                "INPUT",
+                "LOOP_START",
+                "LOOP_END"
+            ]
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -427,7 +395,11 @@ mod tests {
     fn test_comments_only() {
         let tokens = tokenize_brainfuck("hello this is all a comment");
         let n = names(&tokens);
-        assert_eq!(n.len(), 0, "Comments-only source should have no command tokens");
+        assert_eq!(
+            n.len(),
+            0,
+            "Comments-only source should have no command tokens"
+        );
         assert_eq!(tokens.last().unwrap().type_, TokenType::Eof);
     }
 
@@ -448,7 +420,16 @@ mod tests {
         let n = names(&tokens);
         assert_eq!(
             n,
-            vec!["INC", "INC", "LOOP_START", "RIGHT", "INC", "LEFT", "DEC", "LOOP_END"]
+            vec![
+                "INC",
+                "INC",
+                "LOOP_START",
+                "RIGHT",
+                "INC",
+                "LEFT",
+                "DEC",
+                "LOOP_END"
+            ]
         );
         // All command characters should have correct values.
         let v = values(&tokens);
@@ -464,7 +445,9 @@ mod tests {
     #[test]
     fn test_create_lexer() {
         let mut lexer = create_brainfuck_lexer("+");
-        let tokens = lexer.tokenize().expect("Lexer should tokenize successfully");
+        let tokens = lexer
+            .tokenize()
+            .expect("Lexer should tokenize successfully");
         // Should produce: INC, EOF
         assert_eq!(tokens.len(), 2);
         assert_eq!(tokens.last().unwrap().type_, TokenType::Eof);
@@ -482,6 +465,18 @@ mod tests {
         let source = "++ two increments [loop body >+<-] done";
         let tokens = tokenize_brainfuck(source);
         let n = names(&tokens);
-        assert_eq!(n, vec!["INC", "INC", "LOOP_START", "RIGHT", "INC", "LEFT", "DEC", "LOOP_END"]);
+        assert_eq!(
+            n,
+            vec![
+                "INC",
+                "INC",
+                "LOOP_START",
+                "RIGHT",
+                "INC",
+                "LEFT",
+                "DEC",
+                "LOOP_END"
+            ]
+        );
     }
 }

--- a/code/packages/rust/brainfuck/src/parser.rs
+++ b/code/packages/rust/brainfuck/src/parser.rs
@@ -4,10 +4,10 @@
 // This module is the parsing layer for Brainfuck source code. It sits above
 // the lexer in the three-stage front-end pipeline:
 //
-//   brainfuck.grammar    (grammar file on disk — rules for the parser)
-//          |
+//   brainfuck.grammar     (grammar file — rules for the parser)
+//          |               compiled to Rust at BUILD time (see build.rs)
 //          v
-//   grammar-tools        (parses .grammar → ParserGrammar struct)
+//   grammar-tools         (compile_parser_grammar embeds a ParserGrammar literal)
 //          |
 //          v
 //   parser::GrammarParser (builds an AST from tokens using ParserGrammar)
@@ -52,17 +52,36 @@
 //   - LOOP_END → end of enclosing loop
 //   - EOF → end of program
 //
-// # Path navigation
+// # Grammar source
 //
-// This module lives inside the `brainfuck` crate. CARGO_MANIFEST_DIR is
-// `code/packages/rust/brainfuck/`. The grammar file is at:
-//   `code/packages/rust/brainfuck/../../../grammars/brainfuck.grammar`
-//   = `code/grammars/brainfuck.grammar`
+// The grammar is compiled ahead of time by `build.rs` (via
+// `grammar_tools::compiler::compile_parser_grammar`) into Rust source
+// embedded at `$OUT_DIR/brainfuck_parser_grammar.rs`, `include!`d below and
+// cached in a `OnceLock`. See `build.rs` for the full rationale. This
+// mirrors `twig-parser`, the canonical reference for this pattern in the
+// repo — including the `.clone()` on each use: `GrammarParser::new` takes
+// `ParserGrammar` by value, so the cached `&'static ParserGrammar` is
+// cloned per parser construction (cheap relative to re-parsing from disk).
 
-use std::fs;
+use std::sync::OnceLock;
 
-use grammar_tools::parser_grammar::parse_parser_grammar;
-use parser::grammar_parser::{GrammarParser, GrammarASTNode};
+use grammar_tools::parser_grammar::ParserGrammar;
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+// ===========================================================================
+// Generated grammar (build.rs -> grammar-tools::compiler -> Rust)
+// ===========================================================================
+
+mod generated_grammar {
+    // build.rs writes this file; it defines `pub fn parser_grammar() -> ParserGrammar`.
+    include!(concat!(env!("OUT_DIR"), "/brainfuck_parser_grammar.rs"));
+}
+
+static BRAINFUCK_PARSER_GRAMMAR: OnceLock<ParserGrammar> = OnceLock::new();
+
+fn brainfuck_parser_grammar() -> &'static ParserGrammar {
+    BRAINFUCK_PARSER_GRAMMAR.get_or_init(generated_grammar::parser_grammar)
+}
 
 /// Recursion-depth cap for the Brainfuck [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -89,30 +108,6 @@ use parser::grammar_parser::{GrammarParser, GrammarASTNode};
 const MAX_RULE_DEPTH: usize = 170;
 
 // ===========================================================================
-// Grammar file location
-// ===========================================================================
-
-/// Build the path to the `brainfuck.grammar` file.
-///
-/// Uses the same strategy as the lexer module: `env!("CARGO_MANIFEST_DIR")`
-/// gives us the compile-time path to this crate's directory, and we navigate
-/// up to the shared `grammars/` directory.
-///
-/// ```text
-/// code/
-///   grammars/
-///     brainfuck.grammar         <-- target file
-///   packages/
-///     rust/
-///       brainfuck/
-///         Cargo.toml            <-- CARGO_MANIFEST_DIR
-/// ```
-fn grammar_path() -> String {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest_dir}/../../../grammars/brainfuck/brainfuck.grammar")
-}
-
-// ===========================================================================
 // Public API
 // ===========================================================================
 
@@ -123,8 +118,9 @@ fn grammar_path() -> String {
 /// 1. **Tokenization** — calls `super::lexer::tokenize_brainfuck` to break the
 ///    source into command tokens (comment characters are silently discarded).
 ///
-/// 2. **Grammar loading** — reads and parses `brainfuck.grammar`, which defines
-///    4 rules: program, instruction, loop, command.
+/// 2. **Grammar lookup** — clones the build-time-compiled `ParserGrammar`
+///    (see "Generated grammar" above), which defines 4 rules: program,
+///    instruction, loop, command.
 ///
 /// The returned `GrammarParser` is ready to call `.parse()` on.
 ///
@@ -136,12 +132,6 @@ fn grammar_path() -> String {
 /// - Use trace mode for debugging.
 ///
 /// For most use cases, `parse_brainfuck` is simpler.
-///
-/// # Panics
-///
-/// Panics if:
-/// - The `brainfuck.grammar` file cannot be read or parsed.
-/// - (tokenization never panics for Brainfuck — all non-command chars are skipped)
 ///
 /// # Example
 ///
@@ -161,30 +151,13 @@ pub fn create_brainfuck_parser(source: &str) -> GrammarParser {
     // Comment characters are silently consumed by the lexer's skip patterns.
     let tokens = super::lexer::tokenize_brainfuck(source);
 
-    // Step 2: Read the parser grammar from disk.
+    // Step 2: Create and return the parser.
     //
-    // The grammar file defines Brainfuck's syntactic structure in EBNF:
-    //   program     = { instruction } ;
-    //   instruction = loop | command ;
-    //   loop        = LOOP_START { instruction } LOOP_END ;
-    //   command     = RIGHT | LEFT | INC | DEC | OUTPUT | INPUT ;
-    let grammar_text = fs::read_to_string(grammar_path())
-        .unwrap_or_else(|e| panic!("Failed to read brainfuck.grammar: {e}"));
-
-    // Step 3: Parse the grammar text into a structured ParserGrammar.
-    //
-    // The ParserGrammar contains a list of GrammarRule objects, each with
-    // a name and a body (a tree of GrammarElement nodes encoding the EBNF).
-    // The rules are: program, instruction, loop, command.
-    let grammar = parse_parser_grammar(&grammar_text)
-        .unwrap_or_else(|e| panic!("Failed to parse brainfuck.grammar: {e}"));
-
-    // Step 4: Create and return the parser.
-    //
-    // GrammarParser takes ownership of both tokens and grammar. It builds
-    // internal indexes (rule lookup, memo cache) for efficient recursive
-    // descent parsing with packrat memoization.
-    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
+    // GrammarParser takes ownership of both tokens and grammar (hence the
+    // .clone() of the cached ParserGrammar). It builds internal indexes
+    // (rule lookup, memo cache) for efficient recursive descent parsing
+    // with packrat memoization.
+    GrammarParser::new(tokens, brainfuck_parser_grammar().clone()).with_max_depth(MAX_RULE_DEPTH)
 }
 
 /// Parse Brainfuck source text into an AST.
@@ -197,11 +170,10 @@ pub fn create_brainfuck_parser(source: &str) -> GrammarParser {
 /// nodes, each of which is either a `loop` node (for `[...]`) or a `command`
 /// node (for the six non-bracket commands).
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the grammar file is missing/invalid, or if the source has
-/// unmatched brackets. Well-formed Brainfuck (all brackets matched) will
-/// always parse successfully.
+/// Returns `Err` if the source has unmatched brackets. Well-formed
+/// Brainfuck (all brackets matched) will always parse successfully.
 ///
 /// # Example
 ///
@@ -286,7 +258,10 @@ mod tests {
         assert_program_root(&ast);
         // No instruction children expected.
         let instruction_count = count_rule(&ast, "instruction");
-        assert_eq!(instruction_count, 0, "Empty program should have no instructions");
+        assert_eq!(
+            instruction_count, 0,
+            "Empty program should have no instructions"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -299,7 +274,10 @@ mod tests {
         let ast = parse_brainfuck("+").expect("+  should parse");
         assert_program_root(&ast);
         assert!(find_rule(&ast, "command"), "Expected a 'command' node");
-        assert!(find_rule(&ast, "instruction"), "Expected an 'instruction' node");
+        assert!(
+            find_rule(&ast, "instruction"),
+            "Expected an 'instruction' node"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -313,7 +291,11 @@ mod tests {
         for src in &[">", "<", "+", "-", ".", ","] {
             let ast = parse_brainfuck(src).unwrap_or_else(|e| panic!("'{}' failed: {}", src, e));
             assert_program_root(&ast);
-            assert!(find_rule(&ast, "command"), "Expected 'command' for '{}'", src);
+            assert!(
+                find_rule(&ast, "command"),
+                "Expected 'command' for '{}'",
+                src
+            );
         }
     }
 
@@ -328,7 +310,10 @@ mod tests {
         let ast = parse_brainfuck("++>").expect("++> should parse");
         assert_program_root(&ast);
         let instruction_count = count_rule(&ast, "instruction");
-        assert_eq!(instruction_count, 3, "Expected 3 instruction nodes for '++>'");
+        assert_eq!(
+            instruction_count, 3,
+            "Expected 3 instruction nodes for '++>'"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the Rust leg of the runtime-grammar-loading elimination campaign (already done for Ruby, TypeScript, Elixir, Python, Lua, and Perl in this monorepo). An independent survey confirmed this was the *only* remaining gap in Rust — `code/packages/rust/grammar-tools` (with its `compile_token_grammar`/`compile_parser_grammar`) already exists and is already used by `twig-lexer`, `twig-parser`, `mccarthy-lisp-lexer`, `mccarthy-lisp-parser`, and every LSP bridge crate; `brainfuck` was the one holdout still using `env!("CARGO_MANIFEST_DIR")` path-climbing + `std::fs::read_to_string` at runtime.

- Added `code/packages/rust/brainfuck/build.rs`, compiling both `brainfuck.tokens` and `brainfuck.grammar` via `grammar_tools::compiler` at build time — an exact mirror of the existing `twig-lexer`/`twig-parser` pattern, just merged into one script since `brainfuck` houses both the lexer and parser in one crate.
- `lexer.rs`/`parser.rs` now `include!` the generated Rust and cache it in a `OnceLock`, eliminating runtime file I/O (fixes a real packaging gap — a published crate wouldn't ship `code/grammars/` — and restores Miri-sandbox compatibility, since Miri's default isolation mode blocks filesystem access).
- Cleaned up stale doc comments describing the old runtime-read path.

## Test plan

- [x] `cargo build -p brainfuck` and `cargo test -p brainfuck` — 64 unit tests + 5 doc tests pass.
- [x] `cargo clippy -p brainfuck --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` on the 3 touched files — clean (pre-existing drift in untouched `lib.rs` left as-is, out of scope).
- [x] `grep`-verified no `read_to_string`/`CARGO_MANIFEST_DIR` remains in `brainfuck/src/*.rs`.
- [x] Built and tested all downstream consumers (`brainfuck-{ir,iir,jvm,clr,wasm}-compiler`, `ir-to-jvm-class-file`, `ir-to-wasm-compiler`, `lang-aot`) against the new version — all pass. (One unrelated `lang-aot` WASM-closures test failure was confirmed pre-existing on unmodified `main` and unrelated to this change — flagged separately.)
- [x] Security review passed (build.rs paths are compiler-derived via `CARGO_MANIFEST_DIR`, not attacker input; `.clone()` on the cached `ParserGrammar` is ordinary safe Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)