### PR TITLE
fix(hl-c235): Marathi — romanize the script a reader cannot yet read

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3667,7 +3667,7 @@
     {
       "language": "marathi",
       "chapter": 10,
-      "sourceHash": "fnv1a64:0e4c84edabf68889",
+      "sourceHash": "fnv1a64:cf2a8dd578f13505",
       "lessonIds": [
         "MR-C10-paani",
         "MR-C10-chaha",
@@ -3679,7 +3679,7 @@
     {
       "language": "marathi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:101115eb3db6665b",
+      "sourceHash": "fnv1a64:81d9b964581c9a85",
       "lessonIds": [
         "MR-C11-mitra",
         "MR-C11-kutumb",
@@ -3691,7 +3691,7 @@
     {
       "language": "marathi",
       "chapter": 12,
-      "sourceHash": "fnv1a64:53b43a3f45294871",
+      "sourceHash": "fnv1a64:556c8f23ff12cd7f",
       "lessonIds": [
         "MR-C12-dola",
         "MR-C12-kaan",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6381,7 +6381,7 @@
     {
       "language": "marathi",
       "chapter": 2,
-      "sourceHash": "fnv1a64:d7d34ac586baf0bb",
+      "sourceHash": "fnv1a64:76482a70a494ffaa",
       "lessonIds": [
         "MR-C02-aahe",
         "MR-C02-anand",
@@ -6397,13 +6397,13 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch02.txt",
       "json": "marathi/narration/ch02.json",
-      "textHash": "fnv1a64:08018d4e9bd10e1e",
-      "jsonHash": "fnv1a64:25cc1db27e3617dd"
+      "textHash": "fnv1a64:a0339c7c4d56d9f6",
+      "jsonHash": "fnv1a64:63340b4ca91c581c"
     },
     {
       "language": "marathi",
       "chapter": 3,
-      "sourceHash": "fnv1a64:4698352cdd6ad6ca",
+      "sourceHash": "fnv1a64:b3107d9fc5cfb536",
       "lessonIds": [
         "MR-C03-kaahi-harkat-nahi",
         "MR-C03-kasa",
@@ -6416,13 +6416,13 @@
       "drivablePrefix": 1,
       "text": "marathi/narration/ch03.txt",
       "json": "marathi/narration/ch03.json",
-      "textHash": "fnv1a64:cbc91fa67dbc5d81",
-      "jsonHash": "fnv1a64:126295a7b9159325"
+      "textHash": "fnv1a64:ae5f953a10a89eb0",
+      "jsonHash": "fnv1a64:f254ce5e8b59bbeb"
     },
     {
       "language": "marathi",
       "chapter": 4,
-      "sourceHash": "fnv1a64:698a7e2e82e9ad58",
+      "sourceHash": "fnv1a64:58a4518fd27913b8",
       "lessonIds": [
         "MR-C04-bhetu",
         "MR-C04-kalji-ghya",
@@ -6435,13 +6435,13 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch04.txt",
       "json": "marathi/narration/ch04.json",
-      "textHash": "fnv1a64:243a6bf3be8eb0df",
-      "jsonHash": "fnv1a64:7330b409ed42ae39"
+      "textHash": "fnv1a64:c7b5fd7feb54ca0b",
+      "jsonHash": "fnv1a64:bc7f83c92bc78707"
     },
     {
       "language": "marathi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:03f79a98594f4da1",
+      "sourceHash": "fnv1a64:2c216f7d781a9d9b",
       "lessonIds": [
         "MR-C05-bolne",
         "MR-C05-kaam-karne",
@@ -6453,8 +6453,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch05.txt",
       "json": "marathi/narration/ch05.json",
-      "textHash": "fnv1a64:a0c31a7d46cfe4b0",
-      "jsonHash": "fnv1a64:80b8a75cfe0cd05f"
+      "textHash": "fnv1a64:72942e4430489a65",
+      "jsonHash": "fnv1a64:0d409ccd3e6d66b0"
     },
     {
       "language": "marathi",
@@ -6527,7 +6527,7 @@
     {
       "language": "marathi",
       "chapter": 10,
-      "sourceHash": "fnv1a64:507c5abe2c6c17d2",
+      "sourceHash": "fnv1a64:8f01d3226aec18e1",
       "lessonIds": [
         "MR-C10-paani",
         "MR-C10-chaha",
@@ -6538,13 +6538,13 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch10.txt",
       "json": "marathi/narration/ch10.json",
-      "textHash": "fnv1a64:599b69607fc99702",
-      "jsonHash": "fnv1a64:012d45932ec4fc4f"
+      "textHash": "fnv1a64:aa53fc4d4fab5ea1",
+      "jsonHash": "fnv1a64:f6c1e4a50ea95cff"
     },
     {
       "language": "marathi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:bc272c6f569ea8c9",
+      "sourceHash": "fnv1a64:610b366c32d81a38",
       "lessonIds": [
         "MR-C11-mitra",
         "MR-C11-kutumb",
@@ -6555,13 +6555,13 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch11.txt",
       "json": "marathi/narration/ch11.json",
-      "textHash": "fnv1a64:3e0f5651dd0af8ef",
-      "jsonHash": "fnv1a64:23c769ab8b30c43d"
+      "textHash": "fnv1a64:bf9df7a07b834741",
+      "jsonHash": "fnv1a64:47a7ceda76586f18"
     },
     {
       "language": "marathi",
       "chapter": 12,
-      "sourceHash": "fnv1a64:6aa24870cb193793",
+      "sourceHash": "fnv1a64:67dc331760170c58",
       "lessonIds": [
         "MR-C12-dola",
         "MR-C12-kaan",
@@ -6572,8 +6572,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch12.txt",
       "json": "marathi/narration/ch12.json",
-      "textHash": "fnv1a64:f475f24d12c4b38a",
-      "jsonHash": "fnv1a64:f7238830a5c1f3ca"
+      "textHash": "fnv1a64:48c40512c0e05775",
+      "jsonHash": "fnv1a64:25435d54b06f316e"
     },
     {
       "language": "marathi",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:b0d1a06938bf1c09",
+  "sourceHash": "fnv1a64:4f0ac653117531c5",
   "summary": {
     "totalLessons": 3070,
     "voice": 2161,
@@ -43137,7 +43137,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:151eaa22ab083bf1"
+      "sourceHash": "fnv1a64:8d27ba5b3b1cc3b1"
     },
     {
       "id": "MR-C02-naav",
@@ -43176,7 +43176,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dc477000accbb398"
+      "sourceHash": "fnv1a64:fb1c703edb1e5e9e"
     },
     {
       "id": "MR-C02-tu-tumhi",
@@ -43215,7 +43215,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7762eea32e74fd3b"
+      "sourceHash": "fnv1a64:ccc4ebc2a946857f"
     },
     {
       "id": "MR-C03-kaahi-harkat-nahi",
@@ -43311,7 +43311,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:eb7818167410db6b"
+      "sourceHash": "fnv1a64:70dd374d59aaf09d"
     },
     {
       "id": "MR-C03-tumhi-kase-aahat",
@@ -43389,7 +43389,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b2f49ee8ecb088f8"
+      "sourceHash": "fnv1a64:b3595cc3593d4eb2"
     },
     {
       "id": "MR-C04-punha",
@@ -43527,7 +43527,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:360f39186883773c"
+      "sourceHash": "fnv1a64:73fed83793c9bc8c"
     },
     {
       "id": "MR-C05-rahne",
@@ -43900,7 +43900,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f3e23b1f18f70d7b",
+      "sourceHash": "fnv1a64:77a677b7040d48c7",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -43984,7 +43984,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b132b3080165bb37",
+      "sourceHash": "fnv1a64:e9c3e5e20a44ff01",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -44026,7 +44026,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bc4a5ecff53ff890",
+      "sourceHash": "fnv1a64:b11d2c0417823984",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -44047,7 +44047,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:316673ce1d6b6d28",
+      "sourceHash": "fnv1a64:ed891e7565994bd2",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -44068,7 +44068,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:441ee4d94874fd25",
+      "sourceHash": "fnv1a64:545dd0be7cf4e68d",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -44110,7 +44110,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:11066afc3792d53d",
+      "sourceHash": "fnv1a64:a983124140410927",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
@@ -6,7 +6,7 @@ Now a first real exchange --- giving your name, asking for someone else's, and
 saying you are glad to meet them:
 
 \begin{center}
-\mr{माझं नाव मीरा आहे.} \quad(\emph{m\=ajh\d{m} n\=av Mira \=ahe} --- ``My name is Mira.'')\\
+\mr{माझं नाव मीरा आहे.} \quad(\emph{m\=ajh\d{m} n\=av M\={\i}r\=a \=ahe} --- ``My name is Mira.'')\\
 \mr{तुमचं नाव काय आहे?} \quad(\emph{tumch\d{m} n\=av k\=ay \=ahe} --- ``What is your name?'')
 \end{center}
 
@@ -140,14 +140,14 @@ Chapter~4's \emph{punh\=a bhe\d{t}\=u}.
 \label{lesson:MR-C02-practice}
 
 \begin{center}
-\begin{tabular}{@{}ll@{}}
+\begin{tabular}{@{}lll@{}}
 \toprule
-Marathi & English \\
+Marathi & Say it & English \\
 \midrule
-\mr{माझं नाव मीरा आहे.} & My name is Mira. \\
-\mr{तुमचं नाव काय आहे?} & What's your name? \\
-\mr{माझं नाव अरुण आहे.} & My name is Arun. \\
-\mr{भेटून आनंद झाला.} & Pleased to meet you. \\
+\mr{माझं नाव मीरा आहे.} & \emph{mājhaṁ nāv Mīrā āhe.} & My name is Mira. \\
+\mr{तुमचं नाव काय आहे?} & \emph{tumchaṁ nāv kāy āhe?} & What's your name? \\
+\mr{माझं नाव अरुण आहे.} & \emph{mājhaṁ nāv Aruṇ āhe.} & My name is Arun. \\
+\mr{भेटून आनंद झाला.} & \emph{bheṭūn ānand jhālā.} & Pleased to meet you. \\
 \bottomrule
 \end{tabular}
 \end{center}

--- a/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
@@ -140,16 +140,16 @@ Chapter~4's \emph{punh\=a bhe\d{t}\=u}.
 \label{lesson:MR-C02-practice}
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-Marathi & Say it & English \\
+\textbf{Marathi} & \textbf{Say it} & \textbf{English} \\
 \midrule
 \mr{माझं नाव मीरा आहे.} & \emph{mājhaṁ nāv Mīrā āhe.} & My name is Mira. \\
 \mr{तुमचं नाव काय आहे?} & \emph{tumchaṁ nāv kāy āhe?} & What's your name? \\
 \mr{माझं नाव अरुण आहे.} & \emph{mājhaṁ nāv Aruṇ āhe.} & My name is Arun. \\
 \mr{भेटून आनंद झाला.} & \emph{bheṭūn ānand jhālā.} & Pleased to meet you. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Every atom traced: \emph{n\=av} ($\to$ \emph{name}), \emph{m\=ajh\d{m}} ($\to$

--- a/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
@@ -84,15 +84,15 @@ sultanates. An Indo-European negative wrapped around an Arabic noun.
 \label{lesson:MR-C03-practice}
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-Marathi & Say it & English \\
+\textbf{Marathi} & \textbf{Say it} & \textbf{English} \\
 \midrule
 \mr{तुम्ही कसे आहात?} & \emph{tumhī kase āhāt?} & How are you? \\
 \mr{मी बरा आहे, धन्यवाद.} & \emph{mī barā āhe, dhanyavād.} & I'm well, thank you. \\
 \mr{काही हरकत नाही.} & \emph{kāhī harkat nāhī.} & No problem / you're welcome. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Roots banked: \emph{kas\=a} (the \emph{k-} questions, gender-agreeing), \emph{m\=\i}

--- a/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
@@ -84,13 +84,13 @@ sultanates. An Indo-European negative wrapped around an Arabic noun.
 \label{lesson:MR-C03-practice}
 
 \begin{center}
-\begin{tabular}{@{}ll@{}}
+\begin{tabular}{@{}lll@{}}
 \toprule
-Marathi & English \\
+Marathi & Say it & English \\
 \midrule
-\mr{तुम्ही कसे आहात?} & How are you? \\
-\mr{मी बरा आहे, धन्यवाद.} & I'm well, thank you. \\
-\mr{काही हरकत नाही.} & No problem / you're welcome. \\
+\mr{तुम्ही कसे आहात?} & \emph{tumhī kase āhāt?} & How are you? \\
+\mr{मी बरा आहे, धन्यवाद.} & \emph{mī barā āhe, dhanyavād.} & I'm well, thank you. \\
+\mr{काही हरकत नाही.} & \emph{kāhī harkat nāhī.} & No problem / you're welcome. \\
 \bottomrule
 \end{tabular}
 \end{center}

--- a/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
@@ -81,16 +81,16 @@ The respectful \mr{घ्या} (\emph{ghy\=a}) matches \emph{tumh\=\i}; to a f
 \label{lesson:MR-C04-practice}
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-Marathi & Say it & English \\
+\textbf{Marathi} & \textbf{Say it} & \textbf{English} \\
 \midrule
 \mr{येतो} / \mr{येते.} & \emph{yeto / yete.} & I'll be going. (``come again'') \\
 \mr{पुन्हा भेटू.} & \emph{punhā bheṭū.} & See you again. \\
 \mr{उद्या भेटू.} & \emph{udyā bheṭū.} & See you tomorrow. \\
 \mr{काळजी घ्या.} & \emph{kāḷjī ghyā.} & Take care. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 Roots banked: \emph{punh\=a} (\emph{punar} ``again''), \emph{bhe\d{t}\d{n}e}

--- a/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
@@ -81,14 +81,14 @@ The respectful \mr{घ्या} (\emph{ghy\=a}) matches \emph{tumh\=\i}; to a f
 \label{lesson:MR-C04-practice}
 
 \begin{center}
-\begin{tabular}{@{}ll@{}}
+\begin{tabular}{@{}lll@{}}
 \toprule
-Marathi & English \\
+Marathi & Say it & English \\
 \midrule
-\mr{येतो} / \mr{येते.} & I'll be going. (``come again'') \\
-\mr{पुन्हा भेटू.} & See you again. \\
-\mr{उद्या भेटू.} & See you tomorrow. \\
-\mr{काळजी घ्या.} & Take care. \\
+\mr{येतो} / \mr{येते.} & \emph{yeto / yete.} & I'll be going. (``come again'') \\
+\mr{पुन्हा भेटू.} & \emph{punhā bheṭū.} & See you again. \\
+\mr{उद्या भेटू.} & \emph{udyā bheṭū.} & See you tomorrow. \\
+\mr{काळजी घ्या.} & \emph{kāḷjī ghyā.} & Take care. \\
 \bottomrule
 \end{tabular}
 \end{center}

--- a/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
@@ -77,15 +77,15 @@ k\=am karto/karte} (``I work'').
 \label{lesson:MR-C05-practice}
 
 \begin{center}
-\begin{tabular}{@{}lll@{}}
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-Marathi & Say it & English \\
+\textbf{Marathi} & \textbf{Say it} & \textbf{English} \\
 \midrule
 \mr{मी मराठी बोलतो / बोलते.} & \emph{mī marāṭhī bolto / bolte.} & I speak Marathi. \\
 \mr{मी पुण्यात राहतो / राहते.} & \emph{mī puṇyāt rāhto / rāhte.} & I live in Pune. \\
 \mr{मी काम करतो / करते.} & \emph{mī kām karto / karte.} & I work. \\
 \bottomrule
-\end{tabular}
+\end{tabularx}
 \end{center}
 
 One engine: an infinitive in \emph{-\d{n}e}; a present of stem $+$ a

--- a/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
@@ -77,13 +77,13 @@ k\=am karto/karte} (``I work'').
 \label{lesson:MR-C05-practice}
 
 \begin{center}
-\begin{tabular}{@{}ll@{}}
+\begin{tabular}{@{}lll@{}}
 \toprule
-Marathi & English \\
+Marathi & Say it & English \\
 \midrule
-\mr{मी मराठी बोलतो / बोलते.} & I speak Marathi. \\
-\mr{मी पुण्यात राहतो / राहते.} & I live in Pune. \\
-\mr{मी काम करतो / करते.} & I work. \\
+\mr{मी मराठी बोलतो / बोलते.} & \emph{mī marāṭhī bolto / bolte.} & I speak Marathi. \\
+\mr{मी पुण्यात राहतो / राहते.} & \emph{mī puṇyāt rāhto / rāhte.} & I live in Pune. \\
+\mr{मी काम करतो / करते.} & \emph{mī kām karto / karte.} & I work. \\
 \bottomrule
 \end{tabular}
 \end{center}

--- a/code/learning/human-languages/marathi/book/chapters/ch10-request-food-drink.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch10-request-food-drink.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:0e4c84edabf68889
+% canonical-source-hash: fnv1a64:cf2a8dd578f13505
 % canonical-lessons: MR-C10-paani, MR-C10-chaha, MR-C10-dudh, MR-C10-bhakari
 
 \chapter{Water, Tea, Milk, and Bhakri}
@@ -62,7 +62,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%A4\%AA\%E0\%A4\%BE\%E0\%A4\%
 
 
 \begin{quote}
-\textbf{\mr{पाणी}, \mr{कृपया}} — water, please. Say it once more, then ask for something that is not water at all.
+\textbf{\mr{पाणी}, \mr{कृपया}} (\emph{pāṇī, kṛpayā}) — water, please. Say it once more, then ask for something that is not water at all.
 \end{quote}
 
 \subsection*{You'll want to know: \mr{चहा}}

--- a/code/learning/human-languages/marathi/book/chapters/ch11-friend-and-family.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch11-friend-and-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:101115eb3db6665b
+% canonical-source-hash: fnv1a64:81d9b964581c9a85
 % canonical-lessons: MR-C11-mitra, MR-C11-kutumb, MR-C11-bhau, MR-C11-bahin
 
 \chapter{Friend and Family}
@@ -60,7 +60,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%A4\%AE\%E0\%A4\%BF\%E0\%A4\%
 
 
 \begin{quote}
-\textbf{\mr{मित्र}} was taken up whole from Sanskrit, not worn down. This next word was too — and it names the group your friend belongs to as well.
+\textbf{\mr{मित्र}} (\emph{mitra}) was taken up whole from Sanskrit, not worn down. This next word was too — and it names the group your friend belongs to as well.
 \end{quote}
 
 \subsection*{You'll want to know: \mr{कुटुंब}}
@@ -156,8 +156,8 @@ Nothing new. \textbf{\mr{ब}} from \emph{baraṃ}, \textbf{\mr{ह}} from \emph
 \toprule
 \textbf{word} & \textbf{kind} & \textbf{route} \\
 \midrule
-\mr{मित्र}, \mr{कुटुंब} & tatsama & taken up whole from Sanskrit \\
-\mr{भाऊ}, \mr{बहीण} & tadbhava & worn down by Prakrit sound change \\
+\mr{मित्र}, \mr{कुटुंब} (\emph{mitra, kuṭumb}) & tatsama & taken up whole from Sanskrit \\
+\mr{भाऊ}, \mr{बहीण} (\emph{bhāū, bahīṇ}) & tadbhava & worn down by Prakrit sound change \\
 \bottomrule
 \end{tabularx}
 

--- a/code/learning/human-languages/marathi/book/chapters/ch12-face-parts.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch12-face-parts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:53b43a3f45294871
+% canonical-source-hash: fnv1a64:556c8f23ff12cd7f
 % canonical-lessons: MR-C12-dola, MR-C12-kaan, MR-C12-tond, MR-C12-naak
 
 \chapter{Eye, Ear, Mouth, and Nose}
@@ -19,7 +19,7 @@ The chapter closes on \mr{नाक}, completing the face: the reader produces \
 
 
 \begin{quote}
-\textbf{\mr{मित्र}, \mr{कुटुंब}, \mr{भाऊ}, \mr{बहीण}} — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is.
+\textbf{\mr{मित्र}, \mr{कुटुंब}, \mr{भाऊ}, \mr{बहीण}} (\emph{mitra, kuṭumb, bhāū, bahīṇ}) — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is.
 \end{quote}
 
 \subsection*{You'll want to know: \mr{डोळा}}
@@ -56,7 +56,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%A4\%A1\%E0\%A5\%8B\%E0\%A4\%
 
 
 \begin{quote}
-\textbf{\mr{डोळा}}'s own root turned out to be a surprise — a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler.
+\textbf{\mr{डोळा}} (\emph{ḍoḷā}) — its own root turned out to be a surprise, a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler.
 \end{quote}
 
 \subsection*{You'll want to know: \mr{कान}}
@@ -130,7 +130,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%A4\%A4\%E0\%A5\%8B\%E0\%A4\%
 
 
 \begin{quote}
-\textbf{\mr{डोळा}, \mr{कान}, \mr{तोंड}} — say them. One face part left, and it is the one with the plainest history of the four.
+\textbf{\mr{डोळा}, \mr{कान}, \mr{तोंड}} (\emph{ḍoḷā, kān, tõḍ}) — say them. One face part left, and it is the one with the plainest history of the four.
 \end{quote}
 
 \subsection*{You'll want to know: \mr{नाक}}

--- a/code/learning/human-languages/marathi/lessons/MR-C02-majhe-naav-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-majhe-naav-aahe.md
@@ -22,7 +22,7 @@ sentence about yourself.
 ## The phrase, assembled
 
 **माझं** (*mājhaṁ*, my) + **नाव** (*nāv*, name) + **[your name]** + **आहे**
-(*āhe*, is) → **माझं नाव मीरा आहे** (*mājhaṁ nāv Mira āhe*) — "my name is Mira."
+(*āhe*, is) → **माझं नाव मीरा आहे** (*mājhaṁ nāv Mīrā āhe*) — "my name is Mira."
 
 Notice the shape:
 - **माझं** is neuter, agreeing with the neuter **नाव**.
@@ -40,7 +40,7 @@ fact about yourself.
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: "mājhaṁ nāv Mira āhe" — my name is Mira]
+- [YOU SAY: "mājhaṁ nāv Mīrā āhe" — my name is Mira]
 - [YOU SAY: it with your own name in the blank]
 
 ## Wrap-up Recall

--- a/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-practice.md
@@ -20,12 +20,12 @@ reviews_of: [MR-C02-naav, MR-C02-majhe, MR-C02-aahe, MR-C02-majhe-naav-aahe, MR-
 
 ## The whole exchange
 
-| Marathi | English |
-|---|---|
-| माझं नाव मीरा आहे. | My name is Mira. |
-| तुमचं नाव काय आहे? | What's your name? |
-| माझं नाव अरुण आहे. | My name is Arun. |
-| भेटून आनंद झाला. | Pleased to meet you. |
+| Marathi | Say it | English |
+|---|---|---|
+| माझं नाव मीरा आहे. | *mājhaṁ nāv Mīrā āhe.* | My name is Mira. |
+| तुमचं नाव काय आहे? | *tumchaṁ nāv kāy āhe?* | What's your name? |
+| माझं नाव अरुण आहे. | *mājhaṁ nāv Aruṇ āhe.* | My name is Arun. |
+| भेटून आनंद झाला. | *bheṭūn ānand jhālā.* | Pleased to meet you. |
 
 ## Atoms banked this chapter
 

--- a/code/learning/human-languages/marathi/lessons/MR-C02-tumche-naav-kaay-aahe.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C02-tumche-naav-kaay-aahe.md
@@ -29,7 +29,8 @@ The "your" mirrors the "my" set you learned:
 - **तुमचं** (*tumchaṁ*) — your (respectful, from *tumhī*)
 - **तुझं** (*tujhaṁ*) — your (familiar, from *tū*)
 
-All three are shown here in the neuter, agreeing with the neuter **नाव**.
+All three are shown here in the neuter, agreeing with the neuter **नाव**
+(*nāv*).
 
 ## Why it's said this way
 

--- a/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C03-practice.md
@@ -20,11 +20,11 @@ reviews_of: [MR-C03-kasa, MR-C03-tumhi-kase-aahat, MR-C03-mi, MR-C03-mi-bara-aah
 
 ## The whole exchange
 
-| Marathi | English |
-|---|---|
-| तुम्ही कसे आहात? | How are you? |
-| मी बरा आहे, धन्यवाद. | I'm well, thank you. |
-| काही हरकत नाही. | No problem / you're welcome. |
+| Marathi | Say it | English |
+|---|---|---|
+| तुम्ही कसे आहात? | *tumhī kase āhāt?* | How are you? |
+| मी बरा आहे, धन्यवाद. | *mī barā āhe, dhanyavād.* | I'm well, thank you. |
+| काही हरकत नाही. | *kāhī harkat nāhī.* | No problem / you're welcome. |
 
 ## Atoms banked this chapter
 
@@ -34,7 +34,8 @@ reviews_of: [MR-C03-kasa, MR-C03-tumhi-kase-aahat, MR-C03-mi, MR-C03-mi-bara-aah
 - **बरा / बरी / बरं** (*barā/barī/baraṁ*) — well/fine, now gendered.
 - **काही हरकत नाही** (*kāhī harkat nāhī*) — no problem; *nāhī* ← PIE *\*ne*,
   *harkat* ← Arabic.
-- Copula forms: **मी आहे / तू आहेस / तुम्ही आहात** — one verb, reshaped per person.
+- Copula forms: **मी आहे / तू आहेस / तुम्ही आहात** (*mī āhe / tū āhes / tumhī
+  āhāt*) — one verb, reshaped per person.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C04-practice.md
@@ -20,12 +20,12 @@ reviews_of: [MR-C04-punha, MR-C04-bhetu, MR-C04-punha-bhetu, MR-C04-udya-bhetu, 
 
 ## The farewells
 
-| Marathi | English |
-|---|---|
-| येतो / येते. | I'll be going. ("I come again") |
-| पुन्हा भेटू. | See you again. |
-| उद्या भेटू. | See you tomorrow. |
-| काळजी घ्या. | Take care. |
+| Marathi | Say it | English |
+|---|---|---|
+| येतो / येते. | *yeto / yete.* | I'll be going. ("I come again") |
+| पुन्हा भेटू. | *punhā bheṭū.* | See you again. |
+| उद्या भेटू. | *udyā bheṭū.* | See you tomorrow. |
+| काळजी घ्या. | *kāḷjī ghyā.* | Take care. |
 
 ## Atoms banked this chapter
 

--- a/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C05-practice.md
@@ -20,11 +20,11 @@ reviews_of: [MR-C05-bolne, MR-C05-mi-marathi-bolto, MR-C05-rahne, MR-C05-kaam-ka
 
 ## Sentences about yourself
 
-| Marathi | English |
-|---|---|
-| मी मराठी बोलतो / बोलते. | I speak Marathi. |
-| मी पुण्यात राहतो / राहते. | I live in Pune. |
-| मी काम करतो / करते. | I work. |
+| Marathi | Say it | English |
+|---|---|---|
+| मी मराठी बोलतो / बोलते. | *mī marāṭhī bolto / bolte.* | I speak Marathi. |
+| मी पुण्यात राहतो / राहते. | *mī puṇyāt rāhto / rāhte.* | I live in Pune. |
+| मी काम करतो / करते. | *mī kām karto / karte.* | I work. |
 
 ## The engine, in one look
 

--- a/code/learning/human-languages/marathi/lessons/MR-C10-chaha.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C10-chaha.md
@@ -34,7 +34,8 @@ reviews_of: [MR-C10-paani]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-PAANI, MR-PHRASE-KRUPAYA] -->
 
-[PAUSE 2s] **पाणी, कृपया** — water, please. Say it once more, then ask for
+[PAUSE 2s] **पाणी, कृपया** (*pāṇī, kṛpayā*) — water, please. Say it once more,
+then ask for
 something that is not water at all.
 
 ## You'll want to know: चहा

--- a/code/learning/human-languages/marathi/lessons/MR-C11-bahin.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C11-bahin.md
@@ -65,8 +65,8 @@ perfectly are, underneath, unrelated.
 
 | word | kind | route |
 |---|---|---|
-| मित्र, कुटुंब | tatsama | taken up whole from Sanskrit |
-| भाऊ, बहीण | tadbhava | worn down by Prakrit sound change |
+| मित्र, कुटुंब (*mitra, kuṭumb*) | tatsama | taken up whole from Sanskrit |
+| भाऊ, बहीण (*bhāū, bahīṇ*) | tadbhava | worn down by Prakrit sound change |
 
 Notice, too, how each pair *looks*: **मित्र** and **कुटुंब** carry conjuncts
 and marks a learner has to stop for; **भाऊ** and **बहीण** do not — plain

--- a/code/learning/human-languages/marathi/lessons/MR-C11-kutumb.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C11-kutumb.md
@@ -34,7 +34,8 @@ reviews_of: [MR-C11-mitra]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-MITRA, MR-GRAMMAR-TATSAMA-BORROWING] -->
 
-[PAUSE 2s] **मित्र** was taken up whole from Sanskrit, not worn down. This
+[PAUSE 2s] **मित्र** (*mitra*) was taken up whole from Sanskrit, not worn down.
+This
 next word was too — and it names the group your friend belongs to as well.
 
 ## You'll want to know: कुटुंब

--- a/code/learning/human-languages/marathi/lessons/MR-C12-dola.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C12-dola.md
@@ -34,7 +34,8 @@ reviews_of: [MR-C11-bahin, MR-C11-bhau, MR-C07-pahne]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-BAHIN, MR-LEX-BHAU] -->
 
-[PAUSE 2s] **मित्र, कुटुंब, भाऊ, बहीण** — the people you'd introduce. This
+[PAUSE 2s] **मित्र, कुटुंब, भाऊ, बहीण** (*mitra, kuṭumb, bhāū, bahīṇ*) — the
+people you'd introduce. This
 chapter turns to the body you'd ask after when you check how someone is.
 
 ## You'll want to know: डोळा

--- a/code/learning/human-languages/marathi/lessons/MR-C12-kaan.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C12-kaan.md
@@ -34,7 +34,8 @@ reviews_of: [MR-C12-dola, MR-C06-number-differences]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-DOLA, MR-SCRIPT-RETROFLEX-LA] -->
 
-[PAUSE 2s] **डोळा**'s own root turned out to be a surprise — a swing, not the
+[PAUSE 2s] **डोळा** (*ḍoḷā*) — its own root turned out to be a surprise, a
+swing, not the
 old eye-word. This next word has a different kind of surprise: not what it
 meant, but how its middle got simpler.
 

--- a/code/learning/human-languages/marathi/lessons/MR-C12-naak.md
+++ b/code/learning/human-languages/marathi/lessons/MR-C12-naak.md
@@ -34,7 +34,8 @@ reviews_of: [MR-C12-tond, MR-C12-kaan, MR-C12-dola, MR-C07-pahne]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[MR-LEX-DOLA, MR-LEX-KAAN, MR-LEX-TOND] -->
 
-[PAUSE 2s] **डोळा, कान, तोंड** — say them. One face part left, and it is the
+[PAUSE 2s] **डोळा, कान, तोंड** (*ḍoḷā, kān, tõḍ*) — say them. One face part
+left, and it is the
 one with the plainest history of the four.
 
 ## You'll want to know: नाक

--- a/code/learning/human-languages/marathi/narration/ch02.json
+++ b/code/learning/human-languages/marathi/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:d7d34ac586baf0bb",
+  "sourceHash": "fnv1a64:76482a70a494ffaa",
   "lessons": [
     {
       "id": "MR-C02-aahe",
@@ -510,7 +510,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:151eaa22ab083bf1",
+      "sourceHash": "fnv1a64:8d27ba5b3b1cc3b1",
       "notice": null,
       "blocks": [
         {
@@ -537,7 +537,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "माझं (mājhaṁ, my) + नाव (nāv, name) + [your name] + आहे (āhe, is) becomes माझं नाव मीरा आहे (mājhaṁ nāv Mira āhe) — \"my name is Mira.\""
+              "text": "माझं (mājhaṁ, my) + नाव (nāv, name) + [your name] + आहे (āhe, is) becomes माझं नाव मीरा आहे (mājhaṁ nāv Mīrā āhe) — \"my name is Mira.\""
             },
             {
               "kind": "speech",
@@ -582,11 +582,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"mājhaṁ nāv Mira āhe\" — my name is Mira",
+              "instruction": "\"mājhaṁ nāv Mīrā āhe\" — my name is Mira",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"mājhaṁ nāv Mira āhe\" — my name is Mira]"
+              "source": "[YOU SAY: \"mājhaṁ nāv Mīrā āhe\" — my name is Mira]"
             },
             {
               "kind": "prompt",
@@ -756,7 +756,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dc477000accbb398",
+      "sourceHash": "fnv1a64:fb1c703edb1e5e9e",
       "notice": null,
       "blocks": [
         {
@@ -785,15 +785,16 @@
               "kind": "table",
               "headers": [
                 "Marathi",
+                "Say it",
                 "English"
               ],
-              "columns": 2,
+              "columns": 3,
               "rowCount": 4,
               "utterances": [
-                "माझं नाव मीरा आहे. means My name is Mira.",
-                "तुमचं नाव काय आहे? means What's your name?",
-                "माझं नाव अरुण आहे. means My name is Arun.",
-                "भेटून आनंद झाला. means Pleased to meet you."
+                "Marathi: माझं नाव मीरा आहे. Say it: mājhaṁ nāv Mīrā āhe. English: My name is Mira.",
+                "Marathi: तुमचं नाव काय आहे? Say it: tumchaṁ nāv kāy āhe? English: What's your name?",
+                "Marathi: माझं नाव अरुण आहे. Say it: mājhaṁ nāv Aruṇ āhe. English: My name is Arun.",
+                "Marathi: भेटून आनंद झाला. Say it: bheṭūn ānand jhālā. English: Pleased to meet you."
               ]
             }
           ]
@@ -1025,7 +1026,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7762eea32e74fd3b",
+      "sourceHash": "fnv1a64:ccc4ebc2a946857f",
       "notice": null,
       "blocks": [
         {
@@ -1072,7 +1073,7 @@
             },
             {
               "kind": "speech",
-              "text": "All three are shown here in the neuter, agreeing with the neuter नाव."
+              "text": "All three are shown here in the neuter, agreeing with the neuter नाव (nāv)."
             }
           ]
         },

--- a/code/learning/human-languages/marathi/narration/ch02.txt
+++ b/code/learning/human-languages/marathi/narration/ch02.txt
@@ -128,7 +128,7 @@ Warm-up.
 Now assemble the three atoms you just met into your first full sentence about yourself.
 
 The phrase, assembled.
-माझं (mājhaṁ, my) + नाव (nāv, name) + [your name] + आहे (āhe, is) becomes माझं नाव मीरा आहे (mājhaṁ nāv Mira āhe) — "my name is Mira."
+माझं (mājhaṁ, my) + नाव (nāv, name) + [your name] + आहे (āhe, is) becomes माझं नाव मीरा आहे (mājhaṁ nāv Mīrā āhe) — "my name is Mira."
 Notice the shape:
 माझं is neuter, agreeing with the neuter नाव.
 The verb आहे comes last — "my name Mira is."
@@ -139,7 +139,7 @@ Marathi drops nothing and reorders everything to English eyes: possessor, thing,
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: "mājhaṁ nāv Mira āhe" — my name is Mira]
+[your turn — say: "mājhaṁ nāv Mīrā āhe" — my name is Mira]
 [pause 8 seconds for the answer]
 [your turn — say: it with your own name in the blank]
 [pause 8 seconds for the answer]
@@ -188,10 +188,10 @@ Run the whole first exchange, atom by atom, then whole.
 
 The whole exchange.
 [a table of 4 rows, read aloud]
-माझं नाव मीरा आहे. means My name is Mira.
-तुमचं नाव काय आहे? means What's your name?
-माझं नाव अरुण आहे. means My name is Arun.
-भेटून आनंद झाला. means Pleased to meet you.
+Marathi: माझं नाव मीरा आहे. Say it: mājhaṁ nāv Mīrā āhe. English: My name is Mira.
+Marathi: तुमचं नाव काय आहे? Say it: tumchaṁ nāv kāy āhe? English: What's your name?
+Marathi: माझं नाव अरुण आहे. Say it: mājhaṁ nāv Aruṇ āhe. English: My name is Arun.
+Marathi: भेटून आनंद झाला. Say it: bheṭūn ānand jhālā. English: Pleased to meet you.
 
 Atoms banked this chapter.
 नाव (nāv) — name; Sanskrit nāman becomes English name (the m softened to v in Marathi).
@@ -258,7 +258,7 @@ The "your" mirrors the "my" set you learned:
 माझं (mājhaṁ) — my.
 तुमचं (tumchaṁ) — your (respectful, from tumhī).
 तुझं (tujhaṁ) — your (familiar, from tū).
-All three are shown here in the neuter, agreeing with the neuter नाव.
+All three are shown here in the neuter, agreeing with the neuter नाव (nāv).
 
 Why it's said this way.
 To a friend you would say तुझं नाव काय आहे? (tujhaṁ nāv kāy āhe?), swapping the respectful tumchaṁ for the familiar tujhaṁ — the same tū / tumhī choice of respect, now on the possessive.

--- a/code/learning/human-languages/marathi/narration/ch03.json
+++ b/code/learning/human-languages/marathi/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:4698352cdd6ad6ca",
+  "sourceHash": "fnv1a64:b3107d9fc5cfb536",
   "lessons": [
     {
       "id": "MR-C03-kaahi-harkat-nahi",
@@ -534,7 +534,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:eb7818167410db6b",
+      "sourceHash": "fnv1a64:70dd374d59aaf09d",
       "notice": null,
       "blocks": [
         {
@@ -563,14 +563,15 @@
               "kind": "table",
               "headers": [
                 "Marathi",
+                "Say it",
                 "English"
               ],
-              "columns": 2,
+              "columns": 3,
               "rowCount": 3,
               "utterances": [
-                "तुम्ही कसे आहात? means How are you?",
-                "मी बरा आहे, धन्यवाद. means I'm well, thank you.",
-                "काही हरकत नाही. means No problem / you're welcome."
+                "Marathi: तुम्ही कसे आहात? Say it: tumhī kase āhāt? English: How are you?",
+                "Marathi: मी बरा आहे, धन्यवाद. Say it: mī barā āhe, dhanyavād. English: I'm well, thank you.",
+                "Marathi: काही हरकत नाही. Say it: kāhī harkat nāhī. English: No problem / you're welcome."
               ]
             }
           ]
@@ -598,7 +599,7 @@
             },
             {
               "kind": "speech",
-              "text": "Copula forms: मी आहे / तू आहेस / तुम्ही आहात — one verb, reshaped per person."
+              "text": "Copula forms: मी आहे / तू आहेस / तुम्ही आहात (mī āhe / tū āhes / tumhī āhāt) — one verb, reshaped per person."
             }
           ]
         },

--- a/code/learning/human-languages/marathi/narration/ch03.txt
+++ b/code/learning/human-languages/marathi/narration/ch03.txt
@@ -135,16 +135,16 @@ The whole everyday exchange, start to finish.
 
 The whole exchange.
 [a table of 3 rows, read aloud]
-तुम्ही कसे आहात? means How are you?
-मी बरा आहे, धन्यवाद. means I'm well, thank you.
-काही हरकत नाही. means No problem / you're welcome.
+Marathi: तुम्ही कसे आहात? Say it: tumhī kase āhāt? English: How are you?
+Marathi: मी बरा आहे, धन्यवाद. Say it: mī barā āhe, dhanyavād. English: I'm well, thank you.
+Marathi: काही हरकत नाही. Say it: kāhī harkat nāhī. English: No problem / you're welcome.
 
 Atoms banked this chapter.
 कसा / कशी / कसं (kasā/kaśī/kasaṁ) — how; the k- question family, gender-agreeing.
 मी (mī) — I; Sanskrit aham becomes Latin ego, English I.
 बरा / बरी / बरं (barā/barī/baraṁ) — well/fine, now gendered.
 काही हरकत नाही (kāhī harkat nāhī) — no problem; nāhī from PIE ne, harkat from Arabic.
-Copula forms: मी आहे / तू आहेस / तुम्ही आहात — one verb, reshaped per person.
+Copula forms: मी आहे / तू आहेस / तुम्ही आहात (mī āhe / tū āhes / tumhī āhāt) — one verb, reshaped per person.
 
 Guided Practice.
 [pause 1 second]

--- a/code/learning/human-languages/marathi/narration/ch04.json
+++ b/code/learning/human-languages/marathi/narration/ch04.json
@@ -4,7 +4,7 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:698a7e2e82e9ad58",
+  "sourceHash": "fnv1a64:58a4518fd27913b8",
   "lessons": [
     {
       "id": "MR-C04-bhetu",
@@ -269,7 +269,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b2f49ee8ecb088f8",
+      "sourceHash": "fnv1a64:b3595cc3593d4eb2",
       "notice": null,
       "blocks": [
         {
@@ -298,15 +298,16 @@
               "kind": "table",
               "headers": [
                 "Marathi",
+                "Say it",
                 "English"
               ],
-              "columns": 2,
+              "columns": 3,
               "rowCount": 4,
               "utterances": [
-                "येतो / येते. means I'll be going. (\"I come again\").",
-                "पुन्हा भेटू. means See you again.",
-                "उद्या भेटू. means See you tomorrow.",
-                "काळजी घ्या. means Take care."
+                "Marathi: येतो / येते. Say it: yeto / yete. English: I'll be going. (\"I come again\").",
+                "Marathi: पुन्हा भेटू. Say it: punhā bheṭū. English: See you again.",
+                "Marathi: उद्या भेटू. Say it: udyā bheṭū. English: See you tomorrow.",
+                "Marathi: काळजी घ्या. Say it: kāḷjī ghyā. English: Take care."
               ]
             }
           ]

--- a/code/learning/human-languages/marathi/narration/ch04.txt
+++ b/code/learning/human-languages/marathi/narration/ch04.txt
@@ -71,10 +71,10 @@ The parting words, together — none of them a bare "goodbye."
 
 The farewells.
 [a table of 4 rows, read aloud]
-येतो / येते. means I'll be going. ("I come again").
-पुन्हा भेटू. means See you again.
-उद्या भेटू. means See you tomorrow.
-काळजी घ्या. means Take care.
+Marathi: येतो / येते. Say it: yeto / yete. English: I'll be going. ("I come again").
+Marathi: पुन्हा भेटू. Say it: punhā bheṭū. English: See you again.
+Marathi: उद्या भेटू. Say it: udyā bheṭū. English: See you tomorrow.
+Marathi: काळजी घ्या. Say it: kāḷjī ghyā. English: Take care.
 
 Atoms banked this chapter.
 पुन्हा (punhā) — again; Sanskrit punar.

--- a/code/learning/human-languages/marathi/narration/ch05.json
+++ b/code/learning/human-languages/marathi/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:03f79a98594f4da1",
+  "sourceHash": "fnv1a64:2c216f7d781a9d9b",
   "lessons": [
     {
       "id": "MR-C05-bolne",
@@ -405,7 +405,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:360f39186883773c",
+      "sourceHash": "fnv1a64:73fed83793c9bc8c",
       "notice": null,
       "blocks": [
         {
@@ -434,14 +434,15 @@
               "kind": "table",
               "headers": [
                 "Marathi",
+                "Say it",
                 "English"
               ],
-              "columns": 2,
+              "columns": 3,
               "rowCount": 3,
               "utterances": [
-                "मी मराठी बोलतो / बोलते. means I speak Marathi.",
-                "मी पुण्यात राहतो / राहते. means I live in Pune.",
-                "मी काम करतो / करते. means I work."
+                "Marathi: मी मराठी बोलतो / बोलते. Say it: mī marāṭhī bolto / bolte. English: I speak Marathi.",
+                "Marathi: मी पुण्यात राहतो / राहते. Say it: mī puṇyāt rāhto / rāhte. English: I live in Pune.",
+                "Marathi: मी काम करतो / करते. Say it: mī kām karto / karte. English: I work."
               ]
             }
           ]

--- a/code/learning/human-languages/marathi/narration/ch05.txt
+++ b/code/learning/human-languages/marathi/narration/ch05.txt
@@ -104,9 +104,9 @@ Three verbs, one engine — sentences about yourself.
 
 Sentences about yourself.
 [a table of 3 rows, read aloud]
-मी मराठी बोलतो / बोलते. means I speak Marathi.
-मी पुण्यात राहतो / राहते. means I live in Pune.
-मी काम करतो / करते. means I work.
+Marathi: मी मराठी बोलतो / बोलते. Say it: mī marāṭhī bolto / bolte. English: I speak Marathi.
+Marathi: मी पुण्यात राहतो / राहते. Say it: mī puṇyāt rāhto / rāhte. English: I live in Pune.
+Marathi: मी काम करतो / करते. Say it: mī kām karto / karte. English: I work.
 
 The engine, in one look.
 Infinitive ends in -णे (-ṇe): bolṇe, rāhṇe, karṇe.

--- a/code/learning/human-languages/marathi/narration/ch10.json
+++ b/code/learning/human-languages/marathi/narration/ch10.json
@@ -4,7 +4,7 @@
   "chapter": 10,
   "title": "Water, Tea, Milk, and Bhakri",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:507c5abe2c6c17d2",
+  "sourceHash": "fnv1a64:8f01d3226aec18e1",
   "lessons": [
     {
       "id": "MR-C10-paani",
@@ -172,7 +172,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f3e23b1f18f70d7b",
+      "sourceHash": "fnv1a64:77a677b7040d48c7",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -197,7 +197,7 @@
             },
             {
               "kind": "speech",
-              "text": "पाणी (pāṇī), कृपया — water, please. Say it once more, then ask for something that is not water at all."
+              "text": "पाणी, कृपया (pāṇī, kṛpayā) — water, please. Say it once more, then ask for something that is not water at all."
             }
           ]
         },

--- a/code/learning/human-languages/marathi/narration/ch10.txt
+++ b/code/learning/human-languages/marathi/narration/ch10.txt
@@ -46,7 +46,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-पाणी (pāṇī), कृपया — water, please. Say it once more, then ask for something that is not water at all.
+पाणी, कृपया (pāṇī, kṛpayā) — water, please. Say it once more, then ask for something that is not water at all.
 
 You'll want to know: चहा.
 चहा — chahā — tea.

--- a/code/learning/human-languages/marathi/narration/ch11.json
+++ b/code/learning/human-languages/marathi/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Friend and Family",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:bc272c6f569ea8c9",
+  "sourceHash": "fnv1a64:610b366c32d81a38",
   "lessons": [
     {
       "id": "MR-C11-mitra",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b132b3080165bb37",
+      "sourceHash": "fnv1a64:e9c3e5e20a44ff01",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -482,7 +482,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bc4a5ecff53ff890",
+      "sourceHash": "fnv1a64:b11d2c0417823984",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -559,8 +559,8 @@
               "columns": 3,
               "rowCount": 2,
               "utterances": [
-                "word: मित्र (mitra), कुटुंब (kuṭumb). kind: tatsama. route: taken up whole from Sanskrit.",
-                "word: भाऊ (bhāū), बहीण (bahīṇ). kind: tadbhava. route: worn down by Prakrit sound change."
+                "word: मित्र, कुटुंब (mitra, kuṭumb). kind: tatsama. route: taken up whole from Sanskrit.",
+                "word: भाऊ, बहीण (bhāū, bahīṇ). kind: tadbhava. route: worn down by Prakrit sound change."
               ]
             },
             {

--- a/code/learning/human-languages/marathi/narration/ch11.txt
+++ b/code/learning/human-languages/marathi/narration/ch11.txt
@@ -133,8 +133,8 @@ The word, taken apart — not sister's cousin.
 
 Grammar Lens: the chapter's whole shape, in two pairs.
 [a table of 2 rows, read aloud]
-word: मित्र (mitra), कुटुंब (kuṭumb). kind: tatsama. route: taken up whole from Sanskrit.
-word: भाऊ (bhāū), बहीण (bahīṇ). kind: tadbhava. route: worn down by Prakrit sound change.
+word: मित्र, कुटुंब (mitra, kuṭumb). kind: tatsama. route: taken up whole from Sanskrit.
+word: भाऊ, बहीण (bhāū, bahīṇ). kind: tadbhava. route: worn down by Prakrit sound change.
 Notice, too, how each pair looks: मित्र (mitra) and कुटुंब (kuṭumb) carry conjuncts and marks a learner has to stop for; भाऊ (bhāū) and बहीण (bahīṇ) do not — plain consonants and vowels, the shape sound change tends to leave behind. And of the tadbhava pair, only भाऊ (bhāū) is a secure English cousin; बहीण (bahīṇ) is not.
 
 Guided Practice.

--- a/code/learning/human-languages/marathi/narration/ch12.json
+++ b/code/learning/human-languages/marathi/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Eye, Ear, Mouth, and Nose",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6aa24870cb193793",
+  "sourceHash": "fnv1a64:67dc331760170c58",
   "lessons": [
     {
       "id": "MR-C12-dola",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:316673ce1d6b6d28",
+      "sourceHash": "fnv1a64:ed891e7565994bd2",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "मित्र, कुटुंब, भाऊ, बहीण — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is."
+              "text": "मित्र, कुटुंब, भाऊ, बहीण (mitra, kuṭumb, bhāū, bahīṇ) — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is."
             }
           ]
         },
@@ -175,7 +175,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:441ee4d94874fd25",
+      "sourceHash": "fnv1a64:545dd0be7cf4e68d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -201,7 +201,7 @@
             },
             {
               "kind": "speech",
-              "text": "डोळा (ḍoḷā)'s own root turned out to be a surprise — a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler."
+              "text": "डोळा (ḍoḷā) — its own root turned out to be a surprise, a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler."
             }
           ]
         },
@@ -463,7 +463,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:11066afc3792d53d",
+      "sourceHash": "fnv1a64:a983124140410927",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -488,7 +488,7 @@
             },
             {
               "kind": "speech",
-              "text": "डोळा (ḍoḷā), कान (kān), तोंड (tõḍ) — say them. One face part left, and it is the one with the plainest history of the four."
+              "text": "डोळा, कान, तोंड (ḍoḷā, kān, tõḍ) — say them. One face part left, and it is the one with the plainest history of the four."
             }
           ]
         },

--- a/code/learning/human-languages/marathi/narration/ch12.txt
+++ b/code/learning/human-languages/marathi/narration/ch12.txt
@@ -9,7 +9,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-मित्र, कुटुंब, भाऊ, बहीण — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is.
+मित्र, कुटुंब, भाऊ, बहीण (mitra, kuṭumb, bhāū, bahīṇ) — the people you'd introduce. This chapter turns to the body you'd ask after when you check how someone is.
 
 You'll want to know: डोळा.
 डोळा — ḍoḷā — eye (masculine).
@@ -46,7 +46,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-डोळा (ḍoḷā)'s own root turned out to be a surprise — a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler.
+डोळा (ḍoḷā) — its own root turned out to be a surprise, a swing, not the old eye-word. This next word has a different kind of surprise: not what it meant, but how its middle got simpler.
 
 You'll want to know: कान.
 कान — kān — ear (masculine).
@@ -114,7 +114,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-डोळा (ḍoḷā), कान (kān), तोंड (tõḍ) — say them. One face part left, and it is the one with the plainest history of the four.
+डोळा, कान, तोंड (ḍoḷā, kān, tõḍ) — say them. One face part left, and it is the one with the plainest history of the four.
 
 You'll want to know: नाक.
 नाक — nāk — nose (neuter).


### PR DESCRIPTION
Twelve lessons and four hand-written book chapters. Marathi's genuinely-bare untaught glyph pairs fall **57 → 9**, and the nine that remain are section *headings* whose body romanizes the word immediately below — romanizing those would rename book sections for no reader gain.

## Why this, and not the placement pass I was queued to run

Simulating first killed it. Of 4945 violating (lesson, glyph) pairs corpus-wide:

| | pairs | share |
|---|---|---|
| glyph **always** printed beside a romanization — deliberate exposure, working as designed | 4347 | **88%** |
| genuinely bare — the real defect | 597 | 12% |

Tamil's own chapter-one practice lesson says so in prose: *"The Tamil is printed beside each word on purpose. You are not expected to read it yet."* The real defect is narrower and concrete: **a two-column table of Devanagari and English gives a learner the meaning and no way to say it.**

My earlier framings of this number were both wrong and are superseded. *"87% placement"* classified whole tracks rather than glyphs. *"54/46"* was inflated ~3× by a **line-wrap bug in my own classifier** — it tested physical lines, so a sentence whose romanization wrapped onto the next line read as unromanized. Classify per markdown **block**. I found it because a grep and a node probe disagreed on one Punjabi file and I chased the disagreement instead of picking a winner.

## Every romanization is sourced from the corpus, never invented

Frontmatter `romanization:`, a `gloss:` parenthetical, or a `**देवनागरी** (*rom*)` body pattern. The review verified all 46 pairs independently — 44 sourced — and the two it couldn't verify were both real defects:

1. **मीरा *was* already romanized in the corpus, as `Mira`** — my lookup missed it because the existing instance wraps a whole sentence rather than the word. I introduced `Mīrā`, and the regenerated narration then carried **both spellings of the same sentence fifty lines apart in one audio read**. `Mīrā` is the accurate form (मी = *mī*, रा = *rā*), so the legacy under-marked `Mira` is normalized *up* rather than the new one dropped. English prose still says "Mira" — that's the name in English; only the romanization carries diacritics.

2. **Four of the eleven fixes never reached the book.** Marathi chapters 1–5 are **hand-written `.tex`, not generated** — only ch6+ have generation targets. So the "Say it" columns I added in Markdown left the printed ch02–ch05 tables exactly as they were, and **`check:books` passed precisely *because* the generator never sees those files.** The four tables are now hand-edited to three columns to match.

That second one is the transferable lesson: **a corpus edit reaches the reader only where the reader's artifact is generated from it, and this repo is not uniformly generated.**

## Verification

804 + 1231 + 725 tests pass across all three consumer packages, five generator gates clean, validator clean, **no corpus pin moved** (no lessons added). Table columns stay within the `maxLinearisableTableColumns: 3` ceiling; the chapter-references ratchet is unchanged at 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)