### PR TITLE
feat(macsyma-iir-vm): maxima-iir-compiler -- Wave 5 item 1, a thin re-export

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -263,6 +263,7 @@ members = [
     "maxima-runtime",
     "maxima-repl",
     "maxima-to-semantic-ir",
+    "maxima-iir-compiler",
     "wolfram-lexer",
     "wolfram-parser",
     "wolfram-runtime",

--- a/code/packages/rust/maxima-iir-compiler/BUILD
+++ b/code/packages/rust/maxima-iir-compiler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p maxima-iir-compiler

--- a/code/packages/rust/maxima-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/maxima-iir-compiler/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog — maxima-iir-compiler
+
+## v0.1.0 — 2026-08-18 — initial release (macsyma-iir-vm.md, Wave 5 item 1)
+
+The second frontend onto `interpreter_ir` (IIR) in this rollout, and the
+first Wave 5 item — a direct re-export of `macsyma-iir-compiler`'s public
+API (`compile`, `compile_source`, `MacsymaIirError`) under Maxima's own
+name, mirroring `maxima-to-semantic-ir`'s identical relationship to
+`macsyma-to-semantic-ir` on the Semantic-IR side.
+
+* No shim, no Maxima-specific CST, no `maxima-vm` — every compiled
+  `IIRModule` runs unchanged on `macsyma-vm`.
+* 5 tests: re-export symmetry (`compile`/`compile_source`), a
+  representative accepted program running end-to-end through
+  `macsyma-vm`, the `;`/`$` display/suppress terminator pair, one
+  rejected-construct check, and a malformed-input error-not-panic check.

--- a/code/packages/rust/maxima-iir-compiler/Cargo.toml
+++ b/code/packages/rust/maxima-iir-compiler/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "maxima-iir-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "Maxima source -> interpreter_ir::IIRModule, a direct re-export of macsyma-iir-compiler (same algebraic surface, zero shim), executable on macsyma-vm (no maxima-vm exists -- there is nothing Maxima-specific to run)."
+
+[lib]
+name = "maxima_iir_compiler"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+macsyma-iir-compiler = { path = "../macsyma-iir-compiler" }
+
+[dev-dependencies]
+# Used only by the compile()/compile_source() symmetry test and the
+# run-through-macsyma-vm doctest.
+coding-adventures-macsyma-parser = { path = "../macsyma-parser" }
+macsyma-vm = { path = "../macsyma-vm" }

--- a/code/packages/rust/maxima-iir-compiler/README.md
+++ b/code/packages/rust/maxima-iir-compiler/README.md
@@ -1,0 +1,40 @@
+# maxima-iir-compiler
+
+Maxima source → `interpreter_ir::IIRModule`, **v0.1.0**.
+
+A direct re-export of [`macsyma-iir-compiler`](../macsyma-iir-compiler)'s
+public API under Maxima's own name — no shim function, since Maxima and
+Macsyma share the exact same algebraic surface (the same relationship
+[`maxima-to-semantic-ir`](../maxima-to-semantic-ir) already established
+on the Semantic-IR side). See
+[`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) for the full
+design this rollout follows.
+
+There is **no `maxima-vm` crate**. Every compiled `IIRModule` runs
+unchanged on [`macsyma-vm`](../macsyma-vm) — nothing in that dispatch
+loop is Macsyma-specific, and Maxima has never had any runtime code of
+its own anywhere in this repo.
+
+## Scope (v0.1.0)
+
+Identical to `macsyma-iir-compiler`'s own v0 scope — see that crate's
+README for the full accepted/rejected construct list.
+
+## Usage
+
+```rust
+use maxima_iir_compiler::compile_source;
+
+let module = compile_source("2 + 3$", "demo")?;
+let value = macsyma_vm::run(&module)?;
+assert_eq!(value.as_int(), Some(5));
+```
+
+## Verification
+
+`cargo test -p maxima-iir-compiler` covers the re-export symmetry
+(`compile`/`compile_source`), a representative accepted program running
+end-to-end through `macsyma-vm`, and one rejected-construct check. No
+separate oracle test — since this crate has no lowering logic of its own,
+`macsyma-iir-compiler`'s own oracle test already covers every construct
+this crate can produce.

--- a/code/packages/rust/maxima-iir-compiler/src/lib.rs
+++ b/code/packages/rust/maxima-iir-compiler/src/lib.rs
@@ -1,0 +1,111 @@
+//! # maxima-iir-compiler
+//!
+//! Maxima source → [`interpreter_ir::IIRModule`], **v0.1.0** — the next
+//! item in [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md)'s
+//! Wave 5 rollout, right after `macsyma-iir-compiler` itself.
+//!
+//! Maxima and Macsyma share the *exact same* algebraic surface (see
+//! [`coding_adventures_maxima_runtime`]'s own doc comment: "A program
+//! written for one runs on the other"), and `maxima-to-semantic-ir`
+//! already established the precedent on the Semantic-IR side: **zero**
+//! surface normalization needed, so that crate is a direct re-export of
+//! `macsyma-to-semantic-ir`'s public API with no shim function. This
+//! crate does the identical thing one layer over, for IIR: a direct
+//! re-export of [`macsyma_iir_compiler`]'s public API under Maxima's own
+//! name.
+//!
+//! ## No `maxima-vm`
+//!
+//! Unlike every other language in this rollout, Maxima gets **no**
+//! dedicated VM crate. `macsyma_vm::run` executes any `IIRModule`
+//! regardless of the module's `language` field — nothing in its dispatch
+//! loop is Macsyma-specific — and Maxima has never had any runtime code
+//! of its own anywhere in this repo (`maxima-runtime` is itself a thin
+//! façade over `macsyma_runtime::MacsymaSession`). Adding a `maxima-vm`
+//! crate that was a byte-for-byte copy of `macsyma-vm` would be pure
+//! duplication with no offsetting benefit, unlike the *other* five
+//! languages in this rollout (Derive/Reduce/Maple/Axiom/Wolfram), which
+//! each get their own dedicated VM per this rollout's explicit
+//! VM-sharing decision (`macsyma-iir-vm.md` §6) — that decision was
+//! about genuinely *different* languages eventually diverging, not about
+//! an alias language with no surface of its own to diverge.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Maxima source
+//!    │
+//!    ▼  macsyma_iir_compiler::compile_source   (no shim -- same surface)
+//! interpreter_ir::IIRModule                    (v0 subset)
+//!    │
+//!    ▼  macsyma_vm::run
+//! dynval_runtime::LispyValue
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use maxima_iir_compiler::compile_source;
+//! let module = compile_source("2 + 3$\n", "demo").unwrap();
+//! let value = macsyma_vm::run(&module).unwrap();
+//! assert_eq!(value.as_int(), Some(5));
+//! ```
+//!
+//! `compile` (taking an already-parsed `GrammarASTNode`) is re-exported
+//! too, for symmetry with `macsyma-iir-compiler` and every other
+//! `-iir-compiler` frontend's own `compile`/`compile_source` pair — there
+//! is no Maxima-specific CST; the only tree ever built is the Macsyma one
+//! `macsyma_iir_compiler::compile`/`compile_source` construct directly.
+//!
+//! ## Scope
+//!
+//! Identical to `macsyma-iir-compiler` v0's own scope (see that crate's
+//! `src/lower.rs` module doc comment for the full accepted/rejected
+//! construct list) — there is nothing Maxima-specific to add or
+//! restrict, since the surface is unchanged.
+
+pub use macsyma_iir_compiler::{compile, compile_source, MacsymaIirError};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_arithmetic_compiles_and_runs() {
+        let module = compile_source("2 + 3$\n", "demo").unwrap();
+        let value = macsyma_vm::run(&module).unwrap();
+        assert_eq!(value.as_int(), Some(5));
+    }
+
+    #[test]
+    fn a_maxima_style_display_terminated_statement_compiles() {
+        // `;` (display) vs `$` (suppress) is the same Macsyma terminator
+        // pair Maxima itself uses unchanged -- no rewriting needed.
+        let module = compile_source("x: 3;\n", "demo").unwrap();
+        let value = macsyma_vm::run(&module).unwrap();
+        assert_eq!(value.as_int(), Some(3));
+    }
+
+    #[test]
+    fn out_of_scope_construct_is_rejected_identically_to_macsyma() {
+        assert!(compile_source("1.5$\n", "demo").is_err());
+    }
+
+    #[test]
+    fn a_malformed_program_errors_cleanly_not_panicking() {
+        assert!(compile_source("(((\n", "demo").is_err());
+    }
+
+    #[test]
+    fn compile_and_compile_source_are_both_reexported() {
+        // Symmetry check: both entry points must exist under this crate's
+        // own name, mirroring `maxima-to-semantic-ir`'s identical
+        // `compile`/`compile_source` symmetry test.
+        let tree = coding_adventures_macsyma_parser::create_macsyma_parser("1$\n")
+            .parse()
+            .expect("parse should succeed");
+        let module = compile(&tree, "demo").expect("compile should succeed");
+        let value = macsyma_vm::run(&module).unwrap();
+        assert_eq!(value.as_int(), Some(1));
+    }
+}


### PR DESCRIPTION
## Summary
- First item of `macsyma-iir-vm.md`'s Wave 5 (extending Macsyma's IIR bridge across the rest of the SIR23 CAS family).
- `maxima-iir-compiler` is a direct `pub use` re-export of `macsyma-iir-compiler`'s public API, mirroring `maxima-to-semantic-ir`'s identical relationship to `macsyma-to-semantic-ir` on the Semantic-IR side -- Maxima and Macsyma share the exact same algebraic surface, so no shim is needed.
- No `maxima-vm` crate: `macsyma-vm::run` already executes any `IIRModule` regardless of source language, and Maxima has never had any runtime code of its own in this repo.

## Test plan
- [x] `cargo test -p maxima-iir-compiler` -- 5 unit tests + 1 doctest, all passing
- [x] `cargo clippy -p maxima-iir-compiler --all-targets` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `/security-review` -- passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)