### PR TITLE
feat(macsyma-iir-vm): reduce-iir-compiler + reduce-vm -- Wave 5 item 3

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -289,6 +289,8 @@ members = [
     "reduce-runtime",
     "reduce-repl",
     "reduce-to-semantic-ir",
+    "reduce-iir-compiler",
+    "reduce-vm",
     "maple-lexer",
     "maple-parser",
     "maple-runtime",

--- a/code/packages/rust/reduce-iir-compiler/BUILD
+++ b/code/packages/rust/reduce-iir-compiler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p reduce-iir-compiler

--- a/code/packages/rust/reduce-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/reduce-iir-compiler/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — reduce-iir-compiler
+
+## v0.1.0 — 2026-08-18 — initial release (reduce-iir-vm.md, Wave 5 item 3)
+
+The third real-language frontend onto `interpreter_ir` (IIR) in this
+rollout (after Macsyma and Derive) — a retarget of `reduce-runtime`'s/
+`reduce-to-semantic-ir`'s existing CST dispatch, following
+`macsyma-iir-compiler`'s/`derive-iir-compiler`'s precedent directly.
+
+* `compile(&GrammarASTNode, module_name) -> Result<IIRModule, ReduceIirError>`
+  and `compile_source(source, module_name)`.
+* Accepted v0 grammar: integer literals; `+ - * /` (chains + unary `-`
+  only); assignment (`x := expr`); free-symbol references; any other
+  operator/head, or any operand involving a free symbol, lowers to an
+  inert `cons`-chain.
+* Concrete `+`/`-`/`*` always evaluate via a real `call_builtin`; `/`
+  gets the identical narrower exactness rule the other two frontends
+  established.
+* Comparisons, `and`/`or`/`not`, and `^`/`**` are rejected outright (no
+  inert-data fallback), for the identical reason as the other two
+  frontends. `if`/`then`/`else`, `<< ... >>` group statements, `a . b`
+  cons, and `{...}` list literals — all genuinely new surface Derive has
+  no analogue of — are rejected outright too, since v0 has no
+  control-flow or list-cons runtime semantics to give them any
+  verifiably-correct meaning.
+* `h(l, m) := body` (procedure definition) is rejected with a
+  definition-specific error message, disambiguated purely by the LHS's
+  shape — Reduce has only one `:=` token for both plain assignment and
+  definition.
+* 27 unit tests (every accepted construct round-tripped through
+  `reduce-vm`, every rejected construct's explicit-error path, including
+  a trailing-statement-without-terminator case exercising the grammar's
+  optional final bare `statement`) + a 18-case oracle test cross-checking
+  against `reduce-runtime`, both rendered through the same `print_reduce`
+  function.

--- a/code/packages/rust/reduce-iir-compiler/Cargo.toml
+++ b/code/packages/rust/reduce-iir-compiler/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "reduce-iir-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "Lowers a Reduce CST (coding-adventures-reduce-parser's GrammarASTNode) into an IIRModule, per reduce-iir-vm.md's v0 scope: literal integer arithmetic (+ - * /, unary), assignment, and unevaluated symbolic expressions. A retarget of reduce-runtime's/reduce-to-semantic-ir's CST dispatch, following macsyma-iir-compiler's precedent. Emits IIR over the dynval-runtime value model so the module runs end-to-end on reduce-vm."
+
+[lib]
+name = "reduce_iir_compiler"
+path = "src/lib.rs"
+
+[dependencies]
+coding-adventures-reduce-parser = { path = "../reduce-parser" }
+interpreter-ir = { path = "../interpreter-ir" }
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+symbolic-ir = { path = "../symbolic-ir" }
+
+[dev-dependencies]
+reduce-vm = { path = "../reduce-vm" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Oracle ground truth (tests/oracle.rs) + the shared renderer used to
+# format both the ground truth and the compiled-side read-back result.
+coding-adventures-reduce-runtime = { path = "../reduce-runtime" }

--- a/code/packages/rust/reduce-iir-compiler/README.md
+++ b/code/packages/rust/reduce-iir-compiler/README.md
@@ -1,0 +1,49 @@
+# reduce-iir-compiler
+
+Reduce CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+
+The third real-language bridge from a math language in this repo onto
+`interpreter_ir` (IIR) — the shared IR the AOT/lang-vm chain lowers to 7
+real backends (NativeAOT, LLVM, WASM, JVM, CLR, VM interpreter, JIT) —
+rather than only the Semantic IR source-to-source pipeline
+[`reduce-to-semantic-ir`](../reduce-to-semantic-ir) already targets. See
+[`reduce-iir-vm.md`](../../../specs/reduce-iir-vm.md) for the
+per-language deltas from
+[`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md)'s original
+design.
+
+## Scope (v0.1.0)
+
+**Accepted:** integer literals; `+ - * /` (binary chains and unary `-`
+only — Reduce has no unary-plus); assignment (`x := expr`, plain-name
+target only); free-symbol references; any other operator/head — or any
+operand involving a free symbol — represented as an *unevaluated*
+symbolic expression (an inert `cons`-chain).
+
+**Rejected, with an explicit error, never a silent mis-lowering:** `Float`
+literals; `h(l, m) := body` (procedure definition); `if`/`then`/`else`
+(Reduce, unlike Derive, has a dedicated expression-shaped `if`);
+`<< s1; s2; ... >>` group statements; comparisons (`=`/`neq`/`<`/`>`/
+`<=`/`>=`); `and`/`or`/`not`; `^`/`**` (power); `a . b` cons; `{...}`
+list literals; any postfix function call/array subscript `f(x)`.
+
+See `src/lower.rs`'s module doc comment for the full rationale, matching
+`macsyma-iir-compiler`'s and `derive-iir-compiler`'s identical design.
+
+## Usage
+
+```rust
+use reduce_iir_compiler::compile_source;
+
+let module = compile_source("2 + 3;\n", "demo")?;
+let value = reduce_vm::run(&module)?;
+assert_eq!(value.as_int(), Some(5));
+```
+
+## Verification
+
+`cargo test -p reduce-iir-compiler` covers every accepted construct (via
+`reduce-vm`, as a dev-dependency) and every rejected construct's
+explicit-error path. `tests/oracle.rs` additionally cross-checks every
+accepted construct against `reduce-runtime`'s own evaluator, both sides
+rendered through the same `print_reduce` function.

--- a/code/packages/rust/reduce-iir-compiler/src/lib.rs
+++ b/code/packages/rust/reduce-iir-compiler/src/lib.rs
@@ -1,0 +1,276 @@
+//! # reduce-iir-compiler
+//!
+//! Reduce CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+//!
+//! The third real-language frontend (after Macsyma and Derive) to bridge
+//! a math language in this repo onto `interpreter_ir` (IIR) — the shared
+//! IR the AOT/lang-vm chain lowers to 7 real backends (NativeAOT, LLVM,
+//! WASM, JVM, CLR, VM interpreter, JIT) — rather than only the Semantic
+//! IR source-to-source pipeline `reduce-to-semantic-ir` already targets.
+//! See [`reduce-iir-vm.md`](../../../specs/reduce-iir-vm.md) for the
+//! per-language deltas from `macsyma-iir-vm.md`'s original design and
+//! `lower.rs`'s module doc comment for the v0 scope and the `/`
+//! exactness rule. It consumes the generic `GrammarASTNode` CST produced
+//! by `coding-adventures-reduce-parser` and emits an
+//! [`interpreter_ir::IIRModule`], executable on
+//! [`reduce-vm`](../reduce-vm) (v0 targets the VM interpreter backend
+//! only).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Reduce source
+//!    │
+//!    ▼  coding_adventures_reduce_parser::try_parse_reduce(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  reduce_iir_compiler::compile
+//! interpreter_ir::IIRModule                (v0 subset)
+//!    │
+//!    ▼  reduce_vm::run
+//! dynval_runtime::LispyValue
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use reduce_iir_compiler::compile_source;
+//! let module = compile_source("2 + 3;\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, ReduceIirError};
+
+/// Parse `source` as Reduce and lower it into an
+/// [`interpreter_ir::IIRModule`] in one step, mirroring
+/// `reduce-to-semantic-ir::compile_source`'s convenience wrapper.
+///
+/// Needs no worker-thread stack enlargement, for the same reason
+/// `reduce-to-semantic-ir::compile_source` doesn't:
+/// `coding_adventures_reduce_parser`'s own `MAX_RULE_DEPTH` (128) is
+/// already documented safe on a bare default (~2 MiB) stack.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<interpreter_ir::IIRModule, ReduceIirError> {
+    let tree = coding_adventures_reduce_parser::try_parse_reduce(source).map_err(|msg| {
+        ReduceIirError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        }
+    })?;
+    compile(&tree, module_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reduce_vm::run;
+
+    fn eval_int(source: &str) -> i64 {
+        let module = compile_source(source, "t").expect("compile");
+        run(&module).expect("run").as_int().expect("int result")
+    }
+
+    fn eval_symbol(source: &str) -> String {
+        let module = compile_source(source, "t").expect("compile");
+        let v = run(&module).expect("run");
+        dynval_runtime::name_of(v.as_symbol().expect("symbol result")).expect("interned")
+    }
+
+    // ---- accepted: literal arithmetic ----
+
+    #[test]
+    fn integer_literal() {
+        assert_eq!(eval_int("42;\n"), 42);
+    }
+
+    #[test]
+    fn simple_addition() {
+        assert_eq!(eval_int("2 + 3;\n"), 5);
+    }
+
+    #[test]
+    fn precedence() {
+        assert_eq!(eval_int("2 + 3 * 4;\n"), 14);
+    }
+
+    #[test]
+    fn chain() {
+        assert_eq!(eval_int("1 + 2 + 3 + 4;\n"), 10);
+    }
+
+    #[test]
+    fn unary_neg_leaf() {
+        assert_eq!(eval_int("-5 + 3;\n"), -2);
+    }
+
+    #[test]
+    fn unary_neg_compound() {
+        assert_eq!(eval_int("-(5 + 3);\n"), -8);
+    }
+
+    #[test]
+    fn grouping() {
+        assert_eq!(eval_int("(2 + 3) * 4;\n"), 20);
+    }
+
+    #[test]
+    fn exact_division() {
+        assert_eq!(eval_int("20 / 4;\n"), 5);
+    }
+
+    #[test]
+    fn negative_literal_exact_division() {
+        assert_eq!(eval_int("-4 / 2;\n"), -2);
+    }
+
+    #[test]
+    fn trailing_statement_without_terminator() {
+        // `program = { statement_line } [ statement ]` -- the final
+        // statement need not carry a `;`/`$` terminator.
+        assert_eq!(eval_int("1 + 2\n"), 3);
+    }
+
+    // ---- accepted: assignment ----
+
+    #[test]
+    fn assignment_and_reference() {
+        assert_eq!(eval_int("x := 3;\nx + 1;\n"), 4);
+    }
+
+    #[test]
+    fn reassignment_threading() {
+        assert_eq!(eval_int("x := 3;\nx := x + 1;\nx;\n"), 4);
+    }
+
+    #[test]
+    fn two_variables() {
+        assert_eq!(eval_int("a := 2;\nb := 3;\na * b;\n"), 6);
+    }
+
+    // ---- accepted: unevaluated symbolic expressions ----
+
+    #[test]
+    fn free_symbol_addition_is_symbolic() {
+        let module = compile_source("x + y;\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        assert!(v.as_int().is_none());
+    }
+
+    #[test]
+    fn free_symbol_addition_head_is_add() {
+        let module = compile_source("x + y;\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Add")
+        );
+    }
+
+    #[test]
+    fn mixed_concrete_and_symbolic_operand() {
+        let module = compile_source("2 * x;\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Mul")
+        );
+    }
+
+    #[test]
+    fn free_symbol_alone() {
+        assert_eq!(eval_symbol("x;\n"), "x");
+    }
+
+    // ---- rejected: explicit-error paths ----
+
+    #[test]
+    fn float_literal_rejected() {
+        assert!(compile_source("1.5;\n", "t").is_err());
+    }
+
+    #[test]
+    fn non_exact_division_rejected() {
+        let err = compile_source("7 / 2;\n", "t").unwrap_err();
+        assert!(
+            err.message.contains("rational"),
+            "message was: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn division_of_non_literal_concrete_rejected() {
+        assert!(compile_source("x := 6;\nx / 2;\n", "t").is_err());
+    }
+
+    #[test]
+    fn division_by_literal_zero_rejected() {
+        assert!(compile_source("1 / 0;\n", "t").is_err());
+    }
+
+    #[test]
+    fn i64_min_divided_by_neg_one_rejected_not_panicking() {
+        assert!(compile_source("(-9223372036854775807 - 1) / -1;\n", "t").is_err());
+    }
+
+    #[test]
+    fn procedure_definition_rejected() {
+        let err = compile_source("h(x) := x + 1;\n", "t").unwrap_err();
+        assert!(
+            err.message.contains("procedure definition"),
+            "message was: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn function_call_rejected() {
+        assert!(compile_source("first(x);\n", "t").is_err());
+    }
+
+    #[test]
+    fn comparison_rejected() {
+        assert!(compile_source("x = y;\n", "t").is_err());
+    }
+
+    #[test]
+    fn not_equal_rejected() {
+        assert!(compile_source("x neq y;\n", "t").is_err());
+    }
+
+    #[test]
+    fn logical_and_rejected() {
+        assert!(compile_source("x and y;\n", "t").is_err());
+    }
+
+    #[test]
+    fn power_rejected() {
+        assert!(compile_source("x^2;\n", "t").is_err());
+    }
+
+    #[test]
+    fn list_literal_rejected() {
+        assert!(compile_source("{1, 2, 3};\n", "t").is_err());
+    }
+
+    #[test]
+    fn cons_rejected() {
+        assert!(compile_source("a . {b};\n", "t").is_err());
+    }
+
+    #[test]
+    fn if_expr_rejected() {
+        assert!(compile_source("if x > 0 then 1 else 0;\n", "t").is_err());
+    }
+
+    #[test]
+    fn group_expr_rejected() {
+        assert!(compile_source("<< x := 1; x + 1 >>;\n", "t").is_err());
+    }
+}

--- a/code/packages/rust/reduce-iir-compiler/src/lower.rs
+++ b/code/packages/rust/reduce-iir-compiler/src/lower.rs
@@ -1,0 +1,767 @@
+//! The lowering pass from `coding_adventures_reduce_parser`'s generic
+//! [`GrammarASTNode`] CST → [`IIRModule`], **v0.1.0**.
+//!
+//! # Retargeting `reduce-runtime`/`reduce-to-semantic-ir`, a third time
+//!
+//! `reduce-runtime` already walks this exact CST and compiles it to
+//! `symbolic_ir::IRNode`. `reduce-to-semantic-ir` retargets the same
+//! rule-name dispatch to build `semantic_ir::Expr` instead. This module is
+//! a **third retarget**, following `macsyma-iir-compiler`'s and
+//! `derive-iir-compiler`'s precedent directly — see
+//! [`reduce-iir-vm.md`](../../../specs/reduce-iir-vm.md) and
+//! [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) for the shared
+//! design. It emits `interpreter_ir::IIRInstr`s directly and shares no
+//! code with either sibling beyond the parser.
+//!
+//! # Scope (v0.1.0)
+//!
+//! Accepted: integer literals; `+ - * /` (binary chains and unary `-`
+//! only — Reduce's grammar, like Derive's, has no unary-plus); assignment
+//! (`x := expr`, plain-name target only); free-symbol references; any
+//! other head or symbolic operand, represented as an *unevaluated* inert
+//! `cons`-chain (mirrors `macsyma-iir-compiler::inert_apply`).
+//!
+//! Rejected, with an explicit [`ReduceIirError`] rather than a silent
+//! mis-lowering: `Float` literals; `h(l, m) := body` (procedure
+//! definition); `if`/`then`/`else` (`if_expr` — Reduce, unlike Derive,
+//! has a dedicated expression-shaped `if` production); `<< s1; s2; ... >>`
+//! group statements (`group_expr`); comparisons; `and`/`or`/`not`; `^`/
+//! `**` (power); `a . b` cons; `{...}` list literals; any postfix
+//! function call `f(x)`.
+//!
+//! Comparisons and `and`/`or`/`not` are rejected **outright**, for the
+//! identical reason `macsyma-iir-compiler`'s and `derive-iir-compiler`'s
+//! module docs give: `symbolic-vm`'s handler table (the real evaluator
+//! `reduce-runtime` runs) numerically evaluates a concrete pair of
+//! operands for these heads. `^`/`**` gets the identical treatment.
+//! `if_expr`/`group_expr`/cons are rejected outright too — none of them
+//! are arithmetic, and v0 has no control-flow or list-cons runtime
+//! semantics to give them either an evaluated or an inert-data meaning
+//! that would be verifiably correct (unlike Macsyma's own `if`/`while`,
+//! which at least had a well-defined *rejected* status to fall back on —
+//! here they are simply new surface with no v0 story at all).
+//!
+//! # The `/` exactness rule
+//!
+//! Identical hazard and identical fix as `macsyma-iir-compiler`'s/
+//! `derive-iir-compiler`'s own `/` handling: Reduce's `/` on integers
+//! that don't divide evenly returns an exact rational, which
+//! `dynval-runtime` cannot represent. [`Lowerer::combine`] only takes the
+//! evaluated `call_builtin "/"` path when both direct operands are
+//! literal integer tokens at this exact node and their quotient is exact;
+//! a symbolic operand falls back to inert data; anything else is
+//! rejected.
+//!
+//! # `:=` disambiguation has no operator to branch on
+//!
+//! Like `derive-iir-compiler::lower::lower_assignment`'s own note:
+//! Reduce's grammar has exactly ONE assignment token, `ASSIGN` (`:=`) —
+//! `x := 5` and `h(l, m) := l - 2*m` are syntactically identical until
+//! this lowering step. Since v0 has no user-defined-procedure support at
+//! all (any call, LHS or not, is already rejected by [`Lowerer::
+//! lower_postfix`]), [`Lowerer::lower_assignment`] disambiguates purely
+//! by checking whether the LHS is a bare `NAME` token *before* attempting
+//! to lower it as an expression — identical shape to
+//! `derive-iir-compiler`'s own two-branch handling, even though Reduce's
+//! `assignment = logical_or [ ASSIGN expr ]` production has a WIDER RHS
+//! (`expr`, not `derive.grammar`'s self-referential `assignment`) — moot
+//! for v0, since none of the RHS shapes that difference would newly admit
+//! (`if_expr`, `group_expr`) are in scope here anyway.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{ADD, DIV, MUL, NEG, SUB};
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — mirrors `macsyma-iir-compiler::lower::MAX_EXPR_DEPTH` and
+/// `reduce-to-semantic-ir::lower::MAX_EXPR_DEPTH` (same CST, same
+/// generic `GrammarParser` dispatch engine).
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// IIR type-hint string for the nil / cons reference type, matching
+/// `macsyma-iir-compiler`'s `REF_PAIR` convention.
+const REF_PAIR: &str = "ref<LispyPair>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Reduce → IIR lowering.
+///
+/// Mirrors `MacsymaIirError`/`DeriveIirError`'s shape exactly (`message`
+/// + 1-based `line`/`column`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReduceIirError {
+    /// Human-readable explanation.
+    pub message: String,
+    /// 1-based source line.
+    pub line: usize,
+    /// 1-based source column.
+    pub column: usize,
+}
+
+impl std::fmt::Display for ReduceIirError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ReduceIirError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for ReduceIirError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Reduce CST (rooted at the `program` rule) into an
+/// [`IIRModule`].
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<IIRModule, ReduceIirError> {
+    Lowerer::new().lower_file(tree, module_name)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowered value of one CST node: the IIR register holding it, plus
+/// two facts used only to decide how a *later* arithmetic step may
+/// combine it — never observed by the emitted IIR itself. Identical
+/// shape to `macsyma-iir-compiler::lower::Lowered`.
+#[derive(Debug, Clone)]
+struct Lowered {
+    /// The register this value lives in.
+    reg: String,
+    /// `true` if this value was built purely from integer literals and
+    /// bound (concrete) variables combined via `+`/`-`/`*`/`/`/unary
+    /// negate — i.e. it contains no free symbol anywhere.
+    concrete: bool,
+    /// `Some(v)` only when this value is a *direct* integer-literal token
+    /// (or the statically-known result of combining such literals via
+    /// `+`/`-`/`*`/unary negate) — used exclusively by the `/` exactness
+    /// check ([`Lowerer::combine`]). Never propagated through a variable
+    /// reference.
+    literal: Option<i64>,
+}
+
+struct Lowerer {
+    instrs: Vec<IIRInstr>,
+    tmp: usize,
+    /// Assigned variable name → its most recently assigned value.
+    env: std::collections::HashMap<String, Lowered>,
+}
+
+impl Lowerer {
+    fn new() -> Self {
+        Lowerer {
+            instrs: Vec::new(),
+            tmp: 0,
+            env: std::collections::HashMap::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = { statement_line } [ statement ] ;`
+    // `statement_line = statement ( SEMI | DOLLAR ) ;`
+    // -------------------------------------------------------------------
+
+    /// Unlike Derive's `program = { statement_line }`, Reduce's grammar
+    /// adds an OPTIONAL final bare `statement` outside the repetition (so
+    /// a source file need not end with a trailing `;`/`$`) — mirrors
+    /// `reduce-to-semantic-ir::lower::lower_file`'s identical two-shape
+    /// loop.
+    fn lower_file(
+        &mut self,
+        program: &GrammarASTNode,
+        module_name: &str,
+    ) -> Result<IIRModule, ReduceIirError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        let mut last: Option<Lowered> = None;
+        for child in child_nodes(program) {
+            let statement_node = match child.rule_name.as_str() {
+                "statement_line" => child_nodes(child).find(|n| n.rule_name == "statement"),
+                "statement" => Some(child),
+                _ => None,
+            };
+            let Some(statement_node) = statement_node else {
+                continue;
+            };
+            last = Some(self.lower_node(statement_node, 0)?);
+        }
+        let final_val = match last {
+            Some(l) => l,
+            None => self.emit_nil(),
+        };
+        self.emit(IIRInstr::new(
+            "ret",
+            None,
+            vec![Operand::Var(final_val.reg)],
+            "any",
+        ));
+
+        let mut main =
+            IIRFunction::new("main", Vec::new(), "any", std::mem::take(&mut self.instrs));
+        main.register_count = self.tmp;
+
+        let mut module = IIRModule::new(module_name, "reduce");
+        module.functions.push(main);
+        module.entry_point = Some("main".to_string());
+
+        let problems = module.validate();
+        if !problems.is_empty() {
+            return Err(ReduceIirError {
+                message: format!(
+                    "internal: emitted IIR failed validation: {}",
+                    problems.join("; ")
+                ),
+                line: 1,
+                column: 1,
+            });
+        }
+        Ok(module)
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------------------
+
+    fn lower_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => {
+                    Err(self.err_at(node, "nested program node is not an expression".to_string()))
+                }
+                "statement_line" | "statement" | "expr" | "atom" => {
+                    self.lower_first_node(node, depth)
+                }
+                "if_expr" => Err(self.err_unsupported(node, "if/then/else")),
+                "group_expr" => Err(self.err_unsupported(node, "<< ... >> group statements")),
+                "assignment" => self.lower_assignment(node, depth),
+                "logical_or" | "logical_and" | "logical_not" => {
+                    Err(self.err_unsupported(node, "'and'/'or'/'not' logical expressions"))
+                }
+                "comparison" => {
+                    Err(self.err_unsupported(node, "comparisons (=, neq, <, >, <=, >=)"))
+                }
+                "cons" => Err(self.err_unsupported(node, "cons (a . b)")),
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => Err(self.err_unsupported(node, "exponentiation (^ / **)")),
+                "postfix" => self.lower_postfix(node, depth),
+                "list_literal" => Err(self.err_unsupported(node, "list literals ({...})")),
+                "arglist" => Err(self.err_at(
+                    node,
+                    "an arglist cannot be lowered as a scalar expression".to_string(),
+                )),
+                "group" => self.lower_group(node, depth),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol). Reduce has no
+    /// `STRING` token, and its word-spelled operators/keywords (`and`/
+    /// `or`/`not`/`neq`/`if`/`then`/`else`) are always consumed by their
+    /// own grammar rule before reaching here as a bare leaf token — so,
+    /// like `derive-iir-compiler::lower_token`, this only ever needs
+    /// `NUMBER`/`NAME` arms.
+    fn lower_token(&mut self, token: &Token) -> Result<Lowered, ReduceIirError> {
+        match token_type(token) {
+            "NUMBER" => self.lower_number(&token.value, token),
+            "NAME" => Ok(self.symbol_ref(&token.value)),
+            other => Err(ReduceIirError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// Parse a `NUMBER` lexeme. Unlike `reduce-to-semantic-ir`'s
+    /// `number_literal_expr`, this does **not** fall back to a float for
+    /// a too-large integer — v0 has no float representation at all.
+    fn lower_number(&mut self, text: &str, token: &Token) -> Result<Lowered, ReduceIirError> {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            return Err(self
+                .err_unsupported_tok(token, "floating-point literals (not representable in v0)"));
+        }
+        match text.parse::<i64>() {
+            Ok(v) => Ok(self.emit_int(v)),
+            Err(_) => Err(self.err_unsupported_tok(
+                token,
+                "an integer literal too large for i64 (bignum is not representable in v0)",
+            )),
+        }
+    }
+
+    /// A bare `NAME`: a bound (assigned earlier) variable resolves to its
+    /// stored value; anything else is a free symbol.
+    fn symbol_ref(&mut self, name: &str) -> Lowered {
+        if let Some(bound) = self.env.get(name) {
+            Lowered {
+                reg: bound.reg.clone(),
+                concrete: bound.concrete,
+                literal: None,
+            }
+        } else {
+            self.emit_symbol(name)
+        }
+    }
+
+    /// `assignment = logical_or [ ASSIGN expr ] ;`
+    ///
+    /// See the module doc comment's "`:=` disambiguation" section: v0
+    /// rejects a call-shaped LHS as unsupported procedure definition
+    /// *before* attempting to lower it as an expression.
+    fn lower_assignment(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| token_type(t) == "ASSIGN"))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed assignment node".to_string()));
+        }
+
+        let name =
+            match bare_name(&node.children[op_index - 1]) {
+                Some(name) => name,
+                None => return Err(self.err_unsupported(
+                    node,
+                    "procedure definition (h(l, m) := body) -- v0 has no user-defined-procedure \
+                     support",
+                )),
+            };
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        self.env.insert(name, rhs.clone());
+        Ok(rhs)
+    }
+
+    /// `additive`/`multiplicative` — a left-associative binary chain of
+    /// `+`/`-`/`*`/`/`. Same flat-CST-node shape as `macsyma-iir-compiler`
+    /// (see [`Self::check_chain_length`]).
+    fn lower_binary_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs_child = children.next().ok_or_else(|| {
+                self.err_at(node, "binary operator with no right operand".to_string())
+            })?;
+            let rhs = self.lower_child(rhs_child, depth + 1)?;
+            result = self.combine(head, result, rhs, node)?;
+        }
+        Ok(result)
+    }
+
+    /// Combine `lhs op rhs` for `op` one of `Add`/`Sub`/`Mul`/`Div`. See
+    /// the module doc comment's "The `/` exactness rule" section —
+    /// identical logic to `macsyma-iir-compiler::Lowerer::combine`.
+    fn combine(
+        &mut self,
+        head: &str,
+        lhs: Lowered,
+        rhs: Lowered,
+        node: &GrammarASTNode,
+    ) -> Result<Lowered, ReduceIirError> {
+        if head == DIV {
+            if !lhs.concrete || !rhs.concrete {
+                return Ok(self.inert_apply(DIV, vec![lhs, rhs]));
+            }
+            return match (lhs.literal, rhs.literal) {
+                (Some(_), Some(0)) => Err(self.err_at(node, "division by zero".to_string())),
+                (Some(a), Some(b)) if a.checked_rem(b) == Some(0) => {
+                    let reg = self.emit_builtin("/", &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+                    Ok(Lowered {
+                        reg,
+                        concrete: true,
+                        literal: a.checked_div(b),
+                    })
+                }
+                (Some(a), Some(b)) if a.checked_rem(b).is_some() => Err(self.err_at(
+                    node,
+                    "this division does not divide evenly; the exact result would be a \
+                     rational, which is not representable in v0 (see reduce-iir-vm.md)"
+                        .to_string(),
+                )),
+                (Some(_), Some(_)) => Err(self.err_at(
+                    node,
+                    "this division cannot be evaluated in v0 (i64::MIN / -1 is not representable)"
+                        .to_string(),
+                )),
+                _ => Err(self.err_at(
+                    node,
+                    "division of a non-literal value cannot be verified exact at compile time \
+                     in v0 (only literal / literal is supported); see reduce-iir-vm.md"
+                        .to_string(),
+                )),
+            };
+        }
+
+        if lhs.concrete && rhs.concrete {
+            let op_name = op_symbol_for(head);
+            let reg = self.emit_builtin(op_name, &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+            let literal = match (head, lhs.literal, rhs.literal) {
+                (h, Some(a), Some(b)) if h == ADD => a.checked_add(b),
+                (h, Some(a), Some(b)) if h == SUB => a.checked_sub(b),
+                (h, Some(a), Some(b)) if h == MUL => a.checked_mul(b),
+                _ => None,
+            };
+            Ok(Lowered {
+                reg,
+                concrete: true,
+                literal,
+            })
+        } else {
+            Ok(self.inert_apply(head, vec![lhs, rhs]))
+        }
+    }
+
+    /// `unary = MINUS unary | power ;` — Reduce's grammar has NO
+    /// unary-plus alternative at all (matching `derive.grammar`'s
+    /// identical asymmetry).
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            2 => {
+                let operand = self.lower_child(&node.children[1], depth + 1)?;
+                if operand.concrete {
+                    let reg = self.emit_builtin("-", &[operand.reg.as_str()], "i64");
+                    let literal = operand.literal.and_then(i64::checked_neg);
+                    Ok(Lowered {
+                        reg,
+                        concrete: true,
+                        literal,
+                    })
+                } else {
+                    Ok(self.inert_apply(NEG, vec![operand]))
+                }
+            }
+            _ => Err(self.err_at(node, "malformed unary node".to_string())),
+        }
+    }
+
+    /// `postfix = atom { LPAREN [ arglist ] RPAREN } ;` — a bare atom (no
+    /// call suffix) passes through; any `(...)` call suffix is rejected
+    /// (v0 has no user-defined procedures/arrays to call or index).
+    fn lower_postfix(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        let has_call = node
+            .children
+            .iter()
+            .any(|c| as_token(c).is_some_and(|t| token_type(t) == "LPAREN"));
+        if has_call {
+            return Err(self.err_unsupported(node, "function calls / array subscripts (e.g. f(x))"));
+        }
+        let base = node
+            .children
+            .first()
+            .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?;
+        self.lower_child(base, depth + 1)
+    }
+
+    /// `group = LPAREN expr RPAREN ;` — grouping only.
+    fn lower_group(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        let inner = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty group `( )`".to_string()))?;
+        self.lower_node(inner, depth + 1)
+    }
+
+    // -------------------------------------------------------------------
+    // Emission helpers
+    // -------------------------------------------------------------------
+
+    fn fresh(&mut self) -> String {
+        let name = format!("v{}", self.tmp);
+        self.tmp += 1;
+        name
+    }
+
+    fn emit(&mut self, instr: IIRInstr) {
+        self.instrs.push(instr);
+    }
+
+    fn emit_int(&mut self, n: i64) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(n)],
+            "i64",
+        ));
+        Lowered {
+            reg,
+            concrete: true,
+            literal: Some(n),
+        }
+    }
+
+    fn emit_symbol(&mut self, name: &str) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Var(name.to_string())],
+            "symbol",
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_nil(&mut self) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(0)],
+            REF_PAIR,
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_builtin(&mut self, name: &str, args: &[&str], type_hint: &str) -> String {
+        let reg = self.fresh();
+        let mut srcs = vec![Operand::Var(name.to_string())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).to_string())));
+        self.emit(IIRInstr::new(
+            "call_builtin",
+            Some(reg.clone()),
+            srcs,
+            type_hint,
+        ));
+        reg
+    }
+
+    /// Materialise an unevaluated `Apply(head, args)` as an inert
+    /// `cons`-chain `(head arg0 arg1 …)`, mirroring
+    /// `macsyma-iir-compiler::inert_apply` exactly.
+    fn inert_apply(&mut self, head: &str, args: Vec<Lowered>) -> Lowered {
+        let head_reg = self.emit_symbol(head).reg;
+        let mut acc = self.emit_nil().reg;
+        for arg in args.into_iter().rev() {
+            acc = self.emit_builtin("cons", &[arg.reg.as_str(), acc.as_str()], REF_PAIR);
+        }
+        let reg = self.emit_builtin("cons", &[head_reg.as_str(), acc.as_str()], REF_PAIR);
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/
+    /// `multiplicative`) with more than `MAX_EXPR_DEPTH` operands — see
+    /// `macsyma-iir-compiler::lower::Lowerer::check_chain_length`'s doc
+    /// comment for the full DoS rationale, which applies unchanged here.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), ReduceIirError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression chain too long ({operand_count} operands, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        let child = child_nodes(node).next().ok_or_else(|| {
+            self.err_at(
+                node,
+                format!("`{}` has no expression child", node.rule_name),
+            )
+        })?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(
+        &mut self,
+        child: &ASTNodeOrToken,
+        depth: usize,
+    ) -> Result<Lowered, ReduceIirError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> ReduceIirError {
+        ReduceIirError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    fn err_unsupported(&self, node: &GrammarASTNode, what: &str) -> ReduceIirError {
+        self.err_at(
+            node,
+            format!("{what} are not supported in this v0 slice — see reduce-iir-vm.md"),
+        )
+    }
+
+    fn err_unsupported_tok(&self, token: &Token, what: &str) -> ReduceIirError {
+        ReduceIirError {
+            message: format!("{what} are not supported in this v0 slice — see reduce-iir-vm.md"),
+            line: token.line,
+            column: token.column,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Map an arithmetic token type to its canonical IR head. Note `TIMES`,
+/// matching `reduce.tokens`'s own spelling of the multiplication token
+/// (same as Derive's `TIMES`, not Macsyma's `STAR`).
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a canonical arithmetic head to the `call_builtin` name
+/// `dynval-runtime` resolves it to. Only ever called for `ADD`/`SUB`/`MUL`
+/// (see [`Lowerer::combine`] — `DIV` is handled separately).
+fn op_symbol_for(head: &str) -> &'static str {
+    match head {
+        h if h == ADD => "+",
+        h if h == SUB => "-",
+        h if h == MUL => "*",
+        _ => unreachable!("op_symbol_for called with a non-arithmetic head: {head}"),
+    }
+}
+
+/// If `child` (peeling away any single-child wrapper nodes, the same way
+/// [`unwrap_single`] does for lowering) bottoms out at a bare `NAME`
+/// token, return its text. Used by [`Lowerer::lower_assignment`] to check
+/// an assignment target *without* lowering it as an expression.
+fn bare_name(child: &ASTNodeOrToken) -> Option<String> {
+    let token = match child {
+        ASTNodeOrToken::Token(t) => t,
+        ASTNodeOrToken::Node(n) => match unwrap_single(n) {
+            Unwrapped::Token(t) => t,
+            Unwrapped::Node(_) => return None,
+        },
+    };
+    (token_type(token) == "NAME").then(|| token.value.clone())
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with
+/// structure (or a leaf token). Mirrors
+/// `macsyma-iir-compiler::lower::unwrap_single`.
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/reduce-iir-compiler/tests/oracle.rs
+++ b/code/packages/rust/reduce-iir-compiler/tests/oracle.rs
@@ -1,0 +1,237 @@
+//! Oracle/golden test (reduce-iir-vm.md / macsyma-iir-vm.md §7): the SAME
+//! Reduce source, run through **two independent implementations**, and
+//! diffed:
+//!
+//!   (a) `reduce-runtime` (`coding-adventures-reduce-runtime`) — the
+//!       native runtime crate, which lowers to `symbolic-ir` and evaluates
+//!       via `symbolic-vm`'s shared handler table — the ground truth.
+//!   (b) `reduce_iir_compiler::compile_source` → `interpreter_ir::IIRModule`
+//!       → `reduce_vm::run` → a `LispyValue`, read back into a
+//!       `symbolic_ir::IRNode` and rendered through the SAME
+//!       `coding_adventures_reduce_runtime::print_reduce` function the
+//!       native runtime uses.
+//!
+//! Mirrors `derive-iir-compiler/tests/oracle.rs`'s shape exactly, only
+//! diffing the LAST statement's value.
+//!
+//! ## Corpus
+//!
+//! v0's accepted grammar subset only (`reduce-iir-vm.md`): literal
+//! integer arithmetic (`+ - * /`, unary `-` only), assignment (`:=`) and
+//! re-assignment threading, and unevaluated symbolic `Apply` results for
+//! any operand that stays free. Every rejected construct already has a
+//! dedicated `Err`-asserting unit test in `src/lib.rs`'s own `tests`
+//! module — not re-tested here.
+
+use coding_adventures_reduce_runtime::{print_reduce, ReduceSession};
+use dynval_runtime::{builtins, name_of, LispyValue};
+use reduce_iir_compiler::compile_source;
+use symbolic_ir::{apply, int, sym, IRNode};
+
+/// One oracle corpus entry.
+struct Case {
+    name: &'static str,
+    /// The WHOLE program, byte-for-byte identical on both the
+    /// [`ground_truth`] and [`compiled`] sides.
+    source: &'static str,
+    expected: &'static str,
+}
+
+const CORPUS: &[Case] = &[
+    // --- Literal arithmetic: precedence, chains, unary, grouping. ---
+    Case {
+        name: "integer_literal",
+        source: "42;\n",
+        expected: "42",
+    },
+    Case {
+        name: "simple_addition",
+        source: "2 + 3;\n",
+        expected: "5",
+    },
+    Case {
+        name: "precedence",
+        source: "2 + 3 * 4;\n",
+        expected: "14",
+    },
+    Case {
+        name: "left_associative_chain",
+        source: "1 + 2 + 3 + 4;\n",
+        expected: "10",
+    },
+    Case {
+        name: "unary_minus_leaf",
+        source: "-5 + 3;\n",
+        expected: "-2",
+    },
+    Case {
+        name: "unary_minus_compound",
+        source: "-(5 + 3);\n",
+        expected: "-8",
+    },
+    Case {
+        name: "grouping_overrides_precedence",
+        source: "(2 + 3) * 4;\n",
+        expected: "20",
+    },
+    Case {
+        name: "exact_integer_division",
+        source: "20 / 4;\n",
+        expected: "5",
+    },
+    Case {
+        name: "negative_literal_exact_division",
+        source: "-4 / 2;\n",
+        expected: "-2",
+    },
+    // --- Assignment: binding, reference, re-assignment threading, and
+    // multiple independent variables in one program. ---
+    Case {
+        name: "assignment_and_reference",
+        source: "x := 3;\nx + 1;\n",
+        expected: "4",
+    },
+    Case {
+        name: "reassignment_threading",
+        source: "x := 3;\nx := x + 1;\nx;\n",
+        expected: "4",
+    },
+    Case {
+        name: "two_independent_variables",
+        source: "a := 2;\nb := 3;\na * b;\n",
+        expected: "6",
+    },
+    // --- Unevaluated symbolic expressions: a free symbol alone, and every
+    // arithmetic head with a symbolic operand (Add/Sub/Mul/Div/Neg via
+    // `inert_apply`). ---
+    Case {
+        name: "free_symbol_alone",
+        source: "x;\n",
+        expected: "x",
+    },
+    Case {
+        name: "free_symbol_addition",
+        source: "x + y;\n",
+        expected: "x + y",
+    },
+    Case {
+        name: "mixed_concrete_and_symbolic_multiplication",
+        source: "2 * x;\n",
+        expected: "2*x",
+    },
+    Case {
+        name: "symbolic_subtraction",
+        source: "x - y;\n",
+        expected: "x - y",
+    },
+    Case {
+        name: "symbolic_division_stays_unevaluated",
+        source: "x / y;\n",
+        expected: "x/y",
+    },
+    Case {
+        name: "negation_of_a_free_symbol",
+        source: "-x;\n",
+        expected: "-x",
+    },
+    Case {
+        name: "chained_symbolic_addition_nests_left_associatively",
+        source: "x + y + z;\n",
+        expected: "x + y + z",
+    },
+    Case {
+        name: "assigned_value_used_inside_a_symbolic_expression",
+        source: "x := 2;\nx + y;\n",
+        expected: "2 + y",
+    },
+];
+
+/// Ground truth: run `source` through `reduce-runtime`'s own
+/// [`ReduceSession::eval_to_outputs`], taking only the LAST statement's
+/// `Output::text`.
+fn ground_truth(source: &str) -> String {
+    let mut session = ReduceSession::new();
+    let outputs = session
+        .eval_to_outputs(source)
+        .unwrap_or_else(|e| panic!("reduce-runtime eval failed for {source:?}: {e}"));
+    outputs
+        .into_iter()
+        .last()
+        .expect("at least one statement")
+        .text
+}
+
+/// Compiled path: `compile_source` → `reduce_vm::run` → [`read_back`] →
+/// the same `print_reduce` function the native runtime uses.
+fn compiled(name: &str, source: &str) -> String {
+    let module = compile_source(source, "oracle")
+        .unwrap_or_else(|e| panic!("lowering failed for {name} ({source:?}): {e}"));
+    let value = reduce_vm::run(&module)
+        .unwrap_or_else(|e| panic!("VM execution failed for {name} ({source:?}): {e}"));
+    let node = read_back(value);
+    print_reduce(&node)
+}
+
+/// Rebuild the [`symbolic_ir::IRNode`] a [`LispyValue`] represents — the
+/// mirror image of `reduce_iir_compiler`'s own `inert_apply`/`emit_int`/
+/// `emit_symbol`. Plain recursion is appropriate here for the same
+/// reason `macsyma-iir-compiler/tests/oracle.rs`'s own `read_back`
+/// module doc gives: test-only code over a small, hand-authored corpus.
+fn read_back(v: LispyValue) -> IRNode {
+    if let Some(n) = v.as_int() {
+        return int(n);
+    }
+    if let Some(s) = v.as_symbol() {
+        let name = name_of(s).expect("interned symbol has a name");
+        return sym(name);
+    }
+    // Otherwise `v` must be the inert-Apply cons shape: (head . arglist).
+    let head_value = builtins::car(&[v]).unwrap_or_else(|e| panic!("car of apply pair: {e}"));
+    let head_name = match read_back(head_value) {
+        IRNode::Symbol(name) => name,
+        other => panic!("expected a symbol head, got {other:?}"),
+    };
+    let mut rest = builtins::cdr(&[v]).unwrap_or_else(|e| panic!("cdr of apply pair: {e}"));
+    let mut args = Vec::new();
+    while !rest.is_nil() {
+        let arg = builtins::car(&[rest]).unwrap_or_else(|e| panic!("car of arg list: {e}"));
+        args.push(read_back(arg));
+        rest = builtins::cdr(&[rest]).unwrap_or_else(|e| panic!("cdr of arg list: {e}"));
+    }
+    apply(sym(head_name), args)
+}
+
+#[test]
+fn oracle_corpus_matches_native_reduce_runtime() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        if gt != case.expected {
+            failures.push(format!(
+                "{}: reduce-runtime itself disagrees with this corpus entry's own `expected` \
+                 (got {gt:?}, expected {:?}) -- the program or `expected` is wrong, fix the \
+                 corpus rather than this assertion",
+                case.name, case.expected
+            ));
+            continue;
+        }
+
+        let got = compiled(case.name, case.source);
+        if got != case.expected {
+            failures.push(format!(
+                "{}: reduce-iir-compiler -> reduce-vm disagrees with the reduce-runtime ground \
+                 truth (got {got:?}, expected {:?})",
+                case.name, case.expected
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "oracle corpus mismatches ({} of {}):\n{}",
+        failures.len(),
+        CORPUS.len(),
+        failures.join("\n")
+    );
+}

--- a/code/packages/rust/reduce-vm/BUILD
+++ b/code/packages/rust/reduce-vm/BUILD
@@ -1,0 +1,1 @@
+cargo test -p reduce-vm

--- a/code/packages/rust/reduce-vm/CHANGELOG.md
+++ b/code/packages/rust/reduce-vm/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — reduce-vm
+
+## v0.1.0 — 2026-08-18 — initial release (reduce-iir-vm.md, Wave 5 item 3)
+
+Reduce's own dedicated VM interpreter for the v0 arithmetic/assignment
+IIR subset — a direct structural port of `macsyma-vm`'s/`derive-vm`'s
+dispatch loop, per this rollout's explicit VM-sharing decision
+(`macsyma-iir-vm.md` §6): every language gets its own dedicated VM crate.
+
+* `run`/`run_with_budget` executing an `interpreter_ir::IIRModule`,
+  returning a `dynval_runtime::LispyValue`.
+* `resolve_builtin` maps `+`/`-`/`*`/`/`/`cons`/`car`/`cdr` to
+  `dynval-runtime`'s existing builtins — no new runtime logic.
+* 15 unit tests over hand-built IIR covering every opcode, every error
+  path, and the instruction budget.

--- a/code/packages/rust/reduce-vm/Cargo.toml
+++ b/code/packages/rust/reduce-vm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "reduce-vm"
+version = "0.1.0"
+edition = "2021"
+description = "A tiny interpreter for the Reduce v0 arithmetic/assignment IIR subset, built directly on dynval-runtime. Deliberately independent of twig-vm/mccarthy-lisp-vm/macsyma-vm/derive-vm (each language's own VM); shares only the dynval-runtime foundation."
+
+[lib]
+name = "reduce_vm"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Provides `RuntimeError`, the error type dynval-runtime's builtins return.
+lang-runtime-core = { path = "../lang-runtime-core" }

--- a/code/packages/rust/reduce-vm/README.md
+++ b/code/packages/rust/reduce-vm/README.md
@@ -1,0 +1,29 @@
+# reduce-vm
+
+A tiny interpreter for the Reduce v0 arithmetic/assignment IIR subset,
+built directly on `dynval-runtime`. Executes the `interpreter_ir::IIRModule`
+produced by [`reduce-iir-compiler`](../reduce-iir-compiler) against the
+`dynval-runtime` tagged-`i64` value model, returning a `LispyValue`.
+
+Reduce's own VM — deliberately independent of every sibling VM in this
+rollout (see [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) §6
+for the explicit VM-sharing decision). All share only the
+`dynval-runtime` foundation, not any instruction set or opcodes.
+
+## Instruction set
+
+Only three opcodes: `const`, `call_builtin`, `ret` — v0 has no branches,
+calls, or closures.
+
+## Usage
+
+```rust
+use reduce_vm::run;
+
+let value = run(&module)?; // module: interpreter_ir::IIRModule
+```
+
+## Verification
+
+`cargo test -p reduce-vm` — 15 unit tests over hand-built `IIRModule`s
+covering every opcode, every error path, and the instruction budget.

--- a/code/packages/rust/reduce-vm/src/lib.rs
+++ b/code/packages/rust/reduce-vm/src/lib.rs
@@ -1,0 +1,480 @@
+//! # `reduce-vm` — Reduce's own v0 interpreter.
+//!
+//! Executes the [`IIRModule`] produced by `reduce-iir-compiler` against
+//! the [`dynval_runtime`] value model and returns a [`LispyValue`]. See
+//! [`reduce-iir-vm.md`](../../../specs/reduce-iir-vm.md) for the full
+//! design (the v0 scope and why arithmetic evaluates on the VM instead
+//! of being frontend-folded).
+//!
+//! ## Why a dedicated VM
+//!
+//! Every language in this rollout gets its own small VM on top of
+//! [`dynval_runtime`]'s tagged-`i64` value model — deliberately *not*
+//! shared with any sibling (`macsyma-iir-vm.md` §6's explicit
+//! VM-sharing decision for this rollout). Reduce follows the identical
+//! precedent: its own VM, sharing only the `dynval_runtime` foundation.
+//!
+//! ## The v0 instruction set
+//!
+//! `reduce-iir-compiler` emits a deliberately tiny IIR — no branches, no
+//! calls, no closures, since v0's accepted grammar (literal
+//! arithmetic/assignment/unevaluated symbolic expressions) needs none of
+//! those:
+//!
+//! | Op             | Meaning                                                                 |
+//! |----------------|--------------------------------------------------------------------------|
+//! | `const`        | `Int(n)` → tagged int, `Int(0):ref<LispyPair>` → the nil sentinel, `Var(name)` → interned symbol |
+//! | `call_builtin` | `srcs[0]` is the builtin name (a `Var`), the rest are argument registers; dispatched to a `dynval-runtime` builtin |
+//! | `ret`          | return the value in `srcs[0]`                                            |
+//!
+//! ## Quick start
+//!
+//! ```
+//! use reduce_vm::run;
+//! use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+//!
+//! let main = IIRFunction::new(
+//!     "main",
+//!     Vec::new(),
+//!     "any",
+//!     vec![
+//!         IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(42)], "i64"),
+//!         IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "any"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("demo", "reduce");
+//! module.functions.push(main);
+//! module.entry_point = Some("main".into());
+//!
+//! let result = run(&module).expect("run");
+//! assert_eq!(result.as_int(), Some(42));
+//! ```
+
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+
+use dynval_runtime::value::{INT_MAX, INT_MIN};
+use dynval_runtime::{builtins, intern, LispyValue};
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lang_runtime_core::RuntimeError;
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+/// A failure while interpreting a Reduce [`IIRModule`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmError {
+    /// The module has no `entry_point` set.
+    NoEntryPoint,
+    /// `entry_point` names a function the module does not contain.
+    UnknownFunction(String),
+    /// Control reached the end of a function without a `ret`.
+    FellOffEnd(String),
+    /// An instruction this VM doesn't execute (v0 has no branches, calls,
+    /// or closures). Carries the opcode.
+    UnsupportedOp(String),
+    /// An instruction was missing a `dest`, an operand, etc.
+    Malformed(String),
+    /// A register was read before it was written.
+    UndefinedRegister(String),
+    /// A `call_builtin` named a builtin `dynval-runtime` doesn't provide.
+    UnknownBuiltin(String),
+    /// A `dynval-runtime` builtin raised a runtime trap (wrong arity,
+    /// type error, division by zero, overflow, …). Carries its message.
+    Runtime(String),
+    /// The per-run instruction budget was exhausted.
+    InstructionBudgetExceeded(u64),
+    /// An integer literal outside `dynval-runtime`'s tagged-int range
+    /// (`[-2^60, 2^60 - 1]`). A known v0 gap tied to a later wave (bignum
+    /// support) — see `reduce-iir-vm.md`.
+    IntegerOutOfRange(i64),
+}
+
+impl std::fmt::Display for VmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VmError::NoEntryPoint => write!(f, "module has no entry_point"),
+            VmError::UnknownFunction(n) => write!(f, "unknown function {n:?}"),
+            VmError::FellOffEnd(n) => write!(f, "function {n:?} ran off the end without `ret`"),
+            VmError::UnsupportedOp(op) => write!(f, "unsupported opcode {op:?}"),
+            VmError::Malformed(m) => write!(f, "malformed instruction: {m}"),
+            VmError::UndefinedRegister(r) => write!(f, "register {r:?} read before written"),
+            VmError::UnknownBuiltin(b) => write!(f, "unknown builtin {b:?}"),
+            VmError::Runtime(m) => write!(f, "runtime error: {m}"),
+            VmError::InstructionBudgetExceeded(n) => {
+                write!(
+                    f,
+                    "instruction budget ({n}) exceeded — possible infinite loop"
+                )
+            }
+            VmError::IntegerOutOfRange(n) => write!(
+                f,
+                "integer literal {n} is outside dynval-runtime's tagged-int range [-2^60, 2^60-1]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VmError {}
+
+// ===========================================================================
+// Public entry points
+// ===========================================================================
+
+/// Default instruction budget. Far above any real v0 program's step count
+/// (v0 has no loops), but a hard backstop nonetheless.
+pub const DEFAULT_INSTRUCTION_BUDGET: u64 = 10_000_000;
+
+/// Execute `module`'s entry-point function and return its result value.
+///
+/// # Errors
+///
+/// See [`VmError`] for the full list — missing entry point, unsupported
+/// opcode, builtin trap, etc.
+pub fn run(module: &IIRModule) -> Result<LispyValue, VmError> {
+    run_with_budget(module, DEFAULT_INSTRUCTION_BUDGET)
+}
+
+/// Like [`run`], but with an explicit instruction budget (the maximum
+/// number of instructions executed before
+/// [`VmError::InstructionBudgetExceeded`]).
+///
+/// # Errors
+///
+/// See [`VmError`].
+pub fn run_with_budget(module: &IIRModule, budget: u64) -> Result<LispyValue, VmError> {
+    let entry = module.entry_point.as_deref().ok_or(VmError::NoEntryPoint)?;
+    let func = module
+        .get_function(entry)
+        .ok_or_else(|| VmError::UnknownFunction(entry.to_string()))?;
+    let mut steps: u64 = 0;
+    run_function(func, &mut steps, budget)
+}
+
+// ===========================================================================
+// Interpreter core
+// ===========================================================================
+
+/// The register file: register name → live value. A `HashMap` keeps the
+/// VM independent of any register-numbering scheme the compiler uses.
+type Frame = HashMap<String, LispyValue>;
+
+fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<LispyValue, VmError> {
+    let mut frame: Frame = HashMap::new();
+    let mut pc: usize = 0;
+
+    while pc < func.instructions.len() {
+        *steps += 1;
+        if *steps > budget {
+            return Err(VmError::InstructionBudgetExceeded(budget));
+        }
+
+        let instr = &func.instructions[pc];
+        match instr.op.as_str() {
+            "const" => {
+                let value = eval_const(instr)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "call_builtin" => {
+                let value = eval_call_builtin(instr, &frame)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "ret" => {
+                let src = instr
+                    .srcs
+                    .first()
+                    .ok_or_else(|| VmError::Malformed("`ret` requires a source operand".into()))?;
+                return read_operand(src, &frame);
+            }
+            other => return Err(VmError::UnsupportedOp(other.to_string())),
+        }
+    }
+
+    Err(VmError::FellOffEnd(func.name.clone()))
+}
+
+/// Store an instruction's result in its `dest` register.
+fn bind_dest(instr: &IIRInstr, value: LispyValue, frame: &mut Frame) -> Result<(), VmError> {
+    let dest = instr
+        .dest
+        .as_ref()
+        .ok_or_else(|| VmError::Malformed(format!("`{}` requires a dest register", instr.op)))?;
+    frame.insert(dest.clone(), value);
+    Ok(())
+}
+
+/// Materialise a `const` instruction's literal into a [`LispyValue`].
+///
+/// The operand encodings match what `reduce-iir-compiler` emits (the
+/// same conventions `macsyma-iir-compiler`/`derive-iir-compiler`
+/// established for this value model):
+///
+/// - `Int(0)` with `type_hint == "ref<LispyPair>"` → the **nil** sentinel.
+/// - any other `Int(n)` → a tagged integer.
+/// - `Var(name)` → an **interned symbol** (not a register read — inside a
+///   `const`, `Var` carries the symbol's textual name).
+fn eval_const(instr: &IIRInstr) -> Result<LispyValue, VmError> {
+    let src = instr
+        .srcs
+        .first()
+        .ok_or_else(|| VmError::Malformed("`const` requires a source operand".into()))?;
+    match src {
+        Operand::Int(0) if instr.type_hint == "ref<LispyPair>" => Ok(LispyValue::NIL),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Var(name) => Ok(LispyValue::symbol(intern(name))),
+        Operand::Bool(_) => Err(VmError::Malformed(
+            "Reduce v0 has no boolean literals; unexpected Bool operand in `const`".into(),
+        )),
+        Operand::Float(_) => Err(VmError::Malformed(
+            "Reduce v0 has no floats (reduce-iir-vm.md); unexpected Float operand in `const`"
+                .into(),
+        )),
+        Operand::Str(_) => Err(VmError::Malformed(
+            "Reduce v0 has no string literals; unexpected Str operand in `const`".into(),
+        )),
+    }
+}
+
+/// Execute a `call_builtin`: `srcs[0]` is the builtin's name (a `Var`),
+/// the remaining sources are argument registers.
+fn eval_call_builtin(instr: &IIRInstr, frame: &Frame) -> Result<LispyValue, VmError> {
+    let name = match instr.srcs.first() {
+        Some(Operand::Var(n)) => n.as_str(),
+        _ => {
+            return Err(VmError::Malformed(
+                "`call_builtin` requires srcs[0] to be the builtin name (a Var)".into(),
+            ))
+        }
+    };
+
+    let mut args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
+    for src in &instr.srcs[1..] {
+        args.push(read_operand(src, frame)?);
+    }
+
+    let builtin = resolve_builtin(name).ok_or_else(|| VmError::UnknownBuiltin(name.to_string()))?;
+    builtin(&args).map_err(|e| VmError::Runtime(e.to_string()))
+}
+
+/// A `dynval-runtime` builtin: takes a slice of arguments, returns a value
+/// or a runtime trap. This is the shape every `builtins::*` function has.
+type BuiltinFn = fn(&[LispyValue]) -> Result<LispyValue, RuntimeError>;
+
+/// Map a Reduce v0 builtin name to its `dynval-runtime` implementation.
+///
+/// `+`/`-`/`*`/`/` back v0's real arithmetic; `cons` backs its
+/// unevaluated-symbolic-expression representation. `car`/`cdr` are wired
+/// even though v0's own lowering never emits them, matching
+/// `macsyma-vm`'s precedent of a slightly-generous table.
+fn resolve_builtin(name: &str) -> Option<BuiltinFn> {
+    match name {
+        "+" => Some(builtins::add),
+        "-" => Some(builtins::sub),
+        "*" => Some(builtins::mul),
+        "/" => Some(builtins::div),
+        "cons" => Some(builtins::cons),
+        "car" => Some(builtins::car),
+        "cdr" => Some(builtins::cdr),
+        _ => None,
+    }
+}
+
+/// Build a tagged integer, rejecting values outside `dynval-runtime`'s
+/// 61-bit tagged-int range rather than letting `LispyValue::int` silently
+/// truncate them in release builds.
+fn dyn_int(n: i64) -> Result<LispyValue, VmError> {
+    if (INT_MIN..=INT_MAX).contains(&n) {
+        Ok(LispyValue::int(n))
+    } else {
+        Err(VmError::IntegerOutOfRange(n))
+    }
+}
+
+/// Read an operand in *value* position: a `Var` is a register read; an
+/// `Int` is an immediate. (`const` handles its `Var` specially — see
+/// [`eval_const`].)
+fn read_operand(op: &Operand, frame: &Frame) -> Result<LispyValue, VmError> {
+    match op {
+        Operand::Var(name) => frame
+            .get(name)
+            .copied()
+            .ok_or_else(|| VmError::UndefinedRegister(name.clone())),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Bool(_) => Err(VmError::Malformed("unexpected Bool operand".into())),
+        Operand::Float(_) => Err(VmError::Malformed("unexpected Float operand".into())),
+        Operand::Str(_) => Err(VmError::Malformed("unexpected Str operand".into())),
+    }
+}
+
+// ===========================================================================
+// Tests (hand-built IIR; the compiler's own tests cover the source path)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynval_runtime::name_of;
+
+    fn module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let main = IIRFunction::new("main", Vec::new(), "any", instrs);
+        let mut m = IIRModule::new("test", "reduce");
+        m.functions.push(main);
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    fn konst(dest: &str, op: Operand, ty: &str) -> IIRInstr {
+        IIRInstr::new("const", Some(dest.into()), vec![op], ty)
+    }
+
+    fn ret(reg: &str) -> IIRInstr {
+        IIRInstr::new("ret", None, vec![Operand::Var(reg.into())], "any")
+    }
+
+    fn builtin_instr(dest: &str, name: &str, args: &[&str]) -> IIRInstr {
+        let mut srcs = vec![Operand::Var(name.into())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).into())));
+        IIRInstr::new("call_builtin", Some(dest.into()), srcs, "any")
+    }
+
+    #[test]
+    fn integer_const() {
+        let m = module(vec![konst("v0", Operand::Int(42), "i64"), ret("v0")]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(42));
+    }
+
+    #[test]
+    fn nil_const() {
+        let m = module(vec![
+            konst("v0", Operand::Int(0), "ref<LispyPair>"),
+            ret("v0"),
+        ]);
+        assert!(run(&m).unwrap().is_nil());
+    }
+
+    #[test]
+    fn symbol_const_interns() {
+        let m = module(vec![
+            konst("v0", Operand::Var("X".into()), "symbol"),
+            ret("v0"),
+        ]);
+        let v = run(&m).unwrap();
+        assert_eq!(v.as_symbol(), Some(intern("X")));
+        assert_eq!(name_of(v.as_symbol().unwrap()).as_deref(), Some("X"));
+    }
+
+    #[test]
+    fn add_two_concrete_ints() {
+        let m = module(vec![
+            konst("a", Operand::Int(2), "i64"),
+            konst("b", Operand::Int(3), "i64"),
+            builtin_instr("r", "+", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(5));
+    }
+
+    #[test]
+    fn sub_unary_negates() {
+        let m = module(vec![
+            konst("a", Operand::Int(5), "i64"),
+            builtin_instr("r", "-", &["a"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(-5));
+    }
+
+    #[test]
+    fn cons_builds_an_inert_pair() {
+        let m = module(vec![
+            konst("head", Operand::Var("Add".into()), "symbol"),
+            konst("x", Operand::Var("X".into()), "symbol"),
+            konst("y", Operand::Var("Y".into()), "symbol"),
+            konst("nil", Operand::Int(0), "ref<LispyPair>"),
+            builtin_instr("t1", "cons", &["y", "nil"]),
+            builtin_instr("t2", "cons", &["x", "t1"]),
+            builtin_instr("r", "cons", &["head", "t2"]),
+            ret("r"),
+        ]);
+        let v = run(&m).unwrap();
+        let h = builtins::car(&[v]).unwrap();
+        assert_eq!(name_of(h.as_symbol().unwrap()).as_deref(), Some("Add"));
+    }
+
+    #[test]
+    fn missing_entry_point() {
+        let mut m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        m.entry_point = None;
+        assert_eq!(run(&m), Err(VmError::NoEntryPoint));
+    }
+
+    #[test]
+    fn unknown_entry_function() {
+        let mut m = module(vec![ret("v0")]);
+        m.entry_point = Some("nope".into());
+        assert!(matches!(run(&m), Err(VmError::UnknownFunction(_))));
+    }
+
+    #[test]
+    fn fell_off_end_without_ret() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64")]);
+        assert!(matches!(run(&m), Err(VmError::FellOffEnd(_))));
+    }
+
+    #[test]
+    fn unsupported_op() {
+        let m = module(vec![IIRInstr::new("jmp", None, vec![], "void")]);
+        assert!(matches!(run(&m), Err(VmError::UnsupportedOp(_))));
+    }
+
+    #[test]
+    fn unknown_builtin() {
+        let m = module(vec![
+            konst("x", Operand::Int(1), "i64"),
+            builtin_instr("r", "frobnicate", &["x"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::UnknownBuiltin(_))));
+    }
+
+    #[test]
+    fn undefined_register() {
+        let m = module(vec![ret("never_written")]);
+        assert!(matches!(run(&m), Err(VmError::UndefinedRegister(_))));
+    }
+
+    #[test]
+    fn division_by_zero_is_a_clean_runtime_error() {
+        let m = module(vec![
+            konst("a", Operand::Int(1), "i64"),
+            konst("b", Operand::Int(0), "i64"),
+            builtin_instr("r", "/", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn integer_out_of_tagged_range_is_rejected() {
+        let m = module(vec![konst("v0", Operand::Int(i64::MAX), "i64"), ret("v0")]);
+        assert!(matches!(run(&m), Err(VmError::IntegerOutOfRange(_))));
+        let ok = module(vec![
+            konst("v0", Operand::Int((1 << 60) - 1), "i64"),
+            ret("v0"),
+        ]);
+        assert_eq!(run(&ok).unwrap().as_int(), Some((1 << 60) - 1));
+    }
+
+    #[test]
+    fn instruction_budget() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        assert!(matches!(
+            run_with_budget(&m, 1),
+            Err(VmError::InstructionBudgetExceeded(_))
+        ));
+    }
+}

--- a/code/specs/reduce-iir-vm.md
+++ b/code/specs/reduce-iir-vm.md
@@ -1,0 +1,89 @@
+# Reduce → IIR → VM interpreter
+
+**Status:** Draft — 2026-08-18 (spec-first; sign-off = merge)
+**Depends on:** [`macsyma-iir-vm.md`](macsyma-iir-vm.md) — this is Wave 5
+item 3 of that spec's rollout; read it first for the full design.
+[`derive-iir-vm.md`](derive-iir-vm.md) is the closer template (same
+`:=` disambiguation shape). This document only records Reduce's own
+deltas.
+**Unblocks:** the same IIR-bridge pattern for the rest of Wave 5 (Maple,
+Axiom, Wolfram).
+
+## Summary
+
+Bridges Reduce onto `interpreter_ir` (IIR) the same way Macsyma and
+Derive were bridged: a new `reduce-iir-compiler` frontend (a third
+retarget of the `GrammarASTNode` CST `reduce-runtime` and
+`reduce-to-semantic-ir` already walk) and a new `reduce-vm` interpreter
+(its own dedicated VM, per `macsyma-iir-vm.md` §6).
+
+```text
+                                ┌─→ reduce-runtime (+ repl)                [existing, unchanged]
+reduce source → GrammarASTNode ┤─→ reduce-to-semantic-ir → any SIR backend [existing, unchanged]
+                                └─→ reduce-iir-compiler → IIRModule → reduce-vm   [NEW]
+```
+
+## Deltas from Derive's design
+
+Verified directly against `reduce.grammar`/`reduce.tokens`
+(`code/grammars/reduce/`) and `reduce-to-semantic-ir/src/lower.rs`'s
+module doc comment:
+
+1. **Three genuinely new grammar constructs, all outside v0 and all
+   rejected outright**: an expression-shaped `if`/`then`/`else`
+   (`if_expr`), a `<< s1; s2; ... >>` group statement (`group_expr`), and
+   `a . b` cons (`cons`). Unlike arithmetic's inert-data fallback, none of
+   these get one — v0 has no control-flow or list-cons runtime semantics
+   to make either an evaluated or an inert-data representation
+   verifiably correct.
+2. **List literals use `{...}` (curly braces), not Derive's `[...]`.**
+   Also rejected outright (v0 has no list support at all, unlike
+   Macsyma's own `[...]` which is likewise rejected).
+3. **`neq` (not `#`) is the not-equal comparison token**, a lowercase
+   `KEYWORD`-typed token matched by value like `and`/`or`/`not`/`if`/
+   `then`/`else` — moot for v0, since comparisons are rejected outright
+   regardless of spelling.
+4. **Program structure has an optional trailing bare statement**:
+   `program = { statement_line } [ statement ]` (a source file need not
+   end with a `;`/`$` terminator), unlike Derive's uniform
+   `{ statement_line }`. `lower_file`'s loop handles both shapes.
+5. **`assignment`'s RHS is the wider `expr` production**, not Derive's
+   self-referential `assignment` — moot for v0 since none of the newly
+   admitted RHS shapes (`if_expr`, `group_expr`) are in scope.
+6. Everything else — the `:=` bare-name disambiguation, the `/`
+   exactness rule, the inert-`cons`-chain representation, `TIMES`/
+   `SLASH`/no-unary-plus, the outright rejection of comparisons/`and`/
+   `or`/`^` — is unchanged from `derive-iir-vm.md`.
+
+## Oracle ground truth
+
+`reduce-runtime`'s API mirrors `derive-runtime`'s exactly:
+`ReduceSession::eval_to_outputs(source) -> Result<Vec<Output>, String>`,
+each rendered by `reduce-runtime`'s own bespoke printer, `print_reduce`
+(`src/printer.rs`) — not `cas_pretty_printer`. The oracle test's
+`read_back` reader is identical in shape to `derive-iir-compiler`'s.
+
+## Crates
+
+- `code/packages/rust/reduce-iir-compiler` — `compile`/`compile_source`,
+  depends on `coding-adventures-reduce-parser`/`interpreter-ir`/`parser`/
+  `lexer`/`symbolic-ir`; dev-depends on `reduce-vm`/`dynval-runtime`/
+  `coding-adventures-reduce-runtime`.
+- `code/packages/rust/reduce-vm` — `run`/`run_with_budget`, a direct
+  structural port of `macsyma-vm`'s/`derive-vm`'s dispatch loop.
+
+## Verification
+
+- `cargo test -p reduce-iir-compiler -p reduce-vm` — unit tests + the
+  oracle test.
+- `cargo clippy -p reduce-iir-compiler -p reduce-vm --all-targets` /
+  `cargo fmt --check` clean.
+- Oracle corpus has an empty `known_bug` list.
+
+## References
+
+[`macsyma-iir-vm.md`](macsyma-iir-vm.md),
+[`derive-iir-vm.md`](derive-iir-vm.md) (the closer template),
+[`MA08-reduce-language.md`](MA08-reduce-language.md) (the original
+Reduce language spec), `reduce-to-semantic-ir/src/lower.rs` (the
+rule-dispatch table retargeted a third time).


### PR DESCRIPTION
## Summary
- Third item of `macsyma-iir-vm.md`'s Wave 5: bridges Reduce onto `interpreter_ir` (IIR), the third real-language frontend after Macsyma and Derive.
- `reduce-iir-compiler` retargets `reduce-runtime`'s/`reduce-to-semantic-ir`'s existing CST dispatch, following `derive-iir-compiler`'s precedent directly (same `:=` bare-name disambiguation shape). `reduce-vm` is a structural port of the sibling dispatch loops.
- Per-language deltas from Derive, recorded in the new leaf spec `reduce-iir-vm.md`: three genuinely new grammar constructs (`if`/`then`/`else`, `<< ... >>` group statements, `a . b` cons) all rejected outright since v0 has no control-flow/list-cons semantics to give them a verifiably correct meaning; list literals use `{...}` not `[...]`; `neq` not `#`; an optional trailing bare statement with no terminator; oracle test renders both sides through `reduce-runtime`'s own `print_reduce`.

## Test plan
- [x] `cargo test -p reduce-iir-compiler -p reduce-vm` -- 32 + 15 unit tests + 1 oracle test (18 cases) + 2 doctests, all passing
- [x] `cargo clippy -p reduce-iir-compiler -p reduce-vm --all-targets` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `/security-review` -- passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)