### PR TITLE
docs(vault-pm): resolve password-generator phase contradiction (Phase 1A vs 1B)

### DIFF
--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -149,7 +149,7 @@ is `VLT-PM15-operation-audit.md`.
 | Phase | Deliverable | Storage | Client surface | Independently useful result |
 |---|---|---|---|---|
 | 0 | Contract and security closure | in-memory fault model | test harness | formats and invariants fixed before product code |
-| 1A | Local one-shot CLI | filesystem | CLI | usable offline single-user vault — crash-survivable since §23 item 10a; open: §23 items 10b–10c |
+| 1A | Local one-shot CLI | filesystem | CLI | usable offline single-user vault — crash-survivable since §23 item 10a, passphrase-rotatable since item 10b; the generator named in item 10c belongs to Phase 1B |
 | 1B | Complete local CLI | filesystem + removable folder | CLI + interactive shell/local agent | practical daily local password manager |
 | 2 | Bring-your-own-cloud | Google Drive first, then WebDAV/S3 | CLI | multi-device E2EE without our server |
 | 3 | Web client | IndexedDB/OPFS + direct cloud adapters | installable PWA | browser access without a plaintext backend |
@@ -916,7 +916,9 @@ The leading `--vault NAME` selector may prefix any command that operates on an
 existing vault. It is command-scoped and never rewrites `default_vault`.
 
 Phase 1A implements `init`, `status`, `shell`, item CRUD/list, search, history,
-password generation, portable export, audit verification, and `doctor`.
+portable export, audit verification, and `doctor`. `password generate`,
+`totp code`, and the attachment commands are Phase 1B daily-use conveniences
+(§23 item 11), as are the import adapters (§23 item 13).
 Cloud/storage migration commands activate in Phase 2.
 
 ### 14.5 Unlock experience
@@ -1751,12 +1753,28 @@ changelog, focused build, and downstream validation.
       one passphrase opens the vault at each — never both, which would mean the
       retired wrap survived, and never neither, which would mean the vault was
       bricked.
-10c. **Open — found alongside 10b.** §14.4 states that Phase 1A implements
-      "password generation", while §23 item 11 places the password generator in
-      Phase 1B. The two statements contradict each other and the shipped
-      surface has no `password generate`. Decide which document is right and
-      make the other match; if §14.4 is right, the generator is a Phase 1A
-      item and Phase 1A does not close without it.
+10c. password-generator phase contradiction — **resolved, documentation only,
+      in favour of Phase 1B.** §14.4 stated that Phase 1A implements "password
+      generation" while item 11 below placed the generator in Phase 1B; no
+      `password generate` has shipped from either reading, so nothing had been
+      built against the wrong answer. §14.4 was the incorrect half and now
+      agrees with item 11.
+      Three of this document's own statements decide it. §4 defines Phase 1A as
+      "a usable offline single-user vault" and Phase 1B as a "practical daily
+      local password manager": a vault is usable offline once it can hold,
+      retrieve, and prove the integrity of secrets a person already has, and
+      minting new ones is a convenience of daily use rather than a property of
+      custody. §2.1 groups "password generation, clipboard-safe secret
+      retrieval, URL-aware matching, browser autofill" into a single
+      convenience bullet, and item 11 groups the generator with TOTP display,
+      clipboard, and attachments — the same company in both places. And §14.4's
+      own signature is `password generate [policy flags] [--copy|--reveal]`,
+      whose preferred output path is the clipboard, which item 11 delivers:
+      putting the generator in Phase 1A would have shipped a command whose
+      documented primary mode did not yet exist. §14.8's Phase 1A acceptance
+      criteria never mention generation, so no gate is weakened by moving it.
+      No code changes; no `password generate` is added or removed, because none
+      was ever implemented. The generator remains tracked as part of item 11.
 
 ### Phase 1B — daily local use
 

--- a/code/specs/VLT-PM43-cli-passphrase-rotation.md
+++ b/code/specs/VLT-PM43-cli-passphrase-rotation.md
@@ -14,7 +14,10 @@ performed a rotation. VLT-PM42 §Status recorded the finding; this document is
 the ceremony that answers it.
 
 It does not close Phase 1A on its own. §23 item 10c — the `password generate`
-contradiction between §14.4 and §23 — is unrelated and remains open.
+contradiction between §14.4 and §23 — was unrelated to rotation and was
+resolved separately, as documentation only: the generator is a Phase 1B
+daily-use convenience (VLT-PM00 §23 items 10c and 11), so no Phase 1A work
+follows from it.
 
 ## 1. What the criterion is actually asking for
 


### PR DESCRIPTION
## What

Resolves VLT-PM00 §23 item **10c** — the spec said two different things about which phase owns the CLI password generator:

- §14.4 (command surface): "Phase 1A implements ... **password generation** ..."
- §23 item 11 (implementation sequence, Phase 1B): "**password generator**, TOTP display, clipboard, attachments and packing."

Neither had shipped a `password generate`, so nothing was built against the wrong answer — but a spec that says both cannot be used to decide whether Phase 1A is closed.

## Decision: Phase 1B

Decided on the document's own stated reasoning, not preference:

- **§4 milestone table.** Phase 1A is "a usable offline single-user vault"; Phase 1B is a "practical daily local password manager". Custody of secrets a person already has is the 1A promise; minting new ones is a daily-use convenience.
- **Company kept.** §2.1 groups "password generation, clipboard-safe secret retrieval, URL-aware matching, browser autofill" into one convenience bullet, and §23 item 11 groups the generator with TOTP display, clipboard, and attachments. Same company in both places, and that company is 1B.
- **Its own signature.** §14.4 spells the command `password generate [policy flags] [--copy|--reveal]`, whose preferred output path per §14.6 is the clipboard — itself Phase 1B item 11. Shipping it in 1A would ship a command whose documented primary mode did not exist yet.
- **No gate weakened.** §14.8's Phase 1A acceptance criteria never mention generation.

## Changes (documentation only)

- `VLT-PM00` §14.4 — drop "password generation" from the Phase 1A sentence; name `password generate`, `totp code`, and the attachment commands as Phase 1B (item 11), import adapters as item 13.
- `VLT-PM00` §4 — the 1A row still listed items 10b–10c as open although 10b landed with passphrase rotation; now records 10a and 10b as met and points 10c at Phase 1B.
- `VLT-PM00` §23 item 10c — rewritten from an open question into a resolution record, in the same style as the 10a/10b entries (this file's changelog equivalent).
- `VLT-PM43` §Status — said item 10c "remains open"; now records the documentation-only resolution so the two specs agree.

No Rust code is touched and no generator is implemented; that work stays tracked as part of §23 item 11.

## Verification

- `grep -rn "password generat"` across `code/specs/VLT-PM*.md` — every remaining mention is now consistent (VLT-PM42 §Status only records that the item was *filed*, which is still accurate).
- No `password generat` references anywhere under `code/packages/rust/vault-pm-*` or `code/programs`, confirming docs-only.
- `/security-review` passed on the first round: no security requirement, secret-output policy (§14.6), key-hierarchy (§8.1), or acceptance criterion (§14.8) text is altered; no secrets introduced; no guidance toward weak generation policy or insecure RNG. Non-blocking pre-existing observation from the reviewer: the spec states no entropy floor or CSPRNG requirement for `password generate` — worth specifying when item 11 is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)