### PR TITLE
feat(macsyma-iir-vm): wolfram-iir-compiler + wolfram-vm -- Wave 5 item 6 (closes Wave 5)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -269,6 +269,8 @@ members = [
     "wolfram-runtime",
     "wolfram-repl",
     "wolfram-to-semantic-ir",
+    "wolfram-iir-compiler",
+    "wolfram-vm",
     "derive-lexer",
     "derive-parser",
     "derive-runtime",

--- a/code/packages/rust/wolfram-iir-compiler/BUILD
+++ b/code/packages/rust/wolfram-iir-compiler/BUILD
@@ -1,0 +1,1 @@
+cargo test -p wolfram-iir-compiler

--- a/code/packages/rust/wolfram-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/wolfram-iir-compiler/CHANGELOG.md
@@ -31,8 +31,27 @@ closing out Wave 5. A retarget of `wolfram-runtime`'s/
   — Wolfram's `postfix` has several distinct suffix shapes (calls, Part
   indexing, …), so v0 makes no attempt to distinguish them, unlike
   `wolfram-to-semantic-ir`'s own richer handling.
-* 34 unit tests (every accepted construct round-tripped through
+* **Security-review fix (before this crate's first push, not a
+  post-release patch): `compile_source` now parses on an enlarged-stack
+  worker thread, mirroring `wolfram-to-semantic-ir::compile_source`
+  exactly.** The first draft incorrectly reasoned by analogy to
+  `macsyma-iir-compiler::compile_source` (no worker thread needed) —
+  invalid for Wolfram specifically: `wolfram-parser`'s own
+  `MAX_RULE_DEPTH` doc comment documents a bare-stack crash floor of only
+  ~11 real nesting levels (its 20-rule-per-level precedence cascade costs
+  ~20 `parse_rule` frames per level of ordinary `(...)` nesting), so
+  trivially small syntactically-valid input (e.g. 300 levels of
+  parenthesization) crashed the process natively instead of returning a
+  clean `Err`. Fixed with the identical `PARSE_STACK_SIZE` (64 MiB)
+  worker-thread pattern `wolfram-to-semantic-ir` already established;
+  `deeply_nested_parens_fail_cleanly_not_natively` is the regression
+  test. The other five Wave 5 frontends' own no-worker-thread
+  `compile_source` shape is correct for THEM (their parsers' shallower
+  precedence cascades really are bare-stack-safe) — this was a
+  Wolfram-specific gap, not a rollout-wide pattern error.
+* 36 unit tests (every accepted construct round-tripped through
   `wolfram-vm`, every rejected construct's explicit-error path,
-  including the full pattern/rule/replacement/pure-function surface) +
-  a 19-case oracle test cross-checking against `wolfram-runtime`, both
-  rendered through the same `print_wolfram` function.
+  including the full pattern/rule/replacement/pure-function surface, and
+  the deep-nesting stack-safety regression) + a 19-case oracle test
+  cross-checking against `wolfram-runtime`, both rendered through the
+  same `print_wolfram` function.

--- a/code/packages/rust/wolfram-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/wolfram-iir-compiler/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog — wolfram-iir-compiler
+
+## v0.1.0 — 2026-08-18 — initial release (wolfram-iir-vm.md, Wave 5 item 6)
+
+The sixth and final real-language frontend onto `interpreter_ir` (IIR)
+in this rollout (after Macsyma, Derive, Reduce, Maple, and Axiom) —
+closing out Wave 5. A retarget of `wolfram-runtime`'s/
+`wolfram-to-semantic-ir`'s existing CST dispatch.
+
+* `compile(&GrammarASTNode, module_name) -> Result<IIRModule, WolframIirError>`
+  and `compile_source(source, module_name)`.
+* Deliberately narrower than `wolfram-to-semantic-ir`, which covers
+  Wolfram's full grammar — v0 holds the same arithmetic/assignment/
+  unevaluated-Apply scope constant across all six Wave 5 languages,
+  rather than letting the richer grammar widen it.
+* Accepted v0 grammar: integer literals; `+ - * /` (chains) and BOTH
+  unary `-`/`+` (Wolfram is the only Wave 5 language with a real
+  unary-plus, matching Macsyma's own grammar shape); assignment (`x =
+  expr`, `SET` only, bare NAME target); free-symbol references; any
+  other operator/head, or any operand involving a free symbol, lowers
+  to an inert `cons`-chain.
+* `SETDELAYED` (`:=`, function/pattern definition) is rejected outright,
+  mirroring `macsyma-iir-compiler`'s own `COLON`-vs-`COLONEQ` split —
+  Wolfram has two distinct assignment tokens, unlike Derive's/Reduce's
+  single overloaded one.
+* Pattern blanks, rules, replacement, conditions, alternatives, pattern
+  tests, pure functions, and `/@`/`@@` sugar — Wolfram's own genuinely
+  new territory relative to every sibling frontend — are all rejected
+  outright, with no arithmetic analogue to fall back to.
+* `postfix`'s rejection is unconditional on ANY suffix (not just calls)
+  — Wolfram's `postfix` has several distinct suffix shapes (calls, Part
+  indexing, …), so v0 makes no attempt to distinguish them, unlike
+  `wolfram-to-semantic-ir`'s own richer handling.
+* 34 unit tests (every accepted construct round-tripped through
+  `wolfram-vm`, every rejected construct's explicit-error path,
+  including the full pattern/rule/replacement/pure-function surface) +
+  a 19-case oracle test cross-checking against `wolfram-runtime`, both
+  rendered through the same `print_wolfram` function.

--- a/code/packages/rust/wolfram-iir-compiler/Cargo.toml
+++ b/code/packages/rust/wolfram-iir-compiler/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "wolfram-iir-compiler"
+version = "0.1.0"
+edition = "2021"
+description = "Lowers a Wolfram CST (coding-adventures-wolfram-parser's GrammarASTNode) into an IIRModule, per wolfram-iir-vm.md's v0 scope: literal integer arithmetic (+ - * /, unary), assignment, and unevaluated symbolic expressions. A retarget of wolfram-runtime's/wolfram-to-semantic-ir's CST dispatch, following macsyma-iir-compiler's precedent, deliberately cut narrower than Wolfram's own full grammar (no pattern matching/rules/pure functions in v0). Emits IIR over the dynval-runtime value model so the module runs end-to-end on wolfram-vm."
+
+[lib]
+name = "wolfram_iir_compiler"
+path = "src/lib.rs"
+
+[dependencies]
+coding-adventures-wolfram-parser = { path = "../wolfram-parser" }
+interpreter-ir = { path = "../interpreter-ir" }
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+symbolic-ir = { path = "../symbolic-ir" }
+
+[dev-dependencies]
+wolfram-vm = { path = "../wolfram-vm" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Oracle ground truth (tests/oracle.rs) + the shared renderer used to
+# format both the ground truth and the compiled-side read-back result.
+coding-adventures-wolfram-runtime = { path = "../wolfram-runtime" }

--- a/code/packages/rust/wolfram-iir-compiler/README.md
+++ b/code/packages/rust/wolfram-iir-compiler/README.md
@@ -1,0 +1,53 @@
+# wolfram-iir-compiler
+
+Wolfram CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+
+The sixth and final real-language bridge in this rollout (after Macsyma,
+Derive, Reduce, Maple, and Axiom) from a math language onto
+`interpreter_ir` (IIR) — closing out Wave 5. See
+[`wolfram-iir-vm.md`](../../../specs/wolfram-iir-vm.md) for the
+per-language deltas from
+[`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md)'s original
+design.
+
+**Deliberately narrower than [`wolfram-to-semantic-ir`](../wolfram-to-semantic-ir)**,
+which covers Wolfram's *full* grammar (pattern blanks, replacement
+rules, pure functions, `/@`/`@@` sugar) since SIR23's "everything is
+data" design has no scope pressure forcing a narrower cut there. This
+crate holds v0's arithmetic/assignment/unevaluated-Apply scope constant
+across all six Wave 5 languages instead.
+
+## Scope (v0.1.0)
+
+**Accepted:** integer literals; `+ - * /` (binary chains) and **both**
+unary `-`/`+` (Wolfram, unlike Derive/Reduce/Maple/Axiom, has a real
+unary-plus no-op); assignment (`x = expr`, `SET` only, always a bare
+NAME target — `SETDELAYED`/`:=` is rejected outright); free-symbol
+references; any other operator/head — or any operand involving a free
+symbol — represented as an *unevaluated* symbolic expression.
+
+**Rejected, with an explicit error:** `Float`/`String` literals; pattern
+blanks (`_`/`_h`), rules (`->`/`:>`), replacement (`/.`/`//.`),
+conditions (`/;`), alternatives (`|`), pattern tests (`?`) — Wolfram's
+own genuinely new territory, with no arithmetic analogue; comparisons;
+logic (`&&`/`||`/`!`); `^` (power); pure functions (`#`/`#n`/`##`/`expr
+&`); `/@`/`@@` (map/apply sugar); `{...}` list literals; any postfix
+suffix at all (`f[x]`, `x[[i]]`, …).
+
+## Usage
+
+```rust
+use wolfram_iir_compiler::compile_source;
+
+let module = compile_source("2 + 3\n", "demo")?;
+let value = wolfram_vm::run(&module)?;
+assert_eq!(value.as_int(), Some(5));
+```
+
+## Verification
+
+`cargo test -p wolfram-iir-compiler` covers every accepted construct
+(via `wolfram-vm`, as a dev-dependency) and every rejected construct's
+explicit-error path. `tests/oracle.rs` additionally cross-checks every
+accepted construct against `wolfram-runtime`'s own evaluator, both sides
+rendered through the same `print_wolfram` function.

--- a/code/packages/rust/wolfram-iir-compiler/src/lib.rs
+++ b/code/packages/rust/wolfram-iir-compiler/src/lib.rs
@@ -1,0 +1,295 @@
+//! # wolfram-iir-compiler
+//!
+//! Wolfram CST → `interpreter_ir::IIRModule`, **v0.1.0**.
+//!
+//! The sixth and final real-language frontend in this rollout (after
+//! Macsyma, Derive, Reduce, Maple, and Axiom) to bridge a math language
+//! in this repo onto `interpreter_ir` (IIR) — closing out Wave 5. See
+//! [`wolfram-iir-vm.md`](../../../specs/wolfram-iir-vm.md) for the
+//! per-language deltas from `macsyma-iir-vm.md`'s original design and
+//! `lower.rs`'s module doc comment for the v0 scope (deliberately
+//! narrower than the FULL grammar `wolfram-to-semantic-ir` covers — no
+//! pattern matching, rules, replacement, or pure functions in v0). It
+//! consumes the generic `GrammarASTNode` CST produced by
+//! `coding-adventures-wolfram-parser` and emits an
+//! [`interpreter_ir::IIRModule`], executable on
+//! [`wolfram-vm`](../wolfram-vm) (v0 targets the VM interpreter backend
+//! only).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Wolfram source
+//!    │
+//!    ▼  coding_adventures_wolfram_parser::try_parse_wolfram(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  wolfram_iir_compiler::compile
+//! interpreter_ir::IIRModule                (v0 subset)
+//!    │
+//!    ▼  wolfram_vm::run
+//! dynval_runtime::LispyValue
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use wolfram_iir_compiler::compile_source;
+//! let module = compile_source("2 + 3\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, WolframIirError};
+
+/// Parse `source` as Wolfram and lower it into an
+/// [`interpreter_ir::IIRModule`] in one step, mirroring
+/// `wolfram-to-semantic-ir::compile_source`'s convenience wrapper.
+///
+/// Unlike `wolfram-to-semantic-ir::compile_source` (which spawns an
+/// enlarged-stack worker thread because Wolfram's own 20-rule precedence
+/// cascade makes its parser's `MAX_RULE_DEPTH` unsafe on a bare stack),
+/// this crate needs no worker thread here either: `MAX_RULE_DEPTH` is a
+/// property of the PARSER (`coding_adventures_wolfram_parser`), not of
+/// this lowering pass, and this crate's own `compile` trusts the tree it
+/// is handed was already parsed under that guard — see `lower.rs`'s own
+/// `MAX_EXPR_DEPTH` doc comment for the full reasoning (mirrors
+/// `macsyma-iir-compiler::compile_source`'s identical no-worker-thread
+/// shape, not `wolfram-to-semantic-ir`'s).
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<interpreter_ir::IIRModule, WolframIirError> {
+    let tree = coding_adventures_wolfram_parser::try_parse_wolfram(source).map_err(|msg| {
+        WolframIirError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        }
+    })?;
+    compile(&tree, module_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wolfram_vm::run;
+
+    fn eval_int(source: &str) -> i64 {
+        let module = compile_source(source, "t").expect("compile");
+        run(&module).expect("run").as_int().expect("int result")
+    }
+
+    fn eval_symbol(source: &str) -> String {
+        let module = compile_source(source, "t").expect("compile");
+        let v = run(&module).expect("run");
+        dynval_runtime::name_of(v.as_symbol().expect("symbol result")).expect("interned")
+    }
+
+    // ---- accepted: literal arithmetic ----
+
+    #[test]
+    fn integer_literal() {
+        assert_eq!(eval_int("42\n"), 42);
+    }
+
+    #[test]
+    fn simple_addition() {
+        assert_eq!(eval_int("2 + 3\n"), 5);
+    }
+
+    #[test]
+    fn precedence() {
+        assert_eq!(eval_int("2 + 3 * 4\n"), 14);
+    }
+
+    #[test]
+    fn chain() {
+        assert_eq!(eval_int("1 + 2 + 3 + 4\n"), 10);
+    }
+
+    #[test]
+    fn unary_neg_leaf() {
+        assert_eq!(eval_int("-5 + 3\n"), -2);
+    }
+
+    #[test]
+    fn unary_neg_compound() {
+        assert_eq!(eval_int("-(5 + 3)\n"), -8);
+    }
+
+    #[test]
+    fn unary_plus_is_noop() {
+        assert_eq!(eval_int("+5\n"), 5);
+    }
+
+    #[test]
+    fn grouping() {
+        assert_eq!(eval_int("(2 + 3) * 4\n"), 20);
+    }
+
+    #[test]
+    fn exact_division() {
+        assert_eq!(eval_int("20 / 4\n"), 5);
+    }
+
+    #[test]
+    fn negative_literal_exact_division() {
+        assert_eq!(eval_int("-4 / 2\n"), -2);
+    }
+
+    // ---- accepted: assignment ----
+
+    #[test]
+    fn assignment_and_reference() {
+        assert_eq!(eval_int("x = 3\nx + 1\n"), 4);
+    }
+
+    #[test]
+    fn reassignment_threading() {
+        assert_eq!(eval_int("x = 3\nx = x + 1\nx\n"), 4);
+    }
+
+    #[test]
+    fn two_variables() {
+        assert_eq!(eval_int("a = 2\nb = 3\na * b\n"), 6);
+    }
+
+    // ---- accepted: unevaluated symbolic expressions ----
+
+    #[test]
+    fn free_symbol_addition_is_symbolic() {
+        let module = compile_source("x + y\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        assert!(v.as_int().is_none());
+    }
+
+    #[test]
+    fn free_symbol_addition_head_is_add() {
+        let module = compile_source("x + y\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Add")
+        );
+    }
+
+    #[test]
+    fn mixed_concrete_and_symbolic_operand() {
+        let module = compile_source("2 * x\n", "t").expect("compile");
+        let v = run(&module).expect("run");
+        let head = dynval_runtime::builtins::car(&[v]).unwrap();
+        assert_eq!(
+            dynval_runtime::name_of(head.as_symbol().unwrap()).as_deref(),
+            Some("Mul")
+        );
+    }
+
+    #[test]
+    fn free_symbol_alone() {
+        assert_eq!(eval_symbol("x\n"), "x");
+    }
+
+    // ---- rejected: explicit-error paths ----
+
+    #[test]
+    fn float_literal_rejected() {
+        assert!(compile_source("1.5\n", "t").is_err());
+    }
+
+    #[test]
+    fn non_exact_division_rejected() {
+        let err = compile_source("7 / 2\n", "t").unwrap_err();
+        assert!(
+            err.message.contains("rational"),
+            "message was: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn division_of_non_literal_concrete_rejected() {
+        assert!(compile_source("x = 6\nx / 2\n", "t").is_err());
+    }
+
+    #[test]
+    fn division_by_literal_zero_rejected() {
+        assert!(compile_source("1 / 0\n", "t").is_err());
+    }
+
+    #[test]
+    fn i64_min_divided_by_neg_one_rejected_not_panicking() {
+        assert!(compile_source("(-9223372036854775807 - 1) / -1\n", "t").is_err());
+    }
+
+    #[test]
+    fn function_pattern_definition_rejected() {
+        let err = compile_source("f[x_] := x + 1\n", "t").unwrap_err();
+        assert!(
+            err.message.contains("function/pattern definition"),
+            "message was: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn function_call_rejected() {
+        assert!(compile_source("f[x]\n", "t").is_err());
+    }
+
+    #[test]
+    fn part_indexing_rejected() {
+        assert!(compile_source("x[[1]]\n", "t").is_err());
+    }
+
+    #[test]
+    fn comparison_rejected() {
+        assert!(compile_source("x == y\n", "t").is_err());
+    }
+
+    #[test]
+    fn logical_and_rejected() {
+        assert!(compile_source("x && y\n", "t").is_err());
+    }
+
+    #[test]
+    fn power_rejected() {
+        assert!(compile_source("x^2\n", "t").is_err());
+    }
+
+    #[test]
+    fn list_literal_rejected() {
+        assert!(compile_source("{1, 2, 3}\n", "t").is_err());
+    }
+
+    #[test]
+    fn string_literal_rejected() {
+        assert!(compile_source("\"hi\"\n", "t").is_err());
+    }
+
+    #[test]
+    fn pattern_blank_rejected() {
+        assert!(compile_source("_\n", "t").is_err());
+    }
+
+    #[test]
+    fn rule_rejected() {
+        assert!(compile_source("x -> y\n", "t").is_err());
+    }
+
+    #[test]
+    fn replaceall_rejected() {
+        assert!(compile_source("x /. y -> 1\n", "t").is_err());
+    }
+
+    #[test]
+    fn pure_function_rejected() {
+        assert!(compile_source("(# + 1) &\n", "t").is_err());
+    }
+
+    #[test]
+    fn map_sugar_rejected() {
+        assert!(compile_source("f /@ x\n", "t").is_err());
+    }
+}

--- a/code/packages/rust/wolfram-iir-compiler/src/lib.rs
+++ b/code/packages/rust/wolfram-iir-compiler/src/lib.rs
@@ -42,21 +42,92 @@
 mod lower;
 pub use lower::{compile, WolframIirError};
 
+/// Recursion-depth cap `compile_source` parses under, and the enlarged
+/// worker-thread stack size it parses *on*.
+///
+/// **Corrects an earlier, incorrect assumption in this crate**: this
+/// function originally reasoned (by analogy to
+/// `macsyma-iir-compiler::compile_source`) that no worker-thread stack
+/// enlargement was needed here, since `MAX_RULE_DEPTH` is a property of
+/// the parser, not of this lowering pass. That analogy is invalid for
+/// Wolfram specifically — caught in security review, not assumed safe.
+/// `wolfram-parser`'s own `MAX_RULE_DEPTH` doc comment explains why:
+/// Wolfram's 20-rule-per-level precedence cascade means even ordinary
+/// `(...)` nesting costs ~20 `parse_rule` frames per level, so the
+/// parser's own measured bare-stack (~2 MiB) crash floor is only ~276
+/// frames — about **11 real nesting levels** — regardless of
+/// `MAX_RULE_DEPTH`'s cap value. `wolfram-to-semantic-ir::compile_source`
+/// already solved this exact problem (it calls the same
+/// `try_parse_wolfram`); this crate now mirrors that solution exactly
+/// rather than the simpler, bare-stack-safe pattern
+/// `macsyma-iir-compiler`/`derive-iir-compiler`/`reduce-iir-compiler`/
+/// `maple-iir-compiler`/`axiom-iir-compiler` correctly use (those
+/// parsers' own shallower precedence cascades really are bare-stack-safe
+/// — this crate's original doc comment wrongly generalised that to
+/// Wolfram too).
+///
+/// See `wolfram-to-semantic-ir::PARSE_STACK_SIZE`'s own doc comment for
+/// the full derivation of this budget (64 MiB, not `wolfram-runtime`'s
+/// 512 MiB `EVAL_STACK_SIZE` — sized down to avoid CI resource pressure
+/// from many concurrent per-call thread stacks while still supporting
+/// the full default `MAX_RULE_DEPTH` ceiling with comfortable margin).
+const PARSE_STACK_SIZE: usize = 64 * 1024 * 1024;
+
 /// Parse `source` as Wolfram and lower it into an
 /// [`interpreter_ir::IIRModule`] in one step, mirroring
-/// `wolfram-to-semantic-ir::compile_source`'s convenience wrapper.
+/// `wolfram-to-semantic-ir::compile_source`'s convenience wrapper —
+/// including its enlarged-stack worker-thread pattern (see
+/// [`PARSE_STACK_SIZE`]'s doc comment for why, unlike every sibling
+/// `*-iir-compiler::compile_source` in this rollout, this one needs it).
 ///
-/// Unlike `wolfram-to-semantic-ir::compile_source` (which spawns an
-/// enlarged-stack worker thread because Wolfram's own 20-rule precedence
-/// cascade makes its parser's `MAX_RULE_DEPTH` unsafe on a bare stack),
-/// this crate needs no worker thread here either: `MAX_RULE_DEPTH` is a
-/// property of the PARSER (`coding_adventures_wolfram_parser`), not of
-/// this lowering pass, and this crate's own `compile` trusts the tree it
-/// is handed was already parsed under that guard — see `lower.rs`'s own
-/// `MAX_EXPR_DEPTH` doc comment for the full reasoning (mirrors
-/// `macsyma-iir-compiler::compile_source`'s identical no-worker-thread
-/// shape, not `wolfram-to-semantic-ir`'s).
+/// Both thread-spawn failure and a worker-thread panic (from anywhere in
+/// the parse/lower pipeline, not just a stack overflow, which is
+/// unrecoverable regardless and aborts the whole process before `join`
+/// ever runs) are converted into a [`WolframIirError`] rather than
+/// propagated as a panic on the calling thread — mirrors
+/// `wolfram-to-semantic-ir::compile_source`'s identical guarantee.
 pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<interpreter_ir::IIRModule, WolframIirError> {
+    let source = source.to_string();
+    let module_name = module_name.to_string();
+    let handle = std::thread::Builder::new()
+        .name("wolfram-iir-compiler-compile".to_string())
+        .stack_size(PARSE_STACK_SIZE)
+        .spawn(move || compile_on_this_thread(&source, &module_name))
+        .map_err(|e| WolframIirError {
+            message: format!("failed to spawn wolfram-iir-compiler compile worker thread: {e}"),
+            line: 1,
+            column: 1,
+        })?;
+    match handle.join() {
+        Ok(result) => result,
+        Err(panic_payload) => Err(WolframIirError {
+            message: format!(
+                "wolfram-iir-compiler compile worker thread panicked: {}",
+                panic_message(&panic_payload)
+            ),
+            line: 1,
+            column: 1,
+        }),
+    }
+}
+
+/// Extract a human-readable message from a `std::thread::Result::Err`
+/// panic payload — mirrors `wolfram-to-semantic-ir`'s identically-named
+/// free function exactly.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+fn compile_on_this_thread(
     source: &str,
     module_name: &str,
 ) -> Result<interpreter_ir::IIRModule, WolframIirError> {
@@ -291,5 +362,24 @@ mod tests {
     #[test]
     fn map_sugar_rejected() {
         assert!(compile_source("f /@ x\n", "t").is_err());
+    }
+
+    #[test]
+    fn deeply_nested_parens_fail_cleanly_not_natively() {
+        // Regression for a security-review finding: `compile_source`
+        // originally parsed on the caller's own bare-stack thread,
+        // trusting (incorrectly) that Wolfram's parser needed no
+        // enlarged-stack worker thread the way the other five Wave 5
+        // frontends' parsers do. `wolfram-parser`'s own measured
+        // bare-stack crash floor is ~11 real nesting levels (its
+        // 20-rule-per-level precedence cascade costs ~20 parse_rule
+        // frames per level) -- 300 levels of `(...)` nesting is
+        // trivially reachable syntactically valid input that would have
+        // crashed the process natively before this fix, and must now
+        // fail with a clean `Err` (either a parse-depth rejection or
+        // this crate's own `MAX_EXPR_DEPTH` lowering-recursion guard)
+        // instead.
+        let deeply_nested = format!("{}1{}\n", "(".repeat(300), ")".repeat(300));
+        assert!(compile_source(&deeply_nested, "t").is_err());
     }
 }

--- a/code/packages/rust/wolfram-iir-compiler/src/lower.rs
+++ b/code/packages/rust/wolfram-iir-compiler/src/lower.rs
@@ -1,0 +1,754 @@
+//! The lowering pass from `coding_adventures_wolfram_parser`'s generic
+//! [`GrammarASTNode`] CST → [`IIRModule`], **v0.1.0**.
+//!
+//! # Retargeting `wolfram-runtime`/`wolfram-to-semantic-ir`, a third time
+//!
+//! `wolfram-runtime` already walks this exact CST and compiles it to
+//! `symbolic_ir::IRNode`. `wolfram-to-semantic-ir` retargets the same
+//! rule-name dispatch to build `semantic_ir::Expr` instead — covering
+//! Wolfram's **full** grammar (pattern blanks, replacement rules,
+//! `#`/pure functions, `/@`/`@@` sugar, and more), since SIR23's
+//! "everything is data" design has no scope pressure forcing a narrower
+//! cut there. This module is a **third retarget**, following every
+//! sibling in this rollout's precedent directly — see
+//! [`wolfram-iir-vm.md`](../../../specs/wolfram-iir-vm.md) and
+//! [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) — but, unlike
+//! `wolfram-to-semantic-ir`, this crate deliberately does NOT cover the
+//! full grammar: v0's arithmetic/assignment/unevaluated-Apply scope is
+//! identical to every other Wave 5 item, so pattern matching, rules,
+//! replacement, pure functions, and `/@`/`@@` sugar are all rejected
+//! outright here, even though `wolfram-to-semantic-ir` happily lowers
+//! all of them. The richer grammar is real; the v0 scope cut is not
+//! narrower because the grammar demands it (unlike Reduce's/Maple's own
+//! genuinely-new constructs having no arithmetic fallback) — it is
+//! narrower because this crate's OWN v0 scope, set once in
+//! `macsyma-iir-vm.md` and held constant across all six Wave 5 items, is
+//! narrower than what the grammar could support.
+//!
+//! # Scope (v0.1.0)
+//!
+//! Accepted: integer literals; `+ - * /` (binary chains) and **both**
+//! unary `-`/`+` (Wolfram, unlike Derive/Reduce/Maple/Axiom, has a real
+//! unary-plus no-op, matching Macsyma's own grammar); assignment (`x =
+//! expr`, `SET` only, always a bare NAME target — `SETDELAYED` (`:=`,
+//! function/pattern definition) is rejected outright, mirroring
+//! `macsyma-iir-compiler`'s own `COLON`-vs-`COLONEQ` split exactly, since
+//! Wolfram's grammar likewise has two distinct assignment tokens rather
+//! than Derive's/Reduce's single overloaded one); free-symbol
+//! references; any other head or symbolic operand, represented as an
+//! *unevaluated* inert `cons`-chain.
+//!
+//! Rejected, with an explicit [`WolframIirError`]: `Float`/`String`
+//! literals; pattern blanks (`_`/`_h`), rules (`->`/`:>`), replacement
+//! (`/.`/`//.`), conditions (`/;`), alternatives (`|`), pattern tests
+//! (`?`) — Wolfram's own genuinely new territory relative to every
+//! sibling in this rollout, none of which has any arithmetic analogue;
+//! comparisons; logic (`&&`/`||`/`!`); `^` (power); pure functions (`#`/
+//! `#n`/`##`/`expr &`); `/@`/`@@` (map/apply sugar); `{...}` list
+//! literals; any postfix suffix at all (`f[x]`, `x[[i]]` Part-indexing,
+//! …) — Wolfram's `postfix` has several distinct suffix shapes, so v0
+//! rejects the construct the moment ANY suffix is present, rather than
+//! trying to distinguish "a call" from "a Part index" the way
+//! `wolfram-to-semantic-ir` itself has to.
+//!
+//! # The `/` exactness rule
+//!
+//! Identical hazard and identical fix as every sibling frontend's `/`
+//! handling: Wolfram's `/` on integers that don't divide evenly returns
+//! an exact rational, which `dynval-runtime` cannot represent.
+//! [`Lowerer::combine`] only takes the evaluated `call_builtin "/"` path
+//! when both direct operands are literal integer tokens at this exact
+//! node and their quotient is exact; a symbolic operand falls back to
+//! inert data; anything else is rejected.
+
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{ADD, DIV, MUL, NEG, SUB};
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — mirrors every sibling frontend's identically-named guard.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// IIR type-hint string for the nil / cons reference type.
+const REF_PAIR: &str = "ref<LispyPair>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Wolfram → IIR lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WolframIirError {
+    /// Human-readable explanation.
+    pub message: String,
+    /// 1-based source line.
+    pub line: usize,
+    /// 1-based source column.
+    pub column: usize,
+}
+
+impl std::fmt::Display for WolframIirError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "WolframIirError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for WolframIirError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Wolfram CST (rooted at the `program` rule) into an
+/// [`IIRModule`].
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<IIRModule, WolframIirError> {
+    Lowerer::new().lower_file(tree, module_name)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowered value of one CST node: the IIR register holding it, plus
+/// two facts used only to decide how a *later* arithmetic step may
+/// combine it — never observed by the emitted IIR itself.
+#[derive(Debug, Clone)]
+struct Lowered {
+    /// The register this value lives in.
+    reg: String,
+    /// `true` if this value was built purely from integer literals and
+    /// bound (concrete) variables combined via `+`/`-`/`*`/`/`/unary
+    /// negate — i.e. it contains no free symbol anywhere.
+    concrete: bool,
+    /// `Some(v)` only when this value is a *direct* integer-literal token
+    /// (or the statically-known result of combining such literals) —
+    /// used exclusively by the `/` exactness check ([`Lowerer::combine`]).
+    literal: Option<i64>,
+}
+
+struct Lowerer {
+    instrs: Vec<IIRInstr>,
+    tmp: usize,
+    /// Assigned variable name → its most recently assigned value.
+    env: std::collections::HashMap<String, Lowered>,
+}
+
+impl Lowerer {
+    fn new() -> Self {
+        Lowerer {
+            instrs: Vec::new(),
+            tmp: 0,
+            env: std::collections::HashMap::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = { statement_line } ;`
+    // `statement_line = statement (NEWLINE|SEMI) | statement | NEWLINE | SEMI ;`
+    // -------------------------------------------------------------------
+
+    fn lower_file(
+        &mut self,
+        program: &GrammarASTNode,
+        module_name: &str,
+    ) -> Result<IIRModule, WolframIirError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        let mut last: Option<Lowered> = None;
+        for line in child_nodes(program) {
+            if line.rule_name != "statement_line" {
+                continue;
+            }
+            let Some(statement_node) = child_nodes(line).find(|n| n.rule_name == "statement")
+            else {
+                continue;
+            };
+            last = Some(self.lower_node(statement_node, 0)?);
+        }
+        let final_val = match last {
+            Some(l) => l,
+            None => self.emit_nil(),
+        };
+        self.emit(IIRInstr::new(
+            "ret",
+            None,
+            vec![Operand::Var(final_val.reg)],
+            "any",
+        ));
+
+        let mut main =
+            IIRFunction::new("main", Vec::new(), "any", std::mem::take(&mut self.instrs));
+        main.register_count = self.tmp;
+
+        let mut module = IIRModule::new(module_name, "wolfram");
+        module.functions.push(main);
+        module.entry_point = Some("main".to_string());
+
+        let problems = module.validate();
+        if !problems.is_empty() {
+            return Err(WolframIirError {
+                message: format!(
+                    "internal: emitted IIR failed validation: {}",
+                    problems.join("; ")
+                ),
+                line: 1,
+                column: 1,
+            });
+        }
+        Ok(module)
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------------------
+
+    fn lower_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => {
+                    Err(self.err_at(node, "nested program node is not an expression".to_string()))
+                }
+                "statement_line" | "statement" | "expr" | "atom" => {
+                    self.lower_first_node(node, depth)
+                }
+                "assignment" => self.lower_assignment(node, depth),
+                "replaceall" => Err(self.err_unsupported(node, "replacement (/. or //.)")),
+                "rule" => Err(self.err_unsupported(node, "rules (-> or :>)")),
+                "condition" => Err(self.err_unsupported(node, "pattern conditions (/;)")),
+                "alternatives" => Err(self.err_unsupported(node, "pattern alternatives (|)")),
+                "patterntest" => Err(self.err_unsupported(node, "pattern tests (?)")),
+                "logical_or" | "logical_and" | "logical_not" => {
+                    Err(self.err_unsupported(node, "'&&'/'||'/'!' logical expressions"))
+                }
+                "comparison" => {
+                    Err(self.err_unsupported(node, "comparisons (==, !=, <, >, <=, >=)"))
+                }
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => Err(self.err_unsupported(node, "exponentiation (^)")),
+                "amp" => Err(self.err_unsupported(node, "pure functions (expr &)")),
+                "mapapply" => Err(self.err_unsupported(node, "map/apply sugar (/@ or @@)")),
+                "postfix" => self.lower_postfix(node, depth),
+                "slot" => Err(self.err_unsupported(node, "slots (# / #n)")),
+                "list" => Err(self.err_unsupported(node, "list literals ({...})")),
+                "group" => self.lower_group(node, depth),
+                "arglist" => Err(self.err_at(
+                    node,
+                    "an arglist cannot be lowered as a scalar expression".to_string(),
+                )),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol). Pattern-related
+    /// tokens (`BLANK`, `HASH`, `SLOTSEQ`) are rejected explicitly — v0
+    /// has no pattern-matching or pure-function support at all.
+    fn lower_token(&mut self, token: &Token) -> Result<Lowered, WolframIirError> {
+        match token_type(token) {
+            "NUMBER" => self.lower_number(&token.value, token),
+            "NAME" => Ok(self.symbol_ref(&token.value)),
+            "STRING" => Err(self.err_unsupported_tok(token, "string literals")),
+            "BLANK" => Err(self.err_unsupported_tok(token, "pattern blanks (_)")),
+            "HASH" => Err(self.err_unsupported_tok(token, "slots (#)")),
+            "SLOTSEQ" => Err(self.err_unsupported_tok(token, "slot sequences (##)")),
+            other => Err(WolframIirError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// Parse a `NUMBER` lexeme. Unlike `wolfram-to-semantic-ir`'s
+    /// `number_literal_expr`, this does **not** fall back to a float for
+    /// a too-large integer — v0 has no float representation at all.
+    fn lower_number(&mut self, text: &str, token: &Token) -> Result<Lowered, WolframIirError> {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            return Err(self
+                .err_unsupported_tok(token, "floating-point literals (not representable in v0)"));
+        }
+        match text.parse::<i64>() {
+            Ok(v) => Ok(self.emit_int(v)),
+            Err(_) => Err(self.err_unsupported_tok(
+                token,
+                "an integer literal too large for i64 (bignum is not representable in v0)",
+            )),
+        }
+    }
+
+    /// A bare `NAME`: a bound (assigned earlier) variable resolves to its
+    /// stored value; anything else is a free symbol.
+    fn symbol_ref(&mut self, name: &str) -> Lowered {
+        if let Some(bound) = self.env.get(name) {
+            Lowered {
+                reg: bound.reg.clone(),
+                concrete: bound.concrete,
+                literal: None,
+            }
+        } else {
+            self.emit_symbol(name)
+        }
+    }
+
+    /// `assignment = replaceall [ (SET|SETDELAYED) assignment ]` — see
+    /// the module doc comment: `SET` (`=`) is plain assignment, always a
+    /// bare-NAME target in v0; `SETDELAYED` (`:=`, function/pattern
+    /// definition) is rejected outright, mirroring
+    /// `macsyma-iir-compiler`'s own `COLON`-vs-`COLONEQ` split exactly.
+    fn lower_assignment(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        let Some(op_index) = node.children.iter().position(|c| {
+            as_token(c).is_some_and(|t| matches!(token_type(t), "SET" | "SETDELAYED"))
+        }) else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed assignment node".to_string()));
+        }
+        let op = token_type(as_token(&node.children[op_index]).unwrap());
+        if op == "SETDELAYED" {
+            return Err(self.err_unsupported(node, "function/pattern definition (:=)"));
+        }
+
+        let name = match bare_name(&node.children[op_index - 1]) {
+            Some(name) => name,
+            None => {
+                return Err(self.err_at(
+                    node,
+                    "assignment target must be a plain variable name (e.g. `x = 3`)".to_string(),
+                ))
+            }
+        };
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        self.env.insert(name, rhs.clone());
+        Ok(rhs)
+    }
+
+    /// `additive`/`multiplicative` — a left-associative binary chain of
+    /// `+`/`-`/`*`/`/`.
+    fn lower_binary_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs_child = children.next().ok_or_else(|| {
+                self.err_at(node, "binary operator with no right operand".to_string())
+            })?;
+            let rhs = self.lower_child(rhs_child, depth + 1)?;
+            result = self.combine(head, result, rhs, node)?;
+        }
+        Ok(result)
+    }
+
+    /// Combine `lhs op rhs` for `op` one of `Add`/`Sub`/`Mul`/`Div`. See
+    /// the module doc comment's "The `/` exactness rule" section.
+    fn combine(
+        &mut self,
+        head: &str,
+        lhs: Lowered,
+        rhs: Lowered,
+        node: &GrammarASTNode,
+    ) -> Result<Lowered, WolframIirError> {
+        if head == DIV {
+            if !lhs.concrete || !rhs.concrete {
+                return Ok(self.inert_apply(DIV, vec![lhs, rhs]));
+            }
+            return match (lhs.literal, rhs.literal) {
+                (Some(_), Some(0)) => Err(self.err_at(node, "division by zero".to_string())),
+                (Some(a), Some(b)) if a.checked_rem(b) == Some(0) => {
+                    let reg = self.emit_builtin("/", &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+                    Ok(Lowered {
+                        reg,
+                        concrete: true,
+                        literal: a.checked_div(b),
+                    })
+                }
+                (Some(a), Some(b)) if a.checked_rem(b).is_some() => Err(self.err_at(
+                    node,
+                    "this division does not divide evenly; the exact result would be a \
+                     rational, which is not representable in v0 (see wolfram-iir-vm.md)"
+                        .to_string(),
+                )),
+                (Some(_), Some(_)) => Err(self.err_at(
+                    node,
+                    "this division cannot be evaluated in v0 (i64::MIN / -1 is not representable)"
+                        .to_string(),
+                )),
+                _ => Err(self.err_at(
+                    node,
+                    "division of a non-literal value cannot be verified exact at compile time \
+                     in v0 (only literal / literal is supported); see wolfram-iir-vm.md"
+                        .to_string(),
+                )),
+            };
+        }
+
+        if lhs.concrete && rhs.concrete {
+            let op_name = op_symbol_for(head);
+            let reg = self.emit_builtin(op_name, &[lhs.reg.as_str(), rhs.reg.as_str()], "i64");
+            let literal = match (head, lhs.literal, rhs.literal) {
+                (h, Some(a), Some(b)) if h == ADD => a.checked_add(b),
+                (h, Some(a), Some(b)) if h == SUB => a.checked_sub(b),
+                (h, Some(a), Some(b)) if h == MUL => a.checked_mul(b),
+                _ => None,
+            };
+            Ok(Lowered {
+                reg,
+                concrete: true,
+                literal,
+            })
+        } else {
+            Ok(self.inert_apply(head, vec![lhs, rhs]))
+        }
+    }
+
+    /// `unary = ( MINUS | PLUS ) unary | power ;` — Wolfram, unlike every
+    /// other language in this rollout, has a real unary-plus (a no-op),
+    /// matching Macsyma's own grammar shape exactly.
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            2 => {
+                let op =
+                    token_type(as_token(&node.children[0]).ok_or_else(|| {
+                        self.err_at(node, "unary op must be a token".to_string())
+                    })?);
+                let operand = self.lower_child(&node.children[1], depth + 1)?;
+                if op == "MINUS" {
+                    if operand.concrete {
+                        let reg = self.emit_builtin("-", &[operand.reg.as_str()], "i64");
+                        let literal = operand.literal.and_then(i64::checked_neg);
+                        Ok(Lowered {
+                            reg,
+                            concrete: true,
+                            literal,
+                        })
+                    } else {
+                        Ok(self.inert_apply(NEG, vec![operand]))
+                    }
+                } else {
+                    Ok(operand) // unary plus is a no-op
+                }
+            }
+            _ => Err(self.err_at(node, "malformed unary node".to_string())),
+        }
+    }
+
+    /// `postfix = atom { suffix } ;` — a bare atom (no suffix at all)
+    /// passes through; ANY suffix (a call `f[x]`, Part-indexing
+    /// `x[[i]]`, or anything else `wolfram-to-semantic-ir`'s own richer
+    /// `lower_postfix` handles) is rejected — v0 makes no attempt to
+    /// distinguish suffix shapes, unlike that sibling crate.
+    fn lower_postfix(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        if node.children.len() > 1 {
+            return Err(self.err_unsupported(
+                node,
+                "postfix suffixes (function calls, Part-indexing, etc.)",
+            ));
+        }
+        let base = node
+            .children
+            .first()
+            .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?;
+        self.lower_child(base, depth + 1)
+    }
+
+    /// `group = LPAREN expr RPAREN ;` — grouping only.
+    fn lower_group(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        let inner = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty group `( )`".to_string()))?;
+        self.lower_node(inner, depth + 1)
+    }
+
+    // -------------------------------------------------------------------
+    // Emission helpers
+    // -------------------------------------------------------------------
+
+    fn fresh(&mut self) -> String {
+        let name = format!("v{}", self.tmp);
+        self.tmp += 1;
+        name
+    }
+
+    fn emit(&mut self, instr: IIRInstr) {
+        self.instrs.push(instr);
+    }
+
+    fn emit_int(&mut self, n: i64) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(n)],
+            "i64",
+        ));
+        Lowered {
+            reg,
+            concrete: true,
+            literal: Some(n),
+        }
+    }
+
+    fn emit_symbol(&mut self, name: &str) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Var(name.to_string())],
+            "symbol",
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_nil(&mut self) -> Lowered {
+        let reg = self.fresh();
+        self.emit(IIRInstr::new(
+            "const",
+            Some(reg.clone()),
+            vec![Operand::Int(0)],
+            REF_PAIR,
+        ));
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    fn emit_builtin(&mut self, name: &str, args: &[&str], type_hint: &str) -> String {
+        let reg = self.fresh();
+        let mut srcs = vec![Operand::Var(name.to_string())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).to_string())));
+        self.emit(IIRInstr::new(
+            "call_builtin",
+            Some(reg.clone()),
+            srcs,
+            type_hint,
+        ));
+        reg
+    }
+
+    /// Materialise an unevaluated `Apply(head, args)` as an inert
+    /// `cons`-chain `(head arg0 arg1 …)`.
+    fn inert_apply(&mut self, head: &str, args: Vec<Lowered>) -> Lowered {
+        let head_reg = self.emit_symbol(head).reg;
+        let mut acc = self.emit_nil().reg;
+        for arg in args.into_iter().rev() {
+            acc = self.emit_builtin("cons", &[arg.reg.as_str(), acc.as_str()], REF_PAIR);
+        }
+        let reg = self.emit_builtin("cons", &[head_reg.as_str(), acc.as_str()], REF_PAIR);
+        Lowered {
+            reg,
+            concrete: false,
+            literal: None,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/
+    /// `multiplicative`) with more than `MAX_EXPR_DEPTH` operands.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), WolframIirError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression chain too long ({operand_count} operands, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        let child = child_nodes(node).next().ok_or_else(|| {
+            self.err_at(
+                node,
+                format!("`{}` has no expression child", node.rule_name),
+            )
+        })?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(
+        &mut self,
+        child: &ASTNodeOrToken,
+        depth: usize,
+    ) -> Result<Lowered, WolframIirError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> WolframIirError {
+        WolframIirError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    fn err_unsupported(&self, node: &GrammarASTNode, what: &str) -> WolframIirError {
+        self.err_at(
+            node,
+            format!("{what} are not supported in this v0 slice — see wolfram-iir-vm.md"),
+        )
+    }
+
+    fn err_unsupported_tok(&self, token: &Token, what: &str) -> WolframIirError {
+        WolframIirError {
+            message: format!("{what} are not supported in this v0 slice — see wolfram-iir-vm.md"),
+            line: token.line,
+            column: token.column,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Map an arithmetic token type to its canonical IR head.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a canonical arithmetic head to the `call_builtin` name
+/// `dynval-runtime` resolves it to. Only ever called for `ADD`/`SUB`/`MUL`
+/// (see [`Lowerer::combine`] — `DIV` is handled separately).
+fn op_symbol_for(head: &str) -> &'static str {
+    match head {
+        h if h == ADD => "+",
+        h if h == SUB => "-",
+        h if h == MUL => "*",
+        _ => unreachable!("op_symbol_for called with a non-arithmetic head: {head}"),
+    }
+}
+
+/// If `child` (peeling away any single-child wrapper nodes, the same way
+/// [`unwrap_single`] does for lowering) bottoms out at a bare `NAME`
+/// token, return its text. Used by [`Lowerer::lower_assignment`] to check
+/// an assignment target *without* lowering it as an expression.
+fn bare_name(child: &ASTNodeOrToken) -> Option<String> {
+    let token = match child {
+        ASTNodeOrToken::Token(t) => t,
+        ASTNodeOrToken::Node(n) => match unwrap_single(n) {
+            Unwrapped::Token(t) => t,
+            Unwrapped::Node(_) => return None,
+        },
+    };
+    (token_type(token) == "NAME").then(|| token.value.clone())
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with
+/// structure (or a leaf token).
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/wolfram-iir-compiler/tests/oracle.rs
+++ b/code/packages/rust/wolfram-iir-compiler/tests/oracle.rs
@@ -1,0 +1,247 @@
+//! Oracle/golden test (wolfram-iir-vm.md / macsyma-iir-vm.md §7): the SAME
+//! Wolfram source, run through **two independent implementations**, and
+//! diffed:
+//!
+//!   (a) `wolfram-runtime` (`coding-adventures-wolfram-runtime`) — the
+//!       native runtime crate, which lowers to `symbolic-ir` and evaluates
+//!       via `symbolic-vm`'s shared handler table — the ground truth.
+//!   (b) `wolfram_iir_compiler::compile_source` → `interpreter_ir::IIRModule`
+//!       → `wolfram_vm::run` → a `LispyValue`, read back into a
+//!       `symbolic_ir::IRNode` and rendered through the SAME
+//!       `coding_adventures_wolfram_runtime::print_wolfram` function the
+//!       native runtime uses.
+//!
+//! Mirrors `derive-iir-compiler/tests/oracle.rs`'s/`maple-iir-compiler/
+//! tests/oracle.rs`'s shape exactly, only diffing the LAST statement's
+//! value.
+//!
+//! ## Corpus
+//!
+//! v0's accepted grammar subset only (`wolfram-iir-vm.md`) — a
+//! deliberately narrower slice than the FULL grammar
+//! `wolfram-to-semantic-ir` covers: literal integer arithmetic (`+ - *
+//! /`, unary `-`/`+` — Wolfram, unlike Derive/Reduce/Maple/Axiom, has a
+//! real unary-plus), assignment (`=`) and re-assignment threading, and
+//! unevaluated symbolic `Apply` results for any operand that stays free.
+//! Every rejected construct (including Wolfram's own genuinely rich
+//! surface — patterns, rules, replacement, pure functions) already has a
+//! dedicated `Err`-asserting unit test in `src/lib.rs`'s own `tests`
+//! module — not re-tested here.
+
+use coding_adventures_wolfram_runtime::{print_wolfram, WolframSession};
+use dynval_runtime::{builtins, name_of, LispyValue};
+use symbolic_ir::{apply, int, sym, IRNode};
+use wolfram_iir_compiler::compile_source;
+
+/// One oracle corpus entry.
+struct Case {
+    name: &'static str,
+    /// The WHOLE program, byte-for-byte identical on both the
+    /// [`ground_truth`] and [`compiled`] sides.
+    source: &'static str,
+    expected: &'static str,
+}
+
+const CORPUS: &[Case] = &[
+    // --- Literal arithmetic: precedence, chains, unary, grouping. ---
+    Case {
+        name: "integer_literal",
+        source: "42\n",
+        expected: "42",
+    },
+    Case {
+        name: "simple_addition",
+        source: "2 + 3\n",
+        expected: "5",
+    },
+    Case {
+        name: "precedence",
+        source: "2 + 3 * 4\n",
+        expected: "14",
+    },
+    Case {
+        name: "left_associative_chain",
+        source: "1 + 2 + 3 + 4\n",
+        expected: "10",
+    },
+    Case {
+        name: "unary_minus_leaf",
+        source: "-5 + 3\n",
+        expected: "-2",
+    },
+    Case {
+        name: "unary_minus_compound",
+        source: "-(5 + 3)\n",
+        expected: "-8",
+    },
+    Case {
+        name: "unary_plus_is_noop",
+        source: "+5\n",
+        expected: "5",
+    },
+    Case {
+        name: "grouping_overrides_precedence",
+        source: "(2 + 3) * 4\n",
+        expected: "20",
+    },
+    Case {
+        name: "exact_integer_division",
+        source: "20 / 4\n",
+        expected: "5",
+    },
+    Case {
+        name: "negative_literal_exact_division",
+        source: "-4 / 2\n",
+        expected: "-2",
+    },
+    // --- Assignment: binding, reference, re-assignment threading, and
+    // multiple independent variables in one program. ---
+    Case {
+        name: "assignment_and_reference",
+        source: "x = 3\nx + 1\n",
+        expected: "4",
+    },
+    Case {
+        name: "reassignment_threading",
+        source: "x = 3\nx = x + 1\nx\n",
+        expected: "4",
+    },
+    Case {
+        name: "two_independent_variables",
+        source: "a = 2\nb = 3\na * b\n",
+        expected: "6",
+    },
+    // --- Unevaluated symbolic expressions: a free symbol alone, and every
+    // arithmetic head with a symbolic operand (Add/Sub/Mul/Div/Neg via
+    // `inert_apply`). ---
+    Case {
+        name: "free_symbol_alone",
+        source: "x\n",
+        expected: "x",
+    },
+    Case {
+        name: "free_symbol_addition",
+        source: "x + y\n",
+        expected: "x + y",
+    },
+    Case {
+        name: "mixed_concrete_and_symbolic_multiplication",
+        source: "2 * x\n",
+        expected: "2*x",
+    },
+    Case {
+        name: "symbolic_subtraction",
+        source: "x - y\n",
+        expected: "x - y",
+    },
+    Case {
+        name: "symbolic_division_stays_unevaluated",
+        source: "x / y\n",
+        expected: "x/y",
+    },
+    Case {
+        name: "negation_of_a_free_symbol",
+        source: "-x\n",
+        expected: "-x",
+    },
+    Case {
+        name: "chained_symbolic_addition_nests_left_associatively",
+        source: "x + y + z\n",
+        expected: "x + y + z",
+    },
+    Case {
+        name: "assigned_value_used_inside_a_symbolic_expression",
+        source: "x = 2\nx + y\n",
+        expected: "2 + y",
+    },
+];
+
+/// Ground truth: run `source` through `wolfram-runtime`'s own
+/// [`WolframSession::eval_to_outputs`], taking only the LAST statement's
+/// `Output::text`.
+fn ground_truth(source: &str) -> String {
+    let mut session = WolframSession::new();
+    let outputs = session
+        .eval_to_outputs(source)
+        .unwrap_or_else(|e| panic!("wolfram-runtime eval failed for {source:?}: {e}"));
+    outputs
+        .into_iter()
+        .last()
+        .expect("at least one statement")
+        .text
+}
+
+/// Compiled path: `compile_source` → `wolfram_vm::run` → [`read_back`] →
+/// the same `print_wolfram` function the native runtime uses.
+fn compiled(name: &str, source: &str) -> String {
+    let module = compile_source(source, "oracle")
+        .unwrap_or_else(|e| panic!("lowering failed for {name} ({source:?}): {e}"));
+    let value = wolfram_vm::run(&module)
+        .unwrap_or_else(|e| panic!("VM execution failed for {name} ({source:?}): {e}"));
+    let node = read_back(value);
+    print_wolfram(&node)
+}
+
+/// Rebuild the [`symbolic_ir::IRNode`] a [`LispyValue`] represents — the
+/// mirror image of `wolfram_iir_compiler`'s own `inert_apply`/`emit_int`/
+/// `emit_symbol`. Plain recursion is appropriate here for the same
+/// reason `macsyma-iir-compiler/tests/oracle.rs`'s own `read_back`
+/// module doc gives: test-only code over a small, hand-authored corpus.
+fn read_back(v: LispyValue) -> IRNode {
+    if let Some(n) = v.as_int() {
+        return int(n);
+    }
+    if let Some(s) = v.as_symbol() {
+        let name = name_of(s).expect("interned symbol has a name");
+        return sym(name);
+    }
+    // Otherwise `v` must be the inert-Apply cons shape: (head . arglist).
+    let head_value = builtins::car(&[v]).unwrap_or_else(|e| panic!("car of apply pair: {e}"));
+    let head_name = match read_back(head_value) {
+        IRNode::Symbol(name) => name,
+        other => panic!("expected a symbol head, got {other:?}"),
+    };
+    let mut rest = builtins::cdr(&[v]).unwrap_or_else(|e| panic!("cdr of apply pair: {e}"));
+    let mut args = Vec::new();
+    while !rest.is_nil() {
+        let arg = builtins::car(&[rest]).unwrap_or_else(|e| panic!("car of arg list: {e}"));
+        args.push(read_back(arg));
+        rest = builtins::cdr(&[rest]).unwrap_or_else(|e| panic!("cdr of arg list: {e}"));
+    }
+    apply(sym(head_name), args)
+}
+
+#[test]
+fn oracle_corpus_matches_native_wolfram_runtime() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        if gt != case.expected {
+            failures.push(format!(
+                "{}: wolfram-runtime itself disagrees with this corpus entry's own `expected` \
+                 (got {gt:?}, expected {:?}) -- the program or `expected` is wrong, fix the \
+                 corpus rather than this assertion",
+                case.name, case.expected
+            ));
+            continue;
+        }
+
+        let got = compiled(case.name, case.source);
+        if got != case.expected {
+            failures.push(format!(
+                "{}: wolfram-iir-compiler -> wolfram-vm disagrees with the wolfram-runtime \
+                 ground truth (got {got:?}, expected {:?})",
+                case.name, case.expected
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "oracle corpus mismatches ({} of {}):\n{}",
+        failures.len(),
+        CORPUS.len(),
+        failures.join("\n")
+    );
+}

--- a/code/packages/rust/wolfram-vm/BUILD
+++ b/code/packages/rust/wolfram-vm/BUILD
@@ -1,0 +1,1 @@
+cargo test -p wolfram-vm

--- a/code/packages/rust/wolfram-vm/CHANGELOG.md
+++ b/code/packages/rust/wolfram-vm/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — wolfram-vm
+
+## v0.1.0 — 2026-08-18 — initial release (wolfram-iir-vm.md, Wave 5 item 6)
+
+Wolfram's own dedicated VM interpreter for the v0 arithmetic/assignment
+IIR subset — a direct structural port of the sibling VMs in this
+rollout, per the explicit VM-sharing decision (`macsyma-iir-vm.md` §6).
+This closes out Wave 5 — the last of the six CAS languages in this
+repo to get an IIR bridge.
+
+* `run`/`run_with_budget` executing an `interpreter_ir::IIRModule`,
+  returning a `dynval_runtime::LispyValue`.
+* `resolve_builtin` maps `+`/`-`/`*`/`/`/`cons`/`car`/`cdr` to
+  `dynval-runtime`'s existing builtins.
+* 15 unit tests over hand-built IIR.

--- a/code/packages/rust/wolfram-vm/Cargo.toml
+++ b/code/packages/rust/wolfram-vm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wolfram-vm"
+version = "0.1.0"
+edition = "2021"
+description = "A tiny interpreter for the Wolfram v0 arithmetic/assignment IIR subset, built directly on dynval-runtime. Deliberately independent of every sibling VM in this rollout; shares only the dynval-runtime foundation."
+
+[lib]
+name = "wolfram_vm"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+dynval-runtime = { path = "../dynval-runtime" }
+# Provides `RuntimeError`, the error type dynval-runtime's builtins return.
+lang-runtime-core = { path = "../lang-runtime-core" }

--- a/code/packages/rust/wolfram-vm/README.md
+++ b/code/packages/rust/wolfram-vm/README.md
@@ -1,0 +1,25 @@
+# wolfram-vm
+
+A tiny interpreter for the Wolfram v0 arithmetic/assignment IIR subset,
+built directly on `dynval-runtime`. Executes the `interpreter_ir::IIRModule`
+produced by [`wolfram-iir-compiler`](../wolfram-iir-compiler), returning a
+`LispyValue`.
+
+Wolfram's own VM — deliberately independent of every sibling VM in this
+rollout (see [`macsyma-iir-vm.md`](../../../specs/macsyma-iir-vm.md) §6).
+
+## Instruction set
+
+Only three opcodes: `const`, `call_builtin`, `ret`.
+
+## Usage
+
+```rust
+use wolfram_vm::run;
+
+let value = run(&module)?; // module: interpreter_ir::IIRModule
+```
+
+## Verification
+
+`cargo test -p wolfram-vm` — 15 unit tests over hand-built `IIRModule`s.

--- a/code/packages/rust/wolfram-vm/src/lib.rs
+++ b/code/packages/rust/wolfram-vm/src/lib.rs
@@ -1,0 +1,462 @@
+//! # `wolfram-vm` — Wolfram's own v0 interpreter.
+//!
+//! Executes the [`IIRModule`] produced by `wolfram-iir-compiler` against
+//! the [`dynval_runtime`] value model and returns a [`LispyValue`]. See
+//! [`wolfram-iir-vm.md`](../../../specs/wolfram-iir-vm.md) for the full
+//! design.
+//!
+//! ## Why a dedicated VM
+//!
+//! Every language in this rollout gets its own small VM on top of
+//! [`dynval_runtime`]'s tagged-`i64` value model — deliberately *not*
+//! shared with any sibling (`macsyma-iir-vm.md` §6's explicit
+//! VM-sharing decision for this rollout).
+//!
+//! ## The v0 instruction set
+//!
+//! | Op             | Meaning                                                                 |
+//! |----------------|--------------------------------------------------------------------------|
+//! | `const`        | `Int(n)` → tagged int, `Int(0):ref<LispyPair>` → the nil sentinel, `Var(name)` → interned symbol |
+//! | `call_builtin` | `srcs[0]` is the builtin name (a `Var`), the rest are argument registers; dispatched to a `dynval-runtime` builtin |
+//! | `ret`          | return the value in `srcs[0]`                                            |
+//!
+//! ## Quick start
+//!
+//! ```
+//! use wolfram_vm::run;
+//! use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+//!
+//! let main = IIRFunction::new(
+//!     "main",
+//!     Vec::new(),
+//!     "any",
+//!     vec![
+//!         IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(42)], "i64"),
+//!         IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "any"),
+//!     ],
+//! );
+//! let mut module = IIRModule::new("demo", "wolfram");
+//! module.functions.push(main);
+//! module.entry_point = Some("main".into());
+//!
+//! let result = run(&module).expect("run");
+//! assert_eq!(result.as_int(), Some(42));
+//! ```
+
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+
+use dynval_runtime::value::{INT_MAX, INT_MIN};
+use dynval_runtime::{builtins, intern, LispyValue};
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
+use lang_runtime_core::RuntimeError;
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+/// A failure while interpreting a Wolfram [`IIRModule`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmError {
+    /// The module has no `entry_point` set.
+    NoEntryPoint,
+    /// `entry_point` names a function the module does not contain.
+    UnknownFunction(String),
+    /// Control reached the end of a function without a `ret`.
+    FellOffEnd(String),
+    /// An instruction this VM doesn't execute (v0 has no branches, calls,
+    /// or closures). Carries the opcode.
+    UnsupportedOp(String),
+    /// An instruction was missing a `dest`, an operand, etc.
+    Malformed(String),
+    /// A register was read before it was written.
+    UndefinedRegister(String),
+    /// A `call_builtin` named a builtin `dynval-runtime` doesn't provide.
+    UnknownBuiltin(String),
+    /// A `dynval-runtime` builtin raised a runtime trap (wrong arity,
+    /// type error, division by zero, overflow, …). Carries its message.
+    Runtime(String),
+    /// The per-run instruction budget was exhausted.
+    InstructionBudgetExceeded(u64),
+    /// An integer literal outside `dynval-runtime`'s tagged-int range
+    /// (`[-2^60, 2^60 - 1]`). A known v0 gap tied to a later wave (bignum
+    /// support) — see `wolfram-iir-vm.md`.
+    IntegerOutOfRange(i64),
+}
+
+impl std::fmt::Display for VmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VmError::NoEntryPoint => write!(f, "module has no entry_point"),
+            VmError::UnknownFunction(n) => write!(f, "unknown function {n:?}"),
+            VmError::FellOffEnd(n) => write!(f, "function {n:?} ran off the end without `ret`"),
+            VmError::UnsupportedOp(op) => write!(f, "unsupported opcode {op:?}"),
+            VmError::Malformed(m) => write!(f, "malformed instruction: {m}"),
+            VmError::UndefinedRegister(r) => write!(f, "register {r:?} read before written"),
+            VmError::UnknownBuiltin(b) => write!(f, "unknown builtin {b:?}"),
+            VmError::Runtime(m) => write!(f, "runtime error: {m}"),
+            VmError::InstructionBudgetExceeded(n) => {
+                write!(
+                    f,
+                    "instruction budget ({n}) exceeded — possible infinite loop"
+                )
+            }
+            VmError::IntegerOutOfRange(n) => write!(
+                f,
+                "integer literal {n} is outside dynval-runtime's tagged-int range [-2^60, 2^60-1]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VmError {}
+
+// ===========================================================================
+// Public entry points
+// ===========================================================================
+
+/// Default instruction budget. Far above any real v0 program's step count
+/// (v0 has no loops), but a hard backstop nonetheless.
+pub const DEFAULT_INSTRUCTION_BUDGET: u64 = 10_000_000;
+
+/// Execute `module`'s entry-point function and return its result value.
+///
+/// # Errors
+///
+/// See [`VmError`] for the full list — missing entry point, unsupported
+/// opcode, builtin trap, etc.
+pub fn run(module: &IIRModule) -> Result<LispyValue, VmError> {
+    run_with_budget(module, DEFAULT_INSTRUCTION_BUDGET)
+}
+
+/// Like [`run`], but with an explicit instruction budget (the maximum
+/// number of instructions executed before
+/// [`VmError::InstructionBudgetExceeded`]).
+///
+/// # Errors
+///
+/// See [`VmError`].
+pub fn run_with_budget(module: &IIRModule, budget: u64) -> Result<LispyValue, VmError> {
+    let entry = module.entry_point.as_deref().ok_or(VmError::NoEntryPoint)?;
+    let func = module
+        .get_function(entry)
+        .ok_or_else(|| VmError::UnknownFunction(entry.to_string()))?;
+    let mut steps: u64 = 0;
+    run_function(func, &mut steps, budget)
+}
+
+// ===========================================================================
+// Interpreter core
+// ===========================================================================
+
+/// The register file: register name → live value. A `HashMap` keeps the
+/// VM independent of any register-numbering scheme the compiler uses.
+type Frame = HashMap<String, LispyValue>;
+
+fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<LispyValue, VmError> {
+    let mut frame: Frame = HashMap::new();
+    let mut pc: usize = 0;
+
+    while pc < func.instructions.len() {
+        *steps += 1;
+        if *steps > budget {
+            return Err(VmError::InstructionBudgetExceeded(budget));
+        }
+
+        let instr = &func.instructions[pc];
+        match instr.op.as_str() {
+            "const" => {
+                let value = eval_const(instr)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "call_builtin" => {
+                let value = eval_call_builtin(instr, &frame)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            "ret" => {
+                let src = instr
+                    .srcs
+                    .first()
+                    .ok_or_else(|| VmError::Malformed("`ret` requires a source operand".into()))?;
+                return read_operand(src, &frame);
+            }
+            other => return Err(VmError::UnsupportedOp(other.to_string())),
+        }
+    }
+
+    Err(VmError::FellOffEnd(func.name.clone()))
+}
+
+/// Store an instruction's result in its `dest` register.
+fn bind_dest(instr: &IIRInstr, value: LispyValue, frame: &mut Frame) -> Result<(), VmError> {
+    let dest = instr
+        .dest
+        .as_ref()
+        .ok_or_else(|| VmError::Malformed(format!("`{}` requires a dest register", instr.op)))?;
+    frame.insert(dest.clone(), value);
+    Ok(())
+}
+
+/// Materialise a `const` instruction's literal into a [`LispyValue`].
+///
+/// The operand encodings match what `wolfram-iir-compiler` emits (the
+/// same conventions established across this rollout's other frontends).
+fn eval_const(instr: &IIRInstr) -> Result<LispyValue, VmError> {
+    let src = instr
+        .srcs
+        .first()
+        .ok_or_else(|| VmError::Malformed("`const` requires a source operand".into()))?;
+    match src {
+        Operand::Int(0) if instr.type_hint == "ref<LispyPair>" => Ok(LispyValue::NIL),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Var(name) => Ok(LispyValue::symbol(intern(name))),
+        Operand::Bool(_) => Err(VmError::Malformed(
+            "Wolfram v0 has no boolean literals; unexpected Bool operand in `const`".into(),
+        )),
+        Operand::Float(_) => Err(VmError::Malformed(
+            "Wolfram v0 has no floats (wolfram-iir-vm.md); unexpected Float operand in `const`"
+                .into(),
+        )),
+        Operand::Str(_) => Err(VmError::Malformed(
+            "Wolfram v0 has no string literals; unexpected Str operand in `const`".into(),
+        )),
+    }
+}
+
+/// Execute a `call_builtin`: `srcs[0]` is the builtin's name (a `Var`),
+/// the remaining sources are argument registers.
+fn eval_call_builtin(instr: &IIRInstr, frame: &Frame) -> Result<LispyValue, VmError> {
+    let name = match instr.srcs.first() {
+        Some(Operand::Var(n)) => n.as_str(),
+        _ => {
+            return Err(VmError::Malformed(
+                "`call_builtin` requires srcs[0] to be the builtin name (a Var)".into(),
+            ))
+        }
+    };
+
+    let mut args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len().saturating_sub(1));
+    for src in &instr.srcs[1..] {
+        args.push(read_operand(src, frame)?);
+    }
+
+    let builtin = resolve_builtin(name).ok_or_else(|| VmError::UnknownBuiltin(name.to_string()))?;
+    builtin(&args).map_err(|e| VmError::Runtime(e.to_string()))
+}
+
+/// A `dynval-runtime` builtin: takes a slice of arguments, returns a value
+/// or a runtime trap. This is the shape every `builtins::*` function has.
+type BuiltinFn = fn(&[LispyValue]) -> Result<LispyValue, RuntimeError>;
+
+/// Map a Wolfram v0 builtin name to its `dynval-runtime` implementation.
+fn resolve_builtin(name: &str) -> Option<BuiltinFn> {
+    match name {
+        "+" => Some(builtins::add),
+        "-" => Some(builtins::sub),
+        "*" => Some(builtins::mul),
+        "/" => Some(builtins::div),
+        "cons" => Some(builtins::cons),
+        "car" => Some(builtins::car),
+        "cdr" => Some(builtins::cdr),
+        _ => None,
+    }
+}
+
+/// Build a tagged integer, rejecting values outside `dynval-runtime`'s
+/// 61-bit tagged-int range rather than letting `LispyValue::int` silently
+/// truncate them in release builds.
+fn dyn_int(n: i64) -> Result<LispyValue, VmError> {
+    if (INT_MIN..=INT_MAX).contains(&n) {
+        Ok(LispyValue::int(n))
+    } else {
+        Err(VmError::IntegerOutOfRange(n))
+    }
+}
+
+/// Read an operand in *value* position: a `Var` is a register read; an
+/// `Int` is an immediate. (`const` handles its `Var` specially — see
+/// [`eval_const`].)
+fn read_operand(op: &Operand, frame: &Frame) -> Result<LispyValue, VmError> {
+    match op {
+        Operand::Var(name) => frame
+            .get(name)
+            .copied()
+            .ok_or_else(|| VmError::UndefinedRegister(name.clone())),
+        Operand::Int(n) => dyn_int(*n),
+        Operand::Bool(_) => Err(VmError::Malformed("unexpected Bool operand".into())),
+        Operand::Float(_) => Err(VmError::Malformed("unexpected Float operand".into())),
+        Operand::Str(_) => Err(VmError::Malformed("unexpected Str operand".into())),
+    }
+}
+
+// ===========================================================================
+// Tests (hand-built IIR; the compiler's own tests cover the source path)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynval_runtime::name_of;
+
+    fn module(instrs: Vec<IIRInstr>) -> IIRModule {
+        let main = IIRFunction::new("main", Vec::new(), "any", instrs);
+        let mut m = IIRModule::new("test", "wolfram");
+        m.functions.push(main);
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    fn konst(dest: &str, op: Operand, ty: &str) -> IIRInstr {
+        IIRInstr::new("const", Some(dest.into()), vec![op], ty)
+    }
+
+    fn ret(reg: &str) -> IIRInstr {
+        IIRInstr::new("ret", None, vec![Operand::Var(reg.into())], "any")
+    }
+
+    fn builtin_instr(dest: &str, name: &str, args: &[&str]) -> IIRInstr {
+        let mut srcs = vec![Operand::Var(name.into())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).into())));
+        IIRInstr::new("call_builtin", Some(dest.into()), srcs, "any")
+    }
+
+    #[test]
+    fn integer_const() {
+        let m = module(vec![konst("v0", Operand::Int(42), "i64"), ret("v0")]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(42));
+    }
+
+    #[test]
+    fn nil_const() {
+        let m = module(vec![
+            konst("v0", Operand::Int(0), "ref<LispyPair>"),
+            ret("v0"),
+        ]);
+        assert!(run(&m).unwrap().is_nil());
+    }
+
+    #[test]
+    fn symbol_const_interns() {
+        let m = module(vec![
+            konst("v0", Operand::Var("X".into()), "symbol"),
+            ret("v0"),
+        ]);
+        let v = run(&m).unwrap();
+        assert_eq!(v.as_symbol(), Some(intern("X")));
+        assert_eq!(name_of(v.as_symbol().unwrap()).as_deref(), Some("X"));
+    }
+
+    #[test]
+    fn add_two_concrete_ints() {
+        let m = module(vec![
+            konst("a", Operand::Int(2), "i64"),
+            konst("b", Operand::Int(3), "i64"),
+            builtin_instr("r", "+", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(5));
+    }
+
+    #[test]
+    fn sub_unary_negates() {
+        let m = module(vec![
+            konst("a", Operand::Int(5), "i64"),
+            builtin_instr("r", "-", &["a"]),
+            ret("r"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(-5));
+    }
+
+    #[test]
+    fn cons_builds_an_inert_pair() {
+        let m = module(vec![
+            konst("head", Operand::Var("Add".into()), "symbol"),
+            konst("x", Operand::Var("X".into()), "symbol"),
+            konst("y", Operand::Var("Y".into()), "symbol"),
+            konst("nil", Operand::Int(0), "ref<LispyPair>"),
+            builtin_instr("t1", "cons", &["y", "nil"]),
+            builtin_instr("t2", "cons", &["x", "t1"]),
+            builtin_instr("r", "cons", &["head", "t2"]),
+            ret("r"),
+        ]);
+        let v = run(&m).unwrap();
+        let h = builtins::car(&[v]).unwrap();
+        assert_eq!(name_of(h.as_symbol().unwrap()).as_deref(), Some("Add"));
+    }
+
+    #[test]
+    fn missing_entry_point() {
+        let mut m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        m.entry_point = None;
+        assert_eq!(run(&m), Err(VmError::NoEntryPoint));
+    }
+
+    #[test]
+    fn unknown_entry_function() {
+        let mut m = module(vec![ret("v0")]);
+        m.entry_point = Some("nope".into());
+        assert!(matches!(run(&m), Err(VmError::UnknownFunction(_))));
+    }
+
+    #[test]
+    fn fell_off_end_without_ret() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64")]);
+        assert!(matches!(run(&m), Err(VmError::FellOffEnd(_))));
+    }
+
+    #[test]
+    fn unsupported_op() {
+        let m = module(vec![IIRInstr::new("jmp", None, vec![], "void")]);
+        assert!(matches!(run(&m), Err(VmError::UnsupportedOp(_))));
+    }
+
+    #[test]
+    fn unknown_builtin() {
+        let m = module(vec![
+            konst("x", Operand::Int(1), "i64"),
+            builtin_instr("r", "frobnicate", &["x"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::UnknownBuiltin(_))));
+    }
+
+    #[test]
+    fn undefined_register() {
+        let m = module(vec![ret("never_written")]);
+        assert!(matches!(run(&m), Err(VmError::UndefinedRegister(_))));
+    }
+
+    #[test]
+    fn division_by_zero_is_a_clean_runtime_error() {
+        let m = module(vec![
+            konst("a", Operand::Int(1), "i64"),
+            konst("b", Operand::Int(0), "i64"),
+            builtin_instr("r", "/", &["a", "b"]),
+            ret("r"),
+        ]);
+        assert!(matches!(run(&m), Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn integer_out_of_tagged_range_is_rejected() {
+        let m = module(vec![konst("v0", Operand::Int(i64::MAX), "i64"), ret("v0")]);
+        assert!(matches!(run(&m), Err(VmError::IntegerOutOfRange(_))));
+        let ok = module(vec![
+            konst("v0", Operand::Int((1 << 60) - 1), "i64"),
+            ret("v0"),
+        ]);
+        assert_eq!(run(&ok).unwrap().as_int(), Some((1 << 60) - 1));
+    }
+
+    #[test]
+    fn instruction_budget() {
+        let m = module(vec![konst("v0", Operand::Int(1), "i64"), ret("v0")]);
+        assert!(matches!(
+            run_with_budget(&m, 1),
+            Err(VmError::InstructionBudgetExceeded(_))
+        ));
+    }
+}

--- a/code/specs/wolfram-iir-vm.md
+++ b/code/specs/wolfram-iir-vm.md
@@ -1,0 +1,109 @@
+# Wolfram → IIR → VM interpreter
+
+**Status:** Draft — 2026-08-18 (spec-first; sign-off = merge)
+**Depends on:** [`macsyma-iir-vm.md`](macsyma-iir-vm.md) — this is Wave 5
+item 6, the LAST item, closing out that spec's rollout. Read
+`macsyma-iir-vm.md` first for the full design.
+**Unblocks:** nothing further in Wave 5 — this closes it. See
+`macsyma-iir-vm.md` §6 for the next waves (Rational/Float substrate,
+control flow, native codegen backends).
+
+## Summary
+
+Bridges Wolfram onto `interpreter_ir` (IIR), the sixth and final
+real-language frontend in this rollout: a new `wolfram-iir-compiler`
+frontend (a third retarget of the `GrammarASTNode` CST `wolfram-runtime`
+and `wolfram-to-semantic-ir` already walk) and a new `wolfram-vm`
+interpreter (its own dedicated VM, per `macsyma-iir-vm.md` §6).
+
+```text
+                                 ┌─→ wolfram-runtime (+ repl)                [existing, unchanged]
+wolfram source → GrammarASTNode ┤─→ wolfram-to-semantic-ir → any SIR backend [existing, unchanged]
+                                 └─→ wolfram-iir-compiler → IIRModule → wolfram-vm   [NEW]
+```
+
+## Deltas from the rest of Wave 5 — and from `wolfram-to-semantic-ir` itself
+
+Verified directly against `wolfram.grammar`/`wolfram.tokens`
+(`code/grammars/wolfram/`) and `wolfram-to-semantic-ir/src/lower.rs`'s
+module doc comment. Wolfram's grammar is genuinely the richest of the
+six (`wolfram-to-semantic-ir` covers ALL of it — pattern blanks,
+rules, replacement, pure functions, `/@`/`@@` sugar — since SIR23's
+"everything is data" design has no scope pressure narrowing it there).
+**This crate deliberately does not follow that precedent.** v0's
+arithmetic/assignment/unevaluated-Apply scope, set once in
+`macsyma-iir-vm.md` and held constant across all six languages, is
+narrower than what Wolfram's grammar could support — the cut here is a
+choice, not a grammar-forced necessity the way Reduce's/Maple's/Axiom's
+own genuinely-new constructs were.
+
+1. **Both unary `-` AND `+` are real** (`unary = (MINUS|PLUS) unary |
+   power`) — Wolfram is the only language in Wave 5 besides Macsyma
+   itself with a real unary-plus no-op; Derive/Reduce/Maple/Axiom all
+   lack one.
+2. **Two distinct assignment tokens, `SET` (`=`) and `SETDELAYED`
+   (`:=`)** — unlike Derive's/Reduce's single overloaded token. v0
+   accepts `SET` only (bare-NAME target, same disambiguation as
+   Derive's/Reduce's own `bare_name` check) and rejects `SETDELAYED`
+   outright, mirroring `macsyma-iir-compiler`'s own `COLON`-vs-`COLONEQ`
+   split.
+3. **Genuinely new surface with no arithmetic analogue at all**: pattern
+   blanks (`_`/`_h`), rules (`->`/`:>`), replacement (`/.`/`//.`),
+   conditions (`/;`), alternatives (`|`), pattern tests (`?`), pure
+   functions (`#`/`#n`/`##`/`expr &`), `/@`/`@@` sugar. All rejected
+   outright — the same treatment Reduce's `if`/`<<...>>`/cons and Maple's
+   `Set` literal got, just a longer list.
+4. **`postfix` rejects unconditionally on ANY suffix**, not just a call —
+   Wolfram's `postfix` has several distinct suffix shapes (`f[x]` calls,
+   `x[[i]]` Part-indexing, and more), so unlike the narrower single-shape
+   `postfix` in Derive/Reduce/Maple/Axiom, v0 doesn't attempt to
+   distinguish which suffix kind is present.
+5. Program structure (`{ statement_line }`, uniform, no optional trailing
+   bare statement), `TIMES`/`SLASH`, the `/` exactness rule, and the
+   inert-`cons`-chain representation are unchanged from Derive's shape.
+
+## Oracle ground truth
+
+`wolfram-runtime`'s API mirrors Derive's/Reduce's/Maple's exactly:
+`WolframSession::eval_to_outputs(source) -> Result<Vec<Output>, String>`,
+each rendered by `wolfram-runtime`'s own bespoke printer, `print_wolfram`
+— not `cas_pretty_printer`. The oracle test's `read_back` reader is
+identical in shape to the sibling frontends'.
+
+## Crates
+
+- `code/packages/rust/wolfram-iir-compiler` — `compile`/`compile_source`,
+  depends on `coding-adventures-wolfram-parser`/`interpreter-ir`/
+  `parser`/`lexer`/`symbolic-ir`; dev-depends on `wolfram-vm`/
+  `dynval-runtime`/`coding-adventures-wolfram-runtime`.
+- `code/packages/rust/wolfram-vm` — `run`/`run_with_budget`, a direct
+  structural port of the sibling VMs' dispatch loop.
+
+## Verification
+
+- `cargo test -p wolfram-iir-compiler -p wolfram-vm` — unit tests
+  (including a full sweep of Wolfram's rejected pattern/rule/replacement/
+  pure-function surface) + the oracle test.
+- `cargo clippy -p wolfram-iir-compiler -p wolfram-vm --all-targets` /
+  `cargo fmt --check` clean.
+- Oracle corpus has an empty `known_bug` list.
+
+## Wave 5 close-out
+
+This is the sixth and final Wave 5 item. All six SIR23 CAS-family
+languages (Macsyma, Maxima, Derive, Reduce, Maple, Axiom, Wolfram — seven
+counting Maxima's alias) now have an IIR bridge, matching what they
+already had on the Semantic-IR side. See `macsyma-iir-vm.md` §6 for what
+comes next: Wave 2 (Rational/Float, a `dynval-runtime` substrate change),
+Wave 3 (control flow, a real evaluator loop per VM), Wave 4 (the other 6
+IIR backends beyond the VM interpreter).
+
+## References
+
+[`macsyma-iir-vm.md`](macsyma-iir-vm.md),
+[`derive-iir-vm.md`](derive-iir-vm.md) (the closer template for the
+`bare_name` assignment-disambiguation pattern),
+[`MA04-wolfram-language.md`](MA04-wolfram-language.md) (the original
+Wolfram language spec), `wolfram-to-semantic-ir/src/lower.rs` (the
+rule-dispatch table retargeted a third time, covering the full grammar
+this crate deliberately narrows).


### PR DESCRIPTION
## Summary
- Sixth and final item of `macsyma-iir-vm.md`'s Wave 5: bridges Wolfram onto `interpreter_ir` (IIR), closing out the rollout -- all six SIR23 CAS-family languages (Macsyma, Maxima, Derive, Reduce, Maple, Axiom, Wolfram) now have an IIR bridge.
- `wolfram-iir-compiler` retargets `wolfram-runtime`'s/`wolfram-to-semantic-ir`'s existing CST dispatch, but is **deliberately narrower** than `wolfram-to-semantic-ir` (which covers Wolfram's full grammar) -- v0 holds the same arithmetic/assignment/unevaluated-Apply scope constant across all six languages instead of letting the richer grammar widen it.
- Per-language deltas, recorded in the new leaf spec `wolfram-iir-vm.md`: both unary `-` AND `+` are real (Wolfram is the only Wave 5 language besides Macsyma with a genuine unary-plus); two distinct assignment tokens (`SET`/`SETDELAYED`), mirroring `macsyma-iir-compiler`'s own `COLON`-vs-`COLONEQ` split; pattern blanks, rules, replacement, conditions, alternatives, pattern tests, pure functions, and `/@`/`@@` sugar are all rejected outright with no arithmetic analogue; `postfix` rejects unconditionally on ANY suffix since Wolfram's `postfix` has several distinct suffix shapes.

**Security fix included** (caught in review before first push, not a post-release patch): `compile_source` originally assumed no worker-thread stack enlargement was needed, by invalid analogy to `macsyma-iir-compiler`. Wolfram's own parser has a documented bare-stack crash floor of only ~11 real nesting levels (a 20-rule-per-level precedence cascade), so trivially small deeply-nested input could crash the process natively. Fixed by mirroring `wolfram-to-semantic-ir::compile_source`'s existing enlarged-stack worker-thread pattern exactly; verified both by review and by an empirical crash-vs-no-crash differential test against the pre-fix code.

## Test plan
- [x] `cargo test -p wolfram-iir-compiler -p wolfram-vm` -- 36 + 15 unit tests + 1 oracle test (19 cases) + 2 doctests, all passing
- [x] `cargo clippy -p wolfram-iir-compiler -p wolfram-vm --all-targets` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `/security-review` -- one HIGH finding (native stack-overflow DoS in `compile_source`), fixed and re-reviewed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)