### PR TITLE
feat(macsyma-iir-vm): axiom-iir-compiler + axiom-vm -- Wave 5 item 5

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -318,6 +318,8 @@ members = [
     "axiom-runtime",
     "axiom-repl",
     "axiom-to-semantic-ir",
+    "axiom-iir-compiler",
+    "axiom-vm",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/axiom-iir-compiler/BUILD
+++ b/code/packages/rust/axiom-iir-compiler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p axiom-iir-compiler

--- a/code/packages/rust/axiom-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/axiom-iir-compiler/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog — axiom-iir-compiler
+
+## v0.1.0 — 2026-08-18 — initial release (axiom-iir-vm.md, Wave 5 item 5)
+
+The fifth real-language frontend onto `interpreter_ir` (IIR) in this
+rollout (after Macsyma, Derive, Reduce, and Maple) — a retarget of
+`axiom-runtime`'s/`axiom-to-semantic-ir`'s existing CST dispatch.
+
+* `compile(&GrammarASTNode, module_name) -> Result<IIRModule, AxiomIirError>`
+  and `compile_source(source, module_name)`.
+* **`program` is a SINGLE expression** (`axiom.grammar`'s own `program =
+  expr`), unlike every sibling frontend's multi-statement worksheet
+  loop — a real, disclosed structural difference, not an oversight. A
+  consequence: this crate's `Lowerer` has no `env`/binding-threading at
+  all, since a bound variable can never be referenced after its own `x
+  := e` statement in the same compiled module.
+* Accepted v0 grammar: integer literals; `+ - * /` (chains + unary `-`
+  only); assignment (`x := expr`, always a bare NAME target by grammar
+  construction); free-symbol references; any other operator/head, or any
+  operand involving a free symbol, lowers to an inert `cons`-chain.
+* `a : T` (declaration), `e :: T` (coercion), and `D has C`
+  (category-membership query) — Axiom's own genuinely new territory
+  relative to every sibling frontend, with no arithmetic analogue to
+  fall back to — are rejected outright.
+* `String` literals are rejected too (Axiom has real `STRING` tokens,
+  unlike Derive/Reduce/Maple).
+* **Genuine finding while building the oracle test:** `axiom-runtime`
+  domain-tags essentially every result (`format_value` appends `" :
+  <Domain>"`, e.g. `"42 : PositiveInteger"`), not only values that
+  passed through an explicit `:` declaration. Domain inference is an
+  entire fixed-table system this v0 slice does not implement, so
+  `tests/oracle.rs` strips the suffix before comparing ground truth — a
+  disclosed methodology choice, not an accidental first-try match (every
+  case failed against the naive `expected` strings before this fix).
+* 30 unit tests (every accepted construct round-tripped through
+  `axiom-vm`, every rejected construct's explicit-error path) + a
+  17-case oracle test cross-checking against `axiom-runtime`, both
+  rendered through the same `print_axiom` function.

--- a/code/packages/rust/axiom-iir-compiler/Cargo.toml
+++ b/code/packages/rust/axiom-iir-compiler/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "axiom-iir-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "Lowers an Axiom CST (coding-adventures-axiom-parser's GrammarASTNode) into an IIRModule, per axiom-iir-vm.md's v0 scope: literal integer arithmetic (+ - * /, unary), assignment, and unevaluated symbolic expressions. A retarget of axiom-runtime's/axiom-to-semantic-ir's CST dispatch, following macsyma-iir-compiler's precedent. Emits IIR over the dynval-runtime value model so the module runs end-to-end on axiom-vm. Unlike its four siblings, program is a SINGLE expression (axiom.grammar's own program = expr), not a multi-statement worksheet."
+
+[lib]
+name = "axiom_iir_compiler"
+path = "src/lib.rs"
+
+[dependencies]
+coding-adventures-axiom-parser = { path = "../axiom-parser" }
+interpreter-ir = { path = "../interpreter-ir" }
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+symbolic-ir = { path = "../symbolic-ir" }
+
+[dev-dependencies]
+axiom-vm = { path = "../axiom-vm" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Oracle ground truth (tests/oracle.rs) + the shared renderer used to
+# format both the ground truth and the compiled-side read-back result.
+coding-adventures-axiom-runtime = { path = "../axiom-runtime" }

--- a/code/packages/rust/axiom-iir-compiler/README.md
+++ b/code/packages/rust/axiom-iir-compiler/README.md
@@ -1,0 +1,49 @@
+# axiom-iir-compiler
+
+Axiom CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+
+The fifth real-language bridge from a math language in this repo onto
+`interpreter_ir` (IIR). See
+[`axiom-iir-vm.md`](../../../specs/axiom-iir-vm.md) for the per-language
+deltas from
+[`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md)'s original
+design.
+
+**`program` is a SINGLE expression** — `axiom.grammar`'s own `program =
+expr` (Axiom is modeled as a numbered, per-line interactive session),
+unlike every sibling frontend's multi-statement worksheet loop. A
+consequence: this crate has no `env`/binding-threading at all — a bound
+variable can never be referenced after its own `x := e` statement, since
+there is no second statement in the same compiled module.
+
+## Scope (v0.1.0)
+
+**Accepted:** integer literals; `+ - * /` (binary chains and unary `-`
+only); assignment (`x := expr`, always a bare NAME target by grammar
+construction — nothing to disambiguate); free-symbol references; any
+other operator/head — or any operand involving a free symbol —
+represented as an *unevaluated* symbolic expression.
+
+**Rejected, with an explicit error:** `Float`/`String` literals; function
+definitions; `a : T` (declaration), `e :: T` (coercion), `D has C`
+(category-membership query) — Axiom's own genuinely new territory, with
+no arithmetic analogue; `if`/`then`/`else`; comparisons; `^` (power);
+`[...]` list literals; any postfix function call `f(x)`.
+
+## Usage
+
+```rust
+use axiom_iir_compiler::compile_source;
+
+let module = compile_source("2 + 3", "demo")?;
+let value = axiom_vm::run(&module)?;
+assert_eq!(value.as_int(), Some(5));
+```
+
+## Verification
+
+`cargo test -p axiom-iir-compiler` covers every accepted construct (via
+`axiom-vm`, as a dev-dependency) and every rejected construct's
+explicit-error path. `tests/oracle.rs` additionally cross-checks every
+accepted construct against `axiom-runtime`'s own evaluator, both sides
+rendered through the same `print_axiom` function.

--- a/code/packages/rust/axiom-iir-compiler/src/lib.rs
+++ b/code/packages/rust/axiom-iir-compiler/src/lib.rs
@@ -1,0 +1,270 @@
+//! # axiom-iir-compiler
+//!
+//! Axiom CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+//!
+//! The fifth real-language frontend (after Macsyma, Derive, Reduce, and
+//! Maple) to bridge a math language in this repo onto `interpreter_ir`
+//! (IIR). See [`axiom-iir-vm.md`](../../../specs/axiom-iir-vm.md) for the
+//! per-language deltas from `macsyma-iir-vm.md`'s original design and
+//! `lower.rs`'s module doc comment for the v0 scope. It consumes the
+//! generic `GrammarASTNode` CST produced by
+//! `coding-adventures-axiom-parser` and emits an
+//! [`interpreter_ir::IIRModule`], executable on
+//! [`axiom-vm`](../axiom-vm) (v0 targets the VM interpreter backend
+//! only).
+//!
+//! **`program` is a SINGLE expression** — `axiom.grammar`'s own `program
+//! = expr` (Axiom is modeled as a numbered, per-line interactive
+//! session), unlike every sibling frontend's multi-statement worksheet
+//! loop. See `lower.rs`'s module doc comment for the full consequence
+//! (no `env`/binding-threading needed at all).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Axiom source (one expression)
+//!    │
+//!    ▼  coding_adventures_axiom_parser::try_parse_axiom(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  axiom_iir_compiler::compile
+//! interpreter_ir::IIRModule                (v0 subset)
+//!    │
+//!    ▼  axiom_vm::run
+//! dynval_runtime::LispyValue
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use axiom_iir_compiler::compile_source;
+//! let module = compile_source("2 + 3", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, AxiomIirError};
+
+/// Parse `source` as a single Axiom expression and lower it into an
+/// [`interpreter_ir::IIRModule`] in one step, mirroring
+/// `axiom-to-semantic-ir::compile_source`'s convenience wrapper.
+///
+/// Needs no worker-thread stack enlargement, for the same reason
+/// `axiom-to-semantic-ir::compile_source` doesn't:
+/// `coding_adventures_axiom_parser`'s own `MAX_RULE_DEPTH` (140) is
+/// already documented safe on a bare default (~2 MiB) stack.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<interpreter_ir::IIRModule, AxiomIirError> {
+    let tree =
+        coding_adventures_axiom_parser::try_parse_axiom(source).map_err(|msg| AxiomIirError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        })?;
+    compile(&tree, module_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axiom_vm::run;
+
+    fn eval_int(source: &str) -> i64 {
+        let module = compile_source(source, "t").expect("compile");
+        run(&module).expect("run").as_int().expect("int result")
+    }
+
+    fn eval_symbol(source: &str) -> String {
+        let module = compile_source(source, "t").expect("compile");
+        let v = run(&module).expect("run");
+        dynval_runtime::name_of(v.as_symbol().expect("symbol result")).expect("interned")
+    }
+
+    // ---- accepted: literal arithmetic ----
+
+    #[test]
+    fn integer_literal() {
+        assert_eq!(eval_int("42"), 42);
+    }
+
+    #[test]
+    fn simple_addition() {
+        assert_eq!(eval_int("2 + 3"), 5);
+    }
+
+    #[test]
+    fn precedence() {
+        assert_eq!(eval_int("2 + 3 * 4"), 14);
+    }
+
+    #[test]
+    fn chain() {
+        assert_eq!(eval_int("1 + 2 + 3 + 4"), 10);
+    }
+
+    #[test]
+    fn unary_neg_leaf() {
+        assert_eq!(eval_int("-5 + 3"), -2);
+    }
+
+    #[test]
+    fn unary_neg_compound() {
+        assert_eq!(eval_int("-(5 + 3)"), -8);
+    }
+
+    #[test]
+    fn grouping() {
+        assert_eq!(eval_int("(2 + 3) * 4"), 20);
+    }
+
+    #[test]
+    fn exact_division() {
+        assert_eq!(eval_int("20 / 4"), 5);
+    }
+
+    #[test]
+    fn negative_literal_exact_division() {
+        assert_eq!(eval_int("-4 / 2"), -2);
+    }
+
+    // ---- accepted: assignment (single expression -- see the module doc
+    // comment: there is no second statement to reference the binding). ----
+
+    #[test]
+    fn assignment_returns_the_assigned_value() {
+        assert_eq!(eval_int("x := 3"), 3);
+    }
+
+    #[test]
+    fn assignment_with_an_arithmetic_rhs() {
+        assert_eq!(eval_int("x := 2 + 3"), 5);
+    }
+
+    // ---- accepted: unevaluated symbolic expressions ----
+
+    #[test]
+    fn free_symbol_addition_is_symbolic() {
+        let module = compile_source("x + y", "t").expect("compile");
+        let v = run(&module).expect("run");
+        assert!(v.as_int().is_none());
+    }
+
+    #[test]
+    fn free_symbol_addition_head_is_add() {
+        let module = compile_source("x + y", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Add")
+        );
+    }
+
+    #[test]
+    fn mixed_concrete_and_symbolic_operand() {
+        let module = compile_source("2 * x", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Mul")
+        );
+    }
+
+    #[test]
+    fn free_symbol_alone() {
+        assert_eq!(eval_symbol("x"), "x");
+    }
+
+    // ---- rejected: explicit-error paths ----
+
+    #[test]
+    fn float_literal_rejected() {
+        assert!(compile_source("1.5", "t").is_err());
+    }
+
+    #[test]
+    fn string_literal_rejected() {
+        assert!(compile_source("\"hi\"", "t").is_err());
+    }
+
+    #[test]
+    fn non_exact_division_rejected() {
+        let err = compile_source("7 / 2", "t").unwrap_err();
+        assert!(
+            err.message.contains("rational"),
+            "message was: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn division_of_a_concrete_but_non_literal_value_rejected() {
+        // Axiom's single-expression v0 has no `env`, so there is no
+        // `x := 6 / x / 2`-style test available the way sibling crates
+        // have. `9223372036854775807 + 1` overflows `checked_add`, so
+        // `combine`'s literal-tracking degrades to `concrete: true,
+        // literal: None` (the real `call_builtin "+"` is still emitted
+        // for the VM to execute) -- dividing that by a literal exercises
+        // the "concrete but not a direct literal" rejection path, the one
+        // shape of this case reachable without assignment threading.
+        assert!(compile_source("(9223372036854775807 + 1) / 2", "t").is_err());
+    }
+
+    #[test]
+    fn division_by_literal_zero_rejected() {
+        assert!(compile_source("1 / 0", "t").is_err());
+    }
+
+    #[test]
+    fn i64_min_divided_by_neg_one_rejected_not_panicking() {
+        assert!(compile_source("(-9223372036854775807 - 1) / -1", "t").is_err());
+    }
+
+    #[test]
+    fn function_definition_rejected() {
+        assert!(compile_source("f(x: Integer): Integer == x + 1", "t").is_err());
+    }
+
+    #[test]
+    fn function_call_rejected() {
+        assert!(compile_source("f(x)", "t").is_err());
+    }
+
+    #[test]
+    fn comparison_rejected() {
+        assert!(compile_source("x = y", "t").is_err());
+    }
+
+    #[test]
+    fn power_rejected() {
+        assert!(compile_source("x^2", "t").is_err());
+    }
+
+    #[test]
+    fn list_literal_rejected() {
+        assert!(compile_source("[1, 2, 3]", "t").is_err());
+    }
+
+    #[test]
+    fn declaration_rejected() {
+        assert!(compile_source("x : Integer", "t").is_err());
+    }
+
+    #[test]
+    fn coercion_rejected() {
+        assert!(compile_source("x :: Float", "t").is_err());
+    }
+
+    #[test]
+    fn has_query_rejected() {
+        assert!(compile_source("Integer has Ring", "t").is_err());
+    }
+
+    #[test]
+    fn if_expr_rejected() {
+        assert!(compile_source("if x > 0 then 1 else 0", "t").is_err());
+    }
+}

--- a/code/packages/rust/axiom-iir-compiler/src/lower.rs
+++ b/code/packages/rust/axiom-iir-compiler/src/lower.rs
@@ -1,0 +1,700 @@
+//! The lowering pass from `coding_adventures_axiom_parser`'s generic
+//! [`GrammarASTNode`] CST → [`IIRModule`], **v0.1.0**.
+//!
+//! # Retargeting `axiom-runtime`/`axiom-to-semantic-ir`, a third time
+//!
+//! `axiom-runtime` already walks this exact CST and compiles it to
+//! `symbolic_ir::IRNode`. `axiom-to-semantic-ir` retargets the same
+//! rule-name dispatch to build `semantic_ir::Expr` instead. This module is
+//! a **third retarget**, following the precedent every other language in
+//! this rollout has established — see
+//! [`axiom-iir-vm.md`](../../../specs/axiom-iir-vm.md) and
+//! [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md).
+//!
+//! # `program` is a SINGLE expression — unlike every sibling in this rollout
+//!
+//! `axiom.grammar`'s own `program = expr` parses exactly ONE expression per
+//! call (Axiom is modeled as a numbered, per-line interactive session, not a
+//! batch worksheet — see `axiom-to-semantic-ir/src/lower.rs`'s identical
+//! note). So, unlike `macsyma-iir-compiler`/`derive-iir-compiler`/
+//! `reduce-iir-compiler`/`maple-iir-compiler`'s own multi-statement
+//! `lower_file` loops, [`Lowerer::lower_file`] here lowers exactly one
+//! top-level expression into `main`'s body.
+//!
+//! **A genuine consequence, not carried over from any sibling:** since a
+//! compiled module can never contain more than one statement, a bound
+//! variable can never be *referenced* after its own `x := e` statement
+//! within the same compilation — there is no second statement to read it
+//! back in. So this crate's `symbol_ref` needs no `env: HashMap` lookup at
+//! all (every sibling crate has one, since their multi-statement programs
+//! genuinely thread bindings across statements): a bare `NAME` is *always*
+//! a free symbol here. `x := e` still lowers and evaluates `e` and returns
+//! its value (matching `axiom-runtime::eval_assignment`'s own "assignment's
+//! value is the RHS's value" convention, and every sibling crate's
+//! identical treatment) — there is simply no binding to persist, since
+//! nothing in the same compiled module could ever read it back.
+//!
+//! # Scope (v0.1.0)
+//!
+//! Accepted: integer literals; `+ - * /` (binary chains and unary `-`
+//! only); assignment (`x := expr`, always a bare NAME target —
+//! `axiom.grammar`'s own `assignment = NAME ASSIGN expr` guarantees this
+//! structurally, so unlike Derive's/Reduce's own bare-name-vs-call check,
+//! there is nothing to disambiguate); free-symbol references; any other
+//! head or symbolic operand, represented as an *unevaluated* inert
+//! `cons`-chain.
+//!
+//! Rejected, with an explicit [`AxiomIirError`]: `Float`/`String` literals
+//! (Axiom's grammar has real `STRING` tokens, unlike Derive/Reduce/Maple);
+//! `declared_define`/`undeclared_define` (function definitions); `a : T`
+//! (declaration), `e :: T` (coercion), `D has C` (category-membership
+//! query) — Axiom's own genuinely new territory relative to every sibling
+//! in this rollout, with no arithmetic analogue to fall back to; `if`/
+//! `then`/`else`; comparisons; `^`/`**` (power); `[...]` list literals;
+//! any postfix function call `f(x)`.
+//!
+//! # The `/` exactness rule
+//!
+//! Identical hazard and identical fix as every sibling frontend's `/`
+//! handling: Axiom's `/` on integers that don't divide evenly returns an
+//! exact rational, which `dynval-runtime` cannot represent.
+//! [`Lowerer::combine`] only takes the evaluated `call_builtin "/"` path
+//! when both direct operands are literal integer tokens at this exact
+//! node and their quotient is exact; a symbolic operand falls back to
+//! inert data; anything else is rejected.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{ADD, DIV, MUL, NEG, SUB};
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — mirrors every sibling frontend's identically-named guard.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// IIR type-hint string for the nil / cons reference type.
+const REF_PAIR: &str = "ref<LispyPair>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Axiom → IIR lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxiomIirError {
+    /// Human-readable explanation.
+    pub message: String,
+    /// 1-based source line.
+    pub line: usize,
+    /// 1-based source column.
+    pub column: usize,
+}
+
+impl std::fmt::Display for AxiomIirError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AxiomIirError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for AxiomIirError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Axiom CST (rooted at the `program` rule, a SINGLE
+/// expression — see the module doc comment) into an [`IIRModule`].
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<IIRModule, AxiomIirError> {
+    Lowerer::new().lower_file(tree, module_name)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowered value of one CST node: the IIR register holding it, plus
+/// two facts used only to decide how a *later* arithmetic step may
+/// combine it — never observed by the emitted IIR itself.
+#[derive(Debug, Clone)]
+struct Lowered {
+    /// The register this value lives in.
+    reg: String,
+    /// `true` if this value was built purely from integer literals
+    /// combined via `+`/`-`/`*`/`/`/unary negate — i.e. it contains no
+    /// free symbol anywhere.
+    concrete: bool,
+    /// `Some(v)` only when this value is a *direct* integer-literal token
+    /// (or the statically-known result of combining such literals) —
+    /// used exclusively by the `/` exactness check ([`Lowerer::combine`]).
+    literal: Option<i64>,
+}
+
+/// Unlike every sibling crate's `Lowerer`, this one has **no** mutable
+/// environment at all — see the module doc comment's "no `env`" section:
+/// a single-expression program can never reference a binding from an
+/// earlier statement, because there is no earlier statement.
+struct Lowerer {
+    instrs: Vec<IIRInstr>,
+    tmp: usize,
+}
+
+impl Lowerer {
+    fn new() -> Self {
+        Lowerer {
+            instrs: Vec::new(),
+            tmp: 0,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = expr ;` -- a SINGLE expression.
+    // -------------------------------------------------------------------
+
+    fn lower_file(
+        &mut self,
+        program: &GrammarASTNode,
+        module_name: &str,
+    ) -> Result<IIRModule, AxiomIirError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        // `lower_node` peels `program`'s own single child away via
+        // `unwrap_single` before dispatching -- safe to call directly on
+        // the root, mirroring `axiom-to-semantic-ir::Lowerer::
+        // lower_program`'s identical direct call.
+        let final_val = self.lower_node(program, 0)?;
+
+        self.emit(IIRInstr::new(
+            "ret",
+            None,
+            vec![Operand::Var(final_val.reg)],
+            "any",
+        ));
+
+        let mut main =
+            IIRFunction::new("main", Vec::new(), "any", std::mem::take(&mut self.instrs));
+        main.register_count = self.tmp;
+
+        let mut module = IIRModule::new(module_name, "axiom");
+        module.functions.push(main);
+        module.entry_point = Some("main".to_string());
+
+        let problems = module.validate();
+        if !problems.is_empty() {
+            return Err(AxiomIirError {
+                message: format!(
+                    "internal: emitted IIR failed validation: {}",
+                    problems.join("; ")
+                ),
+                line: 1,
+                column: 1,
+            });
+        }
+        Ok(module)
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------------------
+
+    fn lower_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => {
+                    Err(self.err_at(node, "nested program node is not an expression".to_string()))
+                }
+                "if_expr" => Err(self.err_unsupported(node, "if/then/else")),
+                "declared_define" | "undeclared_define" => {
+                    Err(self.err_unsupported(node, "function definitions"))
+                }
+                "assignment" => self.lower_assignment(node, depth),
+                "declaration" => Err(self.err_unsupported(node, "declaration (a : T)")),
+                "has_query" => {
+                    Err(self.err_unsupported(node, "category-membership query (D has C)"))
+                }
+                "comparison" => {
+                    Err(self.err_unsupported(node, "comparisons (=, ~=, <, >, <=, >=)"))
+                }
+                "coercion" => Err(self.err_unsupported(node, "coercion (e :: T)")),
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => Err(self.err_unsupported(node, "exponentiation (^)")),
+                "postfix" => self.lower_postfix(node, depth),
+                "atom" => self.lower_first_node(node, depth),
+                "list_literal" => Err(self.err_unsupported(node, "list literals ([...])")),
+                "group" => self.lower_group(node, depth),
+                "call_args" => Err(self.err_at(
+                    node,
+                    "`call_args` cannot be lowered as a standalone expression".to_string(),
+                )),
+                "arglist" => Err(self.err_at(
+                    node,
+                    "an arglist cannot be lowered as a scalar expression".to_string(),
+                )),
+                "elem_list" => Err(self.err_at(
+                    node,
+                    "an elem_list cannot be lowered as a scalar expression".to_string(),
+                )),
+                "type_expr" => Err(self.err_at(
+                    node,
+                    "a bare type expression is not a value-producing expression".to_string(),
+                )),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol). Axiom has real
+    /// `STRING` tokens (unlike Derive/Reduce/Maple) — v0 rejects them,
+    /// matching its treatment of every other out-of-scope literal kind.
+    fn lower_token(&mut self, token: &Token) -> Result<Lowered, AxiomIirError> {
+        match token_type(token) {
+            "NUMBER" => self.lower_number(&token.value, token),
+            "NAME" => Ok(self.emit_symbol(&token.value)),
+            "STRING" => Err(self.err_unsupported_tok(token, "string literals")),
+            other => Err(AxiomIirError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// Parse a `NUMBER` lexeme. Unlike `axiom-to-semantic-ir`'s
+    /// `number_literal_expr`, this does **not** fall back to a float for
+    /// a too-large integer — v0 has no float representation at all.
+    fn lower_number(&mut self, text: &str, token: &Token) -> Result<Lowered, AxiomIirError> {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            return Err(self
+                .err_unsupported_tok(token, "floating-point literals (not representable in v0)"));
+        }
+        match text.parse::<i64>() {
+            Ok(v) => Ok(self.emit_int(v)),
+            Err(_) => Err(self.err_unsupported_tok(
+                token,
+                "an integer literal too large for i64 (bignum is not representable in v0)",
+            )),
+        }
+    }
+
+    /// `assignment = NAME ASSIGN expr ;` — the grammar guarantees a bare
+    /// NAME target, so there is nothing to disambiguate. See the module
+    /// doc comment's "no `env`" section: the assigned value is lowered
+    /// and returned, but never bound anywhere — there is no later
+    /// statement in the same compiled module that could ever read it
+    /// back.
+    fn lower_assignment(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        let has_name = node
+            .children
+            .iter()
+            .filter_map(as_token)
+            .any(|t| token_type(t) == "NAME");
+        if !has_name {
+            return Err(self.err_at(node, "malformed assignment: missing name".to_string()));
+        }
+        let rhs_node = child_nodes(node).next().ok_or_else(|| {
+            self.err_at(
+                node,
+                "malformed assignment: missing right-hand side".to_string(),
+            )
+        })?;
+        self.lower_node(rhs_node, depth + 1)
+    }
+
+    /// `additive`/`multiplicative` — a left-associative binary chain of
+    /// `+`/`-`/`*`/`/`.
+    fn lower_binary_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs_child = children.next().ok_or_else(|| {
+                self.err_at(node, "binary operator with no right operand".to_string())
+            })?;
+            let rhs = self.lower_child(rhs_child, depth + 1)?;
+            result = self.combine(head, result, rhs, node)?;
+        }
+        Ok(result)
+    }
+
+    /// Combine `lhs op rhs` for `op` one of `Add`/`Sub`/`Mul`/`Div`. See
+    /// the module doc comment's "The `/` exactness rule" section.
+    fn combine(
+        &mut self,
+        head: &str,
+        lhs: Lowered,
+        rhs: Lowered,
+        node: &GrammarASTNode,
+    ) -> Result<Lowered, AxiomIirError> {
+        if head == DIV {
+            if !lhs.concrete || !rhs.concrete {
+                return Ok(self.inert_apply(DIV, vec![lhs, rhs]));
+            }
+            return match (lhs.literal, rhs.literal) {
+                (Some(_), Some(0)) => Err(self.err_at(node, "division by zero".to_string())),
+                (Some(a), Some(b)) if a.checked_rem(b) == Some(0) => {
+                    let reg = self.emit_builtin("/", &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+                    Ok(Lowered {
+                        reg,
+                        concrete: true,
+                        literal: a.checked_div(b),
+                    })
+                }
+                (Some(a), Some(b)) if a.checked_rem(b).is_some() => Err(self.err_at(
+                    node,
+                    "this division does not divide evenly; the exact result would be a \
+                     rational, which is not representable in v0 (see axiom-iir-vm.md)"
+                        .to_string(),
+                )),
+                (Some(_), Some(_)) => Err(self.err_at(
+                    node,
+                    "this division cannot be evaluated in v0 (i64::MIN / -1 is not representable)"
+                        .to_string(),
+                )),
+                _ => Err(self.err_at(
+                    node,
+                    "division of a non-literal value cannot be verified exact at compile time \
+                     in v0 (only literal / literal is supported); see axiom-iir-vm.md"
+                        .to_string(),
+                )),
+            };
+        }
+
+        if lhs.concrete && rhs.concrete {
+            let op_name = op_symbol_for(head);
+            let reg = self.emit_builtin(op_name, &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+            let literal = match (head, lhs.literal, rhs.literal) {
+                (h, Some(a), Some(b)) if h == ADD => a.checked_add(b),
+                (h, Some(a), Some(b)) if h == SUB => a.checked_sub(b),
+                (h, Some(a), Some(b)) if h == MUL => a.checked_mul(b),
+                _ => None,
+            };
+            Ok(Lowered {
+                reg,
+                concrete: true,
+                literal,
+            })
+        } else {
+            Ok(self.inert_apply(head, vec![lhs, rhs]))
+        }
+    }
+
+    /// `unary = MINUS unary | power ;` — Axiom's grammar has no
+    /// unary-plus alternative.
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            2 => {
+                let operand = self.lower_child(&node.children[1], depth + 1)?;
+                if operand.concrete {
+                    let reg = self.emit_builtin("-", &[operand.reg.as_str()], "i64");
+                    let literal = operand.literal.and_then(i64::checked_neg);
+                    Ok(Lowered {
+                        reg,
+                        concrete: true,
+                        literal,
+                    })
+                } else {
+                    Ok(self.inert_apply(NEG, vec![operand]))
+                }
+            }
+            _ => Err(self.err_at(node, "malformed unary node".to_string())),
+        }
+    }
+
+    /// `postfix = atom [ call_args ] ;` — a bare atom (no call suffix)
+    /// passes through; any call suffix is rejected (v0 has no
+    /// user-defined functions to call).
+    fn lower_postfix(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        let has_call = child_nodes(node).any(|n| n.rule_name == "call_args");
+        if has_call {
+            return Err(self.err_unsupported(node, "function calls (e.g. f(x))"));
+        }
+        let base = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?;
+        self.lower_node(base, depth + 1)
+    }
+
+    /// `group = LPAREN expr RPAREN ;` — grouping only.
+    fn lower_group(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        let inner = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty group `( )`".to_string()))?;
+        self.lower_node(inner, depth + 1)
+    }
+
+    // -------------------------------------------------------------------
+    // Emission helpers
+    // -------------------------------------------------------------------
+
+    fn fresh(&mut self) -> String {
+        let name = format!("v{}", self.tmp);
+        self.tmp += 1;
+        name
+    }
+
+    fn emit(&mut self, instr: IIRInstr) {
+        self.instrs.push(instr);
+    }
+
+    fn emit_int(&mut self, n: i64) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(n)],
+            "i64",
+        ));
+        Lowered {
+            reg,
+            concrete: true,
+            literal: Some(n),
+        }
+    }
+
+    fn emit_symbol(&mut self, name: &str) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Var(name.to_string())],
+            "symbol",
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_nil(&mut self) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(0)],
+            REF_PAIR,
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_builtin(&mut self, name: &str, args: &[&str], type_hint: &str) -> String {
+        let reg = self.fresh();
+        let mut srcs = vec![Operand::Var(name.to_string())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).to_string())));
+        self.emit(IIRInstr::new(
+            "call_builtin",
+            Some(reg.clone()),
+            srcs,
+            type_hint,
+        ));
+        reg
+    }
+
+    /// Materialise an unevaluated `Apply(head, args)` as an inert
+    /// `cons`-chain `(head arg0 arg1 …)`.
+    fn inert_apply(&mut self, head: &str, args: Vec<Lowered>) -> Lowered {
+        let head_reg = self.emit_symbol(head).reg;
+        let mut acc = self.emit_nil().reg;
+        for arg in args.into_iter().rev() {
+            acc = self.emit_builtin("cons", &[arg.reg.as_str(), acc.as_str()], REF_PAIR);
+        }
+        let reg = self.emit_builtin("cons", &[head_reg.as_str(), acc.as_str()], REF_PAIR);
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/
+    /// `multiplicative`) with more than `MAX_EXPR_DEPTH` operands.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), AxiomIirError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression chain too long ({operand_count} operands, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        let child = child_nodes(node).next().ok_or_else(|| {
+            self.err_at(
+                node,
+                format!("`{}` has no expression child", node.rule_name),
+            )
+        })?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(
+        &mut self,
+        child: &ASTNodeOrToken,
+        depth: usize,
+    ) -> Result<Lowered, AxiomIirError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> AxiomIirError {
+        AxiomIirError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    fn err_unsupported(&self, node: &GrammarASTNode, what: &str) -> AxiomIirError {
+        self.err_at(
+            node,
+            format!("{what} are not supported in this v0 slice — see axiom-iir-vm.md"),
+        )
+    }
+
+    fn err_unsupported_tok(&self, token: &Token, what: &str) -> AxiomIirError {
+        AxiomIirError {
+            message: format!("{what} are not supported in this v0 slice — see axiom-iir-vm.md"),
+            line: token.line,
+            column: token.column,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Map an arithmetic token type to its canonical IR head.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a canonical arithmetic head to the `call_builtin` name
+/// `dynval-runtime` resolves it to. Only ever called for `ADD`/`SUB`/`MUL`
+/// (see [`Lowerer::combine`] — `DIV` is handled separately).
+fn op_symbol_for(head: &str) -> &'static str {
+    match head {
+        h if h == ADD => "+",
+        h if h == SUB => "-",
+        h if h == MUL => "*",
+        _ => unreachable!("op_symbol_for called with a non-arithmetic head: {head}"),
+    }
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with
+/// structure (or a leaf token).
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/axiom-iir-compiler/tests/oracle.rs
+++ b/code/packages/rust/axiom-iir-compiler/tests/oracle.rs
@@ -1,0 +1,267 @@
+//! Oracle/golden test (axiom-iir-vm.md / macsyma-iir-vm.md §7): the SAME
+//! Axiom source, run through **two independent implementations**, and
+//! diffed:
+//!
+//!   (a) `axiom-runtime` (`coding-adventures-axiom-runtime`) — the native
+//!       runtime crate — the ground truth.
+//!   (b) `axiom_iir_compiler::compile_source` → `interpreter_ir::IIRModule`
+//!       → `axiom_vm::run` → a `LispyValue`, read back into a
+//!       `symbolic_ir::IRNode` and rendered through the SAME
+//!       `coding_adventures_axiom_runtime::print_axiom` function the
+//!       native runtime uses.
+//!
+//! ## Single-expression corpus — unlike every sibling oracle file
+//!
+//! `axiom.grammar`'s own `program = expr` (see `lower.rs`'s module doc
+//! comment) means every corpus entry here is exactly ONE expression, not
+//! a multi-statement program — there is no `x := 3\nx + 1`-style
+//! assignment-then-reference case the sibling oracle files have, since
+//! Axiom's grammar has no way to express that as one `compile_source`
+//! call.
+//!
+//! `axiom-runtime::AxiomSession::eval_to_output` returns a single
+//! [`Output`] (not `Vec<Output>`, unlike every sibling runtime), whose
+//! `text` is `format_value`'s output — `print_axiom(&value.node)`, with a
+//! `" : <Domain>"` suffix appended only when the evaluated value carries a
+//! known domain (via a `:` declaration — out of v0's scope entirely, so
+//! never triggered by anything this corpus can produce).
+//!
+//! ## Corpus
+//!
+//! v0's accepted grammar subset only (`axiom-iir-vm.md`): literal integer
+//! arithmetic (`+ - * /`, unary `-` only), a bare `x := e` assignment
+//! (returning `e`'s value), and unevaluated symbolic `Apply` results for
+//! any operand that stays free. Every rejected construct already has a
+//! dedicated `Err`-asserting unit test in `src/lib.rs`'s own `tests`
+//! module — not re-tested here.
+//!
+//! ## A genuine finding, not assumed: `axiom-runtime` domain-tags EVERY
+//! result, not just declared ones
+//!
+//! Confirmed empirically (this file's own first draft assumed otherwise
+//! and every case failed): `format_value` (`axiom-runtime/src/lib.rs`)
+//! appends `" : <Domain>"` to `print_axiom`'s own output whenever
+//! `AxiomValue::domain` is `Some(_)` — and Axiom's evaluator infers a
+//! domain for essentially every value, not only ones that passed through
+//! an explicit `:` declaration (`42` → `"42 : PositiveInteger"`, `x + y`
+//! → `"x + y : Polynomial(Integer)"`). Domain inference
+//! (`axiom-runtime::domains`) is an entire fixed-table system this v0
+//! slice does not implement at all (declarations/`::`/`has` are all
+//! rejected outright — see `lower.rs`'s module doc comment), so the
+//! compiled side's `read_back`/`print_axiom` pipeline has no domain
+//! concept whatsoever and cannot reproduce this suffix. [`ground_truth`]
+//! below strips it before comparing — a disclosed methodology choice
+//! (compare VALUES only, not domain tags), not an accidental match.
+
+/// Strip axiom-runtime's `" : <Domain>"` suffix (see the module doc
+/// comment) from a ground-truth string, if present. Domain names never
+/// contain `" : "` themselves (confirmed against `axiom-runtime::
+/// domains`' fixed table — every entry is a single `NAME`-shaped
+/// identifier, optionally with `(...)`-nested type arguments, never a
+/// colon), so a single `rsplit_once(" : ")`-free `find`/truncate is exact.
+fn strip_domain_suffix(text: &str) -> &str {
+    match text.find(" : ") {
+        Some(idx) => &text[..idx],
+        None => text,
+    }
+}
+
+use axiom_iir_compiler::compile_source;
+use coding_adventures_axiom_runtime::{print_axiom, AxiomSession};
+use dynval_runtime::{builtins, name_of, LispyValue};
+use symbolic_ir::{apply, int, sym, IRNode};
+
+/// One oracle corpus entry.
+struct Case {
+    name: &'static str,
+    /// The WHOLE program — exactly one expression, byte-for-byte
+    /// identical on both the [`ground_truth`] and [`compiled`] sides.
+    source: &'static str,
+    expected: &'static str,
+}
+
+const CORPUS: &[Case] = &[
+    // --- Literal arithmetic: precedence, chains, unary, grouping. ---
+    Case {
+        name: "integer_literal",
+        source: "42",
+        expected: "42",
+    },
+    Case {
+        name: "simple_addition",
+        source: "2 + 3",
+        expected: "5",
+    },
+    Case {
+        name: "precedence",
+        source: "2 + 3 * 4",
+        expected: "14",
+    },
+    Case {
+        name: "left_associative_chain",
+        source: "1 + 2 + 3 + 4",
+        expected: "10",
+    },
+    Case {
+        name: "unary_minus_leaf",
+        source: "-5 + 3",
+        expected: "-2",
+    },
+    Case {
+        name: "unary_minus_compound",
+        source: "-(5 + 3)",
+        expected: "-8",
+    },
+    Case {
+        name: "grouping_overrides_precedence",
+        source: "(2 + 3) * 4",
+        expected: "20",
+    },
+    Case {
+        name: "exact_integer_division",
+        source: "20 / 4",
+        expected: "5",
+    },
+    Case {
+        name: "negative_literal_exact_division",
+        source: "-4 / 2",
+        expected: "-2",
+    },
+    // --- Assignment: returns the assigned value (no reference case is
+    // expressible -- see the module doc comment). ---
+    Case {
+        name: "assignment_returns_the_assigned_value",
+        source: "x := 3",
+        expected: "3",
+    },
+    Case {
+        name: "assignment_with_an_arithmetic_rhs",
+        source: "x := 2 + 3",
+        expected: "5",
+    },
+    // --- Unevaluated symbolic expressions: a free symbol alone, and every
+    // arithmetic head with a symbolic operand (Add/Sub/Mul/Div/Neg via
+    // `inert_apply`). ---
+    Case {
+        name: "free_symbol_alone",
+        source: "x",
+        expected: "x",
+    },
+    Case {
+        name: "free_symbol_addition",
+        source: "x + y",
+        expected: "x + y",
+    },
+    Case {
+        name: "mixed_concrete_and_symbolic_multiplication",
+        source: "2 * x",
+        expected: "2*x",
+    },
+    Case {
+        name: "symbolic_subtraction",
+        source: "x - y",
+        expected: "x - y",
+    },
+    Case {
+        name: "symbolic_division_stays_unevaluated",
+        source: "x / y",
+        expected: "x/y",
+    },
+    Case {
+        name: "negation_of_a_free_symbol",
+        source: "-x",
+        expected: "-x",
+    },
+    Case {
+        name: "chained_symbolic_addition_nests_left_associatively",
+        source: "x + y + z",
+        expected: "x + y + z",
+    },
+];
+
+/// Ground truth: run `source` through `axiom-runtime`'s own
+/// [`AxiomSession::eval_to_output`] (a single [`Output`], not `Vec` —
+/// see the module doc comment).
+fn ground_truth(source: &str) -> String {
+    let mut session = AxiomSession::new();
+    let text = session
+        .eval_to_output(source)
+        .unwrap_or_else(|e| panic!("axiom-runtime eval failed for {source:?}: {e}"))
+        .text;
+    strip_domain_suffix(&text).to_string()
+}
+
+/// Compiled path: `compile_source` → `axiom_vm::run` → [`read_back`] →
+/// the same `print_axiom` function the native runtime uses.
+fn compiled(name: &str, source: &str) -> String {
+    let module = compile_source(source, "oracle")
+        .unwrap_or_else(|e| panic!("lowering failed for {name} ({source:?}): {e}"));
+    let value = axiom_vm::run(&module)
+        .unwrap_or_else(|e| panic!("VM execution failed for {name} ({source:?}): {e}"));
+    let node = read_back(value);
+    print_axiom(&node)
+}
+
+/// Rebuild the [`symbolic_ir::IRNode`] a [`LispyValue`] represents — the
+/// mirror image of `axiom_iir_compiler`'s own `inert_apply`/`emit_int`/
+/// `emit_symbol`. Plain recursion is appropriate here for the same
+/// reason `macsyma-iir-compiler/tests/oracle.rs`'s own `read_back`
+/// module doc gives: test-only code over a small, hand-authored corpus.
+fn read_back(v: LispyValue) -> IRNode {
+    if let Some(n) = v.as_int() {
+        return int(n);
+    }
+    if let Some(s) = v.as_symbol() {
+        let name = name_of(s).expect("interned symbol has a name");
+        return sym(name);
+    }
+    // Otherwise `v` must be the inert-Apply cons shape: (head . arglist).
+    let head_value = builtins::car(&[v]).unwrap_or_else(|e| panic!("car of apply pair: {e}"));
+    let head_name = match read_back(head_value) {
+        IRNode::Symbol(name) => name,
+        other => panic!("expected a symbol head, got {other:?}"),
+    };
+    let mut rest = builtins::cdr(&[v]).unwrap_or_else(|e| panic!("cdr of apply pair: {e}"));
+    let mut args = Vec::new();
+    while !rest.is_nil() {
+        let arg = builtins::car(&[rest]).unwrap_or_else(|e| panic!("car of arg list: {e}"));
+        args.push(read_back(arg));
+        rest = builtins::cdr(&[rest]).unwrap_or_else(|e| panic!("cdr of arg list: {e}"));
+    }
+    apply(sym(head_name), args)
+}
+
+#[test]
+fn oracle_corpus_matches_native_axiom_runtime() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        if gt != case.expected {
+            failures.push(format!(
+                "{}: axiom-runtime itself disagrees with this corpus entry's own `expected` \
+                 (got {gt:?}, expected {:?}) -- the program or `expected` is wrong, fix the \
+                 corpus rather than this assertion",
+                case.name, case.expected
+            ));
+            continue;
+        }
+
+        let got = compiled(case.name, case.source);
+        if got != case.expected {
+            failures.push(format!(
+                "{}: axiom-iir-compiler -> axiom-vm disagrees with the axiom-runtime ground \
+                 truth (got {got:?}, expected {:?})",
+                case.name, case.expected
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "oracle corpus mismatches ({} of {}):\n{}",
+        failures.len(),
+        CORPUS.len(),
+        failures.join("\n")
+    );
+}

--- a/code/packages/rust/axiom-vm/BUILD
+++ b/code/packages/rust/axiom-vm/BUILD
@@ -1,0 +1,1 @@
+cargo test -p axiom-vm

--- a/code/packages/rust/axiom-vm/CHANGELOG.md
+++ b/code/packages/rust/axiom-vm/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — axiom-vm
+
+## v0.1.0 — 2026-08-18 — initial release (axiom-iir-vm.md, Wave 5 item 5)
+
+Axiom's own dedicated VM interpreter for the v0 arithmetic/assignment
+IIR subset — a direct structural port of the sibling VMs in this
+rollout, per the explicit VM-sharing decision (`macsyma-iir-vm.md` §6).
+
+* `run`/`run_with_budget` executing an `interpreter_ir::IIRModule`,
+  returning a `dynval_runtime::LispyValue`.
+* `resolve_builtin` maps `+`/`-`/`*`/`/`/`cons`/`car`/`cdr` to
+  `dynval-runtime`'s existing builtins.
+* 15 unit tests over hand-built IIR.

--- a/code/packages/rust/axiom-vm/Cargo.toml
+++ b/code/packages/rust/axiom-vm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "axiom-vm"
+version = "0.1.0"
+edition = "2021"
+description = "A tiny interpreter for the Axiom v0 arithmetic/assignment IIR subset, built directly on dynval-runtime. Deliberately independent of every sibling VM in this rollout; shares only the dynval-runtime foundation."
+
+[lib]
+name = "axiom_vm"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Provides `RuntimeError`, the error type dynval-runtime's builtins return.
+lang-runtime-core = { path = "../lang-runtime-core" }

--- a/code/packages/rust/axiom-vm/README.md
+++ b/code/packages/rust/axiom-vm/README.md
@@ -1,0 +1,25 @@
+# axiom-vm
+
+A tiny interpreter for the Axiom v0 arithmetic/assignment IIR subset,
+built directly on `dynval-runtime`. Executes the `interpreter_ir::IIRModule`
+produced by [`axiom-iir-compiler`](../axiom-iir-compiler), returning a
+`LispyValue`.
+
+Axiom's own VM — deliberately independent of every sibling VM in this
+rollout (see [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) §6).
+
+## Instruction set
+
+Only three opcodes: `const`, `call_builtin`, `ret`.
+
+## Usage
+
+```rust
+use axiom_vm::run;
+
+let value = run(&module)?; // module: interpreter_ir::IIRModule
+```
+
+## Verification
+
+`cargo test -p axiom-vm` — 15 unit tests over hand-built `IIRModule`s.

--- a/code/packages/rust/axiom-vm/src/lib.rs
+++ b/code/packages/rust/axiom-vm/src/lib.rs
@@ -1,0 +1,461 @@
+//! # `axiom-vm` — Axiom's own v0 interpreter.
+//!
+//! Executes the [`IIRModule`] produced by `axiom-iir-compiler` against
+//! the [`dynval_runtime`] value model and returns a [`LispyValue`]. See
+//! [`axiom-iir-vm.md`](../../../specs/axiom-iir-vm.md) for the full
+//! design.
+//!
+//! ## Why a dedicated VM
+//!
+//! Every language in this rollout gets its own small VM on top of
+//! [`dynval_runtime`]'s tagged-`i64` value model — deliberately *not*
+//! shared with any sibling (`macsyma-iir-vm.md` §6's explicit
+//! VM-sharing decision for this rollout).
+//!
+//! ## The v0 instruction set
+//!
+//! | Op             | Meaning                                                                 |
+//! |----------------|--------------------------------------------------------------------------|
+//! | `const`        | `Int(n)` → tagged int, `Int(0):ref<LispyPair>` → the nil sentinel, `Var(name)` → interned symbol |
+//! | `call_builtin` | `srcs[0]` is the builtin name (a `Var`), the rest are argument registers; dispatched to a `dynval-runtime` builtin |
+//! | `ret`          | return the value in `srcs[0]`                                            |
+//!
+//! ## Quick start
+//!
+//! ```
+//! use axiom_vm::run;
+//! use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+//!
+//! let main = IIRFunction::new(
+//!     "main",
+//!     Vec::new(),
+//!     "any",
+//!     vec![
+//!         IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(42)], "i64"),
+//!         IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "any"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("demo", "axiom");
+//! module.functions.push(main);
+//! module.entry_point = Some("main".into());
+//!
+//! let result = run(&module).expect("run");
+//! assert_eq!(result.as_int(), Some(42));
+//! ```
+
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+
+use dynval_runtime::value::{INT_MAX, INT_MIN};
+use dynval_runtime::{builtins, intern, LispyValue};
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lang_runtime_core::RuntimeError;
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+/// A failure while interpreting an Axiom [`IIRModule`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmError {
+    /// The module has no `entry_point` set.
+    NoEntryPoint,
+    /// `entry_point` names a function the module does not contain.
+    UnknownFunction(String),
+    /// Control reached the end of a function without a `ret`.
+    FellOffEnd(String),
+    /// An instruction this VM doesn't execute (v0 has no branches, calls,
+    /// or closures). Carries the opcode.
+    UnsupportedOp(String),
+    /// An instruction was missing a `dest`, an operand, etc.
+    Malformed(String),
+    /// A register was read before it was written.
+    UndefinedRegister(String),
+    /// A `call_builtin` named a builtin `dynval-runtime` doesn't provide.
+    UnknownBuiltin(String),
+    /// A `dynval-runtime` builtin raised a runtime trap (wrong arity,
+    /// type error, division by zero, overflow, …). Carries its message.
+    Runtime(String),
+    /// The per-run instruction budget was exhausted.
+    InstructionBudgetExceeded(u64),
+    /// An integer literal outside `dynval-runtime`'s tagged-int range
+    /// (`[-2^60, 2^60 - 1]`). A known v0 gap tied to a later wave (bignum
+    /// support) — see `axiom-iir-vm.md`.
+    IntegerOutOfRange(i64),
+}
+
+impl std::fmt::Display for VmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VmError::NoEntryPoint => write!(f, "module has no entry_point"),
+            VmError::UnknownFunction(n) => write!(f, "unknown function {n:?}"),
+            VmError::FellOffEnd(n) => write!(f, "function {n:?} ran off the end without `ret`"),
+            VmError::UnsupportedOp(op) => write!(f, "unsupported opcode {op:?}"),
+            VmError::Malformed(m) => write!(f, "malformed instruction: {m}"),
+            VmError::UndefinedRegister(r) => write!(f, "register {r:?} read before written"),
+            VmError::UnknownBuiltin(b) => write!(f, "unknown builtin {b:?}"),
+            VmError::Runtime(m) => write!(f, "runtime error: {m}"),
+            VmError::InstructionBudgetExceeded(n) => {
+                write!(
+                    f,
+                    "instruction budget ({n}) exceeded — possible infinite loop"
+                )
+            }
+            VmError::IntegerOutOfRange(n) => write!(
+                f,
+                "integer literal {n} is outside dynval-runtime's tagged-int range [-2^60, 2^60-1]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VmError {}
+
+// ===========================================================================
+// Public entry points
+// ===========================================================================
+
+/// Default instruction budget. Far above any real v0 program's step count
+/// (v0 has no loops), but a hard backstop nonetheless.
+pub const DEFAULT_INSTRUCTION_BUDGET: u64 = 10_000_000;
+
+/// Execute `module`'s entry-point function and return its result value.
+///
+/// # Errors
+///
+/// See [`VmError`] for the full list — missing entry point, unsupported
+/// opcode, builtin trap, etc.
+pub fn run(module: &IIRModule) -> Result<LispyValue, VmError> {
+    run_with_budget(module, DEFAULT_INSTRUCTION_BUDGET)
+}
+
+/// Like [`run`], but with an explicit instruction budget (the maximum
+/// number of instructions executed before
+/// [`VmError::InstructionBudgetExceeded`]).
+///
+/// # Errors
+///
+/// See [`VmError`].
+pub fn run_with_budget(module: &IIRModule, budget: u64) -> Result<LispyValue, VmError> {
+    let entry = module.entry_point.as_deref().ok_or(VmError::NoEntryPoint)?;
+    let func = module
+        .get_function(entry)
+        .ok_or_else(|| VmError::UnknownFunction(entry.to_string()))?;
+    let mut steps: u64 = 0;
+    run_function(func, &mut steps, budget)
+}
+
+// ===========================================================================
+// Interpreter core
+// ===========================================================================
+
+/// The register file: register name → live value. A `HashMap` keeps the
+/// VM independent of any register-numbering scheme the compiler uses.
+type Frame = HashMap<String, LispyValue>;
+
+fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<LispyValue, VmError> {
+    let mut frame: Frame = HashMap::new();
+    let mut pc: usize = 0;
+
+    while pc < func.instructions.len() {
+        *steps += 1;
+        if *steps > budget {
+            return Err(VmError::InstructionBudgetExceeded(budget));
+        }
+
+        let instr = &func.instructions[pc];
+        match instr.op.as_str() {
+            "const" => {
+                let value = eval_const(instr)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "call_builtin" => {
+                let value = eval_call_builtin(instr, &frame)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "ret" => {
+                let src = instr
+                    .srcs
+                    .first()
+                    .ok_or_else(|| VmError::Malformed("`ret` requires a source operand".into()))?;
+                return read_operand(src, &frame);
+            }
+            other => return Err(VmError::UnsupportedOp(other.to_string())),
+        }
+    }
+
+    Err(VmError::FellOffEnd(func.name.clone()))
+}
+
+/// Store an instruction's result in its `dest` register.
+fn bind_dest(instr: &IIRInstr, value: LispyValue, frame: &mut Frame) -> Result<(), VmError> {
+    let dest = instr
+        .dest
+        .as_ref()
+        .ok_or_else(|| VmError::Malformed(format!("`{}` requires a dest register", instr.op)))?;
+    frame.insert(dest.clone(), value);
+    Ok(())
+}
+
+/// Materialise a `const` instruction's literal into a [`LispyValue`].
+///
+/// The operand encodings match what `axiom-iir-compiler` emits (the
+/// same conventions established across this rollout's other frontends).
+fn eval_const(instr: &IIRInstr) -> Result<LispyValue, VmError> {
+    let src = instr
+        .srcs
+        .first()
+        .ok_or_else(|| VmError::Malformed("`const` requires a source operand".into()))?;
+    match src {
+        Operand::Int(0) if instr.type_hint == "ref<LispyPair>" => Ok(LispyValue::NIL),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Var(name) => Ok(LispyValue::symbol(intern(name))),
+        Operand::Bool(_) => Err(VmError::Malformed(
+            "Axiom v0 has no boolean literals; unexpected Bool operand in `const`".into(),
+        )),
+        Operand::Float(_) => Err(VmError::Malformed(
+            "Axiom v0 has no floats (axiom-iir-vm.md); unexpected Float operand in `const`".into(),
+        )),
+        Operand::Str(_) => Err(VmError::Malformed(
+            "Axiom v0 has no string literals; unexpected Str operand in `const`".into(),
+        )),
+    }
+}
+
+/// Execute a `call_builtin`: `srcs[0]` is the builtin's name (a `Var`),
+/// the remaining sources are argument registers.
+fn eval_call_builtin(instr: &IIRInstr, frame: &Frame) -> Result<LispyValue, VmError> {
+    let name = match instr.srcs.first() {
+        Some(Operand::Var(n)) => n.as_str(),
+        _ => {
+            return Err(VmError::Malformed(
+                "`call_builtin` requires srcs[0] to be the builtin name (a Var)".into(),
+            ))
+        }
+    };
+
+    let mut args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
+    for src in &instr.srcs[1..] {
+        args.push(read_operand(src, frame)?);
+    }
+
+    let builtin = resolve_builtin(name).ok_or_else(|| VmError::UnknownBuiltin(name.to_string()))?;
+    builtin(&args).map_err(|e| VmError::Runtime(e.to_string()))
+}
+
+/// A `dynval-runtime` builtin: takes a slice of arguments, returns a value
+/// or a runtime trap. This is the shape every `builtins::*` function has.
+type BuiltinFn = fn(&[LispyValue]) -> Result<LispyValue, RuntimeError>;
+
+/// Map an Axiom v0 builtin name to its `dynval-runtime` implementation.
+fn resolve_builtin(name: &str) -> Option<BuiltinFn> {
+    match name {
+        "+" => Some(builtins::add),
+        "-" => Some(builtins::sub),
+        "*" => Some(builtins::mul),
+        "/" => Some(builtins::div),
+        "cons" => Some(builtins::cons),
+        "car" => Some(builtins::car),
+        "cdr" => Some(builtins::cdr),
+        _ => None,
+    }
+}
+
+/// Build a tagged integer, rejecting values outside `dynval-runtime`'s
+/// 61-bit tagged-int range rather than letting `LispyValue::int` silently
+/// truncate them in release builds.
+fn dyn_int(n: i64) -> Result<LispyValue, VmError> {
+    if (INT_MIN..=INT_MAX).contains(&n) {
+        Ok(LispyValue::int(n))
+    } else {
+        Err(VmError::IntegerOutOfRange(n))
+    }
+}
+
+/// Read an operand in *value* position: a `Var` is a register read; an
+/// `Int` is an immediate. (`const` handles its `Var` specially — see
+/// [`eval_const`].)
+fn read_operand(op: &Operand, frame: &Frame) -> Result<LispyValue, VmError> {
+    match op {
+        Operand::Var(name) => frame
+            .get(name)
+            .copied()
+            .ok_or_else(|| VmError::UndefinedRegister(name.clone())),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Bool(_) => Err(VmError::Malformed("unexpected Bool operand".into())),
+        Operand::Float(_) => Err(VmError::Malformed("unexpected Float operand".into())),
+        Operand::Str(_) => Err(VmError::Malformed("unexpected Str operand".into())),
+    }
+}
+
+// ===========================================================================
+// Tests (hand-built IIR; the compiler's own tests cover the source path)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynval_runtime::name_of;
+
+    fn module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let main = IIRFunction::new("main", Vec::new(), "any", instrs);
+        let mut m = IIRModule::new("test", "axiom");
+        m.functions.push(main);
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    fn konst(dest: &str, op: Operand, ty: &str) -> IIRInstr {
+        IIRInstr::new("const", Some(dest.into()), vec![op], ty)
+    }
+
+    fn ret(reg: &str) -> IIRInstr {
+        IIRInstr::new("ret", None, vec![Operand::Var(reg.into())], "any")
+    }
+
+    fn builtin_instr(dest: &str, name: &str, args: &[&str]) -> IIRInstr {
+        let mut srcs = vec![Operand::Var(name.into())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).into())));
+        IIRInstr::new("call_builtin", Some(dest.into()), srcs, "any")
+    }
+
+    #[test]
+    fn integer_const() {
+        let m = module(vec![konst("v0", Operand::Int(42), "i64"), ret("v0")]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(42));
+    }
+
+    #[test]
+    fn nil_const() {
+        let m = module(vec![
+            konst("v0", Operand::Int(0), "ref<LispyPair>"),
+            ret("v0"),
+        ]);
+        assert!(run(&m).unwrap().is_nil());
+    }
+
+    #[test]
+    fn symbol_const_interns() {
+        let m = module(vec![
+            konst("v0", Operand::Var("X".into()), "symbol"),
+            ret("v0"),
+        ]);
+        let v = run(&m).unwrap();
+        assert_eq!(v.as_symbol(), Some(intern("X")));
+        assert_eq!(name_of(v.as_symbol().unwrap()).as_deref(), Some("X"));
+    }
+
+    #[test]
+    fn add_two_concrete_ints() {
+        let m = module(vec![
+            konst("a", Operand::Int(2), "i64"),
+            konst("b", Operand::Int(3), "i64"),
+            builtin_instr("r", "+", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(5));
+    }
+
+    #[test]
+    fn sub_unary_negates() {
+        let m = module(vec![
+            konst("a", Operand::Int(5), "i64"),
+            builtin_instr("r", "-", &["a"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(-5));
+    }
+
+    #[test]
+    fn cons_builds_an_inert_pair() {
+        let m = module(vec![
+            konst("head", Operand::Var("Add".into()), "symbol"),
+            konst("x", Operand::Var("X".into()), "symbol"),
+            konst("y", Operand::Var("Y".into()), "symbol"),
+            konst("nil", Operand::Int(0), "ref<LispyPair>"),
+            builtin_instr("t1", "cons", &["y", "nil"]),
+            builtin_instr("t2", "cons", &["x", "t1"]),
+            builtin_instr("r", "cons", &["head", "t2"]),
+            ret("r"),
+        ]);
+        let v = run(&m).unwrap();
+        let h = builtins::car(&[v]).unwrap();
+        assert_eq!(name_of(h.as_symbol().unwrap()).as_deref(), Some("Add"));
+    }
+
+    #[test]
+    fn missing_entry_point() {
+        let mut m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        m.entry_point = None;
+        assert_eq!(run(&m), Err(VmError::NoEntryPoint));
+    }
+
+    #[test]
+    fn unknown_entry_function() {
+        let mut m = module(vec![ret("v0")]);
+        m.entry_point = Some("nope".into());
+        assert!(matches!(run(&m), Err(VmError::UnknownFunction(_))));
+    }
+
+    #[test]
+    fn fell_off_end_without_ret() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64")]);
+        assert!(matches!(run(&m), Err(VmError::FellOffEnd(_))));
+    }
+
+    #[test]
+    fn unsupported_op() {
+        let m = module(vec![IIRInstr::new("jmp", None, vec![], "void")]);
+        assert!(matches!(run(&m), Err(VmError::UnsupportedOp(_))));
+    }
+
+    #[test]
+    fn unknown_builtin() {
+        let m = module(vec![
+            konst("x", Operand::Int(1), "i64"),
+            builtin_instr("r", "frobnicate", &["x"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::UnknownBuiltin(_))));
+    }
+
+    #[test]
+    fn undefined_register() {
+        let m = module(vec![ret("never_written")]);
+        assert!(matches!(run(&m), Err(VmError::UndefinedRegister(_))));
+    }
+
+    #[test]
+    fn division_by_zero_is_a_clean_runtime_error() {
+        let m = module(vec![
+            konst("a", Operand::Int(1), "i64"),
+            konst("b", Operand::Int(0), "i64"),
+            builtin_instr("r", "/", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn integer_out_of_tagged_range_is_rejected() {
+        let m = module(vec![konst("v0", Operand::Int(i64::MAX), "i64"), ret("v0")]);
+        assert!(matches!(run(&m), Err(VmError::IntegerOutOfRange(_))));
+        let ok = module(vec![
+            konst("v0", Operand::Int((1 << 60) - 1), "i64"),
+            ret("v0"),
+        ]);
+        assert_eq!(run(&ok).unwrap().as_int(), Some((1 << 60) - 1));
+    }
+
+    #[test]
+    fn instruction_budget() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        assert!(matches!(
+            run_with_budget(&m, 1),
+            Err(VmError::InstructionBudgetExceeded(_))
+        ));
+    }
+}

--- a/code/specs/axiom-iir-vm.md
+++ b/code/specs/axiom-iir-vm.md
@@ -1,0 +1,107 @@
+# Axiom → IIR → VM interpreter
+
+**Status:** Draft — 2026-08-18 (spec-first; sign-off = merge)
+**Depends on:** [`macsyma-iir-vm.md`](macsyma-iir-vm.md) — this is Wave 5
+item 5 of that spec's rollout; read it first for the full design.
+This document records Axiom's own deltas, the largest of the rollout so
+far (a genuinely different `program` shape, not just grammar-surface
+differences).
+**Unblocks:** the same IIR-bridge pattern for the last Wave 5 item
+(Wolfram).
+
+## Summary
+
+Bridges Axiom onto `interpreter_ir` (IIR): a new `axiom-iir-compiler`
+frontend (a third retarget of the `GrammarASTNode` CST `axiom-runtime`
+and `axiom-to-semantic-ir` already walk) and a new `axiom-vm`
+interpreter (its own dedicated VM, per `macsyma-iir-vm.md` §6).
+
+```text
+                               ┌─→ axiom-runtime (+ repl)                [existing, unchanged]
+axiom source → GrammarASTNode ┤─→ axiom-to-semantic-ir → any SIR backend [existing, unchanged]
+                               └─→ axiom-iir-compiler → IIRModule → axiom-vm   [NEW]
+```
+
+## Deltas from the rest of Wave 5
+
+Verified directly against `axiom.grammar`/`axiom.tokens`
+(`code/grammars/axiom/`), `axiom-to-semantic-ir/src/lower.rs`'s module
+doc comment, and `axiom-runtime/src/lib.rs`:
+
+1. **`program` is a SINGLE expression, not a multi-statement worksheet.**
+   `axiom.grammar`'s own `program = expr` — Axiom is modeled as a
+   numbered, per-line interactive session (matching `axiom-repl`'s own
+   step counter), not a batch file. Every prior Wave 5 item's `lower_file`
+   loops over `{ statement_line } [ statement ]`; this crate's
+   `lower_file` lowers exactly one top-level expression.
+2. **No `env`/binding-threading at all — a real simplification, not a
+   missing feature.** Since a compiled module can never contain more than
+   one statement, a bound variable can never be referenced after its own
+   `x := e` — there is no second statement to read it back in. So
+   `Lowerer` carries no `env: HashMap` (every sibling crate does); a bare
+   `NAME` is *always* a free symbol. `x := e` still lowers and returns
+   `e`'s value (matching every sibling's "assignment's value is the RHS's
+   value" convention) — there is simply nothing to bind for.
+3. **`a : T` (declaration), `e :: T` (coercion), `D has C`
+   (category-membership query) — genuinely new territory with no
+   arithmetic analogue.** Unlike `if`/`while`/list-literals in the other
+   four languages (which at least *could* theoretically fall back to
+   inert data the way `Add`/`Sub` do), these three have no sibling
+   precedent at all and are rejected outright, matching how
+   `axiom-to-semantic-ir` itself needed a wholly new design decision
+   (three new reserved `SymApply` head names) to represent them — v0
+   doesn't need to represent them at all, just reject them cleanly.
+4. **`assignment = NAME ASSIGN expr` guarantees a bare-NAME target**,
+   exactly like Maple's (not Derive's/Reduce's own bare-name-vs-call
+   check) — but Axiom has no `arrow_def`-equivalent RHS to check for
+   either, since function definitions are a wholly separate grammar
+   production (`declared_define`/`undeclared_define`), never reachable
+   through `assignment` at all.
+5. **Real `STRING` tokens** (unlike Derive/Reduce/Maple) — rejected in
+   v0, matching every other out-of-scope literal kind.
+6. Arithmetic (`TIMES`/`SLASH`/no-unary-plus), the `/` exactness rule,
+   the inert-`cons`-chain representation, and the outright rejection of
+   comparisons/`^` are unchanged from the rest of Wave 5.
+
+## Oracle ground truth — a genuine finding, not assumed
+
+`axiom-runtime::AxiomSession::eval_to_output` returns a single `Output`
+(not `Vec<Output>`, matching `program`'s single-expression shape), whose
+`text` is `format_value`'s output. **Confirmed empirically** (this
+crate's own first oracle draft assumed otherwise and every case failed):
+`format_value` appends `" : <Domain>"` to `print_axiom`'s plain rendering
+whenever a domain was inferred — and Axiom's evaluator infers a domain
+for essentially *every* value (`42` → `"42 : PositiveInteger"`, `x + y`
+→ `"x + y : Polynomial(Integer)"`), not only ones that passed through an
+explicit `:` declaration. Domain inference (`axiom-runtime::domains`) is
+an entire fixed-table system v0 does not implement at all (declarations
+are rejected outright), so the oracle test's ground truth strips the `"
+: <Domain>"` suffix before comparing — a disclosed methodology choice
+(compare values only, not domain tags), not an accidental match.
+
+## Crates
+
+- `code/packages/rust/axiom-iir-compiler` — `compile`/`compile_source`,
+  depends on `coding-adventures-axiom-parser`/`interpreter-ir`/`parser`/
+  `lexer`/`symbolic-ir`; dev-depends on `axiom-vm`/`dynval-runtime`/
+  `coding-adventures-axiom-runtime`.
+- `code/packages/rust/axiom-vm` — `run`/`run_with_budget`, a direct
+  structural port of the sibling VMs' dispatch loop.
+
+## Verification
+
+- `cargo test -p axiom-iir-compiler -p axiom-vm` — unit tests + the
+  oracle test.
+- `cargo clippy -p axiom-iir-compiler -p axiom-vm --all-targets` /
+  `cargo fmt --check` clean.
+- Oracle corpus has an empty `known_bug` list (domain-suffix stripping
+  handles the one systematic ground-truth difference; no per-case gaps).
+
+## References
+
+[`macsyma-iir-vm.md`](macsyma-iir-vm.md),
+[`MA13-axiom-language.md`](MA13-axiom-language.md) (the original Axiom
+language spec), `axiom-to-semantic-ir/src/lower.rs` (the rule-dispatch
+table retargeted a third time, and the source of the `:`/`::`/`has`
+design-decision precedent this crate deliberately does NOT need to
+replicate, since v0 rejects all three outright).


### PR DESCRIPTION
## Summary
- Fifth item of `macsyma-iir-vm.md`'s Wave 5: bridges Axiom onto `interpreter_ir` (IIR), the fifth real-language frontend in this rollout.
- The largest structural delta of Wave 5 so far: `axiom.grammar`'s own `program = expr` parses exactly ONE expression per call (Axiom is modeled as a numbered per-line session, not a worksheet), so `lower_file` has no multi-statement loop, and `Lowerer` carries no `env`/binding-threading at all -- a bound variable can never be referenced after its own `x := e` in the same compiled module.
- `a : T` (declaration), `e :: T` (coercion), and `D has C` (category query) are Axiom's own genuinely new territory with no arithmetic analogue, rejected outright. Real `STRING` tokens are rejected too, unlike Derive/Reduce/Maple.
- Genuine finding while building the oracle test: `axiom-runtime` domain-tags essentially every result (`"42 : PositiveInteger"`), not just declared ones -- every case failed against naive `expected` strings on the first run. Fixed by stripping the domain suffix from ground truth before comparing, a disclosed methodology choice recorded in `axiom-iir-vm.md`.

## Test plan
- [x] `cargo test -p axiom-iir-compiler -p axiom-vm` -- 30 + 15 unit tests + 1 oracle test (17 cases) + 2 doctests, all passing
- [x] `cargo clippy -p axiom-iir-compiler -p axiom-vm --all-targets` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `/security-review` -- passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)