### PR TITLE
feat(adj-facts-stdlib): add scientific-method-step.adj (experiments, new source)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_scientificmethodstep_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_scientificmethodstep_e2e.rs
@@ -1,0 +1,111 @@
+//! End-to-end test for the science FACTS library
+//! (`adj-facts-stdlib/science/scientific-method-step.adj`) driven through the
+//! built CLI: a native `table` naming the seven steps NASA Space Place's own
+//! "Steps in Scientific Method" student page gives -- state a hypothesis,
+//! define variables and controls, research, design the experiment, run the
+//! experiment and record data, analyze the data, and draw conclusions.
+//! 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_scimethodstep_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("science/scientific-method-step.adj");
+    std::fs::copy(&src, dir.join("scientific-method-step.adj"))
+        .expect("copy shipped scientific-method-step.adj");
+}
+
+#[test]
+fn scientific_method_step_recall_binds_the_action_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-method-step.adj\"\n\
+         ? scientific_method_step(step_1, $A)\n\
+         ? scientific_method_step(step_4, $A)\n\
+         ? scientific_method_step(step_7, $A)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"A\":\"ask_a_question_or_state_a_hypothesis\""),
+        "step 1 means ask_a_question_or_state_a_hypothesis: {out}"
+    );
+    assert!(
+        out.contains("\"A\":\"design_the_experiment\""),
+        "step 4 means design_the_experiment: {out}"
+    );
+    assert!(
+        out.contains("\"A\":\"draw_conclusions_and_write_a_report\""),
+        "step 7 means draw_conclusions_and_write_a_report: {out}"
+    );
+    assert!(
+        out.contains("nasa.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NASA citation: {out}"
+    );
+}
+
+#[test]
+fn scientific_method_step_reverse_binds_the_step_for_that_action() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-method-step.adj\"\n\
+         ? scientific_method_step($S, analyze_the_data)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"S\":\"step_6\""),
+        "the shipped analyze_the_data action is step_6: {out}"
+    );
+}
+
+#[test]
+fn scientific_method_step_abstains_honestly_on_an_undefined_step_number() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-method-step.adj\"\n\
+         ? scientific_method_step(step_8, $A)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "the source page only ever numbers steps 1 through 7 -- there is no step 8 to \
+         recall, so honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/science/scientific-method-step.adj
+++ b/code/specs/data/adj-facts-stdlib/science/scientific-method-step.adj
@@ -1,0 +1,115 @@
+% ============================================================================
+% scientific-method-step — the steps of the scientific method, as NASA Space
+% Place's own student page names them in order (adj-facts-stdlib, SCIENCE).
+% ============================================================================
+% This is the first table in a new `science/` subject directory in this
+% stdlib, and grounds the "experiments" Major Gap the "K-8 science
+% foundations" item's own notes record as fully untouched through six prior
+% cycles of reuse-only causal-composition: a full-tree atom-overlap census
+% (see this item's loop-state notes, cycle 6) found no table anywhere in the
+% stdlib addressing the scientific method, hypotheses, variables, or
+% experimental design as a concept, and confirmed no independently-sourced
+% second table shares an atom with any candidate in this space — so, per
+% this item's own established playbook (the same one that shipped
+% `engineering/engineering-design-step.adj`), this table grounds the concept
+% directly from a fresh primary source instead.
+%
+% This is a DIFFERENT process from `engineering/engineering-design-step.adj`,
+% not a restatement of it under a new name: that table names the repeatable
+% steps an ENGINEER follows to build something (identify the problem, define
+% constraints, brainstorm, select, build/test/refine, share) — an NGSS
+% Engineering Design practice. This table names the repeatable steps a
+% SCIENTIST follows to test an idea about how the world already works (state
+% a hypothesis, define variables and controls, research, design an
+% experiment, run it, analyze the data, conclude) — the NGSS Science
+% practice of planning and carrying out investigations. The two tables share
+% zero atoms: no step name, action, or example overlaps between them.
+%
+% Recall is a binding query:
+%
+%     ? scientific_method_step(step_4, $A)   % design_the_experiment
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `scientific_method_step(step, action)` carrying the citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% action WITH its source, on the CPU, with zero model calls, and abstains on
+% a step number the source does not define (see below). The query also runs
+% BACKWARD — bind the action and recall which step performs it:
+%
+%     ? scientific_method_step($S, analyze_the_data)   % step_6
+%
+% The seven named steps, as a little truth table (the page's own text for
+% each step, verbatim, alongside the atom this table gives it):
+%
+%     step      action                                    heading (verbatim, NASA Space Place)
+%     --------  ----------------------------------------  -----------------------------------------------------------------------------------------------------------------------------
+%     step_1    ask_a_question_or_state_a_hypothesis       "Ask a question or make a statement that you can test by an experiment. This statement is called a hypothesis."
+%     step_2    define_variables_and_controls              "Define the parts of your experiment that will change. These are called variables. Define the parts of your experiment that will not change. These are called controls."
+%     step_3    research_what_is_already_known             "Find out what people have already said or written about the subject."
+%     step_4    design_the_experiment                      "Think of an experiment to test the hypothesis."
+%     step_5    do_the_experiment_and_record_the_data      "Now do the experiment and carefully record the data."
+%     step_6    analyze_the_data                           "Figure out what the data means."
+%     step_7    draw_conclusions_and_write_a_report        "Draw conclusions and write a report."
+%
+% IMPORTANT — why `step_2` is ONE row naming BOTH variables and controls,
+% not two rows: the source page groups both definitions ("Define the parts
+% of your experiment that will change. These are called variables." AND
+% "Define the parts of your experiment that will not change. These are
+% called controls.") under the SINGLE heading "Step 2.", the same way it
+% groups each of the other six steps under their own single heading. Every
+% other step on the page states exactly one instruction under its heading;
+% only step 2 states two, back to back, under the one heading. Splitting
+% that heading into a "step_2a" (variables) and "step_2b" (controls) would
+% assert a numbering the source itself never gives — it never calls either
+% half "Step 2a" or "Step 2b" — so this table keeps the source's own
+% grouping instead of inventing a finer one, the same discipline
+% `engineering/engineering-design-step.adj` already established for its own
+% `steps_5_7` row.
+%
+% Provenance: quoted verbatim from NASA Space Place's "Steps in Scientific
+% Method" page (a NASA Science education resource for students, published
+% under the "One Way to Do Science..." heading), a direct child of the
+% nasa.gov domain. Each step's exact text above is quoted character-for-
+% character from the fetched page (HTML fetched directly; only doubled
+% internal whitespace from the page's own markup was collapsed to a single
+% space — no wording was added, removed, or reordered), so any reader can
+% re-check it. An ADJ `table` carries ONE provenance envelope, so
+% `source`/`locator`/`trust` below hold the strongest single span (step 1's
+% text, which fixes the first row); every OTHER row's own verbatim text is
+% quoted above and additionally carried as its own `cites` entry below, so
+% each step remains independently checkable. The source is a NASA Science
+% education page (nasa.gov), so `trust authoritative`.
+%
+% A term this page uses but that is not itself one of these seven step
+% atoms — "hypothesis" (defined INSIDE step 1's action, never a step name of
+% its own), "variable" or "control" (defined INSIDE step 2's action), or an
+% eighth step the page does not have — has no row, so a recall on it
+% ABSTAINS rather than inventing a step. That honest-abstention property,
+% plus the `step_2` grouping decision above, is what makes this table safe
+% to reason from.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table scientific_method_step {
+    columns step, action
+
+    row (step_1, ask_a_question_or_state_a_hypothesis)
+    row (step_2, define_variables_and_controls)
+    row (step_3, research_what_is_already_known)
+    row (step_4, design_the_experiment)
+    row (step_5, do_the_experiment_and_record_the_data)
+    row (step_6, analyze_the_data)
+    row (step_7, draw_conclusions_and_write_a_report)
+
+    source "Ask a question or make a statement that you can test by an experiment. This statement is called a hypothesis."
+    locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    trust authoritative
+
+    cites "Define the parts of your experiment that will change. These are called variables. Define the parts of your experiment that will not change. These are called controls." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    cites "Find out what people have already said or written about the subject." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    cites "Think of an experiment to test the hypothesis." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    cites "Now do the experiment and carefully record the data." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    cites "Figure out what the data means." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+    cites "Draw conclusions and write a report." locator "https://spaceplace.nasa.gov/review/science-fair/scientific-method.html"
+}

--- a/code/specs/data/adj-facts-stdlib/science/scientific-method-step.query.adj
+++ b/code/specs/data/adj-facts-stdlib/science/scientific-method-step.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% scientific-method-step.query.adj — worked recall over the
+% scientific-method-step library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what happens in step 4
+% of the scientific method?" (direct) or "which step figures out what the
+% data means?" (reverse) — it states no fact of its own — it only `import`s
+% the grounded table and asks binding queries. The final query demonstrates
+% honest abstention: `step_8` is not a step this source names at all (the
+% page only ever numbers steps 1 through 7), so recalling it abstains
+% rather than inventing an eighth step.
+% ============================================================================
+
+import "scientific-method-step.adj"
+
+? scientific_method_step(step_1, $A)              % expect ask_a_question_or_state_a_hypothesis (direct)
+? scientific_method_step(step_4, $A)              % expect design_the_experiment (direct)
+? scientific_method_step(step_7, $A)              % expect draw_conclusions_and_write_a_report (direct)
+? scientific_method_step($S, analyze_the_data)     % expect step_6 (reverse)
+? scientific_method_step(step_8, $A)               % expect abstain -- the source only names steps 1 through 7

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 320 | 323 | 319 (99.7%) | 320 (100.0%) | 320 (100.0%) | 0 (0.0%) |
+| facts | 321 | 324 | 320 (99.7%) | 321 (100.0%) | 321 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -46,6 +46,7 @@ provenance bundle whose CAS graph proves all cited source bytes.
 | `facts/oceanography` | 8 | 8 | 8 | 8 | 8 | 0 |
 | `facts/optics` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/physics` | 31 | 32 | 31 | 31 | 31 | 0 |
+| `facts/science` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/transportation` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `formulas/arithmetic` | 10 | 20 | 10 | 10 | 10 | 0 |
 | `formulas/chemistry` | 7 | 26 | 7 | 7 | 7 | 0 |
@@ -72,7 +73,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (546)
+### Missing pinned source bytes (547)
 
 See the JSON form of this report for the complete machine-readable list.
 

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -2777,6 +2777,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.3to5.scientific_method_step",
+      "title": "Recall the named step of the scientific method that a given action belongs to",
+      "band": "3-5",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/science/scientific-method-step.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Grounds the **"experiments" Major Gap** in the K-8 science foundations item (`ADJ-STDLIB-COVERAGE.md` 5.1/5.2), fully untouched through six prior cycles of reuse-only causal-composition. This cycle's own full-tree grep census (experiment/hypothesis/variable/control group/scientific method) confirmed no table anywhere in the stdlib addresses the scientific method, hypotheses, variables, or experimental design as a concept.
- New `science/` subject directory (first table in it): `scientific_method_step(step, action)`, sourced from **NASA Space Place's "Steps in Scientific Method"** student page (`spaceplace.nasa.gov`, a NASA Science education resource) — 7 rows for the 7 numbered steps the page states, each action quoted verbatim.
- Genuinely distinct from the already-shipped `engineering/engineering-design-step.adj`: that table names the ENGINEER's process (NGSS Engineering Design), this one names the SCIENTIST's process (NGSS Science practice of planning/carrying out investigations). Zero shared atoms.
- Honest abstention verified: `step_8` abstains, since the source only ever numbers seven steps.
- Adds manifest objective `adj.science.3to5.scientific_method_step` (recall, NGSS, band 3-5). Regenerates `COVERAGE.md`.

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI check against `scientific-method-step.query.adj` — all 5 queries resolve as expected (3 direct, 1 reverse, 1 honest abstention)
- [x] `cargo test -p adj-lang-cli --test facts_scientificmethodstep_e2e` — 3/3 pass
- [x] Full `adj-lang-cli` test suite green (no failures)
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, `COVERAGE.md` regenerated and committed
- [x] `adj_stdlib_manifest.py --validate-json-schema` — same 21 pre-existing formula-provenance/CAS-containment errors as the origin/main baseline (confirmed identical via a stash-isolated baseline diff); this objective introduces zero new errors
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Security review sub-agent — PASSED, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)