### PR TITLE
feat(adj-facts-stdlib): add engineering-design-step.adj (engineering design, new source)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_engineeringdesignstep_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_engineeringdesignstep_e2e.rs
@@ -1,0 +1,112 @@
+//! End-to-end test for the engineering FACTS library
+//! (`adj-facts-stdlib/engineering/engineering-design-step.adj`) driven
+//! through the built CLI: a native `table` naming the six steps NASA's own
+//! "Engineering Design Process" student worksheet gives -- identify the
+//! problem, identify criteria and constraints, brainstorm possible
+//! solutions, select a design, build/test/refine (a single combined
+//! heading), and share the design. 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_engdesignstep_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("engineering/engineering-design-step.adj");
+    std::fs::copy(&src, dir.join("engineering-design-step.adj"))
+        .expect("copy shipped engineering-design-step.adj");
+}
+
+#[test]
+fn engineering_design_step_recall_binds_the_action_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"engineering-design-step.adj\"\n\
+         ? engineering_design_step(step_1, $A)\n\
+         ? engineering_design_step(step_3, $A)\n\
+         ? engineering_design_step(step_8, $A)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"A\":\"identify_the_problem\""),
+        "step 1 means identify_the_problem: {out}"
+    );
+    assert!(
+        out.contains("\"A\":\"brainstorm_possible_solutions\""),
+        "step 3 means brainstorm_possible_solutions: {out}"
+    );
+    assert!(
+        out.contains("\"A\":\"share_the_design\""),
+        "step 8 means share_the_design: {out}"
+    );
+    assert!(
+        out.contains("nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NASA citation: {out}"
+    );
+}
+
+#[test]
+fn engineering_design_step_reverse_binds_the_step_for_that_action() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"engineering-design-step.adj\"\n\
+         ? engineering_design_step($S, select_a_design)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"S\":\"step_4\""),
+        "the shipped select_a_design action is step_4: {out}"
+    );
+}
+
+#[test]
+fn engineering_design_step_abstains_honestly_on_an_ungrouped_step_number() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"engineering-design-step.adj\"\n\
+         ? engineering_design_step(step_5, $A)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "step_5 is a real step number the source's own step count implies exists, but the \
+         worksheet only ever names it as part of the COMBINED 'Steps 5-7' heading, never on \
+         its own -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/engineering/engineering-design-step.adj
+++ b/code/specs/data/adj-facts-stdlib/engineering/engineering-design-step.adj
@@ -1,0 +1,106 @@
+% ============================================================================
+% engineering-design-step — the engineering design process, as NASA's own
+% classroom worksheet names its steps in order (adj-facts-stdlib, ENGINEERING).
+% ============================================================================
+% This is the first table in a new `engineering/` subject directory in this
+% stdlib, and the first fresh-WebFetch slice this cycle ships into the
+% "K-8 science foundations" item's `engineering design` Major Gap — the prior
+% SIX cycles ran an exhaustive causal-composition sweep (no new WebFetch,
+% only deriving facts from tables already shipped) and, this cycle's own
+% scoping pass concluded, found no composable pair anywhere in the stdlib for
+% this gap: `physics/simple-machines.adj` and its two siblings
+% (`simple-machine-function.adj`, `simple-machine-alt-example.adj`) all decode
+% the SAME NASA sentence about the six classical machines (lever, wedge,
+% screw, ...) and share no atom with any independently-sourced second table.
+% "Engineering design" as an NGSS practice is a different thing entirely from
+% "name the six simple machines" — it is the repeatable PROCESS an engineer
+% follows (ask, plan, build, test, refine, share), which no simple-machine
+% table states or implies. This table grounds that process directly from a
+% new primary source.
+%
+% Recall is a binding query:
+%
+%     ? engineering_design_step(step_3, $A)   % brainstorm_possible_solutions
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `engineering_design_step(step, action)` carrying the citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% action WITH its source, on the CPU, with zero model calls, and abstains on
+% a step number the source does not name on its own (see below). The query
+% also runs BACKWARD — bind the action and recall which step performs it:
+%
+%     ? engineering_design_step($S, share_the_design)   % step_8
+%
+% The six named steps, as a little truth table (the worksheet's own heading
+% for each step, verbatim, alongside the atom this table gives it):
+%
+%     step        action                                                            heading (verbatim, NASA)
+%     ----------  --------------------------------------------------------------  -----------------------------------------------------------------
+%     step_1      identify_the_problem                                            "Step 1: Identify the problem."
+%     step_2      identify_criteria_and_constraints                               "Step 2: Identify criteria and constraints."
+%     step_3      brainstorm_possible_solutions                                   "Step 3: Brainstorm possible solutions."
+%     step_4      select_a_design                                                 "Step 4: Select a design"
+%     steps_5_7   build_a_prototype_test_and_evaluate_and_refine_the_design       "Steps 5-7: Build a prototype, test and evaluate, and refine the design."
+%     step_8      share_the_design                                                "Step 8: Share the design."
+%
+% IMPORTANT — why `steps_5_7` is ONE row, not three: the source worksheet
+% numbers eight steps overall, but groups the middle three under a SINGLE
+% combined heading, "Steps 5-7: Build a prototype, test and evaluate, and
+% refine the design." It never gives "build a prototype," "test and
+% evaluate," or "refine the design" its OWN "Step 5:" / "Step 6:" / "Step 7:"
+% heading the way it does for every other step — so splitting that heading
+% into three separate rows would assert a numbering precision the source
+% itself declines to state. This table keeps the source's own grouping
+% instead of inventing a finer one. A direct consequence: a query for `step_5`
+% or `step_6` or `step_7` alone ABSTAINS — those are real step numbers the
+% worksheet's own step count implies exist, but the source never names any of
+% them individually, so recalling one honestly abstains rather than guessing
+% which third of the combined heading it would have been.
+%
+% Provenance: quoted verbatim from NASA's "The Engineering Design Process"
+% student worksheet — the companion handout NASA's Next Gen STEM "Engineering
+% Design Process" classroom-connection lesson (Grades 6-12, NGSS standards
+% MS-ETS1-1 and HS-ETS1-3; see the SAME family of Next Gen STEM PDFs that
+% `physics/simple-machines.adj` already cites for a different lesson)
+% instructs the teacher to "Distribute one Engineering Design Process
+% Worksheet per student." Each step's exact heading text above is quoted
+% character-for-character from that worksheet, extracted with `pdftotext
+% -layout` from the fetched PDF, so any reader can re-check it. An ADJ
+% `table` carries ONE provenance envelope, so `source`/`locator`/`trust`
+% below hold the strongest single span (step 1's heading, which fixes the
+% first row); every OTHER row's own verbatim heading is quoted above and
+% additionally carried as its own `cites` entry below, so each step remains
+% independently checkable. The source is a primary U.S. government NASA
+% education page (nasa.gov), so `trust authoritative`.
+%
+% A term related to engineering design but not one of these six step atoms —
+% "prototype" on its own (the worksheet only ever uses it INSIDE the combined
+% steps_5_7 heading, never as a step name of its own) or a ninth step the
+% worksheet does not have — has no row, so a recall on it ABSTAINS rather
+% than inventing a step. That honest-abstention property, plus the
+% `steps_5_7` grouping decision above, is what makes this table safe to
+% reason from.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table engineering_design_step {
+    columns step, action
+
+    row (step_1, identify_the_problem)
+    row (step_2, identify_criteria_and_constraints)
+    row (step_3, brainstorm_possible_solutions)
+    row (step_4, select_a_design)
+    row (steps_5_7, build_a_prototype_test_and_evaluate_and_refine_the_design)
+    row (step_8, share_the_design)
+
+    source "Step 1: Identify the problem."
+    locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+    trust authoritative
+
+    cites "Step 2: Identify criteria and constraints." locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+    cites "Step 3: Brainstorm possible solutions." locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+    cites "Step 4: Select a design" locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+    cites "Steps 5-7: Build a prototype, test and evaluate, and refine the design." locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+    cites "Step 8: Share the design." locator "https://www.nasa.gov/wp-content/uploads/2021/07/the_engineering_design_process_worksheet.pdf"
+}

--- a/code/specs/data/adj-facts-stdlib/engineering/engineering-design-step.query.adj
+++ b/code/specs/data/adj-facts-stdlib/engineering/engineering-design-step.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% engineering-design-step.query.adj — worked recall over the
+% engineering-design-step library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what happens in step 3
+% of the engineering design process?" (direct) or "which step is 'select a
+% design'?" (reverse) — it states no fact of its own — it only `import`s the
+% grounded table and asks binding queries. The final query demonstrates
+% honest abstention: `step_5` is a real step number the source's own step
+% count implies exists, but the worksheet never gives it an individual
+% heading (it only appears inside the COMBINED "Steps 5-7" heading), so
+% recalling it alone abstains rather than guessing.
+% ============================================================================
+
+import "engineering-design-step.adj"
+
+? engineering_design_step(step_1, $A)              % expect identify_the_problem (direct)
+? engineering_design_step(step_3, $A)              % expect brainstorm_possible_solutions (direct)
+? engineering_design_step(step_8, $A)              % expect share_the_design (direct)
+? engineering_design_step($S, select_a_design)      % expect step_4 (reverse)
+? engineering_design_step(step_5, $A)               % expect abstain -- no individual heading for step 5, only the combined steps_5_7 heading

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 318 | 321 | 317 (99.7%) | 318 (100.0%) | 318 (100.0%) | 0 (0.0%) |
+| facts | 320 | 323 | 319 (99.7%) | 320 (100.0%) | 320 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -27,10 +27,11 @@ provenance bundle whose CAS graph proves all cited source bytes.
 | `facts/anatomy` | 32 | 32 | 32 | 32 | 32 | 0 |
 | `facts/art` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/astronomy` | 18 | 18 | 18 | 18 | 18 | 0 |
-| `facts/biology` | 58 | 58 | 57 | 58 | 58 | 0 |
+| `facts/biology` | 59 | 59 | 58 | 59 | 59 | 0 |
 | `facts/calendar` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `facts/chemistry` | 19 | 19 | 19 | 19 | 19 | 0 |
 | `facts/earth-science` | 11 | 11 | 11 | 11 | 11 | 0 |
+| `facts/engineering` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/environment` | 3 | 3 | 3 | 3 | 3 | 0 |
 | `facts/geography` | 12 | 12 | 12 | 12 | 12 | 0 |
 | `facts/geology` | 12 | 12 | 12 | 12 | 12 | 0 |
@@ -71,7 +72,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (544)
+### Missing pinned source bytes (546)
 
 See the JSON form of this report for the complete machine-readable list.
 

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -2762,6 +2762,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.6to8.engineering_design_step",
+      "title": "Recall the named step of the engineering design process that a given action belongs to",
+      "band": "6-8",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/engineering/engineering-design-step.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- First fresh-WebFetch table shipped into the `wave2-k8-science-foundations` item's `engineering design` Major Gap, after six prior cycles of reuse-only causal-composition (deriving facts from already-shipped tables) which exhaustively concluded no composable pair exists for this gap anywhere in the stdlib.
- Grounds the engineering design PROCESS itself (`engineering_design_step(step, action)`), quoted verbatim from NASA's "The Engineering Design Process" student worksheet (nasa.gov, the companion handout to NASA's Next Gen STEM "Engineering Design Process" classroom lesson, Grades 6-12, NGSS MS-ETS1-1/HS-ETS1-3) -- a different angle from the already-shipped `physics/simple-machines.adj` family (which names the six classical machines, not the design process).
- Six named steps; the source's own combined "Steps 5-7" heading is kept as ONE row rather than invented as three separate steps -- querying `step_5`/`step_6`/`step_7` individually abstains honestly.
- New `engineering/` subject directory (first table in it). Adds manifest recall objective `adj.science.6to8.engineering_design_step` (NGSS) and regenerates `COVERAGE.md`.

## Test plan
- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI check against `engineering-design-step.query.adj` -- all 5 queries resolve as expected (3 direct, 1 reverse, 1 honest abstention on `step_5`)
- [x] `cargo test -p adj-lang-cli --test facts_engineeringdesignstep_e2e` (3/3 pass)
- [x] Full `adj-lang-cli` test suite green
- [x] `python3 code/scripts/adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0); regenerated `COVERAGE.md` committed
- [x] `python3 code/scripts/adj_stdlib_manifest.py --validate-json-schema` -- same pre-existing errors present on `origin/main` baseline (formula-provenance/CAS-containment, unrelated to this change and environment-specific); confirmed by diffing against a stash of the baseline
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` clean
- [x] Security review sub-agent: PASSED, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)