### PR TITLE
feat(adj-facts-stdlib): add scientific-model-type.adj (models, new source)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_scientificmodeltype_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_scientificmodeltype_e2e.rs
@@ -1,0 +1,112 @@
+//! End-to-end test for the science FACTS library
+//! (`adj-facts-stdlib/science/scientific-model-type.adj`) driven through the
+//! built CLI: a native `table` naming the three kinds of scientific model
+//! CK-12's Middle School Earth Science FlexBook 2.0 defines -- physical,
+//! conceptual, and mathematical -- each with its own defining sentence.
+//! 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_scimodeltype_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("science/scientific-model-type.adj");
+    std::fs::copy(&src, dir.join("scientific-model-type.adj"))
+        .expect("copy shipped scientific-model-type.adj");
+}
+
+#[test]
+fn scientific_model_type_recall_binds_the_description_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-model-type.adj\"\n\
+         ? scientific_model_type(physical, $D)\n\
+         ? scientific_model_type(conceptual, $D)\n\
+         ? scientific_model_type(mathematical, $D)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"D\":\"smaller_and_simpler_representation_of_the_thing_being_studied\""),
+        "physical means a smaller and simpler representation: {out}"
+    );
+    assert!(
+        out.contains("\"D\":\"ties_together_many_ideas_to_explain_a_phenomenon_or_event\""),
+        "conceptual means tying together many ideas: {out}"
+    );
+    assert!(
+        out.contains(
+            "\"D\":\"sets_of_equations_that_take_into_account_many_factors_to_represent_a_phenomenon\""
+        ),
+        "mathematical means sets of equations: {out}"
+    );
+    assert!(
+        out.contains("k12.libretexts.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the CK-12/LibreTexts citation at consensus trust: {out}"
+    );
+}
+
+#[test]
+fn scientific_model_type_reverse_binds_the_type_for_that_description() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-model-type.adj\"\n\
+         ? scientific_model_type($T, ties_together_many_ideas_to_explain_a_phenomenon_or_event)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"T\":\"conceptual\""),
+        "the shipped ties-together-many-ideas description is the conceptual type: {out}"
+    );
+}
+
+#[test]
+fn scientific_model_type_abstains_honestly_on_an_undefined_computer_type() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"scientific-model-type.adj\"\n\
+         ? scientific_model_type(computer, $D)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "the source closes its taxonomy at physical/conceptual/mathematical -- there is no \
+         separate `computer` type to recall, so honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/science/scientific-model-type.adj
+++ b/code/specs/data/adj-facts-stdlib/science/scientific-model-type.adj
@@ -1,0 +1,145 @@
+% ============================================================================
+% scientific-model-type — the three kinds of scientific model a K-8 Earth
+% Science textbook names, and the one-sentence definition each gets
+% (adj-facts-stdlib, SCIENCE).
+% ============================================================================
+% This grounds "models" — the THIRD and last of the three K-8-science Major
+% Gaps this item's notes have tracked as fully untouched since they were
+% first flagged (alongside "experiments", shipped as
+% `science/scientific-method-step.adj`, and "engineering design", shipped as
+% `engineering/engineering-design-step.adj`). Two prior cycles flagged
+% "models" specifically as HARDER to find table-shaped primary-source
+% content for than the other two gaps, so this cycle's own search tried
+% several distinct angles before landing here:
+%
+%   1. Historical atomic models (Dalton/Thomson/Rutherford/Bohr) as a
+%      numbered sequence, the same shape as `scientific-method-step.adj`'s
+%      seven steps. WebFetched MIT OpenCourseWare's "Atomic Models:
+%      Rutherford & Bohr" lecture page and a UPenn WRDS-classroom timeline
+%      page (the latter did not resolve via DNS at fetch time). MIT OCW
+%      presented Thomson/Rutherford/Bohr as three separate narrative
+%      paragraphs with their own bullet points, not a unified sequential
+%      table naming all four scientists — rejected as not table-shaped.
+%   2. NASA/NOAA/NIST pages defining "types of models" (physical/
+%      conceptual/mathematical/computer) directly. WebSearched and
+%      WebFetched `nasaeclips.arc.nasa.gov` (redirected to a generic
+%      landing page, no model-types content survived the redirect),
+%      `mynasadata.larc.nasa.gov`'s "Developing and Using Models with MND"
+%      page (states the same flat sentence Appendix F does — see angle 3 —
+%      but no table, and confirmed via WebFetch to have no dedicated
+%      types-of-models download), and NSTA's "Using Models to Teach
+%      Science" (discusses HOW to build one model with a class, never
+%      categorizes model types at all) — rejected, no table found.
+%   3. The NGSS Framework/Appendix F's own definitional sentence for the
+%      "Developing and Using Models" practice. WebFetched the official
+%      Appendix F PDF (nextgenscience.org) directly and confirmed via
+%      `pdftotext -layout`: "Models include diagrams, physical replicas,
+%      mathematical representations, analogies, and computer simulations."
+%      — a real, citable, NGSS-authoritative sentence, but a flat list of
+%      SIX nouns with no individual definition attached to any of them, so
+%      building a two-column (type, definition) table from it would mean
+%      inventing definitions the source itself never states — rejected on
+%      that same "don't force a thin source into a table" ground the
+%      sibling sweeps used.
+%   4. Types of scientific models WITH a definition sentence for each type,
+%      from a K-8-audience textbook. WebFetched CK-12 Foundation's Middle
+%      School Earth Science FlexBook 2.0 (as hosted, and lightly re-edited
+%      to LibreTexts house style, at k12.libretexts.org), section "1.10:
+%      Scientific Models" — its own "Models are Useful Tools" section
+%      states, as three separate bullet points, "There are different types
+%      of models" followed immediately by one full defining sentence (two
+%      for physical and mathematical) for EACH of physical, conceptual,
+%      and mathematical models, and its own Summary line closes the
+%      taxonomy explicitly: "Models may be physical, conceptual, or
+%      mathematical." This is genuinely table-shaped (three named types,
+%      each with its own citable defining sentence) and the taxonomy is
+%      exhaustive per the source's own Summary — angle 4 is what this
+%      table grounds.
+%
+% A full-tree grep for `\bmodel\b` across this stdlib (confirming no
+% duplication before scoping, per this item's established playbook) hits
+% dozens of files, but EVERY hit is the incidental phrase "zero model
+% calls" (or "zero answer-time model calls") in each table's own boilerplate
+% commentary about the ADJ engine — never a genuine scientific-model fact.
+% This table is the FIRST genuine scientific-model content anywhere in this
+% stdlib.
+%
+% Recall is a binding query:
+%
+%     ? scientific_model_type(physical, $D)
+%       % smaller_and_simpler_representation_of_the_thing_being_studied
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `scientific_model_type(type, description)` carrying the
+% citation, so the lookup above is the ordinary SLD binding query — the
+% engine returns the description WITH its source, on the CPU, with zero
+% model calls, and abstains on a model type the source does not name (see
+% below). The query also runs BACKWARD — bind the description and recall
+% which type it defines:
+%
+%     ? scientific_model_type($T, ties_together_many_ideas_to_explain_a_phenomenon_or_event)
+%       % conceptual
+%
+% The three named model types, as a little truth table (the page's own text
+% for each, verbatim, alongside the atom this table gives it):
+%
+%     type          description (atom)                                                          quote (verbatim, CK-12 Middle School Earth Science FlexBook 2.0)
+%     ------------  --------------------------------------------------------------------------   -------------------------------------------------------------------------------------------------------------------------------
+%     physical      smaller_and_simpler_representation_of_the_thing_being_studied                "Physical models are smaller and simpler representations of the thing being studied. A globe or a map is a physical model of a portion or all of Earth."
+%     conceptual    ties_together_many_ideas_to_explain_a_phenomenon_or_event                     "Conceptual models tie together many ideas to explain a phenomenon or event."
+%     mathematical  sets_of_equations_that_take_into_account_many_factors_to_represent_a_phenomenon  "Mathematical models are sets of equations that take into account many factors to represent a phenomenon. Mathematical models are usually done on computers."
+%
+% IMPORTANT — why there is no fourth `computer` row: the source's own text
+% mentions computers only as an implementation detail OF a mathematical
+% model ("Mathematical models are usually done on computers... Many models
+% are created on computers... Only computers can handle and manipulate such
+% enormous amounts of data"), never as a fourth category with its own
+% defining sentence — and the page's own Summary line closes the taxonomy
+% at exactly three: "Models may be physical, conceptual, or mathematical."
+% Adding a `computer` row would assert a category the source itself never
+% names as one, so a recall on it ABSTAINS instead (see the query file).
+%
+% Provenance: quoted verbatim from CK-12 Foundation's Middle School Earth
+% Science FlexBook 2.0, section "1.10: Scientific Models", as hosted (and
+% edited to LibreTexts house style, with no change to the quoted sentences
+% themselves) at k12.libretexts.org — an open, CK-12-licensed K-12 science
+% textbook actually used in classrooms, not a primary government or
+% standards-body source, hence `trust consensus` (the same tier
+% `language/figurative-language-type.adj` already established for a
+% reputable secondary/tertiary reference, and NOT `authoritative`, which
+% this stdlib reserves for a primary .gov/.edu/standards source). Each
+% type's exact text above is quoted character-for-character from the
+% fetched page (HTML fetched directly; only doubled internal whitespace
+% from the page's own markup was collapsed to a single space — no wording
+% was added, removed, or reordered), so any reader can re-check it. An ADJ
+% `table` carries ONE provenance envelope, so `source`/`locator`/`trust`
+% below hold the strongest single span (the `physical` row's text, which
+% fixes the first row); every OTHER row's own verbatim text is quoted above
+% and additionally carried as its own `cites` entry below, so each type
+% remains independently checkable.
+%
+% A word this page uses but that is not itself one of these three type
+% atoms — "computer" (see above), "globe" or "map" (named INSIDE the
+% `physical` row's own example, never a type name of its own), or "climate
+% model" (an EXAMPLE the page later gives of a mathematical model, not a
+% fourth type) — has no row, so a recall on it ABSTAINS rather than
+% inventing a type. That honest-abstention property is what makes this
+% table safe to reason from.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table scientific_model_type {
+    columns type, description
+
+    row (physical, smaller_and_simpler_representation_of_the_thing_being_studied)
+    row (conceptual, ties_together_many_ideas_to_explain_a_phenomenon_or_event)
+    row (mathematical, sets_of_equations_that_take_into_account_many_factors_to_represent_a_phenomenon)
+
+    source "Physical models are smaller and simpler representations of the thing being studied. A globe or a map is a physical model of a portion or all of Earth."
+    locator "https://k12.libretexts.org/Bookshelves/Science_and_Technology/Earth_Science/01:_The_Nature_of_Science/1.10:_Scientific_Models"
+    trust consensus
+
+    cites "Conceptual models tie together many ideas to explain a phenomenon or event." locator "https://k12.libretexts.org/Bookshelves/Science_and_Technology/Earth_Science/01:_The_Nature_of_Science/1.10:_Scientific_Models"
+    cites "Mathematical models are sets of equations that take into account many factors to represent a phenomenon. Mathematical models are usually done on computers." locator "https://k12.libretexts.org/Bookshelves/Science_and_Technology/Earth_Science/01:_The_Nature_of_Science/1.10:_Scientific_Models"
+}

--- a/code/specs/data/adj-facts-stdlib/science/scientific-model-type.query.adj
+++ b/code/specs/data/adj-facts-stdlib/science/scientific-model-type.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% scientific-model-type.query.adj — worked recall over the
+% scientific-model-type library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what kind of model is
+% a globe?" (a `physical` model, by definition, direct) or "which type of
+% model ties together many ideas to explain a phenomenon?" (reverse) — it
+% states no fact of its own — it only `import`s the grounded table and asks
+% binding queries. The final query demonstrates honest abstention:
+% `computer` is not a type this source names on its own (the page only ever
+% closes its taxonomy at physical/conceptual/mathematical, mentioning
+% computers only as an implementation detail of a mathematical model), so
+% recalling it abstains rather than inventing a fourth type.
+% ============================================================================
+
+import "scientific-model-type.adj"
+
+? scientific_model_type(physical, $D)         % expect smaller_and_simpler_representation_of_the_thing_being_studied (direct)
+? scientific_model_type(mathematical, $D)     % expect sets_of_equations_that_take_into_account_many_factors_to_represent_a_phenomenon (direct)
+? scientific_model_type($T, ties_together_many_ideas_to_explain_a_phenomenon_or_event)   % expect conceptual (reverse)
+? scientific_model_type(computer, $D)         % expect abstain -- the source closes its taxonomy at physical/conceptual/mathematical

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 321 | 324 | 320 (99.7%) | 321 (100.0%) | 321 (100.0%) | 0 (0.0%) |
+| facts | 322 | 325 | 321 (99.7%) | 322 (100.0%) | 322 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -46,7 +46,7 @@ provenance bundle whose CAS graph proves all cited source bytes.
 | `facts/oceanography` | 8 | 8 | 8 | 8 | 8 | 0 |
 | `facts/optics` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/physics` | 31 | 32 | 31 | 31 | 31 | 0 |
-| `facts/science` | 1 | 1 | 1 | 1 | 1 | 0 |
+| `facts/science` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `facts/transportation` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `formulas/arithmetic` | 10 | 20 | 10 | 10 | 10 | 0 |
 | `formulas/chemistry` | 7 | 26 | 7 | 7 | 7 | 0 |
@@ -73,7 +73,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (547)
+### Missing pinned source bytes (548)
 
 See the JSON form of this report for the complete machine-readable list.
 

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -2792,6 +2792,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.6to8.scientific_model_type",
+      "title": "Recall the defining sentence for a named type of scientific model (physical, conceptual, mathematical)",
+      "band": "6-8",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/science/scientific-model-type.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

Grounds "models" — the third and last of the three K-8-science Major Gaps this item's notes have tracked as fully untouched, after "experiments" (`scientific-method-step.adj`, #11970) and "engineering design" (`engineering-design-step.adj`, #11964).

Two prior cycles flagged "models" as harder to find table-shaped primary-source content for than the other two gaps. This cycle tried four distinct angles before finding a genuinely table-shaped source:

1. Historical atomic models (Dalton/Thomson/Rutherford/Bohr) as a numbered sequence — rejected, no unified sequential table found (MIT OCW presents them as separate narrative paragraphs).
2. NASA/NOAA/NIST "types of models" pages directly — rejected, no table found on any fetched page.
3. NGSS Framework Appendix F's own definitional sentence — rejected: a flat list of six nouns with no individual definition per type, so building a table would mean inventing definitions the source never states.
4. CK-12 Foundation's Middle School Earth Science FlexBook 2.0, "1.10: Scientific Models" (hosted at k12.libretexts.org) — three named model types (physical/conceptual/mathematical), each with its own citable defining sentence, taxonomy explicitly closed by the source's own Summary line. **This is what the table grounds.**

## Changes

- New `code/specs/data/adj-facts-stdlib/science/scientific-model-type.adj` — `scientific_model_type(type, description)`, 3 rows, `trust consensus` (not a primary gov/standards source).
- New companion `.query.adj` with 4 worked queries, including honest abstention on `computer` (mentioned by the source only as an implementation detail of mathematical models, never a fourth category).
- New `code/packages/rust/adj-lang-cli/tests/facts_scientificmodeltype_e2e.rs` (3 tests).
- New manifest objective `adj.science.6to8.scientific_model_type` (recall, NGSS, band 6-8) via surgical edit (15-line diff, not a full reformat).
- Regenerated `COVERAGE.md`.

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI check against the query file — all 4 queries resolve as expected, including the abstain
- [x] `cargo test -p adj-lang-cli --test facts_scientificmodeltype_e2e` — 3/3 pass
- [x] Full `adj-lang-cli` suite green
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, COVERAGE.md regenerated
- [x] `adj_stdlib_manifest.py --validate-json-schema` — same 21 pre-existing formula-provenance/CAS-containment errors as the origin/main baseline, zero new errors
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Security review sub-agent — PASSED (one INFO-level note about a pre-existing shared test temp-dir pattern, not introduced by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)