### PR TITLE
fix(hl-c237): Persian and Arabic — romanize the words a reader had no way to say

### DIFF
--- a/code/learning/human-languages/arabic/book/chapters/ch03-how-are-you.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch03-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:975f075b68b954ae
+% canonical-source-hash: fnv1a64:8cb8e93eac4de300
 % canonical-lessons: AR-W07-hook-family-ha-kha, AR-W08-kaf-and-ra, AR-W09-khayr-bikhayr, AR-C03-kayfa, AR-C03-hal, AR-C03-kayfa-haluka, AR-C03-bi-khayr, AR-C03-al-hamdu-lillah, AR-C03-practice
 
 \chapter{How Are You?}
@@ -409,7 +409,7 @@ What does \textbf{\ar{الحمد} \ar{لله}} literally say? (\textquotedblleft
 
 
 \begin{quote}
-Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can now \textbf{ask after someone and answer back}.
+Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can \textbf{ask after someone and answer back}.
 \end{quote}
 
 \subsection*{The exchange}
@@ -418,15 +418,15 @@ Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter clos
 \toprule
 \textbf{} & \textbf{Arabic} & \textbf{literally} \\
 \midrule
-A & \textbf{\ar{السلام} \ar{عليكم}} & peace {[}be{]} upon you \\
-B & \textbf{\ar{وعليكم} \ar{السلام}} & and upon you, peace \\
-A & \textbf{\ar{كيف} \ar{حالك؟}} & how {[}is{]} your state? \\
-B & \textbf{\ar{الحمد} \ar{لله،} \ar{بخير}.} & the praise {[}is{]} to God — in goodness \\
-B & \textbf{\ar{وأنت؟} \ar{ما} \ar{اسمك؟}} & and you? what {[}is{]} your name? \\
+A & \textbf{\ar{السلام} \ar{عليكم}} (\emph{as-salāmu ʿalaykum}) & peace {[}be{]} upon you \\
+B & \textbf{\ar{وعليكم} \ar{السلام}} (\emph{wa-ʿalaykum as-salām}) & and upon you, peace \\
+A & \textbf{\ar{كيف} \ar{حالك؟}} (\emph{kayfa ḥāluka?}) & how {[}is{]} your state? \\
+B & \textbf{\ar{الحمد} \ar{لله،} \ar{بخير}.} (\emph{al-ḥamdu lillāh, bi-khayr}) & the praise {[}is{]} to God — in goodness \\
+B & \textbf{\ar{وأنت؟} \ar{ما} \ar{اسمك؟}} (\emph{wa-anta? mā ismuka?}) & and you? what {[}is{]} your name? \\
 \bottomrule
 \end{tabularx}
 
-Read down the right-hand column. \textbf{Not one line contains a verb \textquotedblleft{}to be.\textquotedblright{}} Arabic joins things by putting them next to each other.
+Read down the right-hand column. \textbf{Not one line contains a verb \textquotedblleft{}to be.\textquotedblright{}} Arabic just puts the two things next to each other.
 
 \subsection*{You'll want to know — the pieces}
 \noindent
@@ -441,10 +441,10 @@ Read down the right-hand column. \textbf{Not one line contains a verb \textquote
 \bottomrule
 \end{tabularx}
 
-Three tiny attaching pieces — \textbf{al-}, \textbf{bi-}, \textbf{li-} — and two suffixes, \textbf{-ī} and \textbf{-ka/-ki}. That is most of the chapter.
+Three attaching pieces — \textbf{al-}, \textbf{bi-}, \textbf{li-} — and two suffixes, \textbf{-ī} and \textbf{-ka/-ki}. That is most of the chapter.
 
 \begin{grammarlens}[title={Grammar Lens — gender}]
-Every \textquotedblleft{}you\textquotedblright{} in this chapter splits. Say the pair aloud:
+Every \textquotedblleft{}you\textquotedblright{} here splits. Say the pair aloud:
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
@@ -457,7 +457,7 @@ Every \textquotedblleft{}you\textquotedblright{} in this chapter splits. Say the
 \bottomrule
 \end{tabularx}
 
-One vowel mark decides — the \emph{fatḥa} / \emph{kasra} pair from the writing set.
+One vowel mark decides — the \emph{fatḥa} / \emph{kasra} pair.
 \end{grammarlens}
 
 \subsection*{Your turn}

--- a/code/learning/human-languages/arabic/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch04-farewells.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b6ead1e51ea1793c
+% canonical-source-hash: fnv1a64:df6fb15ff943b7f9
 % canonical-lessons: AR-W10-ayn, AR-W11-ha-and-ta-marbuta, AR-W12-maa-salama, AR-C04-maa-with, AR-C04-al-salama, AR-C04-maa-salama, AR-C04-ila-liqaa, AR-C04-practice
 
 \chapter{Farewells}
@@ -414,14 +414,14 @@ Four chapters. Greet, introduce, ask after someone, part. Here it all is in one 
 \toprule
 \textbf{} & \textbf{Arabic} & \textbf{literally} \\
 \midrule
-A & \textbf{\ar{السلام} \ar{عليكم}} & peace {[}be{]} upon you \\
-B & \textbf{\ar{وعليكم} \ar{السلام}} & and upon you, peace \\
-A & \textbf{\ar{ما} \ar{اسمك؟}} & what {[}is{]} your name? \\
-B & \textbf{\ar{اسمي} …\ar{،} \ar{تشرفنا}.} & my name {[}is{]} …, we are honoured \\
-A & \textbf{\ar{كيف} \ar{حالك؟}} & how {[}is{]} your state? \\
-B & \textbf{\ar{الحمد} \ar{لله،} \ar{بخير}.} & the praise {[}is{]} to God — in goodness \\
-A & \textbf{\ar{مع} \ar{السلامة}} & with safety \\
-B & \textbf{\ar{إلى} \ar{اللقاء}} & until the meeting \\
+A & \textbf{\ar{السلام} \ar{عليكم}} (\emph{as-salāmu ʿalaykum}) & peace {[}be{]} upon you \\
+B & \textbf{\ar{وعليكم} \ar{السلام}} (\emph{wa-ʿalaykum as-salām}) & and upon you, peace \\
+A & \textbf{\ar{ما} \ar{اسمك؟}} (\emph{mā ismuka?}) & what {[}is{]} your name? \\
+B & \textbf{\ar{اسمي} …\ar{،} \ar{تشرفنا}.} (\emph{ismī …, tasharrafnā}) & my name {[}is{]} …, we are honoured \\
+A & \textbf{\ar{كيف} \ar{حالك؟}} (\emph{kayfa ḥāluka?}) & how {[}is{]} your state? \\
+B & \textbf{\ar{الحمد} \ar{لله،} \ar{بخير}.} (\emph{al-ḥamdu lillāh, bi-khayr}) & the praise {[}is{]} to God — in goodness \\
+A & \textbf{\ar{مع} \ar{السلامة}} (\emph{maʿa s-salāma}) & with safety \\
+B & \textbf{\ar{إلى} \ar{اللقاء}} (\emph{ilā l-liqāʾ}) & until the meeting \\
 \bottomrule
 \end{tabularx}
 

--- a/code/learning/human-languages/arabic/lessons/AR-C03-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C03-practice.md
@@ -33,21 +33,21 @@ reviews_of: [AR-C03-kayfa, AR-C03-hal, AR-C03-kayfa-haluka, AR-C03-bi-khayr, AR-
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Chapter 1 let you greet. Chapter 2 let you introduce yourself. This
-chapter closes the loop: you can now **ask after someone and answer back**.
+chapter closes the loop: you can **ask after someone and answer back**.
 
 ## The exchange
 <!-- hl-knowledge: introduces=[AR-CONCEPT-C03-PRACTICE-01]; assesses=[] -->
 
 | | Arabic | literally |
 |---|---|---|
-| A | **السلام عليكم** | peace [be] upon you |
-| B | **وعليكم السلام** | and upon you, peace |
-| A | **كيف حالك؟** | how [is] your state? |
-| B | **الحمد لله، بخير.** | the praise [is] to God — in goodness |
-| B | **وأنت؟ ما اسمك؟** | and you? what [is] your name? |
+| A | **السلام عليكم** (*as-salāmu ʿalaykum*) | peace [be] upon you |
+| B | **وعليكم السلام** (*wa-ʿalaykum as-salām*) | and upon you, peace |
+| A | **كيف حالك؟** (*kayfa ḥāluka?*) | how [is] your state? |
+| B | **الحمد لله، بخير.** (*al-ḥamdu lillāh, bi-khayr*) | the praise [is] to God — in goodness |
+| B | **وأنت؟ ما اسمك؟** (*wa-anta? mā ismuka?*) | and you? what [is] your name? |
 
-Read down the right-hand column. **Not one line contains a verb "to be."** Arabic
-joins things by putting them next to each other.
+Read down the right-hand column. **Not one line contains a verb "to be."**
+Arabic just puts the two things next to each other.
 
 ## You'll want to know — the pieces
 <!-- hl-knowledge: introduces=[AR-CONCEPT-C03-PRACTICE-02]; assesses=[] -->
@@ -59,13 +59,13 @@ joins things by putting them next to each other.
 | *al-ḥamdu lillāh* | *al-* + *ḥamd* + **li-** + *allāh* |
 | *ismuka* | *ism* + **-ka/-ki** — the same suffix as *ḥāluka* |
 
-Three tiny attaching pieces — **al-**, **bi-**, **li-** — and two suffixes,
+Three attaching pieces — **al-**, **bi-**, **li-** — and two suffixes,
 **-ī** and **-ka/-ki**. That is most of the chapter.
 
 ## Grammar Lens — gender
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-Every "you" in this chapter splits. Say the pair aloud:
+Every "you" here splits. Say the pair aloud:
 
 | to a man | to a woman |
 |---|---|
@@ -73,7 +73,7 @@ Every "you" in this chapter splits. Say the pair aloud:
 | *mā ism**uka**?* | *mā ism**uki**?* |
 | *ant**a*** | *ant**i*** |
 
-One vowel mark decides — the *fatḥa* / *kasra* pair from the writing set.
+One vowel mark decides — the *fatḥa* / *kasra* pair.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C03-PRACTICE-01, AR-CONCEPT-C03-PRACTICE-02] -->

--- a/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C04-practice.md
@@ -40,14 +40,14 @@ is in one piece.
 
 | | Arabic | literally |
 |---|---|---|
-| A | **السلام عليكم** | peace [be] upon you |
-| B | **وعليكم السلام** | and upon you, peace |
-| A | **ما اسمك؟** | what [is] your name? |
-| B | **اسمي …، تشرفنا.** | my name [is] …, we are honoured |
-| A | **كيف حالك؟** | how [is] your state? |
-| B | **الحمد لله، بخير.** | the praise [is] to God — in goodness |
-| A | **مع السلامة** | with safety |
-| B | **إلى اللقاء** | until the meeting |
+| A | **السلام عليكم** (*as-salāmu ʿalaykum*) | peace [be] upon you |
+| B | **وعليكم السلام** (*wa-ʿalaykum as-salām*) | and upon you, peace |
+| A | **ما اسمك؟** (*mā ismuka?*) | what [is] your name? |
+| B | **اسمي …، تشرفنا.** (*ismī …, tasharrafnā*) | my name [is] …, we are honoured |
+| A | **كيف حالك؟** (*kayfa ḥāluka?*) | how [is] your state? |
+| B | **الحمد لله، بخير.** (*al-ḥamdu lillāh, bi-khayr*) | the praise [is] to God — in goodness |
+| A | **مع السلامة** (*maʿa s-salāma*) | with safety |
+| B | **إلى اللقاء** (*ilā l-liqāʾ*) | until the meeting |
 
 Read the right-hand column top to bottom. **Not one line contains a verb "to
 be."** The zero copula has held for four chapters.

--- a/code/learning/human-languages/arabic/narration/ch03.json
+++ b/code/learning/human-languages/arabic/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:7520b462f31cab77",
+  "sourceHash": "fnv1a64:00cc06864fba2d3d",
   "lessons": [
     {
       "id": "AR-W07-hook-family-ha-kha",
@@ -1315,7 +1315,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:a84e2262a220a4e9",
+      "sourceHash": "fnv1a64:ba0898bc3feaa45b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -1340,7 +1340,7 @@
             },
             {
               "kind": "speech",
-              "text": "Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can now ask after someone and answer back."
+              "text": "Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can ask after someone and answer back."
             }
           ]
         },
@@ -1359,16 +1359,16 @@
               "columns": 3,
               "rowCount": 5,
               "utterances": [
-                "A. Arabic: السلام عليكم. literally: peace [be] upon you.",
-                "B. Arabic: وعليكم السلام. literally: and upon you, peace.",
-                "A. Arabic: كيف حالك؟ (kayfa ḥāluka / kayfa ḥāluki). literally: how [is] your state?",
-                "B. Arabic: الحمد لله (al-ḥamdu lillāh)، بخير (bi-khayr). literally: the praise [is] to God — in goodness.",
-                "B. Arabic: وأنت؟ ما اسمك؟. literally: and you? what [is] your name?"
+                "A. Arabic: السلام عليكم (as-salāmu ʿalaykum). literally: peace [be] upon you.",
+                "B. Arabic: وعليكم السلام (wa-ʿalaykum as-salām). literally: and upon you, peace.",
+                "A. Arabic: كيف حالك؟ (kayfa ḥāluka / kayfa ḥāluki) (kayfa ḥāluka?) literally: how [is] your state?",
+                "B. Arabic: الحمد لله، بخير. (al-ḥamdu lillāh, bi-khayr). literally: the praise [is] to God — in goodness.",
+                "B. Arabic: وأنت؟ ما اسمك؟ (wa-anta? mā ismuka?) literally: and you? what [is] your name?"
               ]
             },
             {
               "kind": "speech",
-              "text": "Read down the right-hand column. Not one line contains a verb \"to be.\" Arabic joins things by putting them next to each other."
+              "text": "Read down the right-hand column. Not one line contains a verb \"to be.\" Arabic just puts the two things next to each other."
             }
           ]
         },
@@ -1394,7 +1394,7 @@
             },
             {
               "kind": "speech",
-              "text": "Three tiny attaching pieces — al-, bi-, li- — and two suffixes, -ī and -ka/-ki. That is most of the chapter."
+              "text": "Three attaching pieces — al-, bi-, li- — and two suffixes, -ī and -ka/-ki. That is most of the chapter."
             }
           ]
         },
@@ -1405,7 +1405,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Every \"you\" in this chapter splits. Say the pair aloud:"
+              "text": "Every \"you\" here splits. Say the pair aloud:"
             },
             {
               "kind": "table",
@@ -1423,7 +1423,7 @@
             },
             {
               "kind": "speech",
-              "text": "One vowel mark decides — the fatḥa / kasra pair from the writing set."
+              "text": "One vowel mark decides — the fatḥa / kasra pair."
             }
           ]
         },

--- a/code/learning/human-languages/arabic/narration/ch03.txt
+++ b/code/learning/human-languages/arabic/narration/ch03.txt
@@ -316,16 +316,16 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can now ask after someone and answer back.
+Chapter 1 let you greet. Chapter 2 let you introduce yourself. This chapter closes the loop: you can ask after someone and answer back.
 
 The exchange.
 [a table of 5 rows, read aloud]
-A. Arabic: السلام عليكم. literally: peace [be] upon you.
-B. Arabic: وعليكم السلام. literally: and upon you, peace.
-A. Arabic: كيف حالك؟ (kayfa ḥāluka / kayfa ḥāluki). literally: how [is] your state?
-B. Arabic: الحمد لله (al-ḥamdu lillāh)، بخير (bi-khayr). literally: the praise [is] to God — in goodness.
-B. Arabic: وأنت؟ ما اسمك؟. literally: and you? what [is] your name?
-Read down the right-hand column. Not one line contains a verb "to be." Arabic joins things by putting them next to each other.
+A. Arabic: السلام عليكم (as-salāmu ʿalaykum). literally: peace [be] upon you.
+B. Arabic: وعليكم السلام (wa-ʿalaykum as-salām). literally: and upon you, peace.
+A. Arabic: كيف حالك؟ (kayfa ḥāluka / kayfa ḥāluki) (kayfa ḥāluka?) literally: how [is] your state?
+B. Arabic: الحمد لله، بخير. (al-ḥamdu lillāh, bi-khayr). literally: the praise [is] to God — in goodness.
+B. Arabic: وأنت؟ ما اسمك؟ (wa-anta? mā ismuka?) literally: and you? what [is] your name?
+Read down the right-hand column. Not one line contains a verb "to be." Arabic just puts the two things next to each other.
 
 You'll want to know — the pieces.
 [a table of 4 rows, read aloud]
@@ -333,15 +333,15 @@ phrase: kayfa ḥāluka. built from: kayfa + ḥāl + -ka/-ki.
 phrase: bi-khayr. built from: bi- + khayr (already inside ṣabāḥ al-khayr).
 phrase: al-ḥamdu lillāh. built from: al- + ḥamd + li- + allāh.
 phrase: ismuka. built from: ism + -ka/-ki — the same suffix as ḥāluka.
-Three tiny attaching pieces — al-, bi-, li- — and two suffixes, -ī and -ka/-ki. That is most of the chapter.
+Three attaching pieces — al-, bi-, li- — and two suffixes, -ī and -ka/-ki. That is most of the chapter.
 
 Grammar Lens — gender.
-Every "you" in this chapter splits. Say the pair aloud:
+Every "you" here splits. Say the pair aloud:
 [a table of 3 rows, read aloud]
 to a man: kayfa ḥāluka? to a woman: kayfa ḥāluki?
 to a man: mā ismuka? to a woman: mā ismuki?
 to a man: anta. to a woman: anti.
-One vowel mark decides — the fatḥa / kasra pair from the writing set.
+One vowel mark decides — the fatḥa / kasra pair.
 
 Guided Practice.
 [pause 1 second]

--- a/code/learning/human-languages/arabic/narration/ch04.json
+++ b/code/learning/human-languages/arabic/narration/ch04.json
@@ -4,7 +4,7 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:578c8067fccd9a7e",
+  "sourceHash": "fnv1a64:c9ca88fe561b8c3d",
   "lessons": [
     {
       "id": "AR-W10-ayn",
@@ -1290,7 +1290,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:05c5e1b72f8cf5f3",
+      "sourceHash": "fnv1a64:dc8602c69aa3d525",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -1334,12 +1334,12 @@
               "columns": 3,
               "rowCount": 8,
               "utterances": [
-                "A. Arabic: السلام عليكم. literally: peace [be] upon you.",
-                "B. Arabic: وعليكم السلام. literally: and upon you, peace.",
-                "A. Arabic: ما اسمك؟. literally: what [is] your name?",
-                "B. Arabic: اسمي …، تشرفنا. literally: my name [is] …, we are honoured.",
-                "A. Arabic: كيف حالك؟. literally: how [is] your state?",
-                "B. Arabic: الحمد لله، بخير. literally: the praise [is] to God — in goodness.",
+                "A. Arabic: السلام عليكم (as-salāmu ʿalaykum). literally: peace [be] upon you.",
+                "B. Arabic: وعليكم السلام (wa-ʿalaykum as-salām). literally: and upon you, peace.",
+                "A. Arabic: ما اسمك؟ (mā ismuka?) literally: what [is] your name?",
+                "B. Arabic: اسمي …، تشرفنا. (ismī …, tasharrafnā). literally: my name [is] …, we are honoured.",
+                "A. Arabic: كيف حالك؟ (kayfa ḥāluka?) literally: how [is] your state?",
+                "B. Arabic: الحمد لله، بخير. (al-ḥamdu lillāh, bi-khayr). literally: the praise [is] to God — in goodness.",
                 "A. Arabic: مع السلامة (as-salāma) (maʿa s-salāma). literally: with safety.",
                 "B. Arabic: إلى اللقاء (ilā l-liqāʾ). literally: until the meeting."
               ]

--- a/code/learning/human-languages/arabic/narration/ch04.txt
+++ b/code/learning/human-languages/arabic/narration/ch04.txt
@@ -311,12 +311,12 @@ Four chapters. Greet, introduce, ask after someone, part. Here it all is in one 
 
 You'll want to know — The full exchange.
 [a table of 8 rows, read aloud]
-A. Arabic: السلام عليكم. literally: peace [be] upon you.
-B. Arabic: وعليكم السلام. literally: and upon you, peace.
-A. Arabic: ما اسمك؟. literally: what [is] your name?
-B. Arabic: اسمي …، تشرفنا. literally: my name [is] …, we are honoured.
-A. Arabic: كيف حالك؟. literally: how [is] your state?
-B. Arabic: الحمد لله، بخير. literally: the praise [is] to God — in goodness.
+A. Arabic: السلام عليكم (as-salāmu ʿalaykum). literally: peace [be] upon you.
+B. Arabic: وعليكم السلام (wa-ʿalaykum as-salām). literally: and upon you, peace.
+A. Arabic: ما اسمك؟ (mā ismuka?) literally: what [is] your name?
+B. Arabic: اسمي …، تشرفنا. (ismī …, tasharrafnā). literally: my name [is] …, we are honoured.
+A. Arabic: كيف حالك؟ (kayfa ḥāluka?) literally: how [is] your state?
+B. Arabic: الحمد لله، بخير. (al-ḥamdu lillāh, bi-khayr). literally: the praise [is] to God — in goodness.
 A. Arabic: مع السلامة (as-salāma) (maʿa s-salāma). literally: with safety.
 B. Arabic: إلى اللقاء (ilā l-liqāʾ). literally: until the meeting.
 Read the right-hand column top to bottom. Not one line contains a verb "to be." The zero copula has held for four chapters.

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -5,7 +5,7 @@
     {
       "language": "arabic",
       "chapter": 3,
-      "sourceHash": "fnv1a64:975f075b68b954ae",
+      "sourceHash": "fnv1a64:8cb8e93eac4de300",
       "lessonIds": [
         "AR-W07-hook-family-ha-kha",
         "AR-W08-kaf-and-ra",
@@ -22,7 +22,7 @@
     {
       "language": "arabic",
       "chapter": 4,
-      "sourceHash": "fnv1a64:b6ead1e51ea1793c",
+      "sourceHash": "fnv1a64:df6fb15ff943b7f9",
       "lessonIds": [
         "AR-W10-ayn",
         "AR-W11-ha-and-ta-marbuta",
@@ -3807,7 +3807,7 @@
     {
       "language": "persian",
       "chapter": 9,
-      "sourceHash": "fnv1a64:189ad694fcec2dda",
+      "sourceHash": "fnv1a64:10653b6e52e9b4a8",
       "lessonIds": [
         "FA-C09-ab",
         "FA-C09-nan",
@@ -3831,7 +3831,7 @@
     {
       "language": "persian",
       "chapter": 11,
-      "sourceHash": "fnv1a64:a2e7207a4816e812",
+      "sourceHash": "fnv1a64:d4c57c48fbf24363",
       "lessonIds": [
         "FA-C11-cheshm",
         "FA-C11-dast",
@@ -3843,7 +3843,7 @@
     {
       "language": "persian",
       "chapter": 12,
-      "sourceHash": "fnv1a64:78d09fa60f45a70c",
+      "sourceHash": "fnv1a64:b7dc258c97b8921c",
       "lessonIds": [
         "FA-C12-nam",
         "FA-C12-del",
@@ -3855,7 +3855,7 @@
     {
       "language": "persian",
       "chapter": 13,
-      "sourceHash": "fnv1a64:f9cced230ff54588",
+      "sourceHash": "fnv1a64:d4c64a5e309e20e0",
       "lessonIds": [
         "FA-C13-aseman",
         "FA-C13-khorshid",
@@ -3868,7 +3868,7 @@
     {
       "language": "persian",
       "chapter": 14,
-      "sourceHash": "fnv1a64:5da7cf393cf4ac91",
+      "sourceHash": "fnv1a64:ee36853a6bd77421",
       "lessonIds": [
         "FA-C14-khahar",
         "FA-C14-pesar",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -58,7 +58,7 @@
     {
       "language": "arabic",
       "chapter": 3,
-      "sourceHash": "fnv1a64:7520b462f31cab77",
+      "sourceHash": "fnv1a64:00cc06864fba2d3d",
       "lessonIds": [
         "AR-W07-hook-family-ha-kha",
         "AR-W08-kaf-and-ra",
@@ -74,13 +74,13 @@
       "drivablePrefix": 0,
       "text": "arabic/narration/ch03.txt",
       "json": "arabic/narration/ch03.json",
-      "textHash": "fnv1a64:6d6599310045eb09",
-      "jsonHash": "fnv1a64:54f9f6f6cf19616a"
+      "textHash": "fnv1a64:e2a62b90f3294641",
+      "jsonHash": "fnv1a64:a34bd93498f5f2f4"
     },
     {
       "language": "arabic",
       "chapter": 4,
-      "sourceHash": "fnv1a64:578c8067fccd9a7e",
+      "sourceHash": "fnv1a64:c9ca88fe561b8c3d",
       "lessonIds": [
         "AR-W10-ayn",
         "AR-W11-ha-and-ta-marbuta",
@@ -95,8 +95,8 @@
       "drivablePrefix": 0,
       "text": "arabic/narration/ch04.txt",
       "json": "arabic/narration/ch04.json",
-      "textHash": "fnv1a64:12db8c44d2a9f92b",
-      "jsonHash": "fnv1a64:f0bb2f3d3c11ce22"
+      "textHash": "fnv1a64:ee7f034c04449c62",
+      "jsonHash": "fnv1a64:82ee7ec7dadb9681"
     },
     {
       "language": "arabic",
@@ -6753,7 +6753,7 @@
     {
       "language": "persian",
       "chapter": 9,
-      "sourceHash": "fnv1a64:b5c1a335c3b471aa",
+      "sourceHash": "fnv1a64:badc825e34e86a15",
       "lessonIds": [
         "FA-C09-ab",
         "FA-C09-nan",
@@ -6764,8 +6764,8 @@
       "drivablePrefix": 4,
       "text": "persian/narration/ch09.txt",
       "json": "persian/narration/ch09.json",
-      "textHash": "fnv1a64:d8706547cba09073",
-      "jsonHash": "fnv1a64:5400575e22102cf6"
+      "textHash": "fnv1a64:94787a353584ca0d",
+      "jsonHash": "fnv1a64:af9160b063012e03"
     },
     {
       "language": "persian",
@@ -6787,7 +6787,7 @@
     {
       "language": "persian",
       "chapter": 11,
-      "sourceHash": "fnv1a64:ae02ea595fd16e54",
+      "sourceHash": "fnv1a64:8f4fa561dca27999",
       "lessonIds": [
         "FA-C11-cheshm",
         "FA-C11-dast",
@@ -6799,12 +6799,12 @@
       "text": "persian/narration/ch11.txt",
       "json": "persian/narration/ch11.json",
       "textHash": "fnv1a64:7e5dec6e313e5b6f",
-      "jsonHash": "fnv1a64:0b0b0c632e56d2fc"
+      "jsonHash": "fnv1a64:de0712ce793d86a4"
     },
     {
       "language": "persian",
       "chapter": 12,
-      "sourceHash": "fnv1a64:8df79aa43b350f9f",
+      "sourceHash": "fnv1a64:3d375573d3417b20",
       "lessonIds": [
         "FA-C12-nam",
         "FA-C12-del",
@@ -6816,12 +6816,12 @@
       "text": "persian/narration/ch12.txt",
       "json": "persian/narration/ch12.json",
       "textHash": "fnv1a64:c0420c20f3d365af",
-      "jsonHash": "fnv1a64:6fe9acf09a5f8577"
+      "jsonHash": "fnv1a64:5b8b0554ba49a7f2"
     },
     {
       "language": "persian",
       "chapter": 13,
-      "sourceHash": "fnv1a64:f682c82bef25fe00",
+      "sourceHash": "fnv1a64:eaf81b9034472f37",
       "lessonIds": [
         "FA-C13-aseman",
         "FA-C13-khorshid",
@@ -6833,13 +6833,13 @@
       "drivablePrefix": 5,
       "text": "persian/narration/ch13.txt",
       "json": "persian/narration/ch13.json",
-      "textHash": "fnv1a64:ed8cbed2cc0dceaf",
-      "jsonHash": "fnv1a64:21d9dd9cbed86b1e"
+      "textHash": "fnv1a64:e5c155fb0714a9cf",
+      "jsonHash": "fnv1a64:18eefd0cff2c4381"
     },
     {
       "language": "persian",
       "chapter": 14,
-      "sourceHash": "fnv1a64:cb22b062034b1bbd",
+      "sourceHash": "fnv1a64:74afbe93603a1852",
       "lessonIds": [
         "FA-C14-khahar",
         "FA-C14-pesar",
@@ -6851,8 +6851,8 @@
       "drivablePrefix": 5,
       "text": "persian/narration/ch14.txt",
       "json": "persian/narration/ch14.json",
-      "textHash": "fnv1a64:a4605dd18532ffca",
-      "jsonHash": "fnv1a64:4909c4cedf569170"
+      "textHash": "fnv1a64:97eb74a09ab3ca6d",
+      "jsonHash": "fnv1a64:ce6efb03162a411a"
     },
     {
       "language": "persian",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:fd7b0f9f9dacad8e",
+  "sourceHash": "fnv1a64:79d8e51e0b335384",
   "summary": {
     "totalLessons": 3070,
     "voice": 2161,
@@ -17201,7 +17201,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:a84e2262a220a4e9"
+      "sourceHash": "fnv1a64:ba0898bc3feaa45b"
     },
     {
       "id": "AR-W10-ayn",
@@ -17365,7 +17365,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:05c5e1b72f8cf5f3"
+      "sourceHash": "fnv1a64:dc8602c69aa3d525"
     },
     {
       "id": "AR-C05-naam",
@@ -45021,7 +45021,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:38ba1bbde851847b"
+      "sourceHash": "fnv1a64:f26a069106bfc347"
     },
     {
       "id": "FA-C09-chay",
@@ -45039,7 +45039,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a26e57f7adf3801e"
+      "sourceHash": "fnv1a64:13e89f0266a2ee3c"
     },
     {
       "id": "FA-C09-kelid",
@@ -45165,7 +45165,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a0073b3f04ec27b6"
+      "sourceHash": "fnv1a64:5e58e15e9a9b069e"
     },
     {
       "id": "FA-C11-pa",
@@ -45237,7 +45237,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e2a338a6b464d934"
+      "sourceHash": "fnv1a64:d9f09ab490244f86"
     },
     {
       "id": "FA-C12-dar",
@@ -45291,7 +45291,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6d992ea29e7bfb60"
+      "sourceHash": "fnv1a64:d1dee18370dc6a76"
     },
     {
       "id": "FA-C13-khorshid",
@@ -45309,7 +45309,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:251ffdeba61e505b"
+      "sourceHash": "fnv1a64:8055697d9d545edf"
     },
     {
       "id": "FA-C13-mah",
@@ -45327,7 +45327,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0e4d867ef70e34a1"
+      "sourceHash": "fnv1a64:89ff5e82aad2582f"
     },
     {
       "id": "FA-C13-setare",
@@ -45363,7 +45363,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:514ee9899221b7ba"
+      "sourceHash": "fnv1a64:569219c452011a28"
     },
     {
       "id": "FA-C14-khahar",
@@ -45417,7 +45417,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0acfe919b99ffa5f"
+      "sourceHash": "fnv1a64:878a7d36dcd4cf57"
     },
     {
       "id": "FA-C14-zan",
@@ -45453,7 +45453,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:2159ff3d4b5fda4a"
+      "sourceHash": "fnv1a64:6dab3630555d9c86"
     },
     {
       "id": "FA-W15-alef",

--- a/code/learning/human-languages/persian/book/chapters/ch09-please-requests.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch09-please-requests.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:189ad694fcec2dda
+% canonical-source-hash: fnv1a64:10653b6e52e9b4a8
 % canonical-lessons: FA-C09-ab, FA-C09-nan, FA-C09-chay, FA-C09-kelid
 
 \chapter{Please: Water, Bread, Tea, Key}
@@ -65,7 +65,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D8\%A2\%D8\%A8}{Wiktionary: \fa{�
 
 
 \begin{quote}
-Say \textbf{\fa{آب،} \fa{لطفاً}}. This chapter's second request names the other thing on every Persian table.
+Say \textbf{\fa{آب،} \fa{لطفاً}} (\emph{âb, lotfan}). This chapter's second request names the other thing on every Persian table.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -107,7 +107,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D9\%86\%D8\%A7\%D9\%86}{Wiktionar
 
 
 \begin{quote}
-Say \textbf{\fa{نان،} \fa{لطفاً}}. Here is the drink that usually comes with it.
+Say \textbf{\fa{نان،} \fa{لطفاً}} (\emph{nân, lotfan}). Here is the drink that usually comes with it.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/persian/book/chapters/ch11-body.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch11-body.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a2e7207a4816e812
+% canonical-source-hash: fnv1a64:d4c57c48fbf24363
 % canonical-lessons: FA-C11-cheshm, FA-C11-dast, FA-C11-pa, FA-C11-zaban
 
 \chapter{Eye, Hand, Foot, Tongue}
@@ -54,7 +54,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%DA\%86\%D8\%B4\%D9\%85}{Wiktionar
 
 
 \begin{quote}
-Say \textbf{\fa{چشم}}. This lesson's word looks nothing like its closest Indo-Iranian relative — and that mismatch is not an accident.
+Say \textbf{\fa{چشم}} (\emph{cheshm}). This lesson's word looks nothing like its closest Indo-Iranian relative — and that mismatch is not an accident.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/persian/book/chapters/ch12-name-heart-door-book.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch12-name-heart-door-book.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:78d09fa60f45a70c
+% canonical-source-hash: fnv1a64:b7dc258c97b8921c
 % canonical-lessons: FA-C12-nam, FA-C12-del, FA-C12-dar, FA-C12-ketab
 
 \chapter{Name, Heart, Door, Book}
@@ -54,7 +54,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D9\%86\%D8\%A7\%D9\%85}{Wiktionar
 
 
 \begin{quote}
-Say \textbf{\fa{نام}}, and its English cousin. This lesson's word has an even more famous one.
+Say \textbf{\fa{نام}} (\emph{nâm}), and its English cousin. This lesson's word has an even more famous one.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/persian/book/chapters/ch13-sky-words.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch13-sky-words.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f9cced230ff54588
+% canonical-source-hash: fnv1a64:d4c64a5e309e20e0
 % canonical-lessons: FA-C13-aseman, FA-C13-khorshid, FA-C13-mah, FA-C13-setare, FA-C13-baran
 
 \chapter{Sky, Sun, Moon, Star, Rain}
@@ -19,7 +19,7 @@ The chapter closes on bârân, a word with no English cousin, then runs all five
 
 
 \begin{quote}
-Say \textbf{\fa{کتاب}}, and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all.
+Say \textbf{\fa{کتاب}} (\emph{ketâb}), and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -54,7 +54,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D8\%A2\%D8\%B3\%D9\%85\%D8\%A7\%D
 
 
 \begin{quote}
-Say \textbf{\fa{آسمان}}, and the root sense it once carried. Look up, and this lesson names what is in it.
+Say \textbf{\fa{آسمان}} (\emph{âsemân}), and the root sense it once carried. Look up, and this lesson names what is in it.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -89,7 +89,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D8\%AE\%D9\%88\%D8\%B1\%D8\%B4\%D
 
 
 \begin{quote}
-Say \textbf{\fa{خورشید}}, and the two old pieces fused inside it. The sky's other light gives Persian one more word doing double duty.
+Say \textbf{\fa{خورشید}} (\emph{khorshid}), and the two old pieces fused inside it. The sky's other light gives Persian one more word doing double duty.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -159,7 +159,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D8\%B3\%D8\%AA\%D8\%A7\%D8\%B1\%D
 
 
 \begin{quote}
-Say \textbf{\fa{ستاره}}, and its root's three attested cousins. Not every sky word gets to keep company like that.
+Say \textbf{\fa{ستاره}} (\emph{setâre}), and its root's three attested cousins. Not every sky word gets to keep company like that.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/persian/book/chapters/ch14-people-words.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch14-people-words.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5da7cf393cf4ac91
+% canonical-source-hash: fnv1a64:ee36853a6bd77421
 % canonical-lessons: FA-C14-khahar, FA-C14-pesar, FA-C14-mard, FA-C14-zan, FA-C14-dust
 
 \chapter{Sister, Son, Man, Woman, Friend}
@@ -90,7 +90,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D9\%BE\%D8\%B3\%D8\%B1}{Wiktionar
 
 
 \begin{quote}
-Say \textbf{\fa{پسر}}, and the Sanskrit word it shares a root with. This lesson's word looks like it should be an easy English cousin. It is not.
+Say \textbf{\fa{پسر}} (\emph{pesar}), and the Sanskrit word it shares a root with. This lesson's word looks like it should be an easy English cousin. It is not.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -160,7 +160,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%D8\%B2\%D9\%86}{Wiktionary: \fa{�
 
 
 \begin{quote}
-Say \textbf{\fa{مرد،} \fa{زن}} — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already.
+Say \textbf{\fa{مرد،} \fa{زن}} (\emph{mard, zan}) — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already.
 \end{quote}
 
 \subsection*{You'll want to know first — one word, already half-known}

--- a/code/learning/human-languages/persian/lessons/FA-C09-chay.md
+++ b/code/learning/human-languages/persian/lessons/FA-C09-chay.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C09-nan]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NAN, FA-PHRASE-LOTFAN] -->
 
-[PAUSE 2s] Say **نان، لطفاً**. Here is the drink that usually comes with it.
+[PAUSE 2s] Say **نان، لطفاً** (*nân, lotfan*). Here is the drink that usually comes with it.
 
 ## You'll want to know first — one word
 <!-- hl-knowledge: introduces=[FA-LEX-CHAY]; assesses=[] -->

--- a/code/learning/human-languages/persian/lessons/FA-C09-nan.md
+++ b/code/learning/human-languages/persian/lessons/FA-C09-nan.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C09-ab]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-AB, FA-PHRASE-LOTFAN] -->
 
-[PAUSE 2s] Say **آب، لطفاً**. This chapter's second request names the other
+[PAUSE 2s] Say **آب، لطفاً** (*âb, lotfan*). This chapter's second request names the other
 thing on every Persian table.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C11-dast.md
+++ b/code/learning/human-languages/persian/lessons/FA-C11-dast.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C11-cheshm]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-CHESHM] -->
 
-[PAUSE 2s] Say **چشم**. This lesson's word looks nothing like its closest
+[PAUSE 2s] Say **چشم** (*cheshm*). This lesson's word looks nothing like its closest
 Indo-Iranian relative — and that mismatch is not an accident.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C12-del.md
+++ b/code/learning/human-languages/persian/lessons/FA-C12-del.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C12-nam]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NAM, FA-ETYMON-NAM] -->
 
-[PAUSE 2s] Say **نام**, and its English cousin. This lesson's word has an
+[PAUSE 2s] Say **نام** (*nâm*), and its English cousin. This lesson's word has an
 even more famous one.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C13-aseman.md
+++ b/code/learning/human-languages/persian/lessons/FA-C13-aseman.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C12-ketab]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KETAB, FA-ETYMON-KETAB] -->
 
-[PAUSE 2s] Say **کتاب**, and which language it came from. This chapter turns
+[PAUSE 2s] Say **کتاب** (*ketâb*), and which language it came from. This chapter turns
 from things in the house to the world above it, starting with the biggest
 word of all.
 

--- a/code/learning/human-languages/persian/lessons/FA-C13-baran.md
+++ b/code/learning/human-languages/persian/lessons/FA-C13-baran.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C13-setare, FA-C04-hal-e-shoma-chetor-ast, FA-C04-khubam, FA-C04
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-SETARE, FA-ETYMON-SETARE] -->
 
-[PAUSE 2s] Say **ستاره**, and its root's three attested cousins. Not every
+[PAUSE 2s] Say **ستاره** (*setâre*), and its root's three attested cousins. Not every
 sky word gets to keep company like that.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C13-khorshid.md
+++ b/code/learning/human-languages/persian/lessons/FA-C13-khorshid.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C13-aseman]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-ASEMAN, FA-ETYMON-ASEMAN] -->
 
-[PAUSE 2s] Say **آسمان**, and the root sense it once carried. Look up, and
+[PAUSE 2s] Say **آسمان** (*âsemân*), and the root sense it once carried. Look up, and
 this lesson names what is in it.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C13-mah.md
+++ b/code/learning/human-languages/persian/lessons/FA-C13-mah.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C13-khorshid]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-KHORSHID, FA-ETYMON-KHORSHID] -->
 
-[PAUSE 2s] Say **خورشید**, and the two old pieces fused inside it. The sky's
+[PAUSE 2s] Say **خورشید** (*khorshid*), and the two old pieces fused inside it. The sky's
 other light gives Persian one more word doing double duty.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/lessons/FA-C14-dust.md
+++ b/code/learning/human-languages/persian/lessons/FA-C14-dust.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C14-zan, FA-C05-khodahafez, FA-C05-hafez, FA-C09-chay, FA-C09-ke
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-MARD, FA-LEX-ZAN] -->
 
-[PAUSE 2s] Say **مرد، زن** — man, woman. One more person word closes the
+[PAUSE 2s] Say **مرد، زن** (*mard, zan*) — man, woman. One more person word closes the
 tranche, and it is a word this track has half-taught already.
 
 ## You'll want to know first — one word, already half-known

--- a/code/learning/human-languages/persian/lessons/FA-C14-mard.md
+++ b/code/learning/human-languages/persian/lessons/FA-C14-mard.md
@@ -34,7 +34,7 @@ reviews_of: [FA-C14-pesar]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-PESAR, FA-ETYMON-PESAR] -->
 
-[PAUSE 2s] Say **پسر**, and the Sanskrit word it shares a root with. This
+[PAUSE 2s] Say **پسر** (*pesar*), and the Sanskrit word it shares a root with. This
 lesson's word looks like it should be an easy English cousin. It is not.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/persian/narration/ch09.json
+++ b/code/learning/human-languages/persian/narration/ch09.json
@@ -4,7 +4,7 @@
   "chapter": 9,
   "title": "Please: Water, Bread, Tea, Key",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:b5c1a335c3b471aa",
+  "sourceHash": "fnv1a64:badc825e34e86a15",
   "lessons": [
     {
       "id": "FA-C09-ab",
@@ -193,7 +193,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:38ba1bbde851847b",
+      "sourceHash": "fnv1a64:f26a069106bfc347",
       "notice": null,
       "blocks": [
         {
@@ -209,7 +209,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say آب (âb)، لطفاً. This chapter's second request names the other thing on every Persian table."
+              "text": "Say آب، لطفاً (âb, lotfan). This chapter's second request names the other thing on every Persian table."
             }
           ]
         },
@@ -355,7 +355,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a26e57f7adf3801e",
+      "sourceHash": "fnv1a64:13e89f0266a2ee3c",
       "notice": null,
       "blocks": [
         {
@@ -371,7 +371,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say نان (nân)، لطفاً. Here is the drink that usually comes with it."
+              "text": "Say نان، لطفاً (nân, lotfan). Here is the drink that usually comes with it."
             }
           ]
         },

--- a/code/learning/human-languages/persian/narration/ch09.txt
+++ b/code/learning/human-languages/persian/narration/ch09.txt
@@ -46,7 +46,7 @@ Lesson 2 of 4.
 
 Warm-up.
 [pause 2 seconds]
-Say آب (âb)، لطفاً. This chapter's second request names the other thing on every Persian table.
+Say آب، لطفاً (âb, lotfan). This chapter's second request names the other thing on every Persian table.
 
 You'll want to know first — one word.
 نان — nân — bread.
@@ -81,7 +81,7 @@ Lesson 3 of 4.
 
 Warm-up.
 [pause 2 seconds]
-Say نان (nân)، لطفاً. Here is the drink that usually comes with it.
+Say نان، لطفاً (nân, lotfan). Here is the drink that usually comes with it.
 
 You'll want to know first — one word.
 چای — chây — tea.

--- a/code/learning/human-languages/persian/narration/ch11.json
+++ b/code/learning/human-languages/persian/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Eye, Hand, Foot, Tongue",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:ae02ea595fd16e54",
+  "sourceHash": "fnv1a64:8f4fa561dca27999",
   "lessons": [
     {
       "id": "FA-C11-cheshm",
@@ -170,7 +170,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a0073b3f04ec27b6",
+      "sourceHash": "fnv1a64:5e58e15e9a9b069e",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/persian/narration/ch12.json
+++ b/code/learning/human-languages/persian/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Name, Heart, Door, Book",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:8df79aa43b350f9f",
+  "sourceHash": "fnv1a64:3d375573d3417b20",
   "lessons": [
     {
       "id": "FA-C12-nam",
@@ -164,7 +164,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e2a338a6b464d934",
+      "sourceHash": "fnv1a64:d9f09ab490244f86",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/persian/narration/ch13.json
+++ b/code/learning/human-languages/persian/narration/ch13.json
@@ -4,7 +4,7 @@
   "chapter": 13,
   "title": "Sky, Sun, Moon, Star, Rain",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:f682c82bef25fe00",
+  "sourceHash": "fnv1a64:eaf81b9034472f37",
   "lessons": [
     {
       "id": "FA-C13-aseman",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6d992ea29e7bfb60",
+      "sourceHash": "fnv1a64:d1dee18370dc6a76",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say کتاب, and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all."
+              "text": "Say کتاب (ketâb), and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all."
             }
           ]
         },
@@ -164,7 +164,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:251ffdeba61e505b",
+      "sourceHash": "fnv1a64:8055697d9d545edf",
       "notice": null,
       "blocks": [
         {
@@ -308,7 +308,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0e4d867ef70e34a1",
+      "sourceHash": "fnv1a64:89ff5e82aad2582f",
       "notice": null,
       "blocks": [
         {
@@ -598,7 +598,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:514ee9899221b7ba",
+      "sourceHash": "fnv1a64:569219c452011a28",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/persian/narration/ch13.txt
+++ b/code/learning/human-languages/persian/narration/ch13.txt
@@ -7,7 +7,7 @@ Lesson 1 of 5.
 
 Warm-up.
 [pause 2 seconds]
-Say کتاب, and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all.
+Say کتاب (ketâb), and which language it came from. This chapter turns from things in the house to the world above it, starting with the biggest word of all.
 
 You'll want to know first — one word.
 آسمان — âsemân — sky.

--- a/code/learning/human-languages/persian/narration/ch14.json
+++ b/code/learning/human-languages/persian/narration/ch14.json
@@ -4,7 +4,7 @@
   "chapter": 14,
   "title": "Sister, Son, Man, Woman, Friend",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:cb22b062034b1bbd",
+  "sourceHash": "fnv1a64:74afbe93603a1852",
   "lessons": [
     {
       "id": "FA-C14-khahar",
@@ -316,7 +316,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0acfe919b99ffa5f",
+      "sourceHash": "fnv1a64:878a7d36dcd4cf57",
       "notice": null,
       "blocks": [
         {
@@ -602,7 +602,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2159ff3d4b5fda4a",
+      "sourceHash": "fnv1a64:6dab3630555d9c86",
       "notice": null,
       "blocks": [
         {
@@ -618,7 +618,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say مرد (mard)، زن (zan) — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already."
+              "text": "Say مرد، زن (mard, zan) — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already."
             }
           ]
         },

--- a/code/learning/human-languages/persian/narration/ch14.txt
+++ b/code/learning/human-languages/persian/narration/ch14.txt
@@ -137,7 +137,7 @@ Lesson 5 of 5.
 
 Warm-up.
 [pause 2 seconds]
-Say مرد (mard)، زن (zan) — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already.
+Say مرد، زن (mard, zan) — man, woman. One more person word closes the tranche, and it is a word this track has half-taught already.
 
 You'll want to know first — one word, already half-known.
 دوست — dust — friend.


### PR DESCRIPTION
Twelve lessons. **Persian's truly-unreachable words go 11 → 0 and Arabic's 12 → 0**; the corpus-wide count falls 74 → 53.

## Two different shapes, one defect

Persian's warm-ups literally instruct the reader to **say** a word and then print it only in Perso-Arabic: *"Say **مرد، زن** — man, woman."* Arabic's chapter-three and chapter-four exchange tables print eight lines of dialogue with a literal English gloss and no pronunciation. In both cases a learner who cannot yet read the script is being asked to speak and given nothing to speak from.

## Arabic's fix had to go inside the cell

Those tables are already three columns — speaker, Arabic, literal — and **three is the ceiling** (`maxLinearisableTableColumns`). So the romanization rides inside the Arabic cell. That isn't a workaround: **`AR-C02-practice` has done exactly that since it was written**, so this matches the house pattern rather than inventing a fourth column.

## Sourcing

**Nineteen of the twenty romanizations are attested verbatim elsewhere in their own track.** The twentieth, `wa-anta`, I composed — called out here rather than buried:

- the hyphen follows the corpus's only other `wa-` proclitic (`wa-ʿalaykum`)
- the dropped hamza follows the corpus writing this word as bare `anta` in seven places, never `ʾanta`

Review judged both choices correct and consistent.

**Review also corrected me twice, both in my favour.** `al-ḥamdu lillāh, bi-khayr` is attested verbatim — comma and all — in `AR-W09-khayr-bikhayr`; I had believed I joined it from two pieces. And a Cyrillic homoglyph I was worried about turned out to be in my own review brief, not in any file.

## The duration ceiling

The romanizations pushed `AR-C03-practice` from 297s to 304s, past the 299s cap. **I trimmed prose rather than the romanizations** — the pronunciation *is* the change. It now computes 299.

That leaves **one second of headroom**, so the next edit to that file will breach it and will need a trim of its own. Recording it here so the next author isn't surprised. Twenty-odd existing lessons sit at exactly 299, so this is the house norm rather than an outlier.

## Verification

Persian uses `â` and Arabic uses `ā`; the schemes are **not mixed** anywhere, checked in both directions with dirty controls. **804 + 1231 + 725 tests pass**, five gates clean, validator clean, no corpus pin moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)