### PR TITLE
fix(hl-c236): Russian — romanize the words a reader had no way to say

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4324,7 +4324,7 @@
     {
       "language": "russian",
       "chapter": 5,
-      "sourceHash": "fnv1a64:4813b2d3159b96d9",
+      "sourceHash": "fnv1a64:cce85948b30a2020",
       "lessonIds": [
         "RU-C05-brat",
         "RU-C05-sprashivat",
@@ -4348,7 +4348,7 @@
     {
       "language": "russian",
       "chapter": 7,
-      "sourceHash": "fnv1a64:5bc7160b809f4065",
+      "sourceHash": "fnv1a64:53daed5cc988927d",
       "lessonIds": [
         "RU-C07-drug",
         "RU-C07-podruga",
@@ -4404,7 +4404,7 @@
     {
       "language": "russian",
       "chapter": 12,
-      "sourceHash": "fnv1a64:77400bcf75b3f11e",
+      "sourceHash": "fnv1a64:3071c43e143a8294",
       "lessonIds": [
         "RU-C12-mama",
         "RU-C12-papa",
@@ -4416,7 +4416,7 @@
     {
       "language": "russian",
       "chapter": 13,
-      "sourceHash": "fnv1a64:e33f8fc7f6b068cb",
+      "sourceHash": "fnv1a64:75e5bba8e91c4f6e",
       "lessonIds": [
         "RU-C13-moloko",
         "RU-C13-syr",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7592,7 +7592,7 @@
     {
       "language": "russian",
       "chapter": 2,
-      "sourceHash": "fnv1a64:f359c6016f6ba24e",
+      "sourceHash": "fnv1a64:8253ed9209494389",
       "lessonIds": [
         "RU-C02-ya",
         "RU-C02-ty-vy",
@@ -7609,8 +7609,8 @@
       "drivablePrefix": 8,
       "text": "russian/narration/ch02.txt",
       "json": "russian/narration/ch02.json",
-      "textHash": "fnv1a64:0499c10826367013",
-      "jsonHash": "fnv1a64:8de1c3f0c415a345"
+      "textHash": "fnv1a64:231b0451122c8000",
+      "jsonHash": "fnv1a64:9f7f1b7a28c4494c"
     },
     {
       "language": "russian",
@@ -7651,7 +7651,7 @@
     {
       "language": "russian",
       "chapter": 5,
-      "sourceHash": "fnv1a64:88e8486d0c691191",
+      "sourceHash": "fnv1a64:48c27977fdd918fe",
       "lessonIds": [
         "RU-C05-brat",
         "RU-C05-sprashivat",
@@ -7662,8 +7662,8 @@
       "drivablePrefix": 4,
       "text": "russian/narration/ch05.txt",
       "json": "russian/narration/ch05.json",
-      "textHash": "fnv1a64:e3357c5d94bc1996",
-      "jsonHash": "fnv1a64:73d2df65ad99c392"
+      "textHash": "fnv1a64:b4a3dd6676ba148c",
+      "jsonHash": "fnv1a64:bf4410dac8203265"
     },
     {
       "language": "russian",
@@ -7685,7 +7685,7 @@
     {
       "language": "russian",
       "chapter": 7,
-      "sourceHash": "fnv1a64:d465fe6d8a8f0a04",
+      "sourceHash": "fnv1a64:9c5167bf6ccca64a",
       "lessonIds": [
         "RU-C07-drug",
         "RU-C07-podruga",
@@ -7696,8 +7696,8 @@
       "drivablePrefix": 4,
       "text": "russian/narration/ch07.txt",
       "json": "russian/narration/ch07.json",
-      "textHash": "fnv1a64:c35c7f394452280a",
-      "jsonHash": "fnv1a64:e1629f7dbdd58140"
+      "textHash": "fnv1a64:bbfb9bc97611ca2f",
+      "jsonHash": "fnv1a64:22491f205ad07cce"
     },
     {
       "language": "russian",
@@ -7766,7 +7766,7 @@
     {
       "language": "russian",
       "chapter": 12,
-      "sourceHash": "fnv1a64:24208299442caa4a",
+      "sourceHash": "fnv1a64:ef74b1d87089fc19",
       "lessonIds": [
         "RU-C12-mama",
         "RU-C12-papa",
@@ -7777,13 +7777,13 @@
       "drivablePrefix": 4,
       "text": "russian/narration/ch12.txt",
       "json": "russian/narration/ch12.json",
-      "textHash": "fnv1a64:01fb048272f36dc5",
-      "jsonHash": "fnv1a64:266cae639390b4d7"
+      "textHash": "fnv1a64:a2f2020759a9e003",
+      "jsonHash": "fnv1a64:484c0d4fef296d08"
     },
     {
       "language": "russian",
       "chapter": 13,
-      "sourceHash": "fnv1a64:1cd466b23489a474",
+      "sourceHash": "fnv1a64:be60dc97d0b76136",
       "lessonIds": [
         "RU-C13-moloko",
         "RU-C13-syr",
@@ -7794,8 +7794,8 @@
       "drivablePrefix": 1,
       "text": "russian/narration/ch13.txt",
       "json": "russian/narration/ch13.json",
-      "textHash": "fnv1a64:16920cd652723f1b",
-      "jsonHash": "fnv1a64:d6590dbc47e4f2df"
+      "textHash": "fnv1a64:7166c40b7c4e2106",
+      "jsonHash": "fnv1a64:781792177b4209d9"
     },
     {
       "language": "russian",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:4f0ac653117531c5",
+  "sourceHash": "fnv1a64:fd7b0f9f9dacad8e",
   "summary": {
     "totalLessons": 3070,
     "voice": 2161,
@@ -49242,7 +49242,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:01a9d848c5acbb2f"
+      "sourceHash": "fnv1a64:953e87b3df5651af"
     },
     {
       "id": "RU-C02-ochen-priyatno",
@@ -49497,7 +49497,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cda6615170c3f19a"
+      "sourceHash": "fnv1a64:b3f937939c7db162"
     },
     {
       "id": "RU-C05-sprashivat",
@@ -49683,7 +49683,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:adc14663fd5e418d"
+      "sourceHash": "fnv1a64:8b86380bc8f593e7"
     },
     {
       "id": "RU-C07-sestra",
@@ -49701,7 +49701,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7bb2afa35ab80406"
+      "sourceHash": "fnv1a64:92abfa643c1d6c0c"
     },
     {
       "id": "RU-C08-semya",
@@ -49938,7 +49938,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ec96d9b13421a7d1"
+      "sourceHash": "fnv1a64:546f4d0fc49f83d9"
     },
     {
       "id": "RU-C12-papa",
@@ -50028,7 +50028,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:6a0dd3d7e96613ef"
+      "sourceHash": "fnv1a64:727d159efe18e5df"
     },
     {
       "id": "RU-C13-sok",
@@ -50064,7 +50064,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7f57478fc076953b"
+      "sourceHash": "fnv1a64:094d82b7f6aa3c65"
     },
     {
       "id": "RU-W06-u",

--- a/code/learning/human-languages/russian/book/chapters/ch02-introducing-yourself.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch02-introducing-yourself.tex
@@ -141,12 +141,12 @@ What does the soft sign pronounce by itself? Nothing. Say the literal two words,
 \begin{usage}
 Read one turn at a time:
 \begin{enumerate}
-  \item A: \ru{Здравствуйте!}
-  \item B: \ru{Здравствуйте!}
-  \item A: \ru{Как вас зовут?}
-  \item B: \ru{Меня зовут Анна.}
-  \item A: \ru{Очень приятно.}
-  \item B: \ru{Спасибо.}
+  \item A: \ru{Здравствуйте!} \quad(\emph{zdrávstvuyte})
+  \item B: \ru{Здравствуйте!} \quad(\emph{zdrávstvuyte})
+  \item A: \ru{Как вас зовут?} \quad(\emph{kak vas zovút})
+  \item B: \ru{Меня зовут Анна.} \quad(\emph{Menyá zovút Anna})
+  \item A: \ru{Очень приятно.} \quad(\emph{óchen priyátno})
+  \item B: \ru{Спасибо.} \quad(\emph{spasíbo})
 \end{enumerate}
 Every expression is already known. Only their conversation order is new.
 \end{usage}

--- a/code/learning/human-languages/russian/book/chapters/ch05-verbs-of-the-hand.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch05-verbs-of-the-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4813b2d3159b96d9
+% canonical-source-hash: fnv1a64:cce85948b30a2020
 % canonical-lessons: RU-C05-brat, RU-C05-sprashivat, RU-C05-pomogat, RU-C05-lyubit
 
 \chapter{Taking, Asking, Helping, Loving}
@@ -38,7 +38,7 @@ The stem grows a vowel: \textbf{\ru{бр}-} in the infinitive, \textbf{\ru{бе�
 Three sentences, all ordinary Russian:
 
 \begin{quote}
-\textbf{\ru{Я} \ru{читаю}. \ru{Я} \ru{пишу}. \ru{Я} \ru{беру}.}
+\textbf{\ru{Я} \ru{читаю}. \ru{Я} \ru{пишу}. \ru{Я} \ru{беру}.} — \emph{ya chitáyu, ya pishú, ya berú.}
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens: a pair with nothing in common}]
@@ -63,7 +63,7 @@ Say these aloud:
 \begin{itemize}
 \raggedright
   \item \textquotedblleft{}\ru{брать}\textquotedblright{} then \textquotedblleft{}\ru{я} \ru{беру}\textquotedblright{} — hear the stem grow its vowel
-  \item \textquotedblleft{}\ru{Я} \ru{читаю}. \ru{Я} \ru{пишу}. \ru{Я} \ru{беру}.\textquotedblright{}
+  \item \textquotedblleft{}\ru{Я} \ru{читаю}. \ru{Я} \ru{пишу}. \ru{Я} \ru{беру}.\textquotedblright{} — \emph{ya chitáyu, ya pishú, ya berú}
   \item the odd pair — \textquotedblleft{}\ru{брать} … \ru{взять}\textquotedblright{}, two words sharing nothing
   \item the other suppletion — \textquotedblleft{}\ru{идти} … \ru{шёл}\textquotedblright{}, \textquotedblleft{}go … went\textquotedblright{}
   \item \textquotedblleft{}\ru{брать}\textquotedblright{} then English \textquotedblleft{}bear, birth, burden, transfer, metaphor\textquotedblright{}

--- a/code/learning/human-languages/russian/book/chapters/ch07-friend-and-siblings.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch07-friend-and-siblings.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5bc7160b809f4065
+% canonical-source-hash: fnv1a64:53daed5cc988927d
 % canonical-lessons: RU-C07-drug, RU-C07-podruga, RU-C07-brat, RU-C07-sestra
 
 \chapter{Friend and Siblings}
@@ -130,7 +130,7 @@ Say these aloud:
   \item \textquotedblleft{}\ru{брат}\textquotedblright{} — hard final t, brother
   \item the minimal pair — \textquotedblleft{}\ru{брат}, \ru{брать}\textquotedblright{} — one soft sign apart
   \item \textquotedblleft{}brother, frāter, bhrātar\textquotedblright{} — the same word, three languages
-  \item the chapter so far — \textquotedblleft{}\ru{друг}, \ru{подруга}, \ru{брат}\textquotedblright{}
+  \item the chapter so far — \textquotedblleft{}\ru{друг}, \ru{подруга}, \ru{брат}\textquotedblright{} (\emph{drug, podrúga, brat})
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
@@ -143,7 +143,7 @@ Say \textquotedblleft{}brother.\textquotedblright{} (\textbf{\ru{Брат}}.) Wh
 
 
 \begin{quote}
-\emph{\ru{Брат}}'s partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place.
+\textbf{\ru{Брат}} (\emph{brat})'s partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place.
 \end{quote}
 
 \subsection*{You'll want to know first — \ru{сестра}}
@@ -168,7 +168,7 @@ Say these aloud:
 \raggedright
   \item \textquotedblleft{}\ru{сестра}\textquotedblright{} — feminine, stress on the end
   \item the pair — \textquotedblleft{}\ru{брат}, \ru{сестра}\textquotedblright{} — brother, sister
-  \item the four people — \textquotedblleft{}\ru{друг}, \ru{подруга}, \ru{брат}, \ru{сестра}\textquotedblright{}
+  \item the four people — \textquotedblleft{}\ru{друг}, \ru{подруга}, \ru{брат}, \ru{сестра}\textquotedblright{} (\emph{drug, podrúga, brat, sestrá})
   \item \textquotedblleft{}sister, soror\textquotedblright{} — same root, one smooth, one bumpy
 \end{itemize}
 

--- a/code/learning/human-languages/russian/book/chapters/ch12-mother-and-father.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch12-mother-and-father.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:77400bcf75b3f11e
+% canonical-source-hash: fnv1a64:3071c43e143a8294
 % canonical-lessons: RU-C12-mama, RU-C12-papa, RU-C12-mat, RU-C12-otets
 
 \chapter{Mother and Father}
@@ -19,7 +19,7 @@ The chapter closes on \ru{отец}, the surprise of the pair: the reader produc
 
 
 \begin{quote}
-Say good night, say see-you-later, and now a new chapter — back to \emph{\ru{семья}} to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all.
+Say good night, say see-you-later, and now a new chapter — back to \textbf{\ru{семья}} (\emph{sem'yá}) to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all.
 \end{quote}
 
 \subsection*{You'll want to know first — \ru{мама}}

--- a/code/learning/human-languages/russian/book/chapters/ch13-milk-cheese-juice-soup.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch13-milk-cheese-juice-soup.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e33f8fc7f6b068cb
+% canonical-source-hash: fnv1a64:75e5bba8e91c4f6e
 % canonical-lessons: RU-C13-moloko, RU-C13-syr, RU-C13-sok, RU-C13-sup
 
 \chapter{Milk, Cheese, Juice, and Soup}
@@ -89,7 +89,7 @@ Say these aloud:
   \item \textquotedblleft{}\ru{сыр}\textquotedblright{} — masculine, the pulled-back \ru{ы}
   \item the double life — \textquotedblleft{}\ru{сыр} and \ru{сырой}, one root\textquotedblright{}
   \item \textquotedblleft{}\ru{сырой}, sour, súrr, sûr\textquotedblright{} — Slavic and Germanic, side by side
-  \item \textquotedblleft{}\ru{Сыр}, \ru{пожалуйста}. \ru{Хлеб}, \ru{пожалуйста}.\textquotedblright{} — cheese and bread, the request pattern's pair
+  \item \textquotedblleft{}\ru{Сыр}, \ru{пожалуйста}. \ru{Хлеб}, \ru{пожалуйста}.\textquotedblright{} (\emph{syr, pazhálusta; khleb, pazhálusta}) — cheese and bread, the request pattern's pair
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
@@ -173,7 +173,7 @@ Say these aloud:
   \item \textquotedblleft{}\ru{суп}\textquotedblright{} — masculine, one syllable
   \item the loan — \textquotedblleft{}French soupe, 1700s, same century as \ru{кофе}\textquotedblright{}
   \item the mirror — \textquotedblleft{}\ru{суп}/soup: one French word, two borrowings; \ru{кофе}/coffee: one Arabic word, two doors\textquotedblright{}
-  \item the whole shelf — \textquotedblleft{}\ru{молоко}, \ru{сыр}, \ru{сок}, \ru{суп}, \ru{пожалуйста}\textquotedblright{}
+  \item the whole shelf — \textquotedblleft{}\ru{молоко}, \ru{сыр}, \ru{сок}, \ru{суп}, \ru{пожалуйста}\textquotedblright{} (\emph{malakó, syr, sok, sup, pazhálusta})
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]

--- a/code/learning/human-languages/russian/lessons/RU-C02-practice.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-practice.md
@@ -42,10 +42,10 @@ formal *you*. (*Я*, *ты*, *вы*.) Everything below is built from those.
 
 Two strangers meet. Say both voices aloud, one after the other:
 
-> — **Здравствуйте!**
-> — **Как вас зовут?**
-> — **Меня зовут Анна. А вас?**
-> — **Меня зовут Иван. Очень приятно.**
+> — **Здравствуйте!** — *Zdrávstvuyte!*
+> — **Как вас зовут?** — *Kak vas zovút?*
+> — **Меня зовут Анна. А вас?** — *Menyá zovút Anna. A vas?*
+> — **Меня зовут Иван. Очень приятно.** — *Menyá zovút Iván. Óchen priyátno.*
 
 Everything in it is formal, because *вы* is the safe opening with an adult you
 do not know.

--- a/code/learning/human-languages/russian/lessons/RU-C05-brat.md
+++ b/code/learning/human-languages/russian/lessons/RU-C05-brat.md
@@ -52,7 +52,7 @@ arrives. Then **ты берёшь**, so this verb sits in the *знать* famil
 
 Three sentences, all ordinary Russian:
 
-> **Я читаю. Я пишу. Я беру.**
+> **Я читаю. Я пишу. Я беру.** — *ya chitáyu, ya pishú, ya berú.*
 
 ## Grammar Lens: a pair with nothing in common
 <!-- hl-knowledge: introduces=[RU-GRAMMAR-SUPPLETIVE-ASPECT-PAIR]; assesses=[RU-GRAMMAR-ASPECT-PARTNER, RU-LEX-IDTI, RU-ETYMON-IDTI-GO-WENT, RU-LEX-PONIMAT, RU-ETYMON-PONIMAT-TAKE-HOLD] -->
@@ -91,7 +91,7 @@ roots that all begin **bʰ** — a family accent, not a shared word.
 
 [PAUSE 1s]
 - [YOU SAY: "брать" then "я беру" — hear the stem grow its vowel]
-- [YOU SAY: "Я читаю. Я пишу. Я беру."]
+- [YOU SAY: "Я читаю. Я пишу. Я беру." — *ya chitáyu, ya pishú, ya berú*]
 - [YOU SAY: the odd pair — "брать … взять", two words sharing nothing]
 - [YOU SAY: the other suppletion — "идти … шёл", "go … went"]
 - [YOU SAY: "брать" then English "bear, birth, burden, transfer, metaphor"]

--- a/code/learning/human-languages/russian/lessons/RU-C07-brat.md
+++ b/code/learning/human-languages/russian/lessons/RU-C07-brat.md
@@ -71,7 +71,7 @@ sound, no shared meaning — a family accent, not a family.
 - [YOU SAY: "брат" — hard final t, brother]
 - [YOU SAY: the minimal pair — "брат, брать" — one soft sign apart]
 - [YOU SAY: "brother, frāter, bhrātar" — the same word, three languages]
-- [YOU SAY: the chapter so far — "друг, подруга, брат"]
+- [YOU SAY: the chapter so far — "друг, подруга, брат" (*drug, podrúga, brat*)]
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-BRAT-NOUN, RU-ETYMON-BRAT-BROTHER, RU-LEX-BRAT, RU-ETYMON-BRAT-BEAR, RU-GRAMMAR-SUPPLETIVE-ASPECT-PAIR, RU-LEX-PODRUGA, RU-GRAMMAR-FEMININE-SUFFIX-A] -->

--- a/code/learning/human-languages/russian/lessons/RU-C07-sestra.md
+++ b/code/learning/human-languages/russian/lessons/RU-C07-sestra.md
@@ -34,7 +34,8 @@ reviews_of: [RU-C07-brat, RU-C07-podruga, RU-C07-drug]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-BRAT-NOUN, RU-LEX-PODRUGA, RU-LEX-DRUG] -->
 
-[PAUSE 2s] *Брат*'s partner, one more secure cognate, and the four people this
+[PAUSE 2s] **Брат** (*brat*)'s partner, one more secure cognate, and the four
+people this
 chapter has introduced you to, gathered in one place.
 
 ## You'll want to know first — сестра
@@ -71,7 +72,8 @@ strange. Everyone else still gets **вы**.
 [PAUSE 1s]
 - [YOU SAY: "сестра" — feminine, stress on the end]
 - [YOU SAY: the pair — "брат, сестра" — brother, sister]
-- [YOU SAY: the four people — "друг, подруга, брат, сестра"]
+- [YOU SAY: the four people — "друг, подруга, брат, сестра" (*drug, podrúga,
+  brat, sestrá*)]
 - [YOU SAY: "sister, soror" — same root, one smooth, one bumpy]
 
 ## Wrap-up Recall

--- a/code/learning/human-languages/russian/lessons/RU-C12-mama.md
+++ b/code/learning/human-languages/russian/lessons/RU-C12-mama.md
@@ -35,7 +35,8 @@ reviews_of: [RU-C11-spokoynoy-nochi, RU-C08-semya]
 <!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-SPOKOYNOY-NOCHI, RU-LEX-DO-VSTRECHI] -->
 
 [PAUSE 2s] Say good night, say see-you-later, and now a new chapter — back
-to *семья* to fill it in, one person at a time, starting with a word that
+to **семья** (*sem'yá*) to fill it in, one person at a time, starting with a word
+that
 looks like a cousin of English and, on close inspection, is not really one
 at all.
 

--- a/code/learning/human-languages/russian/lessons/RU-C13-sup.md
+++ b/code/learning/human-languages/russian/lessons/RU-C13-sup.md
@@ -76,7 +76,8 @@ Ask for the whole shelf the way you already know:
 - [YOU SAY: the loan — "French soupe, 1700s, same century as кофе"]
 - [YOU SAY: the mirror — "суп/soup: one French word, two borrowings;
   кофе/coffee: one Arabic word, two doors"]
-- [YOU SAY: the whole shelf — "молоко, сыр, сок, суп, пожалуйста"]
+- [YOU SAY: the whole shelf — "молоко, сыр, сок, суп, пожалуйста" (*malakó, syr,
+  sok, sup, pazhálusta*)]
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[RU-LEX-SUP, RU-ETYMON-SUP-FRENCH-LOAN, RU-COMPARISON-NAMING-QUESTION-FRAMES, RU-SCRIPT-YA-NOT-R] -->

--- a/code/learning/human-languages/russian/lessons/RU-C13-syr.md
+++ b/code/learning/human-languages/russian/lessons/RU-C13-syr.md
@@ -72,7 +72,8 @@ That gives you the chapter's drink-and-bread shelf a genuine internal logic:
 - [YOU SAY: "сыр" — masculine, the pulled-back ы]
 - [YOU SAY: the double life — "сыр and сырой, one root"]
 - [YOU SAY: "сырой, sour, súrr, sûr" — Slavic and Germanic, side by side]
-- [YOU SAY: "Сыр, пожалуйста. Хлеб, пожалуйста." — cheese and bread,
+- [YOU SAY: "Сыр, пожалуйста. Хлеб, пожалуйста." (*syr, pazhálusta; khleb,
+  pazhálusta*) — cheese and bread,
   the request pattern's pair]
 
 ## Wrap-up Recall

--- a/code/learning/human-languages/russian/narration/ch02.json
+++ b/code/learning/human-languages/russian/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing yourself",
   "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:f359c6016f6ba24e",
+  "sourceHash": "fnv1a64:8253ed9209494389",
   "lessons": [
     {
       "id": "RU-C02-ya",
@@ -924,7 +924,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:01a9d848c5acbb2f",
+      "sourceHash": "fnv1a64:953e87b3df5651af",
       "notice": null,
       "blocks": [
         {
@@ -955,7 +955,7 @@
             },
             {
               "kind": "speech",
-              "text": "— Здравствуйте! — Как вас зовут? — Меня зовут Анна. А вас? — Меня зовут Иван. Очень приятно."
+              "text": "— Здравствуйте! — Zdrávstvuyte! — Как вас зовут? — Kak vas zovút? — Меня зовут Анна. А вас? — Menyá zovút Anna. A vas? — Меня зовут Иван. Очень приятно. — Menyá zovút Iván. Óchen priyátno."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/russian/narration/ch02.txt
+++ b/code/learning/human-languages/russian/narration/ch02.txt
@@ -223,7 +223,7 @@ Give the three words the chapter opened with: I, familiar you, formal you. (Я, 
 
 The exchange.
 Two strangers meet. Say both voices aloud, one after the other:
-— Здравствуйте! — Как вас зовут? — Меня зовут Анна. А вас? — Меня зовут Иван. Очень приятно.
+— Здравствуйте! — Zdrávstvuyte! — Как вас зовут? — Kak vas zovút? — Меня зовут Анна. А вас? — Menyá zovút Anna. A vas? — Меня зовут Иван. Очень приятно. — Menyá zovút Iván. Óchen priyátno.
 Everything in it is formal, because вы is the safe opening with an adult you do not know.
 
 Grammar Lens: what moves when the exchange goes informal.

--- a/code/learning/human-languages/russian/narration/ch05.json
+++ b/code/learning/human-languages/russian/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Taking, Asking, Helping, Loving",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:88e8486d0c691191",
+  "sourceHash": "fnv1a64:48c27977fdd918fe",
   "lessons": [
     {
       "id": "RU-C05-brat",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cda6615170c3f19a",
+      "sourceHash": "fnv1a64:b3f937939c7db162",
       "notice": null,
       "blocks": [
         {
@@ -66,7 +66,7 @@
             },
             {
               "kind": "speech",
-              "text": "Я читаю. Я пишу. Я беру."
+              "text": "Я читаю. Я пишу. Я беру. — ya chitáyu, ya pishú, ya berú."
             }
           ]
         },
@@ -131,11 +131,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"Я читаю. Я пишу. Я беру.\"",
+              "instruction": "\"Я читаю. Я пишу. Я беру.\" — ya chitáyu, ya pishú, ya berú",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"Я читаю. Я пишу. Я беру.\"]"
+              "source": "[YOU SAY: \"Я читаю. Я пишу. Я беру.\" — *ya chitáyu, ya pishú, ya berú*]"
             },
             {
               "kind": "prompt",

--- a/code/learning/human-languages/russian/narration/ch05.txt
+++ b/code/learning/human-languages/russian/narration/ch05.txt
@@ -15,7 +15,7 @@ Five letters, all of them yours, and the familiar -ть.
 Я беру. — ya berú — I take.
 The stem grows a vowel: бр- in the infinitive, бер- once an ending arrives. Then ты берёшь, so this verb sits in the знать family, and that -у is the plain form of the -ю you have been saying.
 Three sentences, all ordinary Russian:
-Я читаю. Я пишу. Я беру.
+Я читаю. Я пишу. Я беру. — ya chitáyu, ya pishú, ya berú.
 
 Grammar Lens: a pair with nothing in common.
 The partners so far were recognisable: читать, прочитать added a prefix, понимать, понять reshaped a middle. Now the hard case.
@@ -31,7 +31,7 @@ Guided Practice.
 [pause 1 second]
 [your turn — say: "брать (brat')" then "я беру" — hear the stem grow its vowel]
 [pause 8 seconds for the answer]
-[your turn — say: "Я читаю. Я пишу. Я беру."]
+[your turn — say: "Я читаю. Я пишу. Я беру." — ya chitáyu, ya pishú, ya berú]
 [pause 8 seconds for the answer]
 [your turn — say: the odd pair — "брать (brat') … взять", two words sharing nothing]
 [pause 8 seconds for the answer]

--- a/code/learning/human-languages/russian/narration/ch07.json
+++ b/code/learning/human-languages/russian/narration/ch07.json
@@ -4,7 +4,7 @@
   "chapter": 7,
   "title": "Friend and Siblings",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:d465fe6d8a8f0a04",
+  "sourceHash": "fnv1a64:9c5167bf6ccca64a",
   "lessons": [
     {
       "id": "RU-C07-drug",
@@ -292,7 +292,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:adc14663fd5e418d",
+      "sourceHash": "fnv1a64:8b86380bc8f593e7",
       "notice": null,
       "blocks": [
         {
@@ -383,11 +383,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the chapter so far — \"друг (drug), подруга (podrúga), брат (brat)\"",
+              "instruction": "the chapter so far — \"друг, подруга, брат\" (drug, podrúga, brat)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the chapter so far — \"друг, подруга, брат\"]"
+              "source": "[YOU SAY: the chapter so far — \"друг, подруга, брат\" (*drug, podrúga, brat*)]"
             }
           ]
         },
@@ -423,7 +423,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7bb2afa35ab80406",
+      "sourceHash": "fnv1a64:92abfa643c1d6c0c",
       "notice": null,
       "blocks": [
         {
@@ -439,7 +439,7 @@
             },
             {
               "kind": "speech",
-              "text": "Брат's partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place."
+              "text": "Брат (brat)'s partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place."
             }
           ]
         },
@@ -512,11 +512,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the four people — \"друг (drug), подруга (podrúga), брат (brat), сестра (sestrá)\"",
+              "instruction": "the four people — \"друг, подруга, брат, сестра\" (drug, podrúga, brat, sestrá)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the four people — \"друг, подруга, брат, сестра\"]"
+              "source": "[YOU SAY: the four people — \"друг, подруга, брат, сестра\" (*drug, podrúga, brat, sestrá*)]"
             },
             {
               "kind": "prompt",

--- a/code/learning/human-languages/russian/narration/ch07.txt
+++ b/code/learning/human-languages/russian/narration/ch07.txt
@@ -90,7 +90,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: "brother, frāter, bhrātar" — the same word, three languages]
 [pause 8 seconds for the answer]
-[your turn — say: the chapter so far — "друг (drug), подруга (podrúga), брат (brat)"]
+[your turn — say: the chapter so far — "друг, подруга, брат" (drug, podrúga, brat)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
@@ -103,7 +103,7 @@ Lesson 4 of 4.
 
 Warm-up.
 [pause 2 seconds]
-Брат's partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place.
+Брат (brat)'s partner, one more secure cognate, and the four people this chapter has introduced you to, gathered in one place.
 
 You'll want to know first — сестра.
 сестра — sestrá — sister. Feminine.
@@ -121,7 +121,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: the pair — "брат (brat), сестра (sestrá)" — brother, sister]
 [pause 8 seconds for the answer]
-[your turn — say: the four people — "друг (drug), подруга (podrúga), брат (brat), сестра (sestrá)"]
+[your turn — say: the four people — "друг, подруга, брат, сестра" (drug, podrúga, brat, sestrá)]
 [pause 8 seconds for the answer]
 [your turn — say: "sister, soror" — same root, one smooth, one bumpy]
 [pause 8 seconds for the answer]

--- a/code/learning/human-languages/russian/narration/ch12.json
+++ b/code/learning/human-languages/russian/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Mother and Father",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:24208299442caa4a",
+  "sourceHash": "fnv1a64:ef74b1d87089fc19",
   "lessons": [
     {
       "id": "RU-C12-mama",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ec96d9b13421a7d1",
+      "sourceHash": "fnv1a64:546f4d0fc49f83d9",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say good night, say see-you-later, and now a new chapter — back to семья to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all."
+              "text": "Say good night, say see-you-later, and now a new chapter — back to семья (sem'yá) to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all."
             }
           ]
         },

--- a/code/learning/human-languages/russian/narration/ch12.txt
+++ b/code/learning/human-languages/russian/narration/ch12.txt
@@ -7,7 +7,7 @@ Lesson 1 of 4.
 
 Warm-up.
 [pause 2 seconds]
-Say good night, say see-you-later, and now a new chapter — back to семья to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all.
+Say good night, say see-you-later, and now a new chapter — back to семья (sem'yá) to fill it in, one person at a time, starting with a word that looks like a cousin of English and, on close inspection, is not really one at all.
 
 You'll want to know first — мама.
 мама — máma — mom, mum (the everyday, affectionate word).

--- a/code/learning/human-languages/russian/narration/ch13.json
+++ b/code/learning/human-languages/russian/narration/ch13.json
@@ -4,7 +4,7 @@
   "chapter": 13,
   "title": "Milk, Cheese, Juice, and Soup",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:1cd466b23489a474",
+  "sourceHash": "fnv1a64:be60dc97d0b76136",
   "lessons": [
     {
       "id": "RU-C13-moloko",
@@ -149,7 +149,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:6a0dd3d7e96613ef",
+      "sourceHash": "fnv1a64:727d159efe18e5df",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -251,11 +251,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"Сыр, пожалуйста. Хлеб, пожалуйста.\" — cheese and bread, the request pattern's pair",
+              "instruction": "\"Сыр, пожалуйста. Хлеб, пожалуйста.\" (syr, pazhálusta; khleb, pazhálusta) — cheese and bread, the request pattern's pair",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"Сыр, пожалуйста. Хлеб, пожалуйста.\" — cheese and bread, the request pattern's pair]"
+              "source": "[YOU SAY: \"Сыр, пожалуйста. Хлеб, пожалуйста.\" (*syr, pazhálusta; khleb, pazhálusta*) — cheese and bread, the request pattern's pair]"
             }
           ]
         },
@@ -426,7 +426,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7f57478fc076953b",
+      "sourceHash": "fnv1a64:094d82b7f6aa3c65",
       "notice": null,
       "blocks": [
         {
@@ -525,11 +525,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the whole shelf — \"молоко (malakó), сыр (syr), сок (sok), суп (sup), пожалуйста\"",
+              "instruction": "the whole shelf — \"молоко, сыр, сок, суп, пожалуйста\" (malakó, syr, sok, sup, pazhálusta)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the whole shelf — \"молоко, сыр, сок, суп, пожалуйста\"]"
+              "source": "[YOU SAY: the whole shelf — \"молоко, сыр, сок, суп, пожалуйста\" (*malakó, syr, sok, sup, pazhálusta*)]"
             }
           ]
         },

--- a/code/learning/human-languages/russian/narration/ch13.txt
+++ b/code/learning/human-languages/russian/narration/ch13.txt
@@ -59,7 +59,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: "сырой, sour, súrr, sûr" — Slavic and Germanic, side by side]
 [pause 8 seconds for the answer]
-[your turn — say: "Сыр, пожалуйста. Хлеб, пожалуйста." — cheese and bread, the request pattern's pair]
+[your turn — say: "Сыр, пожалуйста. Хлеб, пожалуйста." (syr, pazhálusta; khleb, pazhálusta) — cheese and bread, the request pattern's pair]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
@@ -124,7 +124,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: the mirror — "суп (sup)/soup: one French word, two borrowings; кофе/coffee: one Arabic word, two doors"]
 [pause 8 seconds for the answer]
-[your turn — say: the whole shelf — "молоко (malakó), сыр (syr), сок (sok), суп (sup), пожалуйста"]
+[your turn — say: the whole shelf — "молоко, сыр, сок, суп, пожалуйста" (malakó, syr, sok, sup, pazhálusta)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.


### PR DESCRIPTION
Seven lessons and one hand-written book chapter. **Russian's truly-unreachable words go 12 → 0**: every Cyrillic word the track prints is now romanized somewhere in the lesson that prints it.

## The number this chases is not the one the backlog named

`script-closure` reports **4945** violating (lesson, glyph) pairs. Measured honestly:

| | pairs |
|---|---|
| glyph always printed beside a romanization — deliberate exposure, working as designed | 4347 |
| cues like `[YOU SAY: "хлеб"]` in the lesson that *teaches* хлеб, romanization a few lines up | most of the rest |
| **a word printed and never romanized anywhere in its lesson — the real defect** | **90 corpus-wide, 12 Russian** |

My earlier figures were wrong three times over: *"87% placement"* counted whole tracks rather than glyphs; *"597"* came from a per-**line** classifier that read a wrapped romanization as absent; and my first per-lesson test was **vacuous** — it asked whether the lesson romanized *anything*, which is true of nearly every lesson because of its headword, and it returned zero. Reporting "no debt" off that would have been the worst call of the run. The honest test asks whether **that word** is reachable.

## Every romanization is taken from the corpus

`Anna`, `Menyá`, `Óchen`, `priyátno`, `chitáyu`, `pishú`, `berú`, `malakó`, `khleb`, `brat`, `drug`, `podrúga`, `sestrá`, `sem'yá`, `zdrávstvuyte`, `kak vas zovút`, `spasíbo`, `pazhálusta` — each verified against a frontmatter `romanization:` or a body pattern.

**One exception, flagged rather than buried:** Иван has no romanization anywhere in the corpus, so `Iván` is mine. Review judged the stress correct and consistent with the scheme.

## Two review findings, both mine, both fixed

1. **I wrote `pozhálusta`, taking the frontmatter *lemma*.** Every spoken romanization in the corpus is `pazhálusta` — five for five — and one of them sits **nine lines above my edit**, romanizing the identical phrase. Same failure as the Marathi `Mira` case one PR ago, wearing different clothes. It's also wrong against the track's own akanye rule — the one I wrote a lesson about two PRs ago: пожалуйста has a pretonic о, so it reduces. The generated chapter now prints `pazhálusta` ×5 and `pozhálusta` ×0.
2. **Only the fourth turn of the chapter-two exchange got a romanization.** The first three were "reachable" only through an unaccented frontmatter string, so the Markdown was *less* usable than the book page beside it. All four now match.

## The hand-written chapter again

Russian ch01–02 are **not generated** (only ch3–15 have targets), so the book's six-turn exchange was fixed by hand — it printed six Cyrillic lines with no pronunciation at all, and no generator would ever have touched it.

**Left alone deliberately:** one pre-existing `pozhálusta` in a chapter-one vocabulary list, where the lemma form is defensible. Noted rather than silently widened.

**804 + 1231 + 725 tests pass**, five gates clean, validator clean, no corpus pin moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)