### PR TITLE
fix(vault-pm): wire pending-publication recovery into vault open

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to this package are documented here.
 
+## [0.62.0] - 2026-08-18
+
+### Added
+
+- `VaultAccessV1::unlock_recovering_pending_publication` and the closed
+  `UnlockRecoveryV1` outcome it returns (`AlreadyActive` or
+  `RecoveredPendingPublication`). This is the second half of
+  `VLT-PM05-application.md` §8 step 2 — "resume a prepared initialization or
+  **pending publication** when present" — which had been specified from the
+  beginning and never wired to anything.
+
+  `recover_pending_publication` was already here, already correct, and already
+  covered: it replays an exact durable journal idempotently and advances the
+  owner state only after the repository returns the heads that journal
+  expected. Nothing called it. `VLT-PM41-cli-crash-fault-matrix.md` §8 measured
+  what that cost by killing a real process: a vault interrupted mid-publication
+  was intact, exactly journalled, correctly diagnosed as `recovery_required` by
+  both read-only projections — and refused by every command that opened it,
+  because `open_active_vault` accepts only `Active`. That refusal surfaced as
+  the invalid-input class, so a person whose machine died mid-write was told
+  their *command* was wrong, indefinitely.
+
+  The new entry point replays the journal and then performs the ordinary strict
+  `open_active_vault` against the repaired durable state, discarding the
+  `ActiveStateV1` the recovery returned. That is deliberate: every check a
+  later, uninvolved process would perform — bootstrap signature, root-wrap
+  authentication, seed-to-pinned-identity reproduction, repository open against
+  non-empty pins — runs on the repaired bytes. A repair that produced a session
+  only the repairing process could reproduce would be worth less than no repair.
+
+  It costs one extra Argon2id derivation, and only when a repair happens: the
+  recovery and the reopen each consume a passphrase by value. Since `Zeroizing`
+  implements neither `Clone` nor `Debug` on purpose, the recovering branch
+  constructs its duplicate by name; both copies are wiped on drop, including
+  while unwinding.
+
+### Unchanged, deliberately
+
+- `VaultAccessV1::unlock` still accepts only `Active` and still refuses a
+  `PendingPublication` with the invalid-input class, so a host that wants a
+  crash refused rather than repaired keeps exactly that. The recovering unlock
+  is a second named door, not a change of behavior behind the existing one.
+- `open_active_vault` and `recover_pending_publication` are untouched. This
+  release composes them; it does not modify either.
+- A `PreparedInit` owner state is still refused by the recovering unlock. It
+  belongs to initialization, which is the only caller that knows a vault is
+  being created.
+
 ## [0.61.2] - 2026-08-17
 
 ### Fixed

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -507,6 +507,44 @@ still cause. That residual is pre-existing and tracked; it needs a decision
 about what a partly-unreadable item looks like to every ceremony, not a local
 fix. See VLT-PM05 section 13.3 and VLT02 *Decoding never re-encodes*.
 
+## Two doors into an unlocked vault
+
+`VaultAccessV1` offers two named unlocks, and choosing between them is a
+policy decision this crate deliberately leaves to the host.
+
+`unlock` is strict. It accepts only an `Active` owner state and refuses
+everything else with the invalid-input class. A host that wants a vault
+interrupted mid-write to be *refused* rather than silently finished has exactly
+that, unchanged.
+
+`unlock_recovering_pending_publication` is the other door, and it is the second
+half of what VLT-PM05 §8 step 2 has always required: "resume a prepared
+initialization or **pending publication** when present". If the durable owner
+state is a `PendingPublication`, it replays that exact journal through
+`recover_pending_publication` — idempotently, advancing the state only after the
+repository returns the heads the journal expected — and then throws the result
+away and performs the ordinary strict open of the repaired durable bytes. The
+discard is the point: every check a later, uninvolved process would run happens
+here too, on the repaired bytes. It returns `UnlockRecoveryV1` so the host can
+tell a person that something was repaired.
+
+The cost is one extra Argon2id derivation, paid only when a repair actually
+happens, because recovery and open each authenticate the passphrase against the
+bootstrap root wrap. `Zeroizing` implements neither `Clone` nor `Debug`, so the
+duplicate passphrase the recovering branch needs is constructed by name and
+wiped on drop.
+
+`PreparedInit` is refused by both doors. It belongs to initialization, which is
+the only caller that knows a vault is being created.
+
+Why this matters is worth stating plainly: `recover_pending_publication` was
+correct and well tested here for a long time, and nothing called it. A drill
+that killed the real executable
+(`code/specs/VLT-PM41-cli-crash-fault-matrix.md` §8) found that a vault
+interrupted mid-publication was intact, exactly journalled, correctly
+diagnosed — and unopenable by any command. A recovery routine nobody reaches is
+a receipt for a repair that never happens.
+
 ## Verification
 
 The package tests cover exact canonical and cryptographic vectors,

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -54,7 +54,7 @@ pub use initialize::{
     GenerationZeroRandomness, PreparedGenerationZero, AUDITED_GENERATION_ZERO_RANDOM_BYTES,
     GENERATION_ZERO_RANDOM_BYTES,
 };
-pub use lifecycle::{LockedVaultV1, VaultAccessV1};
+pub use lifecycle::{LockedVaultV1, UnlockRecoveryV1, VaultAccessV1};
 pub use mutation::{
     portable_import_random_bytes, AddItemRandomnessV1, AuditedAccessRandomnessV1,
     DeleteItemRandomnessV1, PortableImportRandomnessV1, ReplaceItemRandomnessV1,

--- a/code/packages/rust/vault-pm-application/src/lifecycle.rs
+++ b/code/packages/rust/vault-pm-application/src/lifecycle.rs
@@ -1,6 +1,7 @@
 use crate::{
-    open_active_vault, ApplicationError, ApplicationRepositoryFactory, BootstrapLocator,
-    BootstrapStore, LocalStateStore, UnlockedVaultV1, VaultStatusV1,
+    open_active_vault, recover_pending_publication, ApplicationError, ApplicationRepositoryFactory,
+    BootstrapLocator, BootstrapStore, LocalStateStore, UnlockedVaultV1, VaultStatusStateV1,
+    VaultStatusV1,
 };
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
@@ -30,6 +31,22 @@ impl Debug for LockedVaultV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("LockedVaultV1(<locked>)")
     }
+}
+
+/// What an unlock had to finish before it could open the vault.
+///
+/// A crash inside a mutation publication is invisible to the person who caused
+/// it — the machine simply stopped — so the host that repairs it is the only
+/// party in a position to mention it afterwards. This closed enum is the whole
+/// vocabulary needed for that: it carries no vault, item, revision, object, or
+/// provider identity, and no count.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnlockRecoveryV1 {
+    /// Durable owner state was already `Active`; nothing was published.
+    AlreadyActive,
+    /// One exact `PendingPublication` journal was replayed to completion
+    /// before the vault was opened.
+    RecoveredPendingPublication,
 }
 
 /// Explicit host lifecycle boundary for a locked or unlocked vault.
@@ -132,6 +149,100 @@ impl VaultAccessV1 {
         )?;
         *self = Self::Unlocked(Box::new(session));
         Ok(())
+    }
+
+    /// Finish an interrupted publication if one is durable, then unlock.
+    ///
+    /// # Why this exists
+    ///
+    /// `VLT-PM05-application.md` §8 step 2 requires an open to "resume a
+    /// prepared initialization or pending publication when present". The
+    /// `PreparedInit` half of that sentence is `init`'s resume path. This is
+    /// the other half, and until VLT-PM42 nothing in the product performed it:
+    /// [`Self::unlock`] refuses every owner state but `Active`, so a process
+    /// killed inside [`crate::UnlockedVaultV1`]'s publication path left a vault
+    /// that was intact, exactly journalled, correctly diagnosed — and that no
+    /// command could open. VLT-PM41 §8 found that and measured it as an
+    /// availability defect in shipped code.
+    ///
+    /// # What it does
+    ///
+    /// ```text
+    ///   PendingPublication ──▶ recover_pending_publication ──┐
+    ///                                                        ├──▶ open_active_vault
+    ///   anything else ───────────────────────────────────────┘
+    /// ```
+    ///
+    /// The recovery replays the already-signed bytes idempotently and advances
+    /// the owner state only after the repository returns exactly the heads the
+    /// journal expected. Its result is then deliberately *discarded*: the vault
+    /// is opened from durable state by the ordinary strict
+    /// [`open_active_vault`], so every check a later, uninvolved process would
+    /// perform runs here too, on the repaired bytes. A repair that produced a
+    /// session only the repairing process could reproduce would be worth less
+    /// than no repair at all.
+    ///
+    /// # What it costs
+    ///
+    /// One extra Argon2id derivation, and only when a repair actually happens:
+    /// recovery and open each authenticate the passphrase against the bootstrap
+    /// root wrap. The `AlreadyActive` path derives exactly once, as before. A
+    /// process that finds a wedged vault has already survived a crash; paying
+    /// one more key derivation to reopen it from scratch is the right trade.
+    ///
+    /// # Secret handling
+    ///
+    /// Both callees consume a passphrase by value, and
+    /// [`Zeroizing`] deliberately implements neither `Clone` nor `Debug` so
+    /// that duplicating a secret cannot happen by accident. The duplicate below
+    /// is therefore constructed by name, exists only inside the recovering
+    /// branch, and is wiped on drop — including while unwinding from a panic.
+    ///
+    /// # Failure
+    ///
+    /// A wrong passphrase is rejected by the recovery *before* any publication,
+    /// with the same closed authentication class an ordinary unlock returns,
+    /// and leaves the exact journal in place for a later correct attempt. A
+    /// `PreparedInit` state is refused: it belongs to `init`. Any failure
+    /// leaves this boundary locked, and repeating the whole call is always
+    /// sound because the recovery is idempotent.
+    pub fn unlock_recovering_pending_publication(
+        &mut self,
+        passphrase: Zeroizing<Vec<u8>>,
+        local_state_store: &dyn LocalStateStore,
+        bootstrap_store: &dyn BootstrapStore,
+        repository_factory: &dyn ApplicationRepositoryFactory,
+    ) -> Result<UnlockRecoveryV1, ApplicationError> {
+        let Self::Locked(locked) = self else {
+            return Err(ApplicationError::InvalidInput);
+        };
+        let locator = locked.locator();
+        // The same read-only projection `status` exposes to a locked host, so
+        // there is exactly one place in this crate that decides which durable
+        // owner states mean "recovery required".
+        let recovery_required = matches!(
+            self.status(local_state_store)?.state(),
+            VaultStatusStateV1::RecoveryRequired
+        );
+        let outcome = if recovery_required {
+            recover_pending_publication(
+                Zeroizing::new(passphrase.to_vec()),
+                locator,
+                local_state_store,
+                bootstrap_store,
+                repository_factory,
+            )?;
+            UnlockRecoveryV1::RecoveredPendingPublication
+        } else {
+            UnlockRecoveryV1::AlreadyActive
+        };
+        self.unlock(
+            passphrase,
+            local_state_store,
+            bootstrap_store,
+            repository_factory,
+        )?;
+        Ok(outcome)
     }
 
     /// Synchronously drop the live session and return to a key-free state.

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -5514,6 +5514,297 @@ mod tests {
         assert_eq!(backend.pending_faults().unwrap(), 0);
     }
 
+    // -----------------------------------------------------------------------
+    // VLT-PM42 — the recovering unlock
+    //
+    // `recover_pending_publication` was correct and unreachable. These tests
+    // cover the lifecycle boundary that finally reaches it, and they build
+    // their wedged vault the way a crash builds one — by letting a real
+    // publication start and then taking the provider away — rather than by
+    // hand-assembling journal bytes.
+    // -----------------------------------------------------------------------
+
+    /// One vault whose durable owner state is an exact `PendingPublication`,
+    /// plus those exact pending bytes for later comparison.
+    #[allow(clippy::type_complexity)]
+    fn wedged_by_an_interrupted_publication(
+        passphrase: &[u8],
+    ) -> (
+        BootstrapLocator,
+        MemoryLocalStateStore,
+        MemoryBootstrapStore,
+        V1ApplicationRepositoryFactory<FaultInjectingObjectStore<InMemoryObjectStore>>,
+        Vec<u8>,
+    ) {
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let backend = Arc::new(FaultInjectingObjectStore::new(InMemoryObjectStore::new()));
+        let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&backend));
+        complete_generation_zero(prepared, &local, &bootstrap, &factory).unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        // The commit lands and *then* the provider stops answering: exactly the
+        // ambiguity a `SIGKILL` between the write-ahead journal and the
+        // owner-state advance produces.
+        backend
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+        assert!(matches!(
+            session.activate_audit_epoch(703, audited_access_randomness(0xab), &local),
+            Err(ApplicationError::StorageUnavailable)
+        ));
+
+        let exact_pending = local.0.lock().unwrap().clone().unwrap();
+        assert!(matches!(
+            LocalVaultStateV1::decode(&exact_pending).unwrap(),
+            LocalVaultStateV1::PendingPublication { .. }
+        ));
+        (locator, local, bootstrap, factory, exact_pending)
+    }
+
+    #[test]
+    fn a_recovering_unlock_leaves_an_active_vault_alone() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let mut access = crate::VaultAccessV1::locked(locator);
+
+        let outcome = access
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+
+        assert_eq!(outcome, crate::UnlockRecoveryV1::AlreadyActive);
+        assert!(access.is_unlocked());
+        // Nothing was published, so the durable bytes are the ones we started
+        // with, byte for byte.
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_active.as_slice())
+        );
+    }
+
+    #[test]
+    fn a_recovering_unlock_finishes_an_interrupted_publication_and_opens() {
+        let passphrase = b"active passphrase";
+        let (locator, local, bootstrap, factory, exact_pending) =
+            wedged_by_an_interrupted_publication(passphrase);
+        let LocalVaultStateV1::PendingPublication {
+            active: interrupted,
+            publication,
+        } = LocalVaultStateV1::decode(&exact_pending).unwrap()
+        else {
+            panic!("fixture must be pending")
+        };
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        let outcome = access
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(passphrase.to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            crate::UnlockRecoveryV1::RecoveredPendingPublication
+        );
+        // The durable end state is exactly what the journal intended, which is
+        // the same state `recover_pending_publication` produces on its own.
+        let intended = interrupted.after_publication(&publication).unwrap();
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(
+                LocalVaultStateV1::Active(intended)
+                    .encode()
+                    .unwrap()
+                    .as_slice()
+            )
+        );
+        // And the session is a real one: the recovered audit epoch is present
+        // and the whole chain verifies.
+        let session = access.into_unlocked().unwrap();
+        assert!(session.audit_enabled());
+        let report = session.audit_verify().unwrap();
+        assert_eq!(report.commit_count(), 2);
+        assert_eq!(report.audit_event_count(), 1);
+    }
+
+    #[test]
+    fn a_recovering_unlock_is_idempotent() {
+        let passphrase = b"active passphrase";
+        let (locator, local, bootstrap, factory, _) =
+            wedged_by_an_interrupted_publication(passphrase);
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        access
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(passphrase.to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        let recovered = local.0.lock().unwrap().clone().unwrap();
+
+        // A second process finds an ordinary vault and publishes nothing more.
+        let mut again = crate::VaultAccessV1::locked(locator);
+        let outcome = again
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(passphrase.to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert_eq!(outcome, crate::UnlockRecoveryV1::AlreadyActive);
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(recovered.as_slice())
+        );
+    }
+
+    #[test]
+    fn a_recovering_unlock_refuses_the_wrong_passphrase_and_keeps_the_journal() {
+        let (locator, local, bootstrap, factory, exact_pending) =
+            wedged_by_an_interrupted_publication(b"active passphrase");
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        assert!(matches!(
+            access.unlock_recovering_pending_publication(
+                Zeroizing::new(b"wrong passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::AuthenticationFailed)
+        ));
+
+        // Fails closed: still locked, and the exact journal is untouched so a
+        // later attempt with the right secret still repairs the vault.
+        assert!(access.is_locked());
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_pending.as_slice())
+        );
+        let outcome = access
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            crate::UnlockRecoveryV1::RecoveredPendingPublication
+        );
+    }
+
+    #[test]
+    fn a_recovering_unlock_refuses_a_prepared_initialization() {
+        // A `PreparedInit` journal is `init`'s to finish, not an unlock's: it
+        // has no signed publication to replay and no `Active` state to open.
+        let passphrase = b"prepared passphrase";
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let factory =
+            V1ApplicationRepositoryFactory::from_shared(Arc::new(InMemoryObjectStore::new()));
+        let exact_prepared = prepared.owner_state().encode().unwrap();
+        *local.0.lock().unwrap() = Some(exact_prepared.clone());
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        assert!(matches!(
+            access.unlock_recovering_pending_publication(
+                Zeroizing::new(passphrase.to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_prepared.as_slice())
+        );
+    }
+
+    #[test]
+    fn a_plain_unlock_still_refuses_a_pending_publication() {
+        // The strict door stays strict. A host that wants "open an `Active`
+        // vault and refuse anything else" still has exactly that.
+        let (locator, local, bootstrap, factory, exact_pending) =
+            wedged_by_an_interrupted_publication(b"active passphrase");
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        assert!(matches!(
+            access.unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert!(access.is_locked());
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_pending.as_slice())
+        );
+    }
+
+    #[test]
+    fn a_recovering_unlock_refuses_an_already_unlocked_boundary() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut access = crate::VaultAccessV1::locked(locator);
+        access
+            .unlock_recovering_pending_publication(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert!(matches!(
+            access.unlock_recovering_pending_publication(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
+    }
+
     #[test]
     fn audited_list_refuses_pre_audit_sessions_without_changing_owner_state() {
         let (locator, local, bootstrap, factory) = initialized();

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -43,7 +43,12 @@
   unobservable after-state satisfies "not `RecoveryRequired`" while proving
   nothing, so reading it that way would announce a repair on a vault that is
   still wedged. `observed_a_repair` states the whole truth table and is pinned
-  by a test. Standard output and every exit class are unchanged, and the notice
+  by a test. The second reading is also *conditional* on the first having found
+  `recovery_required`, which is a requirement rather than an optimization:
+  reading owner state initializes its backend, a backend initialization is a
+  durable step VLT-PM41 kills processes at, and reading after every command
+  would append durable writes past each ceremony's own last one. An observation
+  about a command must not move the command. Standard output and every exit class are unchanged, and the notice
   is attached to a failing command too, because a repair is worth saying even
   when the verb that triggered it went on to report `not found`.
 - No change to the crash-injection isolation. The `crash-injection` feature is

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+- **Fixed the availability defect `VLT-PM41-cli-crash-fault-matrix.md` §8
+  found.** A process killed inside the shared mutation publication path left a
+  vault that was intact and one journal replay from healthy, and that every
+  subsequent command refused — as exit 2, `vault-pm: invalid command`. The
+  person was told their command was wrong, over and over, about a vault that
+  was fine. `VLT-PM42-cli-pending-publication-recovery.md` is the repair.
+
+  It adds no verb, no flag, no file format, no on-disk artifact, and no
+  environment variable. The vault-open path finishes the interrupted
+  publication with the passphrase it has already collected, through the
+  application's new `unlock_recovering_pending_publication`, and then opens the
+  repaired vault through the ordinary strict open. Every authenticated command
+  (`item` CRUD/list/show/reveal, `search`, `history`, `conflict`, `audit
+  enable`/`list`/`show`, `import`, `restore`), `export`, and `audit verify`
+  take that path, so the repair reaches a person on whatever command they
+  happened to retry.
+- `init` and `vault create` resume paths now finish a `PendingPublication`
+  instead of refusing it with the conflict class, and report
+  `Vault recovered.`. "Finish what was interrupted" is what those paths already
+  meant for a `PreparedInit` journal; a pending publication is the same promise
+  one generation later, and `init` is the verb a stuck person retries. A vault
+  that is merely already initialized is still refused, unchanged.
+- `doctor` is deliberately **not** a repair, and `--unlock` does not make it
+  one. A wedged vault now short-circuits the authenticated half entirely — no
+  passphrase is collected and nothing is published — and the read-only
+  diagnostic answers `recovery_required` with exit class 5. Only the
+  classification changes: this case used to inherit the refused open's
+  misleading exit 2. `status` is untouched and still reports without repairing,
+  which is what keeps restoring a pre-mutation file-level backup a real option
+  rather than a race against an eager repair.
+- Added one fixed, payload-free notice on standard error,
+  `vault-pm: recovered an interrupted write`, emitted exactly when a command
+  moved the durable state out of `recovery_required`. The composition root
+  observes that transition across the command, both reads inside the
+  cross-process writer lock the command already holds — which is what makes the
+  inference sound, since no other local writer can move the state between them.
+  An observation it cannot make degrades to silence, never to a false claim.
+  Standard output and every exit class are unchanged, and the notice is
+  attached to a failing command too, because a repair is worth saying even when
+  the verb that triggered it went on to report `not found`.
+- No change to the crash-injection isolation. The `crash-injection` feature is
+  still named in no section of the product crate, still enabled only by
+  `code/programs/rust/vault-pm-cli-drill`, and the product executable still
+  fails to compile with it. The new tests reach a wedged vault through
+  `vault-pm-storage`'s ordinary fault-injecting object store — a plain
+  dev-dependency that enables no feature — rather than through that seam.
+
 - Added the composition root's durable-write seam for
   `VLT-PM41-cli-crash-fault-matrix.md`. The new `crash` module names every
   point at which this package makes something durable, so a drill can kill the

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -38,10 +38,14 @@
   observes that transition across the command, both reads inside the
   cross-process writer lock the command already holds — which is what makes the
   inference sound, since no other local writer can move the state between them.
-  An observation it cannot make degrades to silence, never to a false claim.
-  Standard output and every exit class are unchanged, and the notice is
-  attached to a failing command too, because a repair is worth saying even when
-  the verb that triggered it went on to report `not found`.
+  *Both* observations must succeed for the claim to be made, and the security
+  review of this change is why that sentence is worth writing down: an
+  unobservable after-state satisfies "not `RecoveryRequired`" while proving
+  nothing, so reading it that way would announce a repair on a vault that is
+  still wedged. `observed_a_repair` states the whole truth table and is pinned
+  by a test. Standard output and every exit class are unchanged, and the notice
+  is attached to a failing command too, because a repair is worth saying even
+  when the verb that triggered it went on to report `not found`.
 - No change to the crash-injection isolation. The `crash-injection` feature is
   still named in no section of the product crate, still enabled only by
   `code/programs/rust/vault-pm-cli-drill`, and the product executable still

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -30,3 +30,11 @@ crash-injection = ["dep:coding_adventures_vault_pm_crash_injection"]
 
 [dev-dependencies]
 libc = "0.2"
+# VLT-PM42 tests wedge a real on-disk vault the way a crash wedges one: they
+# open it through the ordinary application boundary over a *faulting* view of
+# the very same object root, so the write-ahead journal becomes durable and the
+# publication does not. This adds nothing to the shipped graph -
+# `vault-pm-application` already depends on this crate - and it enables no
+# feature, unlike the crash-injection seam which must stay out of any build the
+# product executable can reach.
+coding_adventures_vault_pm_storage = { path = "../vault-pm-storage" }

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -397,9 +397,14 @@ vault-pm: recovered an interrupted write
 `execute` decides that by reading the durable lifecycle state immediately
 before and immediately after the command, both inside the cross-process writer
 lock the command already holds. That lock is what makes the inference sound —
-no other local writer can move the state between the two reads — and an
-observation that cannot be made degrades to silence rather than to a false
-claim. Standard output and every exit class are unchanged.
+no other local writer can move the state between the two reads.
+
+`observed_a_repair` states the whole rule, and the row worth knowing is the
+quiet one: if the after-state cannot be *observed*, no notice is emitted. "Not
+observed" satisfies "not `recovery_required`" while proving nothing, and
+announcing a repair on a vault that is still wedged would be worse than saying
+nothing at all. Both ends fail toward silence. Standard output and every exit
+class are unchanged.
 
 See `code/specs/VLT-PM42-cli-pending-publication-recovery.md`.
 

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -359,6 +359,50 @@ command one-shot.
 The pre-emptive idle timer that locks a session while nobody is typing remains
 Phase 1B work; this slice ships only the command-boundary bound.
 
+## Finishing what a crash interrupted
+
+A process killed inside a mutation leaves a durable `PendingPublication`
+journal. The bytes in it are already signed; the only open question is whether
+the provider has them yet, and that question has one correct answer the machine
+can check. So every command that opens the vault finishes it, using the
+passphrase it has already collected, through the application's
+`unlock_recovering_pending_publication`.
+
+There is no recovery verb, and that is a design decision rather than an
+omission. The person who needs the repair is by definition someone whose
+ordinary command just failed; a verb they would have to know about would not
+reach them. The repair therefore lives on the path they are already walking:
+
+| Path | On `PendingPublication` |
+|---|---|
+| `authenticated_access` — item CRUD/list/show/reveal, `search`, `history`, `conflict`, `audit enable`/`list`/`show`, `import`, `restore` | recovers, then opens |
+| `export`, `audit verify` | recovers, then opens |
+| `init` and `vault create` resume | recovers, reports `Vault recovered.` |
+| `status`, `doctor`, `doctor --unlock` | **reports, never repairs** |
+
+The last row is the interesting one. `doctor` is a diagnostic, and `--unlock`
+does not turn it into a repair: a wedged vault short-circuits its authenticated
+half entirely — no passphrase is collected, nothing is published — and it
+answers `recovery_required` with exit class 5. Keeping both diagnostics
+read-only is what lets a person look at an interrupted vault, and restore a
+pre-mutation file-level backup instead, without racing an eager repair.
+
+When a command does repair the vault, one fixed payload-free line goes to
+standard error:
+
+```text
+vault-pm: recovered an interrupted write
+```
+
+`execute` decides that by reading the durable lifecycle state immediately
+before and immediately after the command, both inside the cross-process writer
+lock the command already holds. That lock is what makes the inference sound —
+no other local writer can move the state between the two reads — and an
+observation that cannot be made degrades to silence rather than to a false
+claim. Standard output and every exit class are unchanged.
+
+See `code/specs/VLT-PM42-cli-pending-publication-recovery.md`.
+
 ## The durable-write seam
 
 This package is the layer that knows what "durable" means. `vault-pm-application`

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -395,9 +395,18 @@ vault-pm: recovered an interrupted write
 ```
 
 `execute` decides that by reading the durable lifecycle state immediately
-before and immediately after the command, both inside the cross-process writer
-lock the command already holds. That lock is what makes the inference sound —
-no other local writer can move the state between the two reads.
+before the command and — only if that reading found `recovery_required` —
+again immediately after, both inside the cross-process writer lock the command
+already holds. That lock is what makes the inference sound: no other local
+writer can move the state between the two reads.
+
+The second reading is conditional for a reason worth knowing. Reading owner
+state initializes its storage backend, and a backend initialization is itself a
+durable step that VLT-PM41's drill names and kills processes at. Reading after
+*every* command would append durable writes past each ceremony's own last one,
+so "the portable-export artifact is the last thing this command makes durable"
+would stop being true. An observation about a command must not move the
+command.
 
 `observed_a_repair` states the whole rule, and the row worth knowing is the
 quiet one: if the after-state cannot be *observed*, no notice is emitted. "Not

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -1109,7 +1109,19 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
     // command finished an interrupted publication.
     let before = observed_vault_state(prepared.paths(), &writer, selected_vault);
     let result = dispatch(command, host, prepared.paths(), &writer, selected_vault);
-    let after = observed_vault_state(prepared.paths(), &writer, selected_vault);
+    // The second reading is taken only when the first one found something that
+    // could be repaired, and that condition is load-bearing rather than an
+    // optimization. `LocalStateStore::load` initializes its backend, and a
+    // backend initialization is itself a durable step — one VLT-PM41's ledger
+    // names and kills processes at. Reading unconditionally would therefore
+    // append durable writes *after* every ceremony's own last one, making
+    // "the portable-export artifact is the last thing this command makes
+    // durable" false. An observation about a command must not move the command.
+    let after = if matches!(before, Some(VaultStatusStateV1::RecoveryRequired)) {
+        observed_vault_state(prepared.paths(), &writer, selected_vault)
+    } else {
+        None
+    };
     if !observed_a_repair(before, after) {
         return result;
     }
@@ -1131,24 +1143,35 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
 ///
 /// | before | after | repair announced | why |
 /// |---|---|---|---|
-/// | `RecoveryRequired` | anything else, observed | **yes** | only this command held the writer lock, so only this command can have moved it |
+/// | `RecoveryRequired` | `Locked` | **yes** | the journal was replayed and the owner state is `Active`, and only this command held the writer lock |
 /// | `RecoveryRequired` | `RecoveryRequired` | no | still wedged; nothing was finished |
 /// | `RecoveryRequired` | `None` | no | the observation could not be taken, which is not evidence of anything |
+/// | `RecoveryRequired` | `Absent` or `Prepared` | no | not a repair — owner state went missing or backwards |
 /// | anything else | anything | no | there was nothing to repair |
 ///
-/// The third row is the one worth stating out loud. `None` means the state
-/// could not be read — an owner-state file that just became unreadable, a store
-/// that went away mid-command — and `None != Some(RecoveryRequired)` is
-/// perfectly true while proving nothing. Reading it as "no longer recovery
-/// required" would announce a repair on a vault that is still wedged, which is
-/// precisely the false claim [`observed_vault_state`] exists to avoid. Both
-/// ends therefore fail toward silence.
+/// Two rows are worth stating out loud.
+///
+/// `None` means the state could not be read — an owner-state file that just
+/// became unreadable, a store that went away mid-command. `None` is not
+/// `RecoveryRequired`, which makes "the state is no longer `RecoveryRequired`"
+/// perfectly true and completely uninformative; believing it would announce a
+/// repair on a vault that is still wedged, precisely the false claim
+/// [`observed_vault_state`] exists to avoid.
+///
+/// `Absent` and `Prepared` are named rather than lumped into "anything else"
+/// for the same reason. Neither is reachable today — the owner-state store
+/// exposes no delete, and both `PreparedInit` writers demand absence — but if
+/// one ever appeared it would mean the owner state was lost or rolled back, and
+/// calling that "recovered an interrupted write" would be a worse lie than
+/// saying nothing. `Unlocked` cannot appear either, since the observation
+/// always builds a fresh locked handle. So the affirmative row names the one
+/// state a completed repair actually leaves behind.
 const fn observed_a_repair(
     before: Option<VaultStatusStateV1>,
     after: Option<VaultStatusStateV1>,
 ) -> bool {
     matches!(before, Some(VaultStatusStateV1::RecoveryRequired))
-        && matches!(after, Some(state) if !matches!(state, VaultStatusStateV1::RecoveryRequired))
+        && matches!(after, Some(VaultStatusStateV1::Locked))
 }
 
 /// Read the durable lifecycle state of the vault this invocation targets.
@@ -8305,14 +8328,9 @@ mod tests {
     fn a_repair_is_announced_only_when_both_observations_prove_one() {
         use VaultStatusStateV1::{Absent, Locked, Prepared, RecoveryRequired, Unlocked};
 
-        // The only row that speaks: wedged before, demonstrably not wedged
-        // after. Every state the projection can report counts as "not wedged".
-        for after in [Absent, Prepared, Locked, Unlocked] {
-            assert!(
-                observed_a_repair(Some(RecoveryRequired), Some(after)),
-                "{after:?}"
-            );
-        }
+        // The one row that speaks: wedged before, `Active` on disk after,
+        // which a fresh locked handle reports as `Locked`.
+        assert!(observed_a_repair(Some(RecoveryRequired), Some(Locked)));
 
         // Still wedged, so nothing was finished.
         assert!(!observed_a_repair(
@@ -8321,10 +8339,18 @@ mod tests {
         ));
 
         // An observation that could not be taken proves nothing, and
-        // `None != Some(RecoveryRequired)` is exactly the true-but-meaningless
-        // comparison that would otherwise announce a repair on a vault that is
-        // still wedged.
+        // "not `RecoveryRequired`" is exactly the true-but-meaningless claim
+        // that would otherwise announce a repair on a still-wedged vault.
         assert!(!observed_a_repair(Some(RecoveryRequired), None));
+
+        // Owner state that went missing or backwards is the opposite of a
+        // repair, and `Unlocked` cannot come from a freshly locked handle.
+        for after in [Absent, Prepared, Unlocked] {
+            assert!(
+                !observed_a_repair(Some(RecoveryRequired), Some(after)),
+                "{after:?}"
+            );
+        }
 
         // Nothing to repair in the first place.
         for before in [None, Some(Absent), Some(Prepared), Some(Locked)] {

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -1102,11 +1102,14 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
 
     // VLT-PM42 §6. A repair nobody mentions is indistinguishable from no
     // repair, so the composition root watches the durable lifecycle state
-    // across the command it is about to run. Both reads happen inside the
-    // cross-process writer lock the command already holds, which is what makes
-    // the inference sound: no other local writer can move the state between
-    // them, so `RecoveryRequired` before and anything else after means *this*
-    // command finished an interrupted publication.
+    // across the command it is about to run: once before, and — only if that
+    // reading found something repairable — once after. Both readings happen
+    // inside the cross-process writer lock the command already holds, which is
+    // what makes the inference sound: no other local writer can move the state
+    // between them, so `RecoveryRequired` before and `Locked` after means
+    // *this* command finished an interrupted publication.
+    // `observed_a_repair` below states the whole rule, including the rows that
+    // must stay quiet.
     let before = observed_vault_state(prepared.paths(), &writer, selected_vault);
     let result = dispatch(command, host, prepared.paths(), &writer, selected_vault);
     // The second reading is taken only when the first one found something that
@@ -1187,6 +1190,16 @@ const fn observed_a_repair(
 /// false claim about a person's vault. The caller must honour that bias in
 /// *both* observations — see [`execute`], where an unobservable after-state is
 /// treated as "say nothing" rather than as "no longer recovery required".
+///
+/// # This is an observation, not a pure one
+///
+/// Reading owner state is not free of effect. `LocalStateStore::load`
+/// initializes its backend first, and `FsStorageBackend::initialize` creates
+/// missing roots and sweeps stranded temporaries — so this function *writes*,
+/// idempotently, inside the writer lock the command already holds. Under the
+/// `crash-injection` feature that initialization is a named durable step the
+/// VLT-PM41 drill counts and kills processes at, which is why [`execute`] takes
+/// the second reading only when the first found something to repair.
 fn observed_vault_state(
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
@@ -8352,10 +8365,25 @@ mod tests {
             );
         }
 
-        // Nothing to repair in the first place.
-        for before in [None, Some(Absent), Some(Prepared), Some(Locked)] {
-            assert!(!observed_a_repair(before, Some(Locked)), "{before:?}");
-            assert!(!observed_a_repair(before, None), "{before:?}");
+        // Nothing to repair in the first place — every remaining `before`,
+        // against every possible `after`, so the table above is total.
+        for before in [
+            None,
+            Some(Absent),
+            Some(Prepared),
+            Some(Locked),
+            Some(Unlocked),
+        ] {
+            for after in [
+                None,
+                Some(Absent),
+                Some(Prepared),
+                Some(Locked),
+                Some(Unlocked),
+                Some(RecoveryRequired),
+            ] {
+                assert!(!observed_a_repair(before, after), "{before:?} {after:?}");
+            }
         }
     }
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -1109,10 +1109,8 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
     // command finished an interrupted publication.
     let before = observed_vault_state(prepared.paths(), &writer, selected_vault);
     let result = dispatch(command, host, prepared.paths(), &writer, selected_vault);
-    let recovered = before == Some(VaultStatusStateV1::RecoveryRequired)
-        && observed_vault_state(prepared.paths(), &writer, selected_vault)
-            != Some(VaultStatusStateV1::RecoveryRequired);
-    if !recovered {
+    let after = observed_vault_state(prepared.paths(), &writer, selected_vault);
+    if !observed_a_repair(before, after) {
         return result;
     }
     // The notice is attached to a failed command too. A repair that happened
@@ -1125,6 +1123,34 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
     })
 }
 
+/// Whether two observations prove *this* command finished an interrupted
+/// publication.
+///
+/// The whole truth table, because the interesting cases are the ones that must
+/// stay quiet:
+///
+/// | before | after | repair announced | why |
+/// |---|---|---|---|
+/// | `RecoveryRequired` | anything else, observed | **yes** | only this command held the writer lock, so only this command can have moved it |
+/// | `RecoveryRequired` | `RecoveryRequired` | no | still wedged; nothing was finished |
+/// | `RecoveryRequired` | `None` | no | the observation could not be taken, which is not evidence of anything |
+/// | anything else | anything | no | there was nothing to repair |
+///
+/// The third row is the one worth stating out loud. `None` means the state
+/// could not be read — an owner-state file that just became unreadable, a store
+/// that went away mid-command — and `None != Some(RecoveryRequired)` is
+/// perfectly true while proving nothing. Reading it as "no longer recovery
+/// required" would announce a repair on a vault that is still wedged, which is
+/// precisely the false claim [`observed_vault_state`] exists to avoid. Both
+/// ends therefore fail toward silence.
+const fn observed_a_repair(
+    before: Option<VaultStatusStateV1>,
+    after: Option<VaultStatusStateV1>,
+) -> bool {
+    matches!(before, Some(VaultStatusStateV1::RecoveryRequired))
+        && matches!(after, Some(state) if !matches!(state, VaultStatusStateV1::RecoveryRequired))
+}
+
 /// Read the durable lifecycle state of the vault this invocation targets.
 ///
 /// Deliberately total, and deliberately silent about why it failed: this
@@ -1135,7 +1161,9 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
 ///
 /// `None` therefore biases the notice toward silence. That is the safe
 /// direction: a missing notice loses a courtesy, while a wrong one would be a
-/// false claim about a person's vault.
+/// false claim about a person's vault. The caller must honour that bias in
+/// *both* observations — see [`execute`], where an unobservable after-state is
+/// treated as "say nothing" rather than as "no longer recovery required".
 fn observed_vault_state(
     paths: &LocalVaultPaths,
     writer: &LocalWriterGuard,
@@ -8271,6 +8299,38 @@ mod tests {
             .find_map(|line| line.strip_prefix("Item added: "))
             .expect("item-add identifier")
             .to_owned()
+    }
+
+    #[test]
+    fn a_repair_is_announced_only_when_both_observations_prove_one() {
+        use VaultStatusStateV1::{Absent, Locked, Prepared, RecoveryRequired, Unlocked};
+
+        // The only row that speaks: wedged before, demonstrably not wedged
+        // after. Every state the projection can report counts as "not wedged".
+        for after in [Absent, Prepared, Locked, Unlocked] {
+            assert!(
+                observed_a_repair(Some(RecoveryRequired), Some(after)),
+                "{after:?}"
+            );
+        }
+
+        // Still wedged, so nothing was finished.
+        assert!(!observed_a_repair(
+            Some(RecoveryRequired),
+            Some(RecoveryRequired)
+        ));
+
+        // An observation that could not be taken proves nothing, and
+        // `None != Some(RecoveryRequired)` is exactly the true-but-meaningless
+        // comparison that would otherwise announce a repair on a vault that is
+        // still wedged.
+        assert!(!observed_a_repair(Some(RecoveryRequired), None));
+
+        // Nothing to repair in the first place.
+        for before in [None, Some(Absent), Some(Prepared), Some(Locked)] {
+            assert!(!observed_a_repair(before, Some(Locked)), "{before:?}");
+            assert!(!observed_a_repair(before, None), "{before:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -141,7 +141,24 @@ impl CliOutput {
             stderr: format!("{}\n", error.message()),
         }
     }
+
+    /// Prepend the fixed VLT-PM42 repair notice to standard error.
+    ///
+    /// Standard output is untouched on purpose: anything that parses a
+    /// command's output must not have to learn a new line, and the exit class
+    /// of a command that happened to also repair the vault is the exit class of
+    /// the command.
+    fn with_recovery_notice(mut self) -> Self {
+        self.stderr.insert_str(0, RECOVERY_NOTICE);
+        self
+    }
 }
+
+/// The one sentence a repaired vault is announced with.
+///
+/// Fixed at compile time and payload-free: it names no vault, item, revision,
+/// object, provider, path, or count.
+const RECOVERY_NOTICE: &str = "vault-pm: recovered an interrupted write\n";
 
 /// Injected platform authorities used by the testable CLI driver.
 ///
@@ -1077,83 +1094,123 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
     let paths = host.paths().map_err(map_host)?;
     let prepared = paths.prepare().map_err(map_local_host)?;
     let writer = prepared.try_acquire_writer().map_err(map_local_host)?;
-    let selected_vault = invocation.selected_vault.as_ref();
-    match invocation.command {
-        Command::Init { vault, storage } => init(host, prepared.paths(), &writer, vault, storage),
-        Command::VaultCreate { vault } => vault_create(host, prepared.paths(), &writer, vault),
-        Command::Status { json } => status(prepared.paths(), &writer, selected_vault, json),
-        Command::AuditEnable => audit_enable(host, prepared.paths(), &writer, selected_vault),
-        Command::AuditVerify => audit_verify(host, prepared.paths(), &writer, selected_vault),
-        Command::AuditList => audit_list(host, prepared.paths(), &writer, selected_vault),
+    let Invocation {
+        selected_vault,
+        command,
+    } = invocation;
+    let selected_vault = selected_vault.as_ref();
+
+    // VLT-PM42 §6. A repair nobody mentions is indistinguishable from no
+    // repair, so the composition root watches the durable lifecycle state
+    // across the command it is about to run. Both reads happen inside the
+    // cross-process writer lock the command already holds, which is what makes
+    // the inference sound: no other local writer can move the state between
+    // them, so `RecoveryRequired` before and anything else after means *this*
+    // command finished an interrupted publication.
+    let before = observed_vault_state(prepared.paths(), &writer, selected_vault);
+    let result = dispatch(command, host, prepared.paths(), &writer, selected_vault);
+    let recovered = before == Some(VaultStatusStateV1::RecoveryRequired)
+        && observed_vault_state(prepared.paths(), &writer, selected_vault)
+            != Some(VaultStatusStateV1::RecoveryRequired);
+    if !recovered {
+        return result;
+    }
+    // The notice is attached to a failed command too. A repair that happened
+    // is worth saying even when the verb that triggered it went on to report
+    // `not found`, and rendering the failure here produces exactly the output
+    // the caller would have rendered from the error.
+    Ok(match result {
+        Ok(output) => output.with_recovery_notice(),
+        Err(error) => CliOutput::failure(error).with_recovery_notice(),
+    })
+}
+
+/// Read the durable lifecycle state of the vault this invocation targets.
+///
+/// Deliberately total, and deliberately silent about why it failed: this
+/// observation exists only to decide whether one sentence is added to standard
+/// error, so every difficulty — no configuration yet, a selector naming a vault
+/// that does not exist, an unreadable owner-state file — must degrade to
+/// `None`, "say nothing", rather than change what the command itself reports.
+///
+/// `None` therefore biases the notice toward silence. That is the safe
+/// direction: a missing notice loses a courtesy, while a wrong one would be a
+/// false claim about a person's vault.
+fn observed_vault_state(
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Option<VaultStatusStateV1> {
+    let exact_config = writer.load_config().ok()??;
+    let config = decode_config(&exact_config).ok()?;
+    let vault = configured_vault(paths, &config, selected_vault).ok()?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    VaultAccessV1::locked(locator)
+        .status(&application_store)
+        .ok()
+        .map(|report| report.state())
+}
+
+fn dispatch(
+    command: Command,
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+) -> Result<CliOutput, CliFailure> {
+    match command {
+        Command::Init { vault, storage } => init(host, paths, writer, vault, storage),
+        Command::VaultCreate { vault } => vault_create(host, paths, writer, vault),
+        Command::Status { json } => status(paths, writer, selected_vault, json),
+        Command::AuditEnable => audit_enable(host, paths, writer, selected_vault),
+        Command::AuditVerify => audit_verify(host, paths, writer, selected_vault),
+        Command::AuditList => audit_list(host, paths, writer, selected_vault),
         Command::AuditShow { trace_id } => {
-            audit_show(host, prepared.paths(), &writer, selected_vault, trace_id)
+            audit_show(host, paths, writer, selected_vault, trace_id)
         }
-        Command::Doctor { unlock } => {
-            doctor(host, prepared.paths(), &writer, selected_vault, unlock)
+        Command::Doctor { unlock } => doctor(host, paths, writer, selected_vault, unlock),
+        Command::PortableExport { destination } => {
+            portable_export(host, paths, writer, selected_vault, &destination)
         }
-        Command::PortableExport { destination } => portable_export(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            &destination,
-        ),
         Command::PortableImport { source } => {
-            portable_import(host, prepared.paths(), &writer, selected_vault, &source)
+            portable_import(host, paths, writer, selected_vault, &source)
         }
         Command::PortableRestore { source } => {
-            portable_restore(host, prepared.paths(), &writer, selected_vault, &source)
+            portable_restore(host, paths, writer, selected_vault, &source)
         }
         Command::PortableRestoreVerify { source } => {
-            portable_restore_verify(host, prepared.paths(), &writer, selected_vault, &source)
+            portable_restore_verify(host, paths, writer, selected_vault, &source)
         }
-        Command::ItemAddLogin => item_add_login(host, prepared.paths(), &writer, selected_vault),
-        Command::ItemAddSecureNote => {
-            item_add_secure_note(host, prepared.paths(), &writer, selected_vault)
-        }
-        Command::ItemAddCard => item_add_card(host, prepared.paths(), &writer, selected_vault),
-        Command::ItemAddApiKey => item_add_api_key(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemAddLogin => item_add_login(host, paths, writer, selected_vault),
+        Command::ItemAddSecureNote => item_add_secure_note(host, paths, writer, selected_vault),
+        Command::ItemAddCard => item_add_card(host, paths, writer, selected_vault),
+        Command::ItemAddApiKey => item_add_api_key(host, paths, writer, selected_vault),
         Command::ItemAddDatabaseCredential => {
-            item_add_database_credential(host, prepared.paths(), &writer, selected_vault)
+            item_add_database_credential(host, paths, writer, selected_vault)
         }
-        Command::ItemAddTotp => item_add_totp(host, prepared.paths(), &writer, selected_vault),
+        Command::ItemAddTotp => item_add_totp(host, paths, writer, selected_vault),
         Command::ItemEdit { item_id } => {
-            item_edit_login(host, prepared.paths(), &writer, selected_vault, item_id)
+            item_edit_login(host, paths, writer, selected_vault, item_id)
         }
         Command::ItemDelete { item_id } => {
-            item_delete(host, prepared.paths(), &writer, selected_vault, item_id)
+            item_delete(host, paths, writer, selected_vault, item_id)
         }
-        Command::ItemList => item_list(host, prepared.paths(), &writer, selected_vault),
-        Command::ItemShow { item_id } => {
-            item_show(host, prepared.paths(), &writer, selected_vault, item_id)
+        Command::ItemList => item_list(host, paths, writer, selected_vault),
+        Command::ItemShow { item_id } => item_show(host, paths, writer, selected_vault, item_id),
+        Command::ItemReveal { item_id, field } => {
+            item_reveal(host, paths, writer, selected_vault, item_id, field)
         }
-        Command::ItemReveal { item_id, field } => item_reveal(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            field,
-        ),
-        Command::Search { query } => {
-            item_search(host, prepared.paths(), &writer, selected_vault, query)
-        }
+        Command::Search { query } => item_search(host, paths, writer, selected_vault, query),
         Command::HistoryList { item_id } => {
-            history_list(host, prepared.paths(), &writer, selected_vault, item_id)
+            history_list(host, paths, writer, selected_vault, item_id)
         }
         Command::HistoryRestore {
             item_id,
             revision_id,
-        } => history_restore(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            revision_id,
-        ),
+        } => history_restore(host, paths, writer, selected_vault, item_id, revision_id),
         Command::ConflictList { item_id } => {
-            conflict_list(host, prepared.paths(), &writer, selected_vault, item_id)
+            conflict_list(host, paths, writer, selected_vault, item_id)
         }
         Command::ConflictReveal {
             item_id,
@@ -1161,8 +1218,8 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
             field,
         } => conflict_reveal(
             host,
-            prepared.paths(),
-            &writer,
+            paths,
+            writer,
             selected_vault,
             item_id,
             revision_id,
@@ -1171,65 +1228,32 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ConflictChoose {
             item_id,
             revision_id,
-        } => conflict_choose(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            revision_id,
-        ),
+        } => conflict_choose(host, paths, writer, selected_vault, item_id, revision_id),
         Command::ConflictMergeLogin {
             item_id,
             base_revision,
-        } => conflict_merge_login(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => conflict_merge_login(host, paths, writer, selected_vault, item_id, base_revision),
         Command::ConflictMergeSecureNote {
             item_id,
             base_revision,
-        } => conflict_merge_secure_note(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => {
+            conflict_merge_secure_note(host, paths, writer, selected_vault, item_id, base_revision)
+        }
         Command::ConflictMergeCard {
             item_id,
             base_revision,
-        } => conflict_merge_card(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => conflict_merge_card(host, paths, writer, selected_vault, item_id, base_revision),
         Command::ConflictMergeApiKey {
             item_id,
             base_revision,
-        } => conflict_merge_api_key(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => conflict_merge_api_key(host, paths, writer, selected_vault, item_id, base_revision),
         Command::ConflictMergeDatabaseCredential {
             item_id,
             base_revision,
         } => conflict_merge_database_credential(
             host,
-            prepared.paths(),
-            &writer,
+            paths,
+            writer,
             selected_vault,
             item_id,
             base_revision,
@@ -1237,25 +1261,11 @@ fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliF
         Command::ConflictMergeTotp {
             item_id,
             base_revision,
-        } => conflict_merge_totp(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => conflict_merge_totp(host, paths, writer, selected_vault, item_id, base_revision),
         Command::ConflictMergeOpaque {
             item_id,
             base_revision,
-        } => conflict_merge_opaque(
-            host,
-            prepared.paths(),
-            &writer,
-            selected_vault,
-            item_id,
-            base_revision,
-        ),
+        } => conflict_merge_opaque(host, paths, writer, selected_vault, item_id, base_revision),
         Command::Help | Command::Shell => {
             unreachable!("help and shell return before writer acquisition")
         }
@@ -1279,8 +1289,13 @@ fn authenticated_access(
     let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    // VLT-PM42. A process killed inside a mutation publication leaves an exact
+    // journal that this open finishes with the passphrase it just collected.
+    // Before that, every command on this path answered a crash with exit 2
+    // `invalid command` — telling a person their command was wrong about a
+    // vault that was intact and one replay from healthy.
     access
-        .unlock(
+        .unlock_recovering_pending_publication(
             passphrase,
             &application_store,
             &application_store,
@@ -1356,8 +1371,10 @@ fn portable_export(
     let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let vault_passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    // VLT-PM42. An export must describe a settled vault, so an interrupted
+    // publication is finished before the artifact is computed.
     access
-        .unlock(
+        .unlock_recovering_pending_publication(
             vault_passphrase,
             &application_store,
             &application_store,
@@ -3492,11 +3509,13 @@ fn resume_init(
         .ok_or(CliFailure::Integrity)?;
     let state = LocalVaultStateV1::decode(&exact_state).map_err(map_application)?;
     let LocalVaultStateV1::PreparedInit(_) = state else {
-        return Err(match state {
-            LocalVaultStateV1::Active(_) => CliFailure::AlreadyInitialized,
-            LocalVaultStateV1::PendingPublication { .. } => CliFailure::Conflict,
+        return match state {
+            LocalVaultStateV1::Active(_) => Err(CliFailure::AlreadyInitialized),
+            LocalVaultStateV1::PendingPublication { .. } => {
+                resume_pending_publication(host, &config, vault, locator, &application_store)
+            }
             LocalVaultStateV1::PreparedInit(_) => unreachable!(),
-        });
+        };
     };
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
     let prepared = rehydrate_prepared_init(passphrase, state).map_err(map_application)?;
@@ -3509,6 +3528,41 @@ fn resume_init(
     )
     .map_err(map_application)?;
     Ok(CliOutput::success("Vault initialized.\n"))
+}
+
+/// Finish an interrupted mutation publication found by a resume path.
+///
+/// VLT-PM42. `init` and `vault create` both mean "finish whatever was
+/// interrupted here", and both used to refuse a `PendingPublication` with the
+/// conflict class. That refusal answered the right observation the wrong way:
+/// the vault's *creation* had indeed finished, so there was no generation zero
+/// left to resume — a later mutation had been cut short instead. A pending
+/// publication is the same promise one generation on, and these are the verbs
+/// a stuck person retries.
+///
+/// The repaired vault is opened before success is reported, so "recovered"
+/// means a real authenticated open of the repaired durable bytes succeeded,
+/// not merely that a write returned.
+fn resume_pending_publication(
+    host: &dyn CliHost,
+    config: &VaultPmConfigV1,
+    vault: &VaultConfigV1,
+    locator: BootstrapLocator,
+    application_store: &StorageCoreApplicationStore<LocalBackend>,
+) -> Result<CliOutput, CliFailure> {
+    let repository_factory = configured_repository_factory(config, vault)?;
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    let mut access = VaultAccessV1::locked(locator);
+    access
+        .unlock_recovering_pending_publication(
+            passphrase,
+            application_store,
+            application_store,
+            &repository_factory,
+        )
+        .map_err(map_application)?;
+    access.lock();
+    Ok(CliOutput::success("Vault recovered.\n"))
 }
 
 fn vault_create(
@@ -3615,11 +3669,13 @@ fn resume_vault_create(
         .ok_or(CliFailure::Integrity)?;
     let state = LocalVaultStateV1::decode(&exact_state).map_err(map_application)?;
     let LocalVaultStateV1::PreparedInit(_) = state else {
-        return Err(match state {
-            LocalVaultStateV1::Active(_) => CliFailure::AlreadyInitialized,
-            LocalVaultStateV1::PendingPublication { .. } => CliFailure::Conflict,
+        return match state {
+            LocalVaultStateV1::Active(_) => Err(CliFailure::AlreadyInitialized),
+            LocalVaultStateV1::PendingPublication { .. } => {
+                resume_pending_publication(host, config, vault, locator, &application_store)
+            }
             LocalVaultStateV1::PreparedInit(_) => unreachable!(),
-        });
+        };
     };
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
     let prepared = rehydrate_prepared_init(passphrase, state).map_err(map_application)?;
@@ -3701,8 +3757,11 @@ fn audit_verify(
     let repository_factory = configured_repository_factory(&config, vault)?;
     let mut access = VaultAccessV1::locked(locator);
     let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    // VLT-PM42. `audit verify` publishes an audit-only commit of its own
+    // through the very path a crash interrupts, so it finishes an outstanding
+    // publication before starting another.
     access
-        .unlock(
+        .unlock_recovering_pending_publication(
             passphrase,
             &application_store,
             &application_store,
@@ -3793,6 +3852,22 @@ fn doctor(
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
     let mut access = VaultAccessV1::locked(locator);
+    // VLT-PM42. `doctor` is the one command that reports without repairing,
+    // and `--unlock` does not change that: a person who wants to look at a
+    // wedged vault before touching it must be able to. So an interrupted
+    // publication short-circuits the authenticated half entirely — no
+    // passphrase is collected, nothing is published, and the read-only
+    // diagnostic answers `recovery_required` with exit class 5. Only the
+    // *classification* changes: this case used to inherit the refused open's
+    // misleading exit 2 `invalid command`.
+    let unlock = unlock
+        && !matches!(
+            access
+                .status(&application_store)
+                .map_err(map_application)?
+                .state(),
+            VaultStatusStateV1::RecoveryRequired
+        );
     if unlock {
         let repository_factory = configured_repository_factory(&config, vault)?;
         let passphrase = host.read_existing_passphrase().map_err(map_host)?;
@@ -8094,6 +8169,292 @@ mod tests {
         let audit = run(["audit", "verify"], &host);
         assert_eq!(audit.exit_code(), ExitCode::InvalidInput);
         assert_eq!(audit.stderr(), "vault-pm: invalid command\n");
+    }
+
+    // -----------------------------------------------------------------------
+    // VLT-PM42 — a vault wedged by an interrupted publication
+    //
+    // VLT-PM41 proved with a real killed process that a crash inside the shared
+    // mutation publication path leaves an exact, replayable journal, and that
+    // nothing in the product ever replayed it. These tests wedge a real on-disk
+    // vault the same way — by letting the write-ahead journal become durable
+    // and then taking the provider away — and then drive the ordinary command
+    // surface across it.
+    // -----------------------------------------------------------------------
+
+    /// Leave the default vault's durable owner state as an exact
+    /// `PendingPublication`.
+    ///
+    /// The session is opened through the ordinary application boundary over a
+    /// *faulting view of the very same object root* the CLI itself uses, so
+    /// everything on disk afterwards is what a crash leaves: the journal is
+    /// real, its signed bytes are real, and the objects it names are the ones
+    /// the real repository is missing.
+    fn wedge_by_an_interrupted_publication(paths: &LocalVaultPaths, passphrase: &[u8]) {
+        use coding_adventures_vault_pm_application::open_active_vault;
+        use coding_adventures_vault_pm_storage::{
+            FaultAction, FaultEffect, FaultInjectingObjectStore, StoreOperation,
+        };
+        use std::sync::Arc;
+
+        let (locator, object_root) = configured_vault_location(paths);
+        let application_store = application_store(paths);
+        let faulting = Arc::new(FaultInjectingObjectStore::new(StorageCoreObjectStore::new(
+            crash::backend(&object_root),
+        )));
+        let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&faulting));
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &application_store,
+            &application_store,
+            &factory,
+        )
+        .expect("the fixture vault must open");
+        // The commit reaches the provider and the provider then stops
+        // answering — the ambiguity a kill between the journal write and the
+        // owner-state advance produces.
+        faulting
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+        let interrupted = session.audited_list_items(
+            FIXED_TEST_TIME_MS,
+            AuditedAccessRandomnessV1::new([0x5c; AUDITED_ACCESS_RANDOM_BYTES]),
+            &application_store,
+        );
+        assert!(
+            matches!(interrupted, Err(ApplicationError::StorageUnavailable)),
+            "the fixture must interrupt a publication, not complete it",
+        );
+    }
+
+    /// Resolve the default vault's application locator and object root.
+    ///
+    /// The writer lock is acquired and released inside this function, because
+    /// every command the tests run afterwards acquires it for itself.
+    fn configured_vault_location(paths: &LocalVaultPaths) -> (BootstrapLocator, PathBuf) {
+        let prepared = paths.prepare().unwrap();
+        let writer = prepared.try_acquire_writer().unwrap();
+        let exact_config = writer.load_config().unwrap().unwrap();
+        let config = decode_config(&exact_config).unwrap();
+        let vault = configured_vault(prepared.paths(), &config, None).unwrap();
+        let location = config
+            .storage()
+            .get(vault.local_store())
+            .unwrap()
+            .location()
+            .as_str()
+            .to_owned();
+        (
+            application_locator(vault.locator()),
+            PathBuf::from(location),
+        )
+    }
+
+    /// One initialized vault holding one login, and its item identifier.
+    fn vault_with_one_login(paths: &LocalVaultPaths, passphrase: &[u8]) -> String {
+        let init_host = TestHost::new(paths.clone(), [passphrase.to_vec()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.to_vec(), b"first note body".to_vec()],
+            ["First note".to_owned()],
+        );
+        let added = run(["item", "add", "secure-note"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        added
+            .stdout()
+            .lines()
+            .find_map(|line| line.strip_prefix("Item added: "))
+            .expect("item-add identifier")
+            .to_owned()
+    }
+
+    #[test]
+    fn an_ordinary_command_finishes_an_interrupted_publication_and_says_so() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"recovery correct horse battery staple".to_vec();
+        let item = vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        // Before VLT-PM42 this was exit 2, `vault-pm: invalid command`, for
+        // every command that opens the vault, forever.
+        let list_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed.stdout().contains(&item), "{listed:?}");
+        assert_eq!(listed.stderr(), RECOVERY_NOTICE, "{listed:?}");
+
+        // The repair happened once. The next command finds an ordinary vault
+        // and says nothing.
+        let again_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let again = run(["item", "list"], &again_host);
+        assert_eq!(again.exit_code(), ExitCode::Success, "{again:?}");
+        assert!(again.stderr().is_empty(), "{again:?}");
+
+        // And the vault is ordinary in the only sense that matters: it still
+        // takes writes, and its whole audit chain still verifies.
+        // A distinct entropy seed, because this host's randomness is
+        // deterministic and reusing the fixture's would mint the identifiers
+        // the first note already owns.
+        let add_host = TestHost::with_texts_and_entropy_seed(
+            paths.clone(),
+            [passphrase.clone(), b"second note body".to_vec()],
+            ["Second note".to_owned()],
+            29,
+        );
+        let added = run(["item", "add", "secure-note"], &add_host);
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        let verify_host = TestHost::new(paths, [passphrase]);
+        let verified = run(["audit", "verify"], &verify_host);
+        assert_eq!(verified.exit_code(), ExitCode::Success, "{verified:?}");
+    }
+
+    #[test]
+    fn the_read_only_diagnostics_report_a_wedged_vault_without_repairing_it() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"diagnostic correct horse battery staple".to_vec();
+        vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        // `status` and `doctor` answer without a passphrase, and leave the
+        // vault exactly as wedged as they found it — the property a person
+        // restoring a pre-mutation backup depends on.
+        for _ in 0..2 {
+            let status = run(["status"], &TestHost::new(paths.clone(), []));
+            assert_eq!(status.stdout(), "Status: recovery_required\n", "{status:?}");
+            assert!(status.stderr().is_empty(), "{status:?}");
+
+            let doctor = run(["doctor"], &TestHost::new(paths.clone(), []));
+            assert_eq!(doctor.exit_code(), ExitCode::Conflict, "{doctor:?}");
+            assert_eq!(doctor.stdout(), "Doctor: recovery_required\n");
+            assert!(doctor.stderr().is_empty(), "{doctor:?}");
+        }
+
+        // `--unlock` does not turn a diagnostic into a repair. It collects no
+        // passphrase — the host below would panic if asked for one — and it
+        // now reports the state instead of inheriting the refused open's
+        // misleading exit 2 `invalid command`.
+        let unlock_doctor = run(["doctor", "--unlock"], &TestHost::new(paths.clone(), []));
+        assert_eq!(
+            unlock_doctor.exit_code(),
+            ExitCode::Conflict,
+            "{unlock_doctor:?}"
+        );
+        assert_eq!(unlock_doctor.stdout(), "Doctor: recovery_required\n");
+        assert!(unlock_doctor.stderr().is_empty(), "{unlock_doctor:?}");
+
+        // Still wedged, so the repair below is this test's, not a diagnostic's.
+        let recover_host = TestHost::new(paths.clone(), [passphrase]);
+        let recovered = run(["item", "list"], &recover_host);
+        assert_eq!(recovered.exit_code(), ExitCode::Success, "{recovered:?}");
+        assert_eq!(recovered.stderr(), RECOVERY_NOTICE, "{recovered:?}");
+    }
+
+    #[test]
+    fn init_finishes_an_interrupted_publication_instead_of_refusing_it() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"resume correct horse battery staple".to_vec();
+        vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        // `init` is what a stuck person retries. It used to answer the
+        // conflict class; it now finishes what was interrupted.
+        let resume_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let resumed = run(["init"], &resume_host);
+        assert_eq!(resumed.exit_code(), ExitCode::Success, "{resumed:?}");
+        assert_eq!(resumed.stdout(), "Vault recovered.\n");
+        assert_eq!(resumed.stderr(), RECOVERY_NOTICE, "{resumed:?}");
+
+        assert_eq!(
+            run(["status"], &TestHost::new(paths.clone(), [])).stdout(),
+            "Status: locked\n"
+        );
+        // A healthy vault is still refused, so the repair is the only thing
+        // this path learned to do.
+        let repeat = run(["init"], &TestHost::new(paths, [passphrase]));
+        assert_eq!(repeat.exit_code(), ExitCode::InvalidInput, "{repeat:?}");
+        assert_eq!(repeat.stderr(), "vault-pm: already initialized\n");
+    }
+
+    #[test]
+    fn a_wrong_passphrase_leaves_a_wedged_vault_wedged() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"closed correct horse battery staple".to_vec();
+        vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        // Recovery authenticates before it publishes, so a wrong secret buys
+        // nothing and destroys nothing.
+        let wrong_host = TestHost::new(paths.clone(), [b"not the passphrase".to_vec()]);
+        let refused = run(["item", "list"], &wrong_host);
+        assert_eq!(refused.exit_code(), ExitCode::Locked, "{refused:?}");
+        assert_eq!(refused.stderr(), "vault-pm: authentication required\n");
+        assert_eq!(
+            run(["status"], &TestHost::new(paths.clone(), [])).stdout(),
+            "Status: recovery_required\n"
+        );
+
+        let right_host = TestHost::new(paths, [passphrase]);
+        let recovered = run(["item", "list"], &right_host);
+        assert_eq!(recovered.exit_code(), ExitCode::Success, "{recovered:?}");
+    }
+
+    #[test]
+    fn a_recovering_command_that_then_fails_still_reports_the_repair() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"partial correct horse battery staple".to_vec();
+        vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        // The repair is worth saying even when the verb that triggered it went
+        // on to report something else, and the verb keeps its own exit class.
+        let host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let missing_id = ItemId::new([0x55; 16]).to_user_string();
+        let missing = run(["item", "show", missing_id.as_str()], &host);
+        assert_eq!(missing.exit_code(), ExitCode::NotFound, "{missing:?}");
+        assert_eq!(
+            missing.stderr(),
+            format!("{RECOVERY_NOTICE}vault-pm: not found\n"),
+        );
+        assert_eq!(
+            run(["status"], &TestHost::new(paths, [])).stdout(),
+            "Status: locked\n"
+        );
+    }
+
+    #[test]
+    fn a_portable_export_finishes_an_interrupted_publication_first() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"export correct horse battery staple".to_vec();
+        vault_with_one_login(&paths, &passphrase);
+        wedge_by_an_interrupted_publication(&paths, &passphrase);
+
+        let destination = root.0.join("recovered-export.vpm");
+        let export_host = TestHost::new(
+            paths.clone(),
+            [passphrase, b"distinct export passphrase".to_vec()],
+        );
+        let exported = run(
+            ["export", destination.to_str().expect("UTF-8 path")],
+            &export_host,
+        );
+        assert_eq!(exported.exit_code(), ExitCode::Success, "{exported:?}");
+        assert_eq!(exported.stderr(), RECOVERY_NOTICE, "{exported:?}");
+        assert!(destination.exists());
+        assert_eq!(
+            run(["status"], &TestHost::new(paths, [])).stdout(),
+            "Status: locked\n"
+        );
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli-drill/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli-drill/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this package are documented here.
 
+## [0.2.0] - 2026-08-18
+
+### Changed
+
+- Rewrote the assertions `every_publication_landing_point_leaves_an_exact_resumable_journal`
+  had pinned. They required exit 2 and `vault-pm: invalid command` from every
+  command that opened a vault wedged by an interrupted publication — the defect
+  this drill found — and carried a comment instructing the fixing slice to
+  rewrite rather than delete them. `VLT-PM42-cli-pending-publication-recovery.md`
+  is that slice, so the same landing points now require the opposite: the next
+  ordinary command succeeds, announces the repair, and leaves a vault both
+  read-only diagnostics call an ordinary locked one.
+
+### Added
+
+- `an_interrupted_item_create_comes_back_as_the_item_it_was`, which proves what
+  a count of landing points cannot: that the write a person's machine died in
+  the middle of is the write they find afterwards. A killed `item add login` is
+  a listed item with its title and username readable, and it is the only one;
+  the vault then takes a second write and its whole audit chain verifies.
+- `the_read_only_diagnostics_still_refuse_to_repair_a_wedged_vault`, which runs
+  `status` and `doctor` repeatedly against a wedged vault and requires it to
+  stay wedged, and pins `doctor --unlock`'s new `recovery_required`/5 in place
+  of the misleading invalid-command class it used to inherit.
+- `init_finishes_an_interrupted_publication_instead_of_refusing_it`, since
+  `init` is the verb a stuck person retries and it used to answer the conflict
+  class.
+- `wedge`, a helper that searches downward from a ceremony's last landing point
+  for one that leaves a journal. Hard-coding `total - 1` would work today and
+  would silently start measuring nothing the day a ceremony grows a durable
+  write after its owner-state advance.
+
 ## [0.1.0] - 2026-08-18
 
 ### Added

--- a/code/programs/rust/vault-pm-cli-drill/Cargo.toml
+++ b/code/programs/rust/vault-pm-cli-drill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault-pm-cli-drill"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "VLT-PM41 instrumented vault-pm executable and its real-process crash/fault drill"
 license = "MIT"

--- a/code/programs/rust/vault-pm-cli-drill/README.md
+++ b/code/programs/rust/vault-pm-cli-drill/README.md
@@ -83,13 +83,25 @@ Two results are worth reading before trusting the product with anything.
 An interrupted `init` is always repairable by running `init` again, and the
 resumed vault passes authenticated `doctor --unlock`.
 
-An interrupted **mutation** is not repairable from the command surface. The
-tree is never torn and the durable `PendingPublication` journal is exact — but
-no verb replays it, so every later command fails, and it fails as exit 2
-`vault-pm: invalid command`, telling a person their command is wrong about a
-vault that is intact and one journal replay from healthy. See VLT-PM41 section
-8 and VLT-PM00 §23 item 10a. The drill pins that behavior with a comment
-directing the fixing slice to rewrite those assertions rather than delete them.
+An interrupted **mutation** used to be unrepairable from the command surface,
+and that finding is why this crate exists. The tree was never torn and the
+durable `PendingPublication` journal was exact — but nothing replayed it, so
+every later command failed, as exit 2 `vault-pm: invalid command`, telling a
+person their command was wrong about a vault that was intact and one journal
+replay from healthy. See VLT-PM41 section 8 and VLT-PM00 §23 item 10a.
+
+`VLT-PM42-cli-pending-publication-recovery.md` repaired it, and the assertions
+this drill had pinned were rewritten to require the opposite rather than
+deleted. Section 3 of the matrix now proves that every landing point of the
+publication path is finished by the next ordinary command, and section 6 proves
+what a landing-point count cannot: that the write which was interrupted is the
+write that comes back. An `item add` killed after its journal lands is a listed
+item afterwards, with its title and username readable, and it is the only one.
+
+The read-only diagnostics are still not repairs. `status` and `doctor` — with
+or without `--unlock` — report a wedged vault and leave it wedged, however many
+times they are run, which is what keeps restoring a pre-mutation file-level
+backup a real option rather than a race.
 
 ## Verification
 

--- a/code/programs/rust/vault-pm-cli-drill/tests/crash_fault_matrix.rs
+++ b/code/programs/rust/vault-pm-cli-drill/tests/crash_fault_matrix.rs
@@ -41,16 +41,25 @@
 //! The forbidden class is **torn**: a tree that decodes to something neither
 //! the old nor the new state, or that no longer opens at all.
 //!
-//! # The one cell that is neither
+//! # The cell that used to be neither
 //!
-//! `every_publication_landing_point_leaves_an_exact_resumable_journal`
-//! documents a real defect found by this drill. A kill inside the shared
-//! mutation publication path is *not torn* — the durable journal is exact and
-//! `vault-pm-application`'s `recover_pending_publication` would replay it —
-//! but **no CLI verb reaches that function**, so the vault stays wedged and
-//! every later command reports `invalid command`. See VLT-PM41 section 8.
-//! These assertions therefore pin *observed* behavior and are expected to be
-//! rewritten by the slice that adds the recovery verb.
+//! `every_publication_landing_point_leaves_an_exact_resumable_journal` found a
+//! real defect the first time it ran. A kill inside the shared mutation
+//! publication path was *not torn* — the durable journal was exact and
+//! `vault-pm-application`'s `recover_pending_publication` would have replayed
+//! it — but **no CLI code path reached that function**, so the vault stayed
+//! wedged and every later command answered `invalid command`, exit 2, forever.
+//! VLT-PM41 section 8 recorded it, filed it as VLT-PM00 §23 item 10a, and left
+//! the assertions here pinning the observed behavior with instructions to
+//! rewrite rather than delete them.
+//!
+//! VLT-PM42 is that rewrite. Those assertions now require the opposite: the
+//! very next ordinary command finishes the interrupted publication, says so,
+//! and leaves an ordinary locked vault. Both classes of this matrix are
+//! therefore now recoverable by a person who does nothing but retry, and the
+//! tests further down prove the *content* of what was recovered — an
+//! interrupted `item add` is a listed item afterwards, not merely a vault that
+//! opens.
 
 #![cfg(unix)]
 
@@ -921,16 +930,29 @@ fn every_publication_landing_point_leaves_an_exact_resumable_journal() {
                 assert_eq!(report, "recovery_required", "landing point {point}");
                 assert_eq!(code, Some(5), "landing point {point}");
 
-                // VLT-PM41 section 8. The journal is exact and replayable, but
-                // no CLI verb replays it, so every later command fails closed.
-                // This is a *defect*, pinned here so the slice that adds a
-                // recovery verb must come back and rewrite these three lines.
-                let blocked = unlocked(&home, &["item", "list"], Injection::default());
-                assert_eq!(blocked.code(), Some(2), "landing point {point}");
+                // VLT-PM42, rewriting what VLT-PM41 section 8 pinned. These
+                // lines used to require exit 2, `vault-pm: invalid command`,
+                // from every command that opened the vault — the defect this
+                // drill found. The next ordinary command now replays the exact
+                // journal with the passphrase it already collects.
+                let repaired = unlocked(&home, &["item", "list"], Injection::default());
+                repaired.assert_succeeded(&format!("item list after a wedge at {point}"));
                 assert!(
-                    blocked.transcript.contains("vault-pm: invalid command"),
-                    "landing point {point}: {}",
-                    blocked.transcript
+                    repaired
+                        .transcript
+                        .contains("vault-pm: recovered an interrupted write"),
+                    "landing point {point} repaired silently: {}",
+                    repaired.transcript
+                );
+
+                // The repair is complete, not partial: what is left is an
+                // ordinary locked vault, indistinguishable to both read-only
+                // diagnostics from one that was never interrupted.
+                assert_eq!(status(&home), "locked", "landing point {point}");
+                assert_eq!(
+                    doctor(&home),
+                    ("authentication_required".to_owned(), Some(3)),
+                    "landing point {point}"
                 );
             }
             other => panic!("landing point {point} left status {other}"),
@@ -1337,5 +1359,214 @@ fn the_read_only_diagnostics_describe_every_stage_of_an_interrupted_vault() {
     assert_eq!(status(&home), "locked");
     unlocked(&home, &["audit", "verify"], Injection::default())
         .assert_succeeded("audit verify after restore");
+    assert_tree_excludes_secrets(home.path());
+}
+
+// ---------------------------------------------------------------------------
+// 6. VLT-PM42 — what the next real process does about a wedged vault
+//
+// Section 3 proves every landing point of the publication path is repairable
+// by an ordinary retry. This section proves the two things a *count* of
+// landing points cannot: that the write which was interrupted is the write
+// that comes back, and that the read-only diagnostics still refuse to be
+// repairs.
+// ---------------------------------------------------------------------------
+
+/// Kill `run` at a landing point that leaves an exact journal, and return it.
+///
+/// The last durable write of any mutation is the owner-state advance to
+/// `Active`, so the wedge is almost always its "before" phase at `total - 1`.
+/// Searching downward rather than hard-coding that means a ceremony that grows
+/// a durable write after the advance makes this helper slower, not silently
+/// wrong — the difference between a drill and a decoration.
+///
+/// On return the vault is wedged at the landing point named.
+fn wedge(
+    home: &TestHome,
+    snapshot: &Snapshot,
+    total: u64,
+    run: impl Fn(&TestHome, Injection<'_>) -> Outcome,
+) -> u64 {
+    for point in (1..=total).rev() {
+        snapshot.restore(home);
+        run(
+            home,
+            Injection {
+                trace: None,
+                crash_at: Some(point),
+            },
+        )
+        .assert_killed(point);
+        if status(home) == "recovery_required" {
+            return point;
+        }
+    }
+    panic!("no landing point of this ceremony left a journal to recover");
+}
+
+/// The identifiers one `item list` reported, in the order it printed them.
+///
+/// A row is `ID \t SCHEMA \t "TITLE"`, and the schema is what identifies it:
+/// every V1 schema name begins `vault/`, which no prompt, notice, or shell
+/// echo in the transcript does.
+fn listed_item_ids(transcript: &str) -> Vec<String> {
+    transcript
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .filter_map(|line| {
+            let mut fields = line.split('\t');
+            let id = fields.next()?;
+            let schema = fields.next()?;
+            (schema.starts_with("vault/") && !id.is_empty()).then(|| id.to_owned())
+        })
+        .collect()
+}
+
+#[test]
+fn an_interrupted_item_create_comes_back_as_the_item_it_was() {
+    // The strongest statement this drill can make about the repair: the write
+    // a person watched their machine die in the middle of is the write they
+    // find when they come back. Not "the vault opens" — the item is *there*,
+    // with its title, and it is the only one.
+    let home = TestHome::new("recover-create");
+    init(&home, Injection::default()).assert_succeeded("init");
+    let snapshot = Snapshot::capture(&home);
+    let create = |home: &TestHome, injection: Injection<'_>| {
+        drive(
+            home,
+            &["item", "add", "login"],
+            &login_script(
+                b"crash matrix password stays encrypted\n",
+                b"Example account\n",
+            ),
+            injection,
+        )
+    };
+    let total = count_landing_points(&home, Some(&snapshot), create);
+    let point = wedge(&home, &snapshot, total, create);
+    assert_eq!(status(&home), "recovery_required");
+
+    // One ordinary command, no new verb, no flag, no argument.
+    let listed = unlocked(&home, &["item", "list"], Injection::default());
+    listed.assert_succeeded(&format!("item list after a create wedged at {point}"));
+    assert!(
+        listed
+            .transcript
+            .contains("vault-pm: recovered an interrupted write"),
+        "{}",
+        listed.transcript
+    );
+    let ids = listed_item_ids(&listed.transcript);
+    assert_eq!(ids.len(), 1, "{}", listed.transcript);
+    assert!(
+        listed
+            .transcript
+            .contains("vault/login/v1\t\"Example account\""),
+        "the recovered write must be the interrupted create: {}",
+        listed.transcript
+    );
+
+    // The recovered item is a whole item, not a husk: its fields read back.
+    let shown = unlocked(&home, &["item", "show", &ids[0]], Injection::default());
+    shown.assert_succeeded("item show after recovery");
+    assert!(shown.transcript.contains("Title: \"Example account\""));
+    assert!(shown.transcript.contains("ada@example.test"));
+
+    // And the vault is ordinary afterwards: it takes a second write, both
+    // items list, and the whole audit chain still verifies.
+    drive(
+        &home,
+        &["item", "add", "login"],
+        &login_script(
+            b"crash matrix password stays encrypted\n",
+            b"Second account\n",
+        ),
+        Injection::default(),
+    )
+    .assert_succeeded("item add after recovery");
+    let relisted = unlocked(&home, &["item", "list"], Injection::default());
+    relisted.assert_succeeded("item list after the second add");
+    assert_eq!(listed_item_ids(&relisted.transcript).len(), 2);
+    assert!(
+        !relisted
+            .transcript
+            .contains("vault-pm: recovered an interrupted write"),
+        "the repair must be announced once, not on every later command: {}",
+        relisted.transcript
+    );
+    unlocked(&home, &["audit", "verify"], Injection::default())
+        .assert_succeeded("audit verify after recovery");
+    assert_tree_excludes_secrets(home.path());
+}
+
+#[test]
+fn the_read_only_diagnostics_still_refuse_to_repair_a_wedged_vault() {
+    // A person who wants to look before they leap must be able to. `status`
+    // and `doctor` answer from durable state without a passphrase, and running
+    // them any number of times leaves the vault exactly as they found it —
+    // which is what makes restoring a pre-mutation file-level backup a real
+    // option rather than a race against an eager repair.
+    let home = TestHome::new("recover-diagnostics");
+    init(&home, Injection::default()).assert_succeeded("init");
+    let snapshot = Snapshot::capture(&home);
+    let verify =
+        |home: &TestHome, injection: Injection<'_>| unlocked(home, &["audit", "verify"], injection);
+    let total = count_landing_points(&home, Some(&snapshot), verify);
+    wedge(&home, &snapshot, total, verify);
+
+    for _ in 0..3 {
+        assert_eq!(status(&home), "recovery_required");
+        assert_eq!(doctor(&home), ("recovery_required".to_owned(), Some(5)));
+    }
+
+    // `--unlock` does not make a diagnostic into a repair. It collects no
+    // passphrase at all now, and it reports the state in the closed vocabulary
+    // instead of inheriting the refused open's exit 2 `invalid command`.
+    let authenticated = plain(&home, &["doctor", "--unlock"]);
+    assert_eq!(
+        authenticated.code(),
+        Some(5),
+        "{}",
+        authenticated.transcript
+    );
+    assert!(
+        authenticated
+            .transcript
+            .contains("Doctor: recovery_required"),
+        "{}",
+        authenticated.transcript
+    );
+    assert_eq!(status(&home), "recovery_required");
+
+    // The repair below is therefore this test's, and nothing before it.
+    let repaired = unlocked(&home, &["item", "list"], Injection::default());
+    repaired.assert_succeeded("item list after the diagnostics");
+    assert_eq!(status(&home), "locked");
+    assert_tree_excludes_secrets(home.path());
+}
+
+#[test]
+fn init_finishes_an_interrupted_publication_instead_of_refusing_it() {
+    // `init` is what a stuck person retries, and it used to answer a wedged
+    // vault with the conflict class. It now finishes what was interrupted,
+    // which is what its resume path already meant one generation earlier.
+    let home = TestHome::new("recover-init");
+    init(&home, Injection::default()).assert_succeeded("init");
+    let snapshot = Snapshot::capture(&home);
+    let verify =
+        |home: &TestHome, injection: Injection<'_>| unlocked(home, &["audit", "verify"], injection);
+    let total = count_landing_points(&home, Some(&snapshot), verify);
+    wedge(&home, &snapshot, total, verify);
+
+    let resumed = init(&home, Injection::default());
+    resumed.assert_succeeded("init against a wedged vault");
+    assert!(
+        resumed.transcript.contains("Vault recovered."),
+        "{}",
+        resumed.transcript
+    );
+    assert_eq!(status(&home), "locked");
+    unlocked(&home, &["audit", "verify"], Injection::default())
+        .assert_succeeded("audit verify after an init-driven recovery");
     assert_tree_excludes_secrets(home.path());
 }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- The shipped executable now survives a crash inside a mutation. This crate's
+  own sources are unchanged; the repair is in
+  `coding_adventures_vault_pm_cli` under
+  `code/specs/VLT-PM42-cli-pending-publication-recovery.md`, and it is recorded
+  here because it changes what this binary does. A `vault-pm` process killed
+  mid-write used to leave a vault that every later command refused with exit 2
+  `vault-pm: invalid command`; the next command that opens the vault now
+  replays the exact journal with the passphrase it already collects and reports
+  `vault-pm: recovered an interrupted write` on standard error. No verb, flag,
+  file format, on-disk artifact, or environment variable was added.
+- The crash-injection isolation is unchanged and re-verified. This crate still
+  names `crash-injection` in no section, `src/main.rs` still fails to compile
+  with it, and `the_shipped_executable_contains_no_crash_injection` still reads
+  the produced binary and rejects either injection variable name.
+
 - Added `the_shipped_executable_contains_no_crash_injection` to
   `tests/local_cli_e2e.rs`, and kept this crate free of any mention of
   `coding_adventures_vault_pm_cli`'s `crash-injection` feature. VLT-PM41 needs

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -147,12 +147,24 @@ with anything:
 
 - An interrupted `init` is always repairable by running `init` again, and the
   resumed vault passes authenticated `doctor --unlock`.
-- An interrupted **mutation** is not repairable from this command surface. The
-  tree is never torn and the durable journal is exact, but no verb replays it,
-  so every later command fails — as exit 2 `vault-pm: invalid command`, which
-  tells a person their command is wrong about a vault that is intact. See
-  `code/specs/VLT-PM41-cli-crash-fault-matrix.md` section 8 and VLT-PM00 §23
-  item 10a.
+- An interrupted **mutation** is repairable by doing nothing but retrying. The
+  tree is never torn, the durable journal is exact, and the next command that
+  opens the vault replays it with the passphrase it already asks for, then says
+  `vault-pm: recovered an interrupted write` on standard error. There is no
+  recovery verb to learn and no flag to pass, because the person who needs the
+  repair is by definition someone whose ordinary command just failed.
+
+  This is a repair, not a discovery: until
+  `code/specs/VLT-PM42-cli-pending-publication-recovery.md`, an interrupted
+  mutation left a vault every later command refused, as exit 2
+  `vault-pm: invalid command`. See
+  `code/specs/VLT-PM41-cli-crash-fault-matrix.md` section 8 for the finding and
+  VLT-PM00 §23 item 10a for its closure.
+
+`status` and `doctor` are the exception, deliberately. Both report an
+interrupted vault as `recovery_required` — `doctor` with exit class 5 — without
+collecting a passphrase and without repairing anything, so looking before
+leaping, and restoring a pre-mutation backup instead, both stay available.
 
 ## Verification
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -149,7 +149,7 @@ is `VLT-PM15-operation-audit.md`.
 | Phase | Deliverable | Storage | Client surface | Independently useful result |
 |---|---|---|---|---|
 | 0 | Contract and security closure | in-memory fault model | test harness | formats and invariants fixed before product code |
-| 1A | Local one-shot CLI | filesystem | CLI | usable offline single-user vault (open: §23 item 10a) |
+| 1A | Local one-shot CLI | filesystem | CLI | usable offline single-user vault — crash-survivable since §23 item 10a; open: §23 items 10b–10c |
 | 1B | Complete local CLI | filesystem + removable folder | CLI + interactive shell/local agent | practical daily local password manager |
 | 2 | Bring-your-own-cloud | Google Drive first, then WebDAV/S3 | CLI | multi-device E2EE without our server |
 | 3 | Web client | IndexedDB/OPFS + direct cloud adapters | installable PWA | browser access without a plaintext backend |
@@ -974,11 +974,14 @@ and redact item/provider payloads.
   a valid new commit; never a partial logical state. **Verified** by
   `VLT-PM41-cli-crash-fault-matrix.md` against a real `SIGKILL`ed process at
   every landing point of generation zero and of the shared publication path.
-  The repository half of this criterion holds. The *local* half does not yet:
-  the tree is never torn, but a crash inside a publication leaves a vault only
-  §23 item 10a can repair.
+  Both halves now hold. The tree is never torn, and since
+  `VLT-PM42-cli-pending-publication-recovery.md` every landing point is either
+  a clean rollback or a state the next ordinary command finishes: no landing
+  point leaves a vault any command refuses.
 - Search can be deleted and rebuilt from records.
 - Password rotation rewraps the VRK without re-encrypting every item body.
+  **Not met.** Nothing implements passphrase rotation, so this criterion has
+  never been exercised; see §23 item 10b.
 - Export followed by import into a new vault preserves supported records but
   creates new encryption/object identities.
 - CLI end-to-end tests run through the real executable with a pseudo-terminal
@@ -1684,21 +1687,50 @@ changelog, focused build, and downstream validation.
      tree from an ordinary file-level backup. Using
      `VLT-PM41-cli-crash-fault-matrix.md`. The remaining cross-product is
      enumerated in that document rather than left implicit.
-10a. **Open — found by item 10.** A `SIGKILL` anywhere inside the shared
-      mutation publication path leaves a durable `PendingPublication` journal
-      that is exact and replayable, that both read-only diagnostics correctly
-      report as `recovery_required`, and that
-      `vault-pm-application::recover_pending_publication` would finish — but
-      no CLI code path calls that function. Every subsequent command that
-      opens the vault therefore fails, and it fails as exit 2
-      `vault-pm: invalid command`, telling a person their command is wrong
-      about a vault that is intact. No secret is exposed and no data is lost;
-      the vault is recoverable in principle and unrecoverable in practice.
-      This is an availability defect in already-shipped code. Phase 1A does
-      not close until a recovery ceremony reaches
-      `recover_pending_publication` from the command surface, with its own
-      spec, prompt policy, audit ordering, and exit class. See
-      `VLT-PM41-cli-crash-fault-matrix.md` section 8.
+10a. completed pending-publication recovery at vault open — **fixed**, the
+      availability defect item 10 found. A `SIGKILL` anywhere inside the shared
+      mutation publication path left a durable `PendingPublication` journal
+      that was exact and replayable, that both read-only diagnostics correctly
+      reported as `recovery_required`, and that
+      `vault-pm-application::recover_pending_publication` would have finished —
+      but no CLI code path called that function, so every subsequent command
+      that opened the vault failed, as exit 2 `vault-pm: invalid command`,
+      telling a person their command was wrong about a vault that was intact.
+      `VLT-PM05-application.md` §8 step 2 had required an open to "resume a
+      prepared initialization or pending publication when present" from the
+      start; only the first half had ever been wired. The vault-open boundary
+      now performs the second: a new `VaultAccessV1`
+      `unlock_recovering_pending_publication` replays the exact journal with
+      the passphrase the open already collected and then opens the repaired
+      vault through the ordinary strict open, so every verification a later
+      uninvolved process would perform runs on the repaired bytes. Every
+      authenticated command, portable export, audit verification, and both
+      resume paths of `init` and `vault create` take that door; `status` and
+      `doctor` deliberately do not, keeping their read-only contract, with
+      `doctor --unlock` reclassified from the misleading invalid-command class
+      to `recovery_required`/5. One fixed payload-free line on standard error
+      reports a repair that happened. No verb, flag, file format, on-disk
+      artifact, or environment variable is added. Using
+      `VLT-PM42-cli-pending-publication-recovery.md`, with real-process
+      pseudo-terminal proof in the VLT-PM41 drill that an interrupted
+      `item add` comes back as the item it was.
+10b. **Open — found while verifying §14.8 for item 10a.** §14.8 requires that
+      "password rotation rewraps the VRK without re-encrypting every item
+      body", and nothing implements it. There is no rotation command in §14.4's
+      surface, no rotation use case in `vault-pm-application`, and no Phase 1A
+      item that would have added one, so the criterion has never been
+      exercised. The property the criterion describes is a consequence of the
+      key hierarchy — the VRK is wrapped under a passphrase-derived KEK, so
+      re-wrapping it touches no item body — but a property nothing performs is
+      a property nothing tests. Phase 1A does not close until a passphrase
+      rotation ceremony exists, with its own spec, prompt policy, crash
+      journal, audit ordering, and exit class.
+10c. **Open — found alongside 10b.** §14.4 states that Phase 1A implements
+      "password generation", while §23 item 11 places the password generator in
+      Phase 1B. The two statements contradict each other and the shipped
+      surface has no `password generate`. Decide which document is right and
+      make the other match; if §14.4 is right, the generator is a Phase 1A
+      item and Phase 1A does not close without it.
 
 ### Phase 1B — daily local use
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -516,6 +516,20 @@ failure leaves it locked. Lock synchronously replaces and drops the live
 session before returning; repeated lock is idempotent. Timers, terminal-loss
 signals, prompts, and process lifecycle remain host authorities.
 
+Step 2 above is composed at that lifecycle boundary rather than inside the
+open itself, and the two journals it names are resumed by different callers.
+A `PreparedInit` journal is rehydrated and completed by initialization, which
+is the only caller that knows a vault is being created. A `PendingPublication`
+journal is replayed by a *recovering* unlock, which is a second named entry
+point beside the plain one: it replays the exact journal with the passphrase it
+was given and then performs the ordinary strict open of the repaired durable
+state, so every verification listed above runs on the repaired bytes, and it
+reports which of the two things it did. The plain unlock keeps its strict
+contract and accepts only `Active`, so a host that wants a crash to be refused
+rather than repaired still has exactly that. `VLT-PM42-cli-pending-publication-
+recovery.md` specifies which callers take which door and why the read-only
+status and doctor projections take neither.
+
 Phase 1A does not auto-accept a provider view when pins are absent. The only
 automatic first pin is the receipt from the locally prepared generation-zero
 publication. Device enrollment defines the later fresh-device ceremony.

--- a/code/specs/VLT-PM41-cli-crash-fault-matrix.md
+++ b/code/specs/VLT-PM41-cli-crash-fault-matrix.md
@@ -386,6 +386,18 @@ completion.
 ## 8. What the drill found
 
 > This section is the most important output of this slice.
+>
+> **Resolved.** The defect below was repaired by
+> `VLT-PM42-cli-pending-publication-recovery.md` and VLT-PM00 §23 item 10a is
+> closed. The finding is kept in the past tense it was written in, because the
+> value of a drill is the defect it finds and deleting the record would delete
+> the evidence that this one works. What changed: the vault-open boundary now
+> replays the exact journal with the passphrase it already collects, so every
+> landing point in section 6.1's sweep is either a clean rollback or a state
+> the next ordinary command finishes. The assertions section 8's last paragraph
+> left pinned have been rewritten to require that, and the drill additionally
+> proves the *content* of the repair — an interrupted `item add` is a listed,
+> readable item afterwards. The read-only diagnostics still repair nothing.
 
 **A kill anywhere inside the shared publication path leaves a vault that no
 `vault-pm` command can repair.**
@@ -425,6 +437,17 @@ item 10a** and Phase 1A cannot be declared complete until it lands.
 `every_publication_landing_point_leaves_an_exact_resumable_journal` pins the
 observed behavior, including the misleading exit class, with a comment
 directing the fixing slice to rewrite those assertions rather than delete them.
+
+**What the repair turned out to be.** Not a verb. VLT-PM42 found that
+`VLT-PM05-application.md` §8 step 2 had specified the fix all along — an open
+must "resume a prepared initialization or pending publication when present" —
+and that only the first half had ever been wired. So the repair added no
+command, flag, or artifact: the vault-open boundary gained a second, explicitly
+named door that replays the journal with the passphrase the open already
+collects and then performs the ordinary strict open of the repaired bytes. The
+prediction above that this needed "a new verb" was wrong in a useful direction:
+a verb a wedged person does not know about would not have reached the person
+whose command was failing.
 
 ### 8.1 Secondary observations
 

--- a/code/specs/VLT-PM42-cli-pending-publication-recovery.md
+++ b/code/specs/VLT-PM42-cli-pending-publication-recovery.md
@@ -1,0 +1,340 @@
+# VLT-PM42 — Pending-Publication Recovery at Vault Open
+
+## Status
+
+Normative Phase 1A contract for finishing an interrupted mutation publication.
+Closes VLT-PM00 §23 item 10a, the defect
+`VLT-PM41-cli-crash-fault-matrix.md` §8 found and pinned, and with it the
+crash clause of VLT-PM00 §14.8.
+
+It does **not** close Phase 1A. Verifying §14.8 for this contract turned up one
+acceptance criterion — passphrase rotation rewrapping the VRK — that nothing
+implements and no item tracked, plus a contradiction between §14.4 and §23
+about which phase owns the password generator. Both are now VLT-PM00 §23 items
+10b and 10c. They are unrelated to crash recovery and out of scope here; they
+are named so that "the last open item is closed" is not mistaken for "the phase
+is done".
+
+## 1. The defect this contract repairs
+
+VLT-PM41 killed a real `vault-pm` process with `SIGKILL` at every landing point
+of the shared mutation publication path and asked the next real process what it
+could see. The answer was good news and bad news.
+
+The good news, and it is the larger half: **the tree is never torn.** A kill
+inside `publish_mutation` leaves a durable `PendingPublication` owner state
+whose journal is exact. It holds the complete already-signed bytes, the base
+heads they were computed against, and the heads the provider must return. Both
+read-only diagnostics recognise it: `status` prints `recovery_required` and
+`doctor` reports `recovery_required` with exit class 5, neither of them asking
+for a passphrase. `vault-pm-application::recover_pending_publication` replays
+that journal idempotently — same counter, same object identifiers, same
+commit — and advances the owner state to `Active` only after the provider
+returns exactly the expected heads.
+
+The bad news is one sentence long: **nothing ever called it.**
+
+`recover_pending_publication` was exported from `vault-pm-application` and
+referenced only by that crate's own tests. There was no verb that reached it,
+`init`'s resume path refused a `PendingPublication` outright, and
+`open_active_vault` accepted only an `Active` owner state. So from the instant
+of the crash, every command that opens the vault failed — `item list`,
+`item show`, `search`, `audit verify`, `export`, `doctor --unlock` — and failed
+as exit 2, `vault-pm: invalid command`.
+
+That last detail is what turns a recoverable state into an unrecoverable
+product. A person whose laptop lost power mid-write was told, over and over,
+that their *command* was wrong, about a vault that was intact and one journal
+replay away from healthy. Severity: availability, high. No secret exposed, no
+integrity claim broken, no data lost — and no way to get at any of it.
+
+Surviving exactly this is the reason a local-first password manager keeps a
+write-ahead journal at all. A journal nobody replays is a receipt for a repair
+that never happens.
+
+### 1.1 The contract already said so
+
+This is not a change of mind. `VLT-PM05-application.md` §8 enumerates what an
+open performs, and step 2 of that list reads:
+
+> resume a prepared initialization or pending publication when present
+
+Both halves of that sentence were specified from the beginning. The
+`PreparedInit` half shipped — `init`'s resume path rehydrates it and completes
+generation zero. The `PendingPublication` half was implemented as a function
+and then never connected to an open. So the repair below is not a new
+capability being argued for; it is an existing normative requirement finally
+being met, and VLT-PM05 §8 is amended to say where the resume is composed
+rather than to say something new.
+
+## 2. What this contract adds, and what it deliberately does not
+
+It adds **no verb, no flag, no file format, no on-disk artifact, and no
+environment variable**. VLT-PM00 §14.4 lists the Phase 1A command surface and
+this contract does not extend it.
+
+What it adds is a rule at the vault-open boundary:
+
+> When a command that must open the vault finds a `PendingPublication` owner
+> state, it finishes that publication with the passphrase it has already
+> collected, and then opens the vault. When it finds anything else, it behaves
+> exactly as before.
+
+This is deliberately *not* a `vault-pm recover` verb. Three reasons, in order
+of weight:
+
+1. **A verb the wedged person does not know about does not help them.** The
+   failure they see is a command that does not work. The repair has to live on
+   the path they are already walking.
+2. **Recovery needs precisely the authority an open needs, and no more.** It
+   authenticates the same passphrase against the same bootstrap root wrap. A
+   separate verb would collect the same secret at the same prompt to do a
+   strictly smaller thing.
+3. **Replaying a write-ahead journal is not a decision a user is qualified to
+   make.** The bytes were signed before the crash; the only question is whether
+   the provider has them yet. That question has one correct answer, and the
+   machine can check it.
+
+The corresponding non-goals: this contract does not garbage-collect the
+unreachable frames an abandoned mutation can strand (VLT-PM00 §19.4, Phase 2),
+does not change the durability asymmetry VLT-PM41 §8.1 recorded, does not touch
+the `PreparedInit` resume path's existing behavior beyond the case below, and
+does not make the crash-injection instrumentation reachable from the shipped
+binary in any build.
+
+## 3. Placement
+
+```text
+vault-pm-application   VaultAccessV1::unlock_recovering_pending_publication
+                       UnlockRecoveryV1
+vault-pm-cli           authenticated_access, portable_export, audit_verify
+                       resume_init, resume_vault_create
+                       doctor  (read-only; reclassified, never repaired)
+                       execute (observes the transition, renders the notice)
+```
+
+The composition happens in `vault-pm-application`'s lifecycle boundary because
+that is the layer that already owns "a host decides when to unlock". It does
+*not* happen inside `open_active_vault`, and `VaultAccessV1::unlock` keeps its
+strict contract unchanged: a host that wants a plain authenticated open of an
+`Active` vault, with a `PendingPublication` refused, still has one. The
+recovering entry point is a second, explicitly named door, and every caller
+that walks through it says so at the call site.
+
+## 4. The recovering unlock
+
+```text
+unlock_recovering_pending_publication(passphrase, local, bootstrap, factory)
+    -> UnlockRecoveryV1
+```
+
+```text
+                    ┌─────────────────────────────┐
+   locked access ──▶│ read durable owner state    │
+                    └──────────────┬──────────────┘
+                                   │
+              PendingPublication   │   anything else
+                 ┌─────────────────┴──────────────────┐
+                 ▼                                    │
+    ┌────────────────────────────┐                    │
+    │ recover_pending_publication│                    │
+    │  · republish exact journal │                    │
+    │  · require expected heads  │                    │
+    │  · compare-exchange Active │                    │
+    └──────────────┬─────────────┘                    │
+                   │                                  │
+                   └──────────────┬───────────────────┘
+                                  ▼
+                    ┌─────────────────────────────┐
+                    │ open_active_vault           │  ← unchanged, strict
+                    └──────────────┬──────────────┘
+                                   ▼
+              RecoveredPendingPublication | AlreadyActive
+```
+
+Five properties this shape is chosen for:
+
+**The reopen is a full independent open, not a continuation.** Recovery returns
+an `ActiveStateV1`, and this function then throws it away and opens the vault
+from durable state exactly as the *next* process would. Every verification an
+ordinary unlock performs — bootstrap signature, root-wrap authentication, seed
+to pinned-public-identity reproduction, repository open against non-empty local
+pins — runs after the repair, on the repaired bytes. A recovery that produced a
+vault only the recovering process could open would be worth less than no
+recovery at all.
+
+**It costs one extra Argon2id derivation, and only on the crash path.** The
+recovery and the reopen each consume a passphrase by value, so the crash branch
+derives the vault root key twice. That is the price of the previous paragraph
+and it is paid only by a process that found a wedged vault. The `AlreadyActive`
+path derives exactly once, as before.
+
+**The second copy of the passphrase is explicit.** `Zeroizing` deliberately
+implements neither `Clone` nor `Debug`, so duplicating a secret cannot happen by
+accident. The recovering branch constructs its duplicate by name, and both
+copies are wiped on drop, including on the unwind path.
+
+**A wrong passphrase fails closed before anything is published.** Recovery
+authenticates the root wrap before it touches the provider, so an attempt with
+the wrong secret returns the same closed authentication class an ordinary
+unlock returns and leaves the exact journal untouched for a later, correct
+attempt.
+
+**Failure is idempotent-safe.** `recover_pending_publication` leaves the journal
+in place on provider ambiguity and accepts a concurrent local winner only when
+that winner installed the identical intended `Active` bytes. Repeating the whole
+ceremony after any failure is therefore always sound.
+
+`UnlockRecoveryV1` is a closed two-variant enum — `AlreadyActive` and
+`RecoveredPendingPublication`. It carries no identity, no count, and no byte;
+it exists so a host can tell a person that something was repaired.
+
+## 5. Which CLI paths recover, and which must not
+
+| Path | On `PendingPublication` | Why |
+|---|---|---|
+| `authenticated_access` (item CRUD/list/show/reveal, search, history, conflict, audit enable/list/show, import, restore) | recovers, then opens | the path every wedged person is already on |
+| `portable_export` | recovers, then opens | an export must describe a settled vault |
+| `audit_verify` | recovers, then opens | it publishes an audit-only commit itself |
+| `init` resume | recovers, reports repair | it is the verb a stuck person retries |
+| `vault create` resume | recovers, reports repair | same shape, same reasoning |
+| `status` | **reports, never repairs** | it must answer without a passphrase |
+| `doctor` (locked) | **reports, never repairs** | same |
+| `doctor --unlock` | **reports, never repairs** | doctor is a diagnostic |
+
+The two read-only diagnostics keep their VLT-PM41-pinned behavior exactly:
+`status` prints `recovery_required`, `doctor` reports `recovery_required` with
+exit class 5, and neither writes anything. A person who wants to look before
+they leap can still look, and a person restoring a pre-mutation tree from an
+ordinary file-level backup still sees that tree accepted.
+
+`doctor --unlock` changes in one respect and it is a reclassification, not a
+repair. Previously it inherited the misleading exit 2 `invalid command` from
+the refused open. It now short-circuits on the durable state it can already
+read and emits the same `recovery_required`/5 the locked diagnostic emits. It
+still repairs nothing, and it still never publishes.
+
+`init`'s resume path previously refused a `PendingPublication` with the
+conflict class. It now finishes the publication and reports success, because
+"finish what was interrupted" is precisely what `init`'s resume path already
+means for a `PreparedInit` journal; a `PendingPublication` is the same promise
+one generation later. `vault create`'s resume path is the same code shape and
+gets the same treatment.
+
+## 6. Telling the person
+
+A repair that happens silently is indistinguishable from no repair, and this is
+a password manager: a write completing later than the user watched it complete
+is exactly the kind of thing they are entitled to know.
+
+The composition root observes the durable owner state immediately before and
+immediately after the command runs, both reads under the same cross-process
+writer lock the command already holds. When the state was `RecoveryRequired`
+before and is not after, one fixed payload-free line is added to standard
+error:
+
+```text
+vault-pm: recovered an interrupted write
+```
+
+Standard output is untouched, so nothing that parses a command's output has to
+change, and the exit class is unchanged.
+
+Three notes on why the observation is trustworthy:
+
+- **It cannot produce a false positive.** The writer lock excludes every other
+  local writer for the whole command, so nothing but this command can move the
+  state out of `RecoveryRequired` between the two reads.
+- **It can produce a false negative, and that is the safe direction.** If the
+  configuration cannot be read, or the selector names a vault the observation
+  cannot resolve, the observation is simply skipped and the repair happens
+  without the notice.
+- **It says "recovered", not "your command did something extra".** The
+  observation is of the vault, not of the verb, so the same sentence is correct
+  for `item list`, for `init`, and for a shell command.
+
+## 7. Security analysis
+
+**Does the newly reachable path need a secret it did not need before?** No. It
+needs exactly the passphrase the open already collected, at the same prompt,
+under the same no-echo terminal policy. No new prompt, no new secret, no secret
+in argv, an environment variable, or a file. The duplicate passphrase copy
+lives strictly inside one function call and is wiped on drop.
+
+**Does it weaken the authentication boundary?** No. The unlock that follows a
+repair is the ordinary strict unlock, so a caller cannot reach an unlocked
+session by any route an `Active` vault does not already offer. A wrong
+passphrase is rejected by the recovery before publication and by the open after
+it.
+
+**Does it let an attacker with write access to the vault directory cause a
+publication?** Only of bytes that were already signed by the device key before
+the crash. An attacker who can forge a `PendingPublication` journal would have
+to forge the signed commit inside it, which is the same forgery the ordinary
+verified open already refuses.
+
+**Does it make crash injection reachable from the shipped binary?** No, and
+this contract touches none of the isolation VLT-PM41 built. The
+`crash-injection` feature remains an optional dependency of the
+`vault-pm-cli` library, enabled by exactly one crate — the separate
+`vault-pm-cli-drill` program — through its ordinary `[dependencies]`. The
+product executable still asserts `!CRASH_INJECTION_COMPILED` at compile time
+and still contains neither `VAULT_PM_CRASH_AT` nor `VAULT_PM_CRASH_TRACE`.
+
+**Does the notice leak anything?** It is one fixed string chosen at compile
+time. It names no vault, item, revision, object, provider, path, or count.
+
+## 8. Acceptance gates
+
+1. `unlock_recovering_pending_publication` returns `AlreadyActive` on an
+   `Active` vault and produces a session byte-identical in observable content
+   to the one `unlock` produces.
+2. It returns `RecoveredPendingPublication` on a `PendingPublication` vault,
+   the resulting durable state is exactly the `Active` state
+   `recover_pending_publication` produces on its own, and the opened session
+   sees the recovered mutation.
+3. A wrong passphrase against a `PendingPublication` vault fails with the
+   authentication class and leaves the exact pending bytes unchanged.
+4. A `PreparedInit` owner state is still refused by the recovering unlock; it
+   belongs to `init`.
+5. Recovering twice is a no-op: the second call observes `AlreadyActive`.
+6. `VaultAccessV1::unlock` still refuses a `PendingPublication`.
+7. Real-process, pseudo-terminal proof: a `vault-pm-drill` process killed at a
+   landing point that leaves a journal is followed by an ordinary `item list`
+   that **succeeds**, and by a `status` that reports `locked`, and a `doctor`
+   that reports `authentication_required`/3.
+8. Real-process proof that the recovered write actually landed: an `item add`
+   killed after its journal is durable is visible in a later `item list`, with
+   the identifier the interrupted process announced.
+9. Real-process proof that the vault is ordinary afterwards: a new `item add`
+   following a recovery succeeds and both items are listed.
+10. Real-process proof that `init` on a wedged vault repairs it.
+11. Real-process proof that the read-only diagnostics still refuse to repair:
+    `status` and `doctor` run against a wedged vault leave it wedged.
+12. The recovery notice appears on standard error exactly when a repair
+    happened, and never on a command that only reported the wedged state.
+13. Every landing point of the shared publication path is, after this contract,
+    either a clean rollback or a state the very next ordinary command repairs.
+    No landing point leaves a vault any command refuses.
+14. The shipped binary still fails to compile with the crash-injection feature
+    and still contains neither environment-variable name.
+
+## 9. References
+
+### Internal
+
+- `VLT-PM00-local-first-password-manager.md` §14.4 command surface, §14.7 exit
+  classes, §14.8 Phase 1A acceptance criteria, §23 items 10 and 10a.
+- `VLT-PM41-cli-crash-fault-matrix.md` §8 (the finding), §8.1 (what is
+  deliberately left open), §4.6 (the isolation this contract preserves).
+- `VLT-PM05-application.md` §6b pending-publication recovery.
+- `VLT-PM09-cli-bootstrap.md` init and resume.
+- `VLT-PM40-cli-interactive-shell.md` per-command verified open.
+
+### Code
+
+- `code/packages/rust/vault-pm-application/src/lifecycle.rs`
+- `code/packages/rust/vault-pm-application/src/open.rs`
+- `code/packages/rust/vault-pm-cli/src/lib.rs`
+- `code/programs/rust/vault-pm-cli-drill/tests/crash_fault_matrix.rs` sections
+  3 and 6

--- a/code/specs/VLT-PM42-cli-pending-publication-recovery.md
+++ b/code/specs/VLT-PM42-cli-pending-publication-recovery.md
@@ -227,11 +227,12 @@ A repair that happens silently is indistinguishable from no repair, and this is
 a password manager: a write completing later than the user watched it complete
 is exactly the kind of thing they are entitled to know.
 
-The composition root observes the durable owner state immediately before and
-immediately after the command runs, both reads under the same cross-process
-writer lock the command already holds. When the state was `RecoveryRequired`
-before and is not after, one fixed payload-free line is added to standard
-error:
+The composition root observes the durable owner state immediately before the
+command runs and, **only if that reading found `RecoveryRequired`**, again
+immediately after. Both reads happen under the same cross-process writer lock
+the command already holds. When the state was `RecoveryRequired` before and is
+observably something else after, one fixed payload-free line is added to
+standard error:
 
 ```text
 vault-pm: recovered an interrupted write
@@ -244,10 +245,18 @@ The complete rule, because the interesting rows are the silent ones:
 
 | before | after | notice | why |
 |---|---|---|---|
-| `RecoveryRequired` | anything else, observed | **yes** | only this command held the writer lock |
+| `RecoveryRequired` | `Locked` | **yes** | owner state is `Active`, and only this command held the writer lock |
 | `RecoveryRequired` | `RecoveryRequired` | no | still wedged; nothing was finished |
 | `RecoveryRequired` | unobservable | no | an observation that could not be taken is not evidence |
+| `RecoveryRequired` | `Absent` or `Prepared` | no | not a repair — owner state went missing or backwards |
 | anything else | anything | no | there was nothing to repair |
+
+The affirmative row names one state rather than "anything else" on purpose.
+`Absent` and `Prepared` are unreachable after a repair today — the owner-state
+store exposes no delete and both `PreparedInit` writers demand absence — but if
+either ever appeared it would mean owner state was lost or rolled back, and
+calling that "recovered an interrupted write" would be a worse lie than
+silence.
 
 Three notes on why this is trustworthy:
 
@@ -265,6 +274,16 @@ Three notes on why this is trustworthy:
 - **It says "recovered", not "your command did something extra".** The
   observation is of the vault, not of the verb, so the same sentence is correct
   for `item list`, for `init`, and for a shell command.
+
+The conditional second reading is a requirement, not an optimization. Reading
+owner state initializes its storage backend, and a backend initialization is a
+*durable step* — one VLT-PM41's ledger names and kills real processes at. An
+unconditional second reading therefore appends durable writes after every
+ceremony's own last one, which makes "the portable-export artifact is the last
+thing this command makes durable" false and invalidates the landing-point
+sweeps. An observation about a command must not move the command.
+VLT-PM41's `an_interrupted_portable_export_never_publishes_a_partial_artifact`
+is what enforces this, and it is the test that caught the mistake.
 
 ## 7. Security analysis
 

--- a/code/specs/VLT-PM42-cli-pending-publication-recovery.md
+++ b/code/specs/VLT-PM42-cli-pending-publication-recovery.md
@@ -240,15 +240,28 @@ vault-pm: recovered an interrupted write
 Standard output is untouched, so nothing that parses a command's output has to
 change, and the exit class is unchanged.
 
-Three notes on why the observation is trustworthy:
+The complete rule, because the interesting rows are the silent ones:
+
+| before | after | notice | why |
+|---|---|---|---|
+| `RecoveryRequired` | anything else, observed | **yes** | only this command held the writer lock |
+| `RecoveryRequired` | `RecoveryRequired` | no | still wedged; nothing was finished |
+| `RecoveryRequired` | unobservable | no | an observation that could not be taken is not evidence |
+| anything else | anything | no | there was nothing to repair |
+
+Three notes on why this is trustworthy:
 
 - **It cannot produce a false positive.** The writer lock excludes every other
   local writer for the whole command, so nothing but this command can move the
   state out of `RecoveryRequired` between the two reads.
-- **It can produce a false negative, and that is the safe direction.** If the
+- **Both ends fail toward silence, and that is the safe direction.** If the
   configuration cannot be read, or the selector names a vault the observation
-  cannot resolve, the observation is simply skipped and the repair happens
-  without the notice.
+  cannot resolve, or the owner state becomes unreadable while the command runs,
+  the notice is withheld and the repair — if it happened — happens quietly. The
+  third row above is the trap this rule exists to avoid: "not observed" is not
+  the same as "no longer wedged", and reading it as such would announce a repair
+  on a vault that is still broken. A missing notice costs a courtesy; a wrong
+  one is a false claim about a person's vault.
 - **It says "recovered", not "your command did something extra".** The
   observation is of the vault, not of the verb, so the same sentence is correct
   for `item list`, for `init`, and for a shell command.
@@ -312,7 +325,9 @@ time. It names no vault, item, revision, object, provider, path, or count.
 11. Real-process proof that the read-only diagnostics still refuse to repair:
     `status` and `doctor` run against a wedged vault leave it wedged.
 12. The recovery notice appears on standard error exactly when a repair
-    happened, and never on a command that only reported the wedged state.
+    happened, and never on a command that only reported the wedged state. The
+    complete truth table of §6 is pinned directly, including the row where the
+    after-state cannot be observed and the notice must be withheld.
 13. Every landing point of the shared publication path is, after this contract,
     either a clean rollback or a state the very next ordinary command repairs.
     No landing point leaves a vault any command refuses.


### PR DESCRIPTION
Closes **VLT-PM00 §23 item 10a** — the availability defect the crash/fault
matrix (#11979) found by killing a real `vault-pm` process.

## What was broken

A `SIGKILL` anywhere inside the shared mutation publication path left a vault
that was, by every measure, *fine*: the tree was never torn, the durable
`PendingPublication` journal was exact, both read-only diagnostics correctly
reported `recovery_required`, and
`vault-pm-application::recover_pending_publication` would have replayed it
idempotently — same counter, same object identifiers, same commit.

**Nothing called that function.** `open_active_vault` accepts only `Active`;
`init`'s resume path refused a `PendingPublication` outright. So from the
instant of the crash, every command that opened the vault failed — and failed
as exit 2, `vault-pm: invalid command`. A person whose laptop lost power
mid-write was told, repeatedly, that their *command* was wrong, about a vault
that was intact and one journal replay from healthy.

Recoverable in principle, unrecoverable in practice — the exact failure a
local-first password manager most needs to survive.

## The contract already required the fix

`VLT-PM05-application.md` §8 step 2 has always said an open must

> resume a prepared initialization **or pending publication** when present

Only the first half had ever been wired. This is not a new capability being
argued for; it is an existing normative requirement finally being met.

## What changed

**No verb, flag, file format, on-disk artifact, or environment variable is
added.** A recovery verb would have been the wrong shape: the person who needs
the repair is by definition someone whose ordinary command just failed, and a
verb they have to know about does not reach them.

- **`vault-pm-application`** gains `VaultAccessV1::unlock_recovering_pending_publication`
  and the closed `UnlockRecoveryV1` outcome. It replays the journal, then
  *discards* the returned `ActiveStateV1` and performs the ordinary strict
  `open_active_vault` against the repaired durable state — so every check a
  later, uninvolved process would run happens here too, on the repaired bytes.
  `VaultAccessV1::unlock` keeps its strict contract unchanged.
- **`vault-pm-cli`** takes that door from `authenticated_access`,
  `portable_export`, `audit_verify`, and both resume paths of `init` and
  `vault create` (which now report `Vault recovered.` instead of the conflict
  class).
- **`status` and `doctor` deliberately do not.** `doctor --unlock` on a wedged
  vault short-circuits its authenticated half — collecting no passphrase,
  publishing nothing — and answers `recovery_required`/5 in place of the
  misleading exit 2 it used to inherit. Keeping both diagnostics read-only is
  what lets a person look before they leap, and restore a pre-mutation backup
  instead, without racing an eager repair.
- One fixed payload-free line on standard error when a repair happened:
  `vault-pm: recovered an interrupted write`.

## Cost and secret handling

One extra Argon2id derivation, paid only when a repair actually happens.
`Zeroizing` implements neither `Clone` nor `Debug` on purpose, so the duplicate
passphrase the recovery branch needs is constructed by name and wiped on drop,
unwind included.

## Tests

- The three assertions #11979 pinned *with instructions to rewrite rather than
  delete* now require the opposite, at every landing point of the publication
  sweep.
- Three new real-process pseudo-terminal drills prove what a landing-point count
  cannot: an `item add` killed after its journal lands **comes back as a listed
  item** with its title and username readable and is the only one; the read-only
  diagnostics leave a wedged vault wedged however often they run; and `init`
  repairs one.
- Seven new application-crate tests and six new CLI tests, the latter wedging a
  real on-disk vault through `vault-pm-storage`'s ordinary fault-injecting
  object store — a plain dev-dependency enabling no feature, **not** the
  VLT-PM41 crash-injection seam, whose isolation from the shipped binary is
  untouched and re-verified.

## Security review

Three rounds. Two real findings, both fixed here:

1. The repair notice could be emitted on a vault that was **still wedged**, when
   the after-observation failed — `None` satisfies "not `RecoveryRequired`"
   while proving nothing. The rule now lives in `observed_a_repair` with its
   full truth table and a test for every row.
2. The after-observation is **not read-only** — `LocalStateStore::load`
   initializes its backend, which under `crash-injection` is a counted durable
   step. Reading unconditionally appended durable writes past each ceremony's
   last one and broke three drill cells, including
   `an_interrupted_portable_export_never_publishes_a_partial_artifact`. The
   reading is now conditional, and the comment says it is load-bearing. An
   observation about a command must not move the command.

## Phase 1A is *not* closed by this

This closes the last *tracked* Phase 1A item and the crash clause of §14.8.
Verifying §14.8 while doing so turned up two things nothing tracked:

- **§23 item 10b (new, open)** — §14.8 requires "password rotation rewraps the
  VRK without re-encrypting every item body", and nothing implements passphrase
  rotation anywhere. The property follows from the key hierarchy, but a property
  nothing performs is a property nothing tests.
- **§23 item 10c (new, open)** — §14.4 places the password generator in Phase 1A
  while §23 item 11 places it in Phase 1B, and the shipped surface has neither.

Both are unrelated to crash recovery and out of scope here; they are recorded so
"the last open item is closed" is not mistaken for "the phase is done".

## Specs

New `VLT-PM42-cli-pending-publication-recovery.md`. `VLT-PM00` §4, §14.8, and
§23 items 10a/10b/10c updated; `VLT-PM05` §8 amended to say where the resume is
composed; `VLT-PM41` §8 marked resolved in the past tense it was written in,
because deleting the record would delete the evidence that the drill works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
