### PR TITLE
feat(vault-pm): password generator with an 80-bit entropy floor and an unbiased OS-CSPRNG sampler (VLT-PM44)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1130,6 +1130,7 @@ members = [
   "vault-pm-config",
   "vault-pm-cli-host",
   "vault-pm-crash-injection",
+  "vault-pm-password-policy",
   "vault-pm-cli",
   "chief-of-staff-channel-epoch-activation",
 ]

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 ## Unreleased
 
+- **Added `vault-pm password generate`**, the first of `VLT-PM00` §23 item 11
+  and the first command in this grammar that opens no vault. Specified by
+  `VLT-PM44-cli-password-generate.md`.
+
+  It is dispatched beside `help`, before `execute`: no platform layout is
+  resolved, no cross-process writer lock is taken, no passphrase is collected,
+  and no audit event is published. It works on a machine where `init` has never
+  run, which is the most common moment to want a generated password. VLT-PM44
+  §1 records the three reasons that scoping is deliberate — `VLT-PM15` §2
+  already exempts operations that reveal no vault content, a vault-scoped event
+  would correlate an instant with whichever item is created next, and requiring
+  the master passphrase for an operation that never opens the vault would train
+  a person to type it at prompts that do not need it.
+
+  The command surface is `[--length N] [--no-lowercase] [--no-uppercase]
+  [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)`. This
+  is the crate's first real flag parser; every other command's arguments are
+  positional or a single boolean and are matched as exhaustive slice patterns.
+  Duplicate rejection needs no bookkeeping flags because the state being built
+  *is* the record — a class starts selected and can only be cleared once, an
+  output mode starts absent and can only be set once — so a second occurrence
+  has nowhere to go and falls into the same `_` arm as an unknown flag.
+
+  `--length` accepts one to three ASCII decimal digits with no sign, no
+  separator, no whitespace, and no leading zero. `str::parse` alone would take
+  `+24` and `007`, and a grammar with two spellings of one number is a grammar
+  where a typo can silently mean something else.
+
+- **Exactly one output mode is required**, and there is no plain-stdout mode.
+  VLT-PM00 §14.6 makes ordinary output redacted, and this command has nothing
+  but a secret to say: a default stdout mode would put a live credential into
+  shell history, terminal scrollback, `tee` pipelines, and CI logs the first
+  time anyone redirected it.
+
+  `--reveal` reuses `item reveal`'s fixed confirmation prompt and terminal
+  adapter unchanged rather than inventing a second ceremony, so the value is
+  quoted, control-escaped, written to the reopened controlling terminal, and
+  never enters `CliOutput`, stdout, stderr, argv, or a `Debug` rendering.
+  Confirmation runs *before* generation, which buys a property `item reveal`
+  cannot have: on refusal no password is ever created, so there is no secret to
+  wipe. Nothing forces the other order here, because unlike a stored-secret
+  reveal there is no audit event that must be published before the answer is
+  known.
+
+  `--copy` is recognized and refused with the unsupported class. No clipboard
+  adapter exists anywhere in this product — `clipboard_clear_seconds` is a
+  configuration value with no writer behind it — and §14.4 documents the flag,
+  so someone who reads the specification and types it deserves "not yet" rather
+  than "invalid command". It is refused before any prompt, since confirming a
+  reveal nobody asked for and then failing would be worse than failing at once.
+
+- **Added `CliFailure::WeakPasswordPolicy`**, carrying the invalid exit class
+  with its own fixed message, `vault-pm: password policy below the minimum
+  entropy floor`. It is the one rejection in this grammar a person will hit
+  while doing something entirely reasonable — asking for a shorter password, or
+  narrowing the alphabet for a site that refuses symbols — and "invalid
+  command" would send them hunting for a typo that is not there. The message
+  names no length, alphabet, or bit count.
+
+- **The `--vault` selector is refused for `password generate`**, joining
+  `init`, `vault create`, and `help`. The selector names a target for a command
+  to operate on, and this command operates on none; accepting and ignoring it
+  would let someone believe they had aimed a command that was never aimable.
+
+  The interactive shell prefixes every delegated command with its bound vault,
+  so it now asks `takes_no_vault_selector` first and delegates this one verb
+  unprefixed. Refusing the verb in the shell instead would have been the
+  smaller change and the worse one: a generator is exactly what you reach for
+  mid-session.
+
+- **Randomness comes from the operating-system CSPRNG** through the existing
+  `CliHost::fill_entropy` → `OsEntropy::fill` → `csprng::fill_random` path, in
+  one reservation, into a wipe-on-drop buffer. No new host method, no new
+  adapter, and no general-purpose RNG. The policy and sampler live in the new
+  pure `coding_adventures_vault_pm_password_policy` crate, which sources no
+  randomness at all.
+
+- Added ten unit tests and 25 new closed-parser rows, covering the flag surface
+  and its rejections, the entropy floor on both sides of three documented
+  policies, terminal-only delivery with empty stdout and stderr, determinism
+  under a fixed host and divergence under a different one, narrowed alphabets,
+  five confirmation answers that must not authorize a reveal, `--copy`,
+  an unavailable CSPRNG, an untouched vault root, and a full shell session that
+  runs the verb without ever unlocking.
+
 - **Added `vault-pm [--vault NAME] passphrase rotate`**, the ceremony
   `VLT-PM00` §14.8 has required since before there was any code and that
   nothing performed. Specified by `VLT-PM43-cli-passphrase-rotation.md`; closes

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -14,6 +14,7 @@ coding_adventures_vault_pm_config = { path = "../vault-pm-config" }
 coding_adventures_vault_pm_crash_injection = { path = "../vault-pm-crash-injection", optional = true }
 coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_local_host = { path = "../vault-pm-local-host" }
+coding_adventures_vault_pm_password_policy = { path = "../vault-pm-password-policy" }
 coding_adventures_vault_records = { path = "../vault-records" }
 coding_adventures_vault_pm_storage_storage_core = { path = "../vault-pm-storage-storage-core" }
 coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -471,6 +471,58 @@ unlinks a file rather than overwriting media.
 it collected once still opens the vault, and a rotation is the event that makes
 that false.
 
+## Generating a password
+
+```text
+vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase]
+                           [--no-digits] [--no-symbols] [--exclude-ambiguous]
+                           (--reveal|--copy)
+```
+
+This is the one command in the grammar that opens no vault. It unlocks nothing,
+reads no item, publishes no audit event, and takes no `--vault` selector,
+because a selector names a target and this command has none. It works on a
+machine where `init` has never run, which is the most common moment to want a
+generated password.
+
+`VLT-PM44-cli-password-generate.md` §1 records why that scoping is deliberate
+rather than incomplete. Briefly: `VLT-PM15` §2 already exempts operations that
+reveal no vault content; a vault-scoped event would be a *new* disclosure,
+correlating an instant with whichever item is created next; and requiring the
+master passphrase to perform an operation that never opens the vault would
+train a person to type it at prompts that do not need it.
+
+The strength of what it produces is fixed by two rules, both in the pure
+`vault-pm-password-policy` crate:
+
+- **The randomness is the operating-system CSPRNG**, reached through
+  `CliHost::fill_entropy` → `OsEntropy::fill` → `csprng::fill_random` →
+  `getrandom`/`getentropy`/`BCryptGenRandom`. That path is fail-closed: an
+  unavailable source is a provider failure, never a weaker draw.
+- **The floor is 80 bits**, checked as the exact integer comparison
+  `alphabet^length >= 2^80`. The default — 24 characters over all four classes
+  — is 155 bits, so the floor only ever bites on a policy someone deliberately
+  narrowed. A 12-character all-class password is 77.7 bits and is refused, one
+  character short, with its own message rather than a generic
+  "invalid command".
+
+Exactly one output mode is required. There is no plain-stdout mode: this
+command has nothing but a secret to say, and a default stdout mode would put a
+live credential into shell history, scrollback, `tee` pipelines, and CI logs
+the first time anyone redirected it. `--reveal` confirms on the controlling
+terminal and writes there and nowhere else, reusing the `item reveal` prompt
+and adapter unchanged. `--copy` is recognized and refused with the unsupported
+class until the clipboard ceremony ships — VLT-PM00 §14.4 documents the flag,
+so someone who reads the spec and types it deserves "not yet" rather than
+"invalid command".
+
+Confirmation happens *before* generation, which buys a property `item reveal`
+cannot have: on refusal no password is ever created, so there is no secret to
+wipe.
+
+The interactive shell can run this verb, and is the one place it is delegated
+*without* the session's bound-vault prefix — see `takes_no_vault_selector`.
+
 ## The durable-write seam
 
 This package is the layer that knows what "durable" means. `vault-pm-application`

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -56,6 +56,10 @@ use coding_adventures_vault_pm_domain::{
     RedactedRecordView, RevisionId,
 };
 use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
+use coding_adventures_vault_pm_password_policy::{
+    generate_password, CharacterClassesV1, PasswordPolicyError, PasswordPolicyV1,
+    DEFAULT_PASSWORD_LENGTH,
+};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
 use coding_adventures_vault_records::{
     AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed, API_KEY_V1, CARD_V1,
@@ -77,7 +81,7 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase] [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -622,6 +626,17 @@ where
     if matches!(invocation.command, Command::Help) {
         return CliOutput::success(USAGE);
     }
+    // VLT-PM44 §1. `password generate` is dispatched here, beside `help`,
+    // because it is the only other command that touches no vault: it must not
+    // resolve the platform layout, must not take the cross-process writer lock,
+    // and must work on a machine where `init` has never run — which is the most
+    // common moment to want a generated password.
+    if let Command::PasswordGenerate { policy, output } = &invocation.command {
+        return match password_generate(host, policy, *output) {
+            Ok(generated) => generated,
+            Err(error) => CliOutput::failure(error),
+        };
+    }
     // The shell is dispatched before `execute` because `execute` acquires the
     // cross-process writer lock for the whole command. A shell must not hold
     // that lock while it waits at a prompt, and its own per-command
@@ -669,6 +684,17 @@ enum Command {
     },
     /// Re-wrap the vault root key under a newly collected master passphrase.
     PassphraseRotate,
+    /// Mint one password that no vault ever stores (VLT-PM44).
+    ///
+    /// The policy is already validated by the time this variant exists: it
+    /// cannot be constructed below the entropy floor, so the ceremony never has
+    /// to re-check strength after the person has been prompted.
+    PasswordGenerate {
+        /// The validated length, alphabet, and entropy reservation.
+        policy: PasswordPolicyV1,
+        /// Where the one secret this command produces is delivered.
+        output: PasswordOutputMode,
+    },
     PortableExport {
         destination: PathBuf,
     },
@@ -754,6 +780,21 @@ enum Command {
     Help,
 }
 
+/// Where `password generate` delivers the one secret it produces.
+///
+/// There is no third arm, and in particular no "print it to standard output".
+/// VLT-PM00 §14.6 makes ordinary output redacted, and this command has nothing
+/// but a secret to say — a default stdout mode would put a live credential into
+/// shell history, terminal scrollback, `tee` pipelines, and CI logs the first
+/// time anyone redirected it. One of the two below is required.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PasswordOutputMode {
+    /// Confirm on the controlling terminal, then write there and nowhere else.
+    Reveal,
+    /// Reserved by VLT-PM00 §14.4; refused until a clipboard adapter exists.
+    Copy,
+}
+
 struct SearchQuery(Zeroizing<String>);
 
 impl SearchQuery {
@@ -836,6 +877,7 @@ where
         "audit" => parse_audit(tail),
         "doctor" => parse_doctor(tail),
         "passphrase" => parse_passphrase(tail),
+        "password" => parse_password(tail),
         "export" => parse_export(tail),
         "import" => parse_import(tail),
         "restore" => parse_restore(tail),
@@ -844,10 +886,19 @@ where
         "conflict" => parse_conflict(tail),
         _ => Err(CliFailure::InvalidCommand),
     }?;
+    // A `--vault` selector names a target for the command to operate on.
+    // `init` and `vault create` build a vault rather than opening one, `help`
+    // reads nothing, and `password generate` (VLT-PM44 §2.2) touches no vault
+    // at all — so for these four the selector would be a statement with no
+    // referent, and accepting it silently would let a person believe they had
+    // aimed a command that was never aimable.
     if selected_vault.is_some()
         && matches!(
             &command,
-            Command::Init { .. } | Command::VaultCreate { .. } | Command::Help
+            Command::Init { .. }
+                | Command::VaultCreate { .. }
+                | Command::Help
+                | Command::PasswordGenerate { .. }
         )
     {
         return Err(CliFailure::InvalidCommand);
@@ -1107,6 +1158,151 @@ fn parse_passphrase(arguments: &[String]) -> Result<Command, CliFailure> {
     }
 }
 
+/// Whether a verb refuses the leading `--vault` selector because it opens no
+/// vault.
+///
+/// The interactive shell binds one vault at session start and prefixes every
+/// delegated command with that selector, so it has to ask. `password generate`
+/// is the only verb in the grammar that a session can usefully run and that
+/// takes no target: it mints a value and hands it to the terminal, consulting
+/// neither the retained authenticator nor the bound vault. Refusing the verb in
+/// the shell instead would have been the smaller change and the worse one — a
+/// generator is exactly the thing you reach for mid-session, while adding a
+/// vault name to a command that ignores it would be a decoration that reads as
+/// a fact.
+pub(crate) fn takes_no_vault_selector(verb: &str) -> bool {
+    verb == "password"
+}
+
+/// Parse the `password` noun.
+///
+/// `generate` is the only verb, and this is the crate's one real flag parser.
+/// Every other command's arguments are positional or a single boolean, so they
+/// are matched as exhaustive slice patterns; a policy is genuinely a set of
+/// independent options and needs a loop.
+///
+/// The loop's structure carries three rules at once, and all three come out of
+/// the `_` arm:
+///
+/// | Input | Why it fails |
+/// |---|---|
+/// | `--jumble` | matches no arm |
+/// | `--reveal --copy` | the second output mode finds `output` already set |
+/// | `--no-digits --no-digits` | the second one finds `digits` already cleared |
+/// | `--length` at the end | there is no following value to take |
+/// | `--length=24` | `--length=24` is one token and matches no arm |
+///
+/// Duplicate rejection needs no bookkeeping flags because the state being built
+/// *is* the record: a class starts selected and can only be cleared once, and
+/// an output mode starts absent and can only be set once. There is nowhere for
+/// a second occurrence to go.
+///
+/// Validation deliberately happens here, at parse time, rather than in the
+/// ceremony. A policy below the entropy floor is a malformed request, not a
+/// runtime failure, and finding out before the confirmation prompt means an
+/// under-strength request costs the person no terminal interaction and this
+/// process no randomness.
+fn parse_password(arguments: &[String]) -> Result<Command, CliFailure> {
+    let Some((verb, flags)) = arguments.split_first() else {
+        return Err(CliFailure::InvalidCommand);
+    };
+    if verb != "generate" {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let mut length: Option<usize> = None;
+    let mut classes = CharacterClassesV1::all();
+    let mut exclude_ambiguous = false;
+    let mut output: Option<PasswordOutputMode> = None;
+    let mut index = 0;
+    while index < flags.len() {
+        match flags[index].as_str() {
+            "--length" if length.is_none() => {
+                let value = flags.get(index + 1).ok_or(CliFailure::InvalidCommand)?;
+                length = Some(parse_password_length(value)?);
+                index += 2;
+                continue;
+            }
+            "--no-lowercase" if classes.lowercase => classes.lowercase = false,
+            "--no-uppercase" if classes.uppercase => classes.uppercase = false,
+            "--no-digits" if classes.digits => classes.digits = false,
+            "--no-symbols" if classes.symbols => classes.symbols = false,
+            "--exclude-ambiguous" if !exclude_ambiguous => exclude_ambiguous = true,
+            "--reveal" if output.is_none() => output = Some(PasswordOutputMode::Reveal),
+            "--copy" if output.is_none() => output = Some(PasswordOutputMode::Copy),
+            _ => return Err(CliFailure::InvalidCommand),
+        }
+        index += 1;
+    }
+    let output = output.ok_or(CliFailure::InvalidCommand)?;
+    let policy = PasswordPolicyV1::new(
+        length.unwrap_or(DEFAULT_PASSWORD_LENGTH),
+        classes,
+        exclude_ambiguous,
+    )
+    .map_err(map_password_policy)?;
+    Ok(Command::PasswordGenerate { policy, output })
+}
+
+/// Read the one number this grammar accepts.
+///
+/// One to three ASCII decimal digits, no sign, no separator, no whitespace, no
+/// leading zero. `str::parse` alone would accept `+24`, `24 ` on some inputs,
+/// and `007`, and a grammar with two spellings of one number is a grammar where
+/// a typo can silently mean something else. The range itself is checked by
+/// `PasswordPolicyV1::new`, so this function's only job is the spelling.
+fn parse_password_length(value: &str) -> Result<usize, CliFailure> {
+    let digits = value.as_bytes();
+    if digits.is_empty()
+        || digits.len() > 3
+        || !digits.iter().all(u8::is_ascii_digit)
+        || (digits.len() > 1 && digits[0] == b'0')
+    {
+        return Err(CliFailure::InvalidCommand);
+    }
+    value.parse().map_err(|_| CliFailure::InvalidCommand)
+}
+
+/// Mint one password and deliver it to the controlling terminal.
+///
+/// The order of the four steps below is the contract from VLT-PM44 §5, not an
+/// implementation detail.
+///
+/// `--copy` is refused *first*, before any prompt, because a person who typed
+/// it asked for a delivery this build cannot perform; confirming a reveal they
+/// did not ask for and then failing would be worse than failing immediately.
+///
+/// Confirmation comes *before* generation. VLT-PM00 §14.6 requires an
+/// interactive confirmation before any reveal, and putting it first buys a
+/// property `item reveal` cannot have: on refusal no password is ever created,
+/// so there is no secret to wipe because none existed. Unlike a stored-secret
+/// reveal there is no audit event that must be published before the answer is
+/// known, so nothing forces the other order.
+///
+/// The randomness is reserved in one call, from the operating-system CSPRNG by
+/// way of [`CliHost::fill_entropy`], and both the reserve and the password live
+/// in wipe-on-drop buffers for their whole lifetime. The password is borrowed
+/// for the terminal write and never copied into [`CliOutput`], so ordinary
+/// standard output and standard error are empty on success.
+fn password_generate(
+    host: &dyn CliHost,
+    policy: &PasswordPolicyV1,
+    output: PasswordOutputMode,
+) -> Result<CliOutput, CliFailure> {
+    if matches!(output, PasswordOutputMode::Copy) {
+        return Err(CliFailure::Unsupported);
+    }
+    if !host.confirm_secret_reveal().map_err(map_host)? {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let mut reserve = Zeroizing::new(vec![0_u8; policy.required_entropy_bytes()]);
+    host.fill_entropy(reserve.as_mut_slice())
+        .map_err(map_host)?;
+    let password = generate_password(policy, &reserve).map_err(map_password_policy)?;
+    host.write_revealed_text(password.as_str())
+        .map_err(map_host)?;
+    Ok(CliOutput::success(""))
+}
+
 fn execute(invocation: Invocation, host: &dyn CliHost) -> Result<CliOutput, CliFailure> {
     let paths = host.paths().map_err(map_host)?;
     let prepared = paths.prepare().map_err(map_local_host)?;
@@ -1348,8 +1544,8 @@ fn dispatch(
             item_id,
             base_revision,
         } => conflict_merge_opaque(host, paths, writer, selected_vault, item_id, base_revision),
-        Command::Help | Command::Shell => {
-            unreachable!("help and shell return before writer acquisition")
+        Command::Help | Command::Shell | Command::PasswordGenerate { .. } => {
+            unreachable!("help, shell, and password generate return before writer acquisition")
         }
     }
 }
@@ -4312,6 +4508,17 @@ fn locator_hex(locator: &[u8; 32]) -> String {
 enum CliFailure {
     InvalidCommand,
     AlreadyInitialized,
+    /// A `password generate` policy worth fewer than 80 bits (VLT-PM44 §4.3).
+    ///
+    /// This is an invalid request and carries the invalid exit class, but it
+    /// gets its own fixed message. It is the one rejection in the grammar a
+    /// person will hit while doing something entirely reasonable — asking for
+    /// a shorter password, or narrowing the alphabet for a site that will not
+    /// accept symbols — and "invalid command" would send them hunting for a
+    /// typo that is not there. The message still names no length, alphabet, or
+    /// bit count: it says which rule was broken, and the specification says
+    /// what the rule is.
+    WeakPasswordPolicy,
     Locked,
     NotFound,
     Conflict,
@@ -4324,7 +4531,9 @@ enum CliFailure {
 impl CliFailure {
     const fn exit_code(self) -> ExitCode {
         match self {
-            Self::InvalidCommand | Self::AlreadyInitialized => ExitCode::InvalidInput,
+            Self::InvalidCommand | Self::AlreadyInitialized | Self::WeakPasswordPolicy => {
+                ExitCode::InvalidInput
+            }
             Self::Locked => ExitCode::Locked,
             Self::NotFound => ExitCode::NotFound,
             Self::Conflict => ExitCode::Conflict,
@@ -4339,6 +4548,7 @@ impl CliFailure {
         match self {
             Self::InvalidCommand => "vault-pm: invalid command",
             Self::AlreadyInitialized => "vault-pm: already initialized",
+            Self::WeakPasswordPolicy => "vault-pm: password policy below the minimum entropy floor",
             Self::Locked => "vault-pm: authentication required",
             Self::NotFound => "vault-pm: not found",
             Self::Conflict => "vault-pm: recovery or conflict required",
@@ -4371,6 +4581,27 @@ fn map_application(error: ApplicationError) -> CliFailure {
         ApplicationError::StorageUnavailable => CliFailure::Provider,
         ApplicationError::Unsupported => CliFailure::Unsupported,
         ApplicationError::InternalInvariant => CliFailure::Internal,
+    }
+}
+
+/// Translate a password-policy failure into a process-visible class.
+///
+/// The two internal-looking arms are deliberate rather than defensive. A
+/// randomness block of the wrong size means this crate and the policy crate
+/// disagree about a number both of them compute — a code defect, not a
+/// condition a person can cause or fix, so it is reported as an internal
+/// invariant failure rather than dressed up as bad input. An exhausted reserve
+/// is a genuine (if astronomically improbable) failure of the randomness path,
+/// so it joins the other provider failures; what it must never do is fall back
+/// to a biased draw, and the policy crate makes that impossible.
+fn map_password_policy(error: PasswordPolicyError) -> CliFailure {
+    match error {
+        PasswordPolicyError::NoCharacterClass | PasswordPolicyError::LengthOutOfRange => {
+            CliFailure::InvalidCommand
+        }
+        PasswordPolicyError::EntropyFloorNotMet => CliFailure::WeakPasswordPolicy,
+        PasswordPolicyError::EntropyExhausted => CliFailure::Provider,
+        PasswordPolicyError::EntropyBlockSizeMismatch => CliFailure::Internal,
     }
 }
 
@@ -4569,6 +4800,18 @@ mod tests {
             Self::build(paths, secrets, [], 1, false, 0)
         }
 
+        /// A host that can answer prompts but whose CSPRNG has failed.
+        ///
+        /// `password generate` confirms before it draws, so proving it fails
+        /// closed on an unavailable entropy source needs a scripted `yes` *and*
+        /// a broken source at the same time.
+        fn without_entropy_with_texts(
+            paths: LocalVaultPaths,
+            texts: impl IntoIterator<Item = String>,
+        ) -> Self {
+            Self::build(paths, [], texts, 1, false, 0)
+        }
+
         /// Build a host whose clock advances by `clock_step_ms` per reading.
         fn with_clock_step(
             paths: LocalVaultPaths,
@@ -4642,6 +4885,17 @@ mod tests {
 
         fn revealed_count(&self) -> usize {
             self.revealed.lock().unwrap().len()
+        }
+
+        /// Copy out the single value this host was asked to reveal.
+        ///
+        /// Only a test may do this, and only because the "secret" a generator
+        /// test inspects was minted by the test's own deterministic host rather
+        /// than read out of a vault.
+        fn revealed_only(&self) -> Vec<u8> {
+            let revealed = self.revealed.lock().unwrap();
+            assert_eq!(revealed.len(), 1, "expected exactly one revealed value");
+            revealed[0].as_slice().to_vec()
         }
     }
 
@@ -4959,6 +5213,57 @@ mod tests {
                 "not-a-revision",
             ],
             vec!["unlock"],
+            // VLT-PM44 §2. Every one of these must fail before a prompt, a
+            // reservation, or a single byte of randomness.
+            vec!["password"],
+            vec!["password", "make"],
+            vec!["password", "generate"],
+            vec!["password", "generate", "extra"],
+            vec!["password", "generate", "--reveal", "extra"],
+            vec!["password", "generate", "--reveal", "--copy"],
+            vec!["password", "generate", "--copy", "--reveal"],
+            vec!["password", "generate", "--reveal", "--reveal"],
+            vec!["password", "generate", "--reveal", "--jumble"],
+            vec!["password", "generate", "--reveal", "--length"],
+            vec!["password", "generate", "--reveal", "--length=24"],
+            vec![
+                "password", "generate", "--reveal", "--length", "24", "--length", "32",
+            ],
+            vec!["password", "generate", "--reveal", "--length", "+24"],
+            vec!["password", "generate", "--reveal", "--length", "-24"],
+            vec!["password", "generate", "--reveal", "--length", "024"],
+            vec!["password", "generate", "--reveal", "--length", "2_4"],
+            vec!["password", "generate", "--reveal", "--length", "24 "],
+            vec!["password", "generate", "--reveal", "--length", "twenty"],
+            vec!["password", "generate", "--reveal", "--length", ""],
+            vec!["password", "generate", "--reveal", "--length", "1024"],
+            vec!["password", "generate", "--reveal", "--length", "129"],
+            vec!["password", "generate", "--reveal", "--length", "0"],
+            vec![
+                "password",
+                "generate",
+                "--reveal",
+                "--exclude-ambiguous",
+                "--exclude-ambiguous",
+            ],
+            vec![
+                "password",
+                "generate",
+                "--reveal",
+                "--no-digits",
+                "--no-digits",
+            ],
+            vec![
+                "password",
+                "generate",
+                "--reveal",
+                "--no-lowercase",
+                "--no-uppercase",
+                "--no-digits",
+                "--no-symbols",
+            ],
+            // The selector names a target this command never opens.
+            vec!["--vault", "work", "password", "generate", "--reveal"],
         ] {
             let output = run(arguments, &host);
             assert_eq!(output.exit_code(), ExitCode::InvalidInput);
@@ -9643,5 +9948,335 @@ mod tests {
             session.authenticator(&host),
             Err(HostError::Unavailable)
         ));
+    }
+
+    /// Build the host a successful `password generate --reveal` needs: one
+    /// scripted `yes` for the confirmation, and nothing else.
+    fn confirming_host(root: &TestRoot, seed: u8) -> TestHost {
+        TestHost::with_texts_and_entropy_seed(root.paths(), [], ["yes".to_owned()], seed)
+    }
+
+    #[test]
+    fn password_generate_parses_the_whole_documented_policy_surface() {
+        assert_eq!(
+            parse(["password", "generate", "--reveal"]),
+            default_invocation(Command::PasswordGenerate {
+                policy: PasswordPolicyV1::new(
+                    DEFAULT_PASSWORD_LENGTH,
+                    CharacterClassesV1::all(),
+                    false
+                )
+                .unwrap(),
+                output: PasswordOutputMode::Reveal,
+            })
+        );
+        assert_eq!(
+            parse(["password", "generate", "--copy"]),
+            default_invocation(Command::PasswordGenerate {
+                policy: PasswordPolicyV1::new(
+                    DEFAULT_PASSWORD_LENGTH,
+                    CharacterClassesV1::all(),
+                    false
+                )
+                .unwrap(),
+                output: PasswordOutputMode::Copy,
+            })
+        );
+        // Flags compose, in any order, and each one narrows exactly one thing.
+        let narrowed = parse([
+            "password",
+            "generate",
+            "--exclude-ambiguous",
+            "--length",
+            "32",
+            "--no-symbols",
+            "--reveal",
+            "--no-uppercase",
+        ]);
+        assert_eq!(
+            narrowed,
+            default_invocation(Command::PasswordGenerate {
+                policy: PasswordPolicyV1::new(
+                    32,
+                    CharacterClassesV1 {
+                        lowercase: true,
+                        uppercase: false,
+                        digits: true,
+                        symbols: false,
+                    },
+                    true
+                )
+                .unwrap(),
+                output: PasswordOutputMode::Reveal,
+            })
+        );
+        // Lowercase 25 + digits 8, with the ambiguous characters gone.
+        let Ok(Invocation {
+            command: Command::PasswordGenerate { policy, .. },
+            ..
+        }) = narrowed
+        else {
+            panic!("the narrowed policy must parse");
+        };
+        assert_eq!(policy.alphabet().len(), 33);
+        assert_eq!(policy.length(), 32);
+        for ambiguous in b"01IOl|" {
+            assert!(!policy.alphabet().contains(ambiguous));
+        }
+    }
+
+    #[test]
+    fn password_generate_refuses_an_under_strength_policy_with_its_own_message() {
+        let root = TestRoot::new();
+        for arguments in [
+            // 12 characters over all 89 is 77.7 bits: one character short.
+            vec!["password", "generate", "--length", "12", "--reveal"],
+            // Lowercase only needs 18; 17 is 79.9 bits.
+            vec![
+                "password",
+                "generate",
+                "--length",
+                "17",
+                "--no-uppercase",
+                "--no-digits",
+                "--no-symbols",
+                "--reveal",
+            ],
+            // A numeric PIN needs 25 digits to earn the name.
+            vec![
+                "password",
+                "generate",
+                "--length",
+                "24",
+                "--no-lowercase",
+                "--no-uppercase",
+                "--no-symbols",
+                "--reveal",
+            ],
+        ] {
+            let host = confirming_host(&root, 1);
+            let refused = run(arguments.clone(), &host);
+            assert_eq!(
+                refused.exit_code(),
+                ExitCode::InvalidInput,
+                "{arguments:?} must be refused"
+            );
+            assert_eq!(
+                refused.stderr(),
+                "vault-pm: password policy below the minimum entropy floor\n"
+            );
+            assert!(refused.stdout().is_empty());
+            // Refused before the confirmation prompt, so nothing was consumed
+            // and nothing was minted.
+            assert_eq!(host.revealed_count(), 0);
+            assert_eq!(host.texts.lock().unwrap().len(), 1);
+        }
+        // And one character more is accepted in each case.
+        for arguments in [
+            vec!["password", "generate", "--length", "13", "--reveal"],
+            vec![
+                "password",
+                "generate",
+                "--length",
+                "18",
+                "--no-uppercase",
+                "--no-digits",
+                "--no-symbols",
+                "--reveal",
+            ],
+            vec![
+                "password",
+                "generate",
+                "--length",
+                "25",
+                "--no-lowercase",
+                "--no-uppercase",
+                "--no-symbols",
+                "--reveal",
+            ],
+        ] {
+            let host = confirming_host(&root, 1);
+            let accepted = run(arguments.clone(), &host);
+            assert_eq!(
+                accepted.exit_code(),
+                ExitCode::Success,
+                "{arguments:?} must be accepted"
+            );
+            assert_eq!(host.revealed_count(), 1);
+        }
+    }
+
+    #[test]
+    fn password_generate_delivers_only_through_the_terminal() {
+        let root = TestRoot::new();
+        let host = confirming_host(&root, 1);
+        let generated = run(["password", "generate", "--reveal"], &host);
+
+        assert_eq!(generated.exit_code(), ExitCode::Success, "{generated:?}");
+        // The one secret this command produces never enters ordinary output.
+        assert!(generated.stdout().is_empty());
+        assert!(generated.stderr().is_empty());
+
+        let revealed = host.revealed_only();
+        assert_eq!(revealed.len(), DEFAULT_PASSWORD_LENGTH);
+        let alphabet =
+            PasswordPolicyV1::new(DEFAULT_PASSWORD_LENGTH, CharacterClassesV1::all(), false)
+                .unwrap();
+        for byte in &revealed {
+            assert!(
+                alphabet.alphabet().contains(byte),
+                "{byte} is outside the selected alphabet"
+            );
+        }
+        // Nothing about the request is echoed either.
+        assert!(!generated.stdout().contains("24"));
+
+        // The same host, driven again, produces the same value: the CLI adds no
+        // randomness of its own on top of what the host supplied.
+        let repeat_host = confirming_host(&root, 1);
+        assert_eq!(
+            run(["password", "generate", "--reveal"], &repeat_host).exit_code(),
+            ExitCode::Success
+        );
+        assert_eq!(repeat_host.revealed_only(), revealed);
+
+        // A different entropy source produces a different value, which is what
+        // proves the randomness is actually reaching the sampler.
+        let other_host = confirming_host(&root, 200);
+        assert_eq!(
+            run(["password", "generate", "--reveal"], &other_host).exit_code(),
+            ExitCode::Success
+        );
+        assert_ne!(other_host.revealed_only(), revealed);
+    }
+
+    #[test]
+    fn password_generate_honours_a_narrowed_alphabet() {
+        let root = TestRoot::new();
+        let host = confirming_host(&root, 3);
+        let generated = run(
+            [
+                "password",
+                "generate",
+                "--length",
+                "40",
+                "--no-symbols",
+                "--exclude-ambiguous",
+                "--reveal",
+            ],
+            &host,
+        );
+        assert_eq!(generated.exit_code(), ExitCode::Success, "{generated:?}");
+        let revealed = host.revealed_only();
+        assert_eq!(revealed.len(), 40);
+        for byte in &revealed {
+            assert!(byte.is_ascii_alphanumeric(), "{byte} is not alphanumeric");
+            assert!(!b"01IOl|".contains(byte), "{byte} is ambiguous");
+        }
+    }
+
+    #[test]
+    fn password_generate_mints_nothing_when_the_reveal_is_refused() {
+        let root = TestRoot::new();
+        for answer in ["no", "", "YES", "yes please", "y"] {
+            let host = TestHost::with_texts(root.paths(), [], [answer.to_owned()]);
+            let refused = run(["password", "generate", "--reveal"], &host);
+            assert_eq!(
+                refused.exit_code(),
+                ExitCode::InvalidInput,
+                "{answer:?} must not authorize a reveal"
+            );
+            assert_eq!(refused.stderr(), "vault-pm: invalid command\n");
+            assert_eq!(host.revealed_count(), 0);
+        }
+        // A host that cannot collect the answer at all is a provider failure,
+        // and still delivers nothing.
+        let silent = TestHost::new(root.paths(), []);
+        let unavailable = run(["password", "generate", "--reveal"], &silent);
+        assert_eq!(unavailable.exit_code(), ExitCode::Provider);
+        assert_eq!(silent.revealed_count(), 0);
+    }
+
+    #[test]
+    fn password_generate_copy_is_recognized_and_refused_before_any_prompt() {
+        let root = TestRoot::new();
+        let host = confirming_host(&root, 1);
+        let refused = run(["password", "generate", "--copy"], &host);
+        assert_eq!(refused.exit_code(), ExitCode::Unsupported);
+        assert_eq!(refused.stderr(), "vault-pm: unsupported capability\n");
+        assert!(refused.stdout().is_empty());
+        assert_eq!(host.revealed_count(), 0);
+        // The scripted confirmation was never consumed: `--copy` fails before
+        // asking a person to authorize a delivery this build cannot perform.
+        assert_eq!(host.texts.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn password_generate_fails_closed_when_the_os_csprng_is_unavailable() {
+        let root = TestRoot::new();
+        let host = TestHost::without_entropy_with_texts(root.paths(), ["yes".to_owned()]);
+        let failed = run(["password", "generate", "--reveal"], &host);
+        assert_eq!(failed.exit_code(), ExitCode::Provider);
+        assert_eq!(failed.stderr(), "vault-pm: storage unavailable\n");
+        assert!(failed.stdout().is_empty());
+        // No weaker source is substituted, so nothing is delivered.
+        assert_eq!(host.revealed_count(), 0);
+    }
+
+    #[test]
+    fn password_generate_never_touches_the_vault_layout() {
+        let root = TestRoot::new();
+        let host = confirming_host(&root, 1);
+        assert_eq!(
+            run(["password", "generate", "--reveal"], &host).exit_code(),
+            ExitCode::Success
+        );
+        // The most common moment to want a generated password is before the
+        // vault exists, so this must work on an untouched root and must leave
+        // it untouched: no config, no writer lock, no owner state.
+        assert!(!root.0.join("config").exists());
+        assert_eq!(host.remaining_secrets(), 0);
+        // And no passphrase was ever asked for: the scripted secret queue is
+        // empty, and a command that prompted would have failed instead.
+        assert_eq!(host.revealed_count(), 1);
+    }
+
+    #[test]
+    fn usage_lists_password_generate_and_the_shell_delegates_it_unprefixed() {
+        assert!(USAGE.contains("vault-pm password generate"));
+        // The one-shot table names no `--vault` prefix for this verb, because
+        // the parser refuses one.
+        assert!(!USAGE.contains("[--vault NAME] password"));
+        assert!(takes_no_vault_selector("password"));
+        for vault_scoped in ["item", "status", "audit", "search", "conflict", "history"] {
+            assert!(!takes_no_vault_selector(vault_scoped));
+        }
+        // A session must be able to run it: it is neither refused by the shell
+        // nor prefixed with the bound vault.
+        assert!(!shell::is_refused("password"));
+    }
+
+    #[test]
+    fn password_generate_runs_inside_an_interactive_shell() {
+        let root = TestRoot::new();
+        let passphrase = b"shell generate passphrase".to_vec();
+        let init_host = TestHost::new(root.paths(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let host = TestHost::with_texts(root.paths(), [], ["yes".to_owned()]);
+        let terminal = ScriptedTerminal::new(["password generate --reveal", "exit"]);
+        let session = run_with_terminal(["shell"], &host, &terminal);
+        assert_eq!(session.exit_code(), ExitCode::Success, "{session:?}");
+        // Delivered once, through the terminal adapter, without ever unlocking:
+        // the scripted passphrase queue is untouched.
+        assert_eq!(host.revealed_count(), 1);
+        assert_eq!(host.remaining_secrets(), 0);
+        // The session's rendered output never carries the value either: the
+        // shell renders exactly what the one-shot command produced, which is
+        // nothing.
+        let generated = host.revealed_only();
+        let generated = core::str::from_utf8(&generated).expect("generated passwords are ASCII");
+        assert!(!terminal.transcript().contains(generated));
+        assert_eq!(terminal.exit_codes(), vec![ExitCode::Success]);
     }
 }

--- a/code/packages/rust/vault-pm-cli/src/shell.rs
+++ b/code/packages/rust/vault-pm-cli/src/shell.rs
@@ -568,9 +568,20 @@ fn dispatch(
     if tokens.first().is_some_and(|token| is_refused(token)) {
         return CliOutput::failure(CliFailure::InvalidCommand);
     }
+    // Nearly every delegated command carries the session's bound vault as an
+    // explicit selector, so a command can never be aimed somewhere the person
+    // did not authenticate against. `password generate` is the exception, and
+    // for the opposite reason: VLT-PM44 §2.2 refuses the selector because the
+    // command opens no vault, so prefixing it would turn a usable verb into an
+    // invalid one. See `crate::takes_no_vault_selector`.
+    let vault_free = tokens
+        .first()
+        .is_some_and(|token| crate::takes_no_vault_selector(token));
     let mut arguments = Vec::with_capacity(tokens.len() + 2);
-    arguments.push("--vault".to_owned());
-    arguments.push(bound.name.as_str().to_owned());
+    if !vault_free {
+        arguments.push("--vault".to_owned());
+        arguments.push(bound.name.as_str().to_owned());
+    }
     arguments.extend(tokens);
     let output = crate::run(arguments, session_host);
     if output.exit_code() == ExitCode::Locked {

--- a/code/packages/rust/vault-pm-password-policy/BUILD
+++ b/code/packages/rust/vault-pm-password-policy/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_password_policy -- --nocapture

--- a/code/packages/rust/vault-pm-password-policy/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-password-policy/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+## Unreleased
+
+- Added the crate, as the pure half of `VLT-PM44-cli-password-generate.md`.
+
+- Added `CharacterClassesV1` and the four class tables — lowercase (26),
+  uppercase (26), digits (10), and 27 symbols. The symbol set is the printable
+  US-ASCII punctuation minus `"`, `'`, `` ` ``, `\`, and `/`, which are the
+  characters most likely to be mangled by a shell, a CSV import, a JSON blob,
+  or a hand-written SQL string on the way to the site the password is for.
+
+- Added `AMBIGUOUS_CHARACTERS` (`0`, `1`, `I`, `O`, `l`, `|`) for
+  `--exclude-ambiguous`. Each belongs to exactly one class, so the exclusion can
+  never empty a class the caller selected; a test asserts that property rather
+  than trusting the table.
+
+- Added `PasswordPolicyV1`, a validated policy that cannot exist unless it is
+  1–128 characters long, selects at least one class, and reaches the entropy
+  floor. Validation runs shape, then alphabet, then strength, so a request that
+  is wrong twice reports the most basic problem.
+
+- Added `MIN_PASSWORD_ENTROPY_BITS = 80` and `meets_minimum_entropy`, which
+  decides the floor by the exact integer comparison `alphabet^length >= 2^80`
+  rather than by comparing `length * log2(n)` against `80.0`. Two of the eight
+  documented policy rows land within 0.2 bits of the line, so a floating-point
+  check would put rounding in charge of a security boundary and could answer
+  differently on different platforms. Tests assert acceptance and refusal on
+  both sides of all eight rows.
+
+- Added `generate_password`, which consumes exactly
+  `PasswordPolicyV1::required_entropy_bytes` caller-supplied bytes as 8-byte
+  big-endian words and returns a wipe-on-drop `Zeroizing<String>`:
+  - Selection is **exactly** uniform. A word below `floor(2^64 / n) * n`
+    selects `alphabet[word mod n]`; a word at or above it is discarded and the
+    next word is read. The bound is computed in `u128` because the span being
+    divided is `2^64`, which a `u64` cannot hold.
+  - `SPARE_ENTROPY_WORDS = 8` covers discards. Exhausting the reserve is
+    `EntropyExhausted`, never a fallback to a biased `word mod n` — otherwise
+    the one branch nobody ever exercises would be the branch that silently
+    weakens the output.
+  - The string is allocated at its exact final capacity before the first push,
+    so growth can never strand an unwiped plaintext prefix on the heap.
+  - A reserve of the wrong size is refused in **both** directions; an over-long
+    buffer means the caller and this crate disagree about the reservation, which
+    is not a disagreement to paper over.
+
+- Deliberately sources no randomness: no `rand`, no thread-local generator, no
+  seeding, and no entry point that produces a password without being handed
+  bytes. The only dependency is `coding_adventures_zeroize`, and
+  `required_capabilities.json` is empty.
+
+- Deliberately does not force class inclusion. Every character is drawn
+  independently from the whole alphabet, because constraining a uniform
+  sampler's output removes entropy and would make the strength claim the floor
+  is checked against untrue.
+
+- Added 19 unit tests plus a doc test, covering the class tables and their
+  disjointness, alphabet composition for twelve class/ambiguity combinations,
+  both sides of every entropy-floor row, degenerate alphabets, validation
+  ordering, determinism, alphabet containment, reserve-size mismatch in both
+  directions, the acceptance bound's maximality, discard-versus-reduce
+  behaviour proven against what a biased sampler would have emitted, reserve
+  exhaustion, spare-word absorption at exactly its limit, and a distribution
+  sanity check over 25,600 draws that also rejects short-period cycles and
+  repeated outputs.

--- a/code/packages/rust/vault-pm-password-policy/Cargo.toml
+++ b/code/packages/rust/vault-pm-password-policy/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding_adventures_vault_pm_password_policy"
+version = "0.1.0"
+edition = "2021"
+description = "VLT-PM44 pure password-generation policy, entropy floor, and unbiased sampler"
+license = "MIT"
+
+[dependencies]
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-pm-password-policy/README.md
+++ b/code/packages/rust/vault-pm-password-policy/README.md
@@ -1,0 +1,71 @@
+# `coding_adventures_vault_pm_password_policy`
+
+The pure half of `vault-pm password generate`, specified by
+`code/specs/VLT-PM44-cli-password-generate.md`.
+
+This crate validates a password policy, states exactly how many random bytes
+that policy needs, and turns exactly those bytes into a password. It is the
+answer to "how strong is this, and is it strong enough" — not to "where does
+randomness come from".
+
+## Where it fits
+
+```text
+vault-pm password generate            <- grammar, ceremony    (vault-pm-cli)
+  └─ CliHost::fill_entropy            <- one reservation      (vault-pm-cli)
+       └─ OsEntropy::fill             <- the trust boundary   (vault-pm-cli-host)
+            └─ fill_random            <- getrandom/getentropy (csprng)
+  └─ PasswordPolicyV1 / generate_password   <- this crate
+  └─ ControllingTerminal::write_revealed_text  <- delivery    (vault-pm-cli-host)
+```
+
+## What it does
+
+- **`PasswordPolicyV1::new(length, classes, exclude_ambiguous)`** validates a
+  request. A value of this type is proof that the policy is within 1–128
+  characters, selects at least one character class, and reaches the 80-bit
+  entropy floor. There is no way to build one that does not.
+- **`PasswordPolicyV1::required_entropy_bytes`** states the exact reservation:
+  one 8-byte word per character plus eight spare words.
+- **`generate_password(policy, entropy)`** maps exactly that many bytes to a
+  wipe-on-drop `Zeroizing<String>`, deterministically.
+- **`meets_minimum_entropy(alphabet_len, length)`** is the floor itself, exposed
+  because the rule deserves to be checkable on its own.
+
+## What it deliberately does not do
+
+- **It sources no randomness.** No `rand`, no thread-local generator, no
+  seeding. Nothing in this crate produces a password without being handed bytes
+  first, which forces the caller to name its entropy source out loud — and the
+  CLI's only source is the operating-system CSPRNG.
+- **It does not touch a vault, a clock, a terminal, a file, or the network.**
+  `required_capabilities.json` is empty and stays empty.
+- **It does not force class inclusion.** Every character is drawn independently
+  and uniformly from the whole alphabet. Constraining the output of a uniform
+  sampler removes entropy, which would make the strength claim the floor is
+  checked against untrue. VLT-PM44 §3.1 argues this at length, including the
+  honest cost: a default 24-character draw contains no digit about 5.7% of the
+  time.
+
+## The two properties worth reading the source for
+
+**The entropy floor is integer arithmetic, not floating point.** A policy is
+accepted when `alphabet^length >= 2^80`, computed by multiplying and stopping
+early. Deciding a security boundary by comparing `length * log2(n)` against
+`80.0` would put rounding in charge of rows that land within 0.2 bits of the
+line, and would let the answer differ between platforms.
+
+**Selection is exactly uniform, not negligibly biased.** Randomness is consumed
+as 8-byte big-endian words. A word below `floor(2^64 / n) * n` selects
+`alphabet[word mod n]`; a word above it is discarded and the next is read. That
+is why a reserve exists, and why exhausting the reserve is an error rather than
+a fallback to `word mod n` — a fallback would make the branch nobody ever
+exercises the one that silently weakens the output.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_password_policy --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_password_policy --no-deps
+```

--- a/code/packages/rust/vault-pm-password-policy/required_capabilities.json
+++ b/code/packages/rust/vault-pm-password-policy/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-password-policy",
+  "capabilities": [],
+  "justification": "Pure policy validation and a deterministic sampler over caller-supplied random bytes. The crate sources no randomness of its own and performs no filesystem, network, process, environment, clock, entropy, persistence, or secret-input access."
+}

--- a/code/packages/rust/vault-pm-password-policy/src/lib.rs
+++ b/code/packages/rust/vault-pm-password-policy/src/lib.rs
@@ -1,0 +1,934 @@
+//! VLT-PM44 pure password-generation policy, entropy floor, and sampler.
+//!
+//! # What this crate is
+//!
+//! This crate answers three questions and refuses to answer any others:
+//!
+//! 1. **Is this policy allowed?** A length, a set of character classes, and an
+//!    ambiguity choice either describe a password worth minting or they do not.
+//! 2. **How much randomness does it need?** An exact byte count, computed
+//!    before a single byte is asked for.
+//! 3. **Given exactly those bytes, what is the password?** A deterministic,
+//!    exactly uniform mapping from bytes to characters.
+//!
+//! It deliberately owns **no randomness of its own**. There is no `rand`, no
+//! thread-local generator, no seeding, and no way to call anything in here and
+//! get a password without handing it bytes first. That is the whole design
+//! idea, and it buys two things that matter more than convenience:
+//!
+//! - The caller — the CLI — is forced to name its entropy source out loud, and
+//!   the only source it has is the operating-system CSPRNG.
+//! - Every security property in `VLT-PM44-cli-password-generate.md` §3 and §4
+//!   is testable against fixed byte vectors. "This sampler is unbiased" becomes
+//!   an assertion about specific bytes rather than a statistical hope.
+//!
+//! # The three ideas, in order
+//!
+//! ## Idea one: entropy is a multiplication, so the floor is a comparison
+//!
+//! A password drawn by picking `length` characters independently and uniformly
+//! from an alphabet of `n` characters is one of exactly `n^length` equally
+//! likely strings. Its strength — "entropy", the number of bits an attacker
+//! must brute-force — is `log2(n^length)`, which is `length * log2(n)`.
+//!
+//! | Policy | `n` | `length` | `n^length` | bits |
+//! |---|---:|---:|---|---:|
+//! | all four classes, default | 89 | 24 | ~10^46 | 155.4 |
+//! | all four classes | 89 | 13 | ~10^25 | 84.2 |
+//! | all four classes | 89 | 12 | ~10^23 | 77.7 |
+//! | digits only | 10 | 4 | 10^4 | 13.3 |
+//!
+//! The floor is 80 bits, so the third row is refused and the second is not.
+//!
+//! Notice what the check does *not* do: it never computes `log2`. Comparing
+//! `length * log2(n)` against `80.0` means deciding a security boundary with
+//! floating-point rounding, and the 52-character and 26-character rows of
+//! §4.3's table land within 0.2 bits of the line. Instead
+//! [`meets_minimum_entropy`] asks the equivalent integer question
+//! `n^length >= 2^80` by multiplying and stopping early. Same answer, no
+//! rounding, identical on every platform.
+//!
+//! ## Idea two: reducing a random number modulo `n` is biased, and it needn't be
+//!
+//! Suppose you have a fair six-sided die and want a fair coin. "Odd is heads,
+//! even is tails" works because 6 divides evenly by 2. Now suppose you want a
+//! fair *four*-sided result from that die: "take the roll modulo 4" gives
+//!
+//! | roll | 1 | 2 | 3 | 4 | 5 | 6 |
+//! |---|---|---|---|---|---|---|
+//! | `roll mod 4` | 1 | 2 | 3 | 0 | 1 | 2 |
+//!
+//! and now `1` and `2` come up twice as often as `0` and `3`. The bias appears
+//! because 4 does not divide 6 — the last two faces are leftovers.
+//!
+//! The fix is the obvious one: **throw the leftovers away**. Roll again if you
+//! get a 5 or a 6. That is exactly what this crate does, with a 64-bit word in
+//! place of a die:
+//!
+//! ```text
+//!   0                                    bound                   2^64
+//!   |------------- a whole number of n-sized blocks -------|-- leftovers --|
+//!         word here  ->  accept, use  word mod n                 word here  ->  discard
+//! ```
+//!
+//! where `bound = floor(2^64 / n) * n`. Below `bound` every residue appears
+//! the same number of times, so `word mod n` is *exactly* uniform — not
+//! approximately, not negligibly-biased. See `acceptance_bound` in the source.
+//!
+//! Discarding means the sampler can ask for more randomness than one word per
+//! character, so the caller must reserve extra. With `n <= 89` the leftover
+//! region is at most 88 values out of 2^64, so the chance of discarding any
+//! given word is below `4.8e-18` — you would expect to wait longer than the
+//! age of the universe to see one. [`SPARE_ENTROPY_WORDS`] covers eight of
+//! them anyway, and running out is an error rather than a fallback to the
+//! biased path. A fallback would mean the one branch nobody ever exercises is
+//! the one that silently weakens the output.
+//!
+//! ## Idea three: the alphabet is a table, and every character has one home
+//!
+//! Four classes, selected independently. `--exclude-ambiguous` removes six
+//! characters that get misread off a screen, and each of the six belongs to
+//! exactly one class, so the flag can never empty a class that was selected:
+//!
+//! | class | full | ambiguous removed | remaining |
+//! |---|---:|---|---:|
+//! | lowercase | 26 | `l` | 25 |
+//! | uppercase | 26 | `I`, `O` | 24 |
+//! | digits | 10 | `0`, `1` | 8 |
+//! | symbols | 27 | `\|` | 26 |
+//!
+//! # Usage
+//!
+//! ```
+//! use coding_adventures_vault_pm_password_policy::{
+//!     generate_password, CharacterClassesV1, PasswordPolicyV1,
+//! };
+//!
+//! let policy = PasswordPolicyV1::new(24, CharacterClassesV1::all(), false)
+//!     .expect("24 characters over all four classes is 155 bits");
+//!
+//! // The caller supplies the randomness. This crate never sources any.
+//! let reserve = vec![0x5a; policy.required_entropy_bytes()];
+//! let password = generate_password(&policy, &reserve).expect("exact reserve");
+//! assert_eq!(password.len(), 24);
+//! ```
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Display, Formatter};
+
+/// The lowercase Latin letters, in order.
+pub const LOWERCASE_ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
+
+/// The uppercase Latin letters, in order.
+pub const UPPERCASE_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/// The decimal digits, in order.
+pub const DIGIT_ALPHABET: &[u8] = b"0123456789";
+
+/// The accepted punctuation, in ASCII order.
+///
+/// These are the 32 printable US-ASCII punctuation characters minus `"`, `'`,
+/// `` ` ``, `\`, and `/`. The exclusions are not decoration. Those five are the
+/// characters most likely to survive a trip through a shell, a CSV import, a
+/// JSON blob, or a hand-written SQL string as *something other than
+/// themselves*, and a generated password that a downstream system silently
+/// mangles is a password its owner can no longer log in with. The space
+/// character is printable but is not punctuation, and was never a candidate:
+/// it is invisible at both ends of a value and is stripped by a large fraction
+/// of login forms.
+pub const SYMBOL_ALPHABET: &[u8] = b"!#$%&()*+,-.:;<=>?@[]^_{|}~";
+
+/// The characters `--exclude-ambiguous` removes.
+///
+/// `0`/`O`, `1`/`l`/`I`, and `|` against the same trio. Each belongs to exactly
+/// one class, so removing all six leaves every class non-empty.
+pub const AMBIGUOUS_CHARACTERS: &[u8] = b"01IOl|";
+
+/// The minimum entropy, in bits, this product will mint a password at.
+///
+/// The number is argued in `VLT-PM44-cli-password-generate.md` §4.3 against
+/// offline attack on a leaked credential database rather than against online
+/// guessing: `2^80` guesses is centuries at `10^14` attempts per second, while
+/// 64 bits is under a day. It is a floor and not a recommendation — the
+/// default policy is nearly twice it.
+pub const MIN_PASSWORD_ENTROPY_BITS: u32 = 80;
+
+/// The length used when no `--length` is given: 155 bits over all four classes.
+pub const DEFAULT_PASSWORD_LENGTH: usize = 24;
+
+/// The shortest structurally accepted length.
+///
+/// A length of one is still refused, by the entropy floor rather than by this
+/// bound. The two checks answer different questions and are kept separate on
+/// purpose: this one asks whether the request is *shaped* like a password,
+/// [`meets_minimum_entropy`] asks whether it is *worth* minting.
+pub const MIN_PASSWORD_LENGTH: usize = 1;
+
+/// The longest accepted length.
+///
+/// This exists to bound the single entropy reservation the caller makes — at
+/// most `(128 + 8) * 8 = 1088` bytes — not because 128 characters means
+/// anything.
+pub const MAX_PASSWORD_LENGTH: usize = 128;
+
+/// Bytes in one randomness word consumed by the sampler.
+pub const ENTROPY_WORD_BYTES: usize = 8;
+
+/// Extra randomness words reserved to cover discards.
+///
+/// See the module documentation: a word is discarded with probability below
+/// `4.8e-18`, so eight spares is an enormous margin over an event that will
+/// never be observed. They are reserved anyway because "never observed" is not
+/// "cannot happen", and the alternative to having spares is falling back to a
+/// biased draw.
+pub const SPARE_ENTROPY_WORDS: usize = 8;
+
+/// Closed, payload-free password-policy failures.
+///
+/// Every variant names a rule that was broken. None carries the requested
+/// length, the alphabet, a bit count, or any part of a generated value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PasswordPolicyError {
+    /// Every character class was disabled, leaving nothing to draw from.
+    NoCharacterClass,
+    /// The requested length was outside `MIN_PASSWORD_LENGTH..=MAX_PASSWORD_LENGTH`.
+    LengthOutOfRange,
+    /// The policy would produce fewer than [`MIN_PASSWORD_ENTROPY_BITS`] bits.
+    EntropyFloorNotMet,
+    /// The supplied randomness was not exactly [`PasswordPolicyV1::required_entropy_bytes`].
+    EntropyBlockSizeMismatch,
+    /// Every reserved word was discarded before the password was complete.
+    EntropyExhausted,
+}
+
+impl Display for PasswordPolicyError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::NoCharacterClass => "vault-pm password policy: no character class selected",
+            Self::LengthOutOfRange => "vault-pm password policy: length out of range",
+            Self::EntropyFloorNotMet => "vault-pm password policy: below the minimum entropy floor",
+            Self::EntropyBlockSizeMismatch => "vault-pm password policy: wrong randomness size",
+            Self::EntropyExhausted => "vault-pm password policy: randomness reserve exhausted",
+        })
+    }
+}
+
+impl std::error::Error for PasswordPolicyError {}
+
+/// Which character classes a policy draws from.
+///
+/// All four are selected by default; the CLI's `--no-*` flags clear them one at
+/// a time. Clearing all four is an error rather than an empty alphabet, because
+/// an empty alphabet has no honest interpretation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CharacterClassesV1 {
+    /// Draw from `a`–`z`.
+    pub lowercase: bool,
+    /// Draw from `A`–`Z`.
+    pub uppercase: bool,
+    /// Draw from `0`–`9`.
+    pub digits: bool,
+    /// Draw from [`SYMBOL_ALPHABET`].
+    pub symbols: bool,
+}
+
+impl CharacterClassesV1 {
+    /// Select every class — the default policy.
+    #[must_use]
+    pub const fn all() -> Self {
+        Self {
+            lowercase: true,
+            uppercase: true,
+            digits: true,
+            symbols: true,
+        }
+    }
+
+    /// Whether at least one class is selected.
+    #[must_use]
+    pub const fn any(self) -> bool {
+        self.lowercase || self.uppercase || self.digits || self.symbols
+    }
+}
+
+impl Default for CharacterClassesV1 {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+/// One validated password policy: a length and the exact alphabet to draw from.
+///
+/// A value of this type is proof that the policy passed every check in
+/// `VLT-PM44` §3 and §4.3. There is no way to construct one that is under the
+/// entropy floor, so [`generate_password`] never has to re-check it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PasswordPolicyV1 {
+    length: usize,
+    alphabet: Vec<u8>,
+}
+
+impl PasswordPolicyV1 {
+    /// Validate one policy, or say exactly which rule it broke.
+    ///
+    /// The checks run in a fixed order — shape, then alphabet, then strength —
+    /// so a request that is wrong in more than one way reports the most basic
+    /// problem first.
+    ///
+    /// # Errors
+    ///
+    /// - [`PasswordPolicyError::LengthOutOfRange`] outside 1–128.
+    /// - [`PasswordPolicyError::NoCharacterClass`] when every class is cleared.
+    /// - [`PasswordPolicyError::EntropyFloorNotMet`] when
+    ///   `alphabet^length < 2^80`.
+    pub fn new(
+        length: usize,
+        classes: CharacterClassesV1,
+        exclude_ambiguous: bool,
+    ) -> Result<Self, PasswordPolicyError> {
+        if !(MIN_PASSWORD_LENGTH..=MAX_PASSWORD_LENGTH).contains(&length) {
+            return Err(PasswordPolicyError::LengthOutOfRange);
+        }
+        if !classes.any() {
+            return Err(PasswordPolicyError::NoCharacterClass);
+        }
+        let alphabet = assemble_alphabet(classes, exclude_ambiguous);
+        if !meets_minimum_entropy(alphabet.len(), length) {
+            return Err(PasswordPolicyError::EntropyFloorNotMet);
+        }
+        Ok(Self { length, alphabet })
+    }
+
+    /// How many characters this policy produces.
+    #[must_use]
+    pub const fn length(&self) -> usize {
+        self.length
+    }
+
+    /// The exact ordered alphabet drawn from.
+    ///
+    /// Not secret: it is a function of the flags the person typed, and it is
+    /// exposed so tests can assert composition directly rather than inferring
+    /// it from generated output.
+    #[must_use]
+    pub fn alphabet(&self) -> &[u8] {
+        &self.alphabet
+    }
+
+    /// The exact number of random bytes [`generate_password`] requires.
+    ///
+    /// One 8-byte word per character, plus [`SPARE_ENTROPY_WORDS`] to cover
+    /// discards. The caller reserves this in a single request so that a
+    /// password is never assembled from randomness collected at two different
+    /// moments.
+    #[must_use]
+    pub const fn required_entropy_bytes(&self) -> usize {
+        (self.length + SPARE_ENTROPY_WORDS) * ENTROPY_WORD_BYTES
+    }
+}
+
+/// Whether `alphabet_len^length` reaches `2^MIN_PASSWORD_ENTROPY_BITS`.
+///
+/// The integer form of "is this policy worth at least 80 bits?". It multiplies
+/// and stops the instant the target is passed, so the accumulator never exceeds
+/// `2^80 * 89 < 2^87` for any alphabet this crate can build, and
+/// `saturating_mul` keeps it total even for a caller-invented alphabet size.
+///
+/// An alphabet of fewer than two characters carries no entropy at all — every
+/// draw returns the same character no matter how long the password is — so it
+/// is rejected outright instead of being multiplied a hundred times.
+#[must_use]
+pub fn meets_minimum_entropy(alphabet_len: usize, length: usize) -> bool {
+    let Ok(alphabet_len) = u128::try_from(alphabet_len) else {
+        return false;
+    };
+    if alphabet_len < 2 {
+        return false;
+    }
+    let target: u128 = 1u128 << MIN_PASSWORD_ENTROPY_BITS;
+    let mut reachable_strings: u128 = 1;
+    for _ in 0..length {
+        reachable_strings = reachable_strings.saturating_mul(alphabet_len);
+        if reachable_strings >= target {
+            return true;
+        }
+    }
+    false
+}
+
+/// Turn exactly `policy.required_entropy_bytes()` random bytes into a password.
+///
+/// Deterministic: the same policy and the same bytes always produce the same
+/// string. That is what makes the sampler testable, and it is safe precisely
+/// because this crate cannot produce the bytes — they come from the operating
+/// system, once, and are wiped afterwards.
+///
+/// The returned string is allocated at its exact final capacity before the
+/// first character is pushed. That is not a micro-optimization: a `String` that
+/// grows copies its contents to a fresh allocation and leaves the old buffer
+/// behind unwiped, so a reallocation would strand a plaintext prefix of the
+/// password on the heap where nothing will ever clear it.
+///
+/// # Errors
+///
+/// - [`PasswordPolicyError::EntropyBlockSizeMismatch`] if the buffer is not
+///   exactly the required size. Both a short and an over-long buffer are
+///   refused: a short one cannot be served, and an over-long one means the
+///   caller and this function disagree about the reserve, which is not a
+///   disagreement to paper over.
+/// - [`PasswordPolicyError::EntropyExhausted`] if every reserved word,
+///   including the spares, fell in the discard region.
+pub fn generate_password(
+    policy: &PasswordPolicyV1,
+    entropy: &[u8],
+) -> Result<Zeroizing<String>, PasswordPolicyError> {
+    if entropy.len() != policy.required_entropy_bytes() {
+        return Err(PasswordPolicyError::EntropyBlockSizeMismatch);
+    }
+    let alphabet = policy.alphabet();
+    let modulus =
+        u64::try_from(alphabet.len()).expect("an assembled alphabet is at most 89 characters wide");
+    let bound = acceptance_bound(modulus);
+    let mut words = entropy.chunks_exact(ENTROPY_WORD_BYTES);
+    let mut password = Zeroizing::new(String::with_capacity(policy.length()));
+    for _ in 0..policy.length() {
+        let residue = loop {
+            let Some(word) = words.next() else {
+                return Err(PasswordPolicyError::EntropyExhausted);
+            };
+            let mut buffer = [0_u8; ENTROPY_WORD_BYTES];
+            buffer.copy_from_slice(word);
+            let draw = u64::from_be_bytes(buffer);
+            if u128::from(draw) < bound {
+                break draw % modulus;
+            }
+        };
+        let index =
+            usize::try_from(residue).expect("a residue modulo the alphabet length fits in usize");
+        password.push(char::from(alphabet[index]));
+    }
+    Ok(password)
+}
+
+/// The largest multiple of `modulus` that fits in a 64-bit word.
+///
+/// Words strictly below this value cover every residue the same number of
+/// times, which is what makes `draw % modulus` exactly uniform. Words at or
+/// above it are the leftovers from the module documentation's die, and are
+/// discarded.
+///
+/// The arithmetic is done in `u128` because the span being divided is `2^64`,
+/// which a `u64` cannot hold — computing the bound in 64-bit arithmetic is the
+/// classic way to get this one wrong by exactly one block.
+fn acceptance_bound(modulus: u64) -> u128 {
+    let span: u128 = 1u128 << 64;
+    let modulus = u128::from(modulus);
+    (span / modulus) * modulus
+}
+
+/// Concatenate the selected classes, minus the ambiguous characters.
+///
+/// Order is fixed — lowercase, uppercase, digits, symbols — so an alphabet is a
+/// pure function of the flags and can be asserted character for character in a
+/// test. Order has no effect on the output distribution, because every index is
+/// equally likely.
+fn assemble_alphabet(classes: CharacterClassesV1, exclude_ambiguous: bool) -> Vec<u8> {
+    let mut alphabet = Vec::with_capacity(
+        LOWERCASE_ALPHABET.len()
+            + UPPERCASE_ALPHABET.len()
+            + DIGIT_ALPHABET.len()
+            + SYMBOL_ALPHABET.len(),
+    );
+    let selected = [
+        (classes.lowercase, LOWERCASE_ALPHABET),
+        (classes.uppercase, UPPERCASE_ALPHABET),
+        (classes.digits, DIGIT_ALPHABET),
+        (classes.symbols, SYMBOL_ALPHABET),
+    ];
+    for (enabled, class) in selected {
+        if !enabled {
+            continue;
+        }
+        alphabet.extend(
+            class
+                .iter()
+                .copied()
+                .filter(|byte| !exclude_ambiguous || !AMBIGUOUS_CHARACTERS.contains(byte)),
+        );
+    }
+    alphabet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    /// A deterministic test-only stream, used where a *distribution* is under
+    /// test rather than an exact string.
+    ///
+    /// This is SplitMix64. It is emphatically not a cryptographic generator and
+    /// is never compiled into the library — it exists so that the statistical
+    /// sanity check in this module is reproducible on every run and on every
+    /// machine, which a real CSPRNG could not be. The production entropy path
+    /// is the operating-system CSPRNG and nothing else.
+    struct SplitMix64(u64);
+
+    impl SplitMix64 {
+        fn next_u64(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            z ^ (z >> 31)
+        }
+
+        fn bytes(&mut self, count: usize) -> Vec<u8> {
+            let mut out = Vec::with_capacity(count);
+            while out.len() < count {
+                out.extend_from_slice(&self.next_u64().to_be_bytes());
+            }
+            out.truncate(count);
+            out
+        }
+    }
+
+    fn classes(
+        lowercase: bool,
+        uppercase: bool,
+        digits: bool,
+        symbols: bool,
+    ) -> CharacterClassesV1 {
+        CharacterClassesV1 {
+            lowercase,
+            uppercase,
+            digits,
+            symbols,
+        }
+    }
+
+    /// Unwrap the refusal a generation was supposed to produce.
+    ///
+    /// Tests cannot write `assert_eq!(generate_password(..), Err(..))`, because
+    /// the success arm is a `Zeroizing<String>` and that type implements
+    /// neither `Debug` nor `PartialEq` — a secret must not be printable by an
+    /// assertion failure or comparable in non-constant time. That restriction
+    /// is a property worth keeping, so the tests bend around it rather than
+    /// asking for derives on the wrapper.
+    fn refusal(result: Result<Zeroizing<String>, PasswordPolicyError>) -> PasswordPolicyError {
+        match result {
+            Ok(_) => panic!("expected a refusal, but a password was generated"),
+            Err(error) => error,
+        }
+    }
+
+    #[test]
+    fn class_tables_have_the_documented_sizes_and_no_overlap() {
+        assert_eq!(LOWERCASE_ALPHABET.len(), 26);
+        assert_eq!(UPPERCASE_ALPHABET.len(), 26);
+        assert_eq!(DIGIT_ALPHABET.len(), 10);
+        assert_eq!(SYMBOL_ALPHABET.len(), 27);
+        assert_eq!(AMBIGUOUS_CHARACTERS.len(), 6);
+
+        let mut seen = BTreeSet::new();
+        for class in [
+            LOWERCASE_ALPHABET,
+            UPPERCASE_ALPHABET,
+            DIGIT_ALPHABET,
+            SYMBOL_ALPHABET,
+        ] {
+            for byte in class {
+                assert!(byte.is_ascii_graphic(), "{byte} is not printable ASCII");
+                assert!(seen.insert(*byte), "{byte} appears in two classes");
+            }
+        }
+        assert_eq!(seen.len(), 89);
+
+        // The five characters most likely to be mangled downstream, plus space.
+        for excluded in b"\"'`\\/ " {
+            assert!(!seen.contains(excluded), "{excluded} should be excluded");
+        }
+    }
+
+    #[test]
+    fn every_ambiguous_character_belongs_to_exactly_one_class() {
+        for ambiguous in AMBIGUOUS_CHARACTERS {
+            let homes = [
+                LOWERCASE_ALPHABET,
+                UPPERCASE_ALPHABET,
+                DIGIT_ALPHABET,
+                SYMBOL_ALPHABET,
+            ]
+            .into_iter()
+            .filter(|class| class.contains(ambiguous))
+            .count();
+            assert_eq!(homes, 1, "{ambiguous} has {homes} homes");
+        }
+    }
+
+    #[test]
+    fn alphabet_composition_matches_the_specification_table() {
+        let table: [(CharacterClassesV1, bool, usize); 12] = [
+            (classes(true, true, true, true), false, 89),
+            (classes(true, true, true, true), true, 83),
+            (classes(true, true, true, false), false, 62),
+            (classes(true, true, true, false), true, 57),
+            (classes(true, true, false, false), false, 52),
+            (classes(true, true, false, false), true, 49),
+            (classes(true, false, true, false), false, 36),
+            (classes(true, false, true, false), true, 33),
+            (classes(true, false, false, false), false, 26),
+            (classes(false, false, true, false), false, 10),
+            (classes(false, false, true, false), true, 8),
+            (classes(false, false, false, true), false, 27),
+        ];
+        for (selected, exclude_ambiguous, expected) in table {
+            let alphabet = assemble_alphabet(selected, exclude_ambiguous);
+            assert_eq!(
+                alphabet.len(),
+                expected,
+                "{selected:?} exclude_ambiguous={exclude_ambiguous}"
+            );
+            let unique: BTreeSet<u8> = alphabet.iter().copied().collect();
+            assert_eq!(unique.len(), alphabet.len(), "duplicate characters");
+            if exclude_ambiguous {
+                for ambiguous in AMBIGUOUS_CHARACTERS {
+                    assert!(!alphabet.contains(ambiguous), "{ambiguous} survived");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn excluding_ambiguous_characters_never_empties_a_selected_class() {
+        let per_class = [
+            (classes(true, false, false, false), 25),
+            (classes(false, true, false, false), 24),
+            (classes(false, false, true, false), 8),
+            (classes(false, false, false, true), 26),
+        ];
+        for (selected, expected) in per_class {
+            assert_eq!(assemble_alphabet(selected, true).len(), expected);
+        }
+    }
+
+    #[test]
+    fn the_entropy_floor_is_exact_on_both_sides_of_every_documented_row() {
+        // (alphabet size, first accepted length). One below must be refused.
+        let table = [
+            (89_usize, 13_usize),
+            (83, 13),
+            (62, 14),
+            (52, 15),
+            (36, 16),
+            (26, 18),
+            (10, 25),
+            (8, 27),
+        ];
+        for (alphabet_len, minimum) in table {
+            assert!(
+                meets_minimum_entropy(alphabet_len, minimum),
+                "{alphabet_len}^{minimum} should reach the floor"
+            );
+            assert!(
+                !meets_minimum_entropy(alphabet_len, minimum - 1),
+                "{alphabet_len}^{} should miss the floor",
+                minimum - 1
+            );
+        }
+    }
+
+    #[test]
+    fn a_degenerate_alphabet_carries_no_entropy_at_any_length() {
+        assert!(!meets_minimum_entropy(0, MAX_PASSWORD_LENGTH));
+        assert!(!meets_minimum_entropy(1, MAX_PASSWORD_LENGTH));
+        assert!(!meets_minimum_entropy(1, usize::MAX));
+        assert!(meets_minimum_entropy(2, 80));
+        assert!(!meets_minimum_entropy(2, 79));
+    }
+
+    #[test]
+    fn policy_validation_reports_the_most_basic_problem_first() {
+        assert_eq!(
+            PasswordPolicyV1::new(0, CharacterClassesV1::all(), false),
+            Err(PasswordPolicyError::LengthOutOfRange)
+        );
+        assert_eq!(
+            PasswordPolicyV1::new(MAX_PASSWORD_LENGTH + 1, CharacterClassesV1::all(), false),
+            Err(PasswordPolicyError::LengthOutOfRange)
+        );
+        // Length is checked before classes: a request that is wrong twice
+        // reports the shape problem, not the alphabet one.
+        assert_eq!(
+            PasswordPolicyV1::new(0, classes(false, false, false, false), false),
+            Err(PasswordPolicyError::LengthOutOfRange)
+        );
+        assert_eq!(
+            PasswordPolicyV1::new(24, classes(false, false, false, false), false),
+            Err(PasswordPolicyError::NoCharacterClass)
+        );
+        assert_eq!(
+            PasswordPolicyV1::new(12, CharacterClassesV1::all(), false),
+            Err(PasswordPolicyError::EntropyFloorNotMet),
+            "12 characters over 89 is 77.7 bits and must be refused"
+        );
+        assert!(PasswordPolicyV1::new(13, CharacterClassesV1::all(), false).is_ok());
+    }
+
+    #[test]
+    fn the_default_policy_is_accepted_and_reserves_the_documented_size() {
+        let policy = PasswordPolicyV1::new(
+            DEFAULT_PASSWORD_LENGTH,
+            CharacterClassesV1::default(),
+            false,
+        )
+        .expect("the default policy must be valid");
+        assert_eq!(policy.length(), 24);
+        assert_eq!(policy.alphabet().len(), 89);
+        assert_eq!(policy.required_entropy_bytes(), (24 + 8) * 8);
+
+        let longest = PasswordPolicyV1::new(MAX_PASSWORD_LENGTH, CharacterClassesV1::all(), false)
+            .expect("128 characters is valid");
+        assert_eq!(longest.required_entropy_bytes(), 1088);
+    }
+
+    #[test]
+    fn generation_is_deterministic_and_stays_inside_the_alphabet() {
+        let policy = PasswordPolicyV1::new(24, CharacterClassesV1::all(), false).unwrap();
+        let reserve = SplitMix64(0x0123_4567_89ab_cdef).bytes(policy.required_entropy_bytes());
+
+        let first = generate_password(&policy, &reserve).expect("exact reserve");
+        let second = generate_password(&policy, &reserve).expect("exact reserve");
+        assert_eq!(
+            first.as_str(),
+            second.as_str(),
+            "sampling must be a function"
+        );
+        assert_eq!(first.len(), 24);
+        for byte in first.as_bytes() {
+            assert!(policy.alphabet().contains(byte), "{byte} left the alphabet");
+        }
+    }
+
+    #[test]
+    fn excluded_characters_never_appear_in_output() {
+        let policy = PasswordPolicyV1::new(128, CharacterClassesV1::all(), true).unwrap();
+        let mut stream = SplitMix64(0xfeed_face_dead_beef);
+        for _ in 0..64 {
+            let reserve = stream.bytes(policy.required_entropy_bytes());
+            let password = generate_password(&policy, &reserve).unwrap();
+            for ambiguous in AMBIGUOUS_CHARACTERS {
+                assert!(
+                    !password.as_bytes().contains(ambiguous),
+                    "{ambiguous} appeared under --exclude-ambiguous"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_narrowed_policy_draws_only_from_its_classes() {
+        let policy = PasswordPolicyV1::new(64, classes(false, false, true, false), false).unwrap();
+        let reserve = SplitMix64(7).bytes(policy.required_entropy_bytes());
+        let password = generate_password(&policy, &reserve).unwrap();
+        assert!(password.chars().all(|character| character.is_ascii_digit()));
+    }
+
+    #[test]
+    fn the_reserve_size_must_match_exactly_in_both_directions() {
+        let policy = PasswordPolicyV1::new(24, CharacterClassesV1::all(), false).unwrap();
+        let exact = policy.required_entropy_bytes();
+        for wrong in [0, 1, exact - 1, exact + 1] {
+            let buffer = vec![0x11; wrong];
+            assert_eq!(
+                refusal(generate_password(&policy, &buffer)),
+                PasswordPolicyError::EntropyBlockSizeMismatch,
+                "a {wrong}-byte reserve must be refused"
+            );
+        }
+        let buffer = vec![0x11; exact];
+        assert!(generate_password(&policy, &buffer).is_ok());
+    }
+
+    #[test]
+    fn acceptance_bound_is_the_largest_multiple_of_the_modulus() {
+        for modulus in [2_u64, 8, 10, 26, 27, 36, 52, 62, 83, 89] {
+            let bound = acceptance_bound(modulus);
+            assert_eq!(bound % u128::from(modulus), 0, "bound must be a multiple");
+            assert!(bound <= 1u128 << 64);
+            assert!(
+                bound + u128::from(modulus) > 1u128 << 64,
+                "bound must be the largest such multiple"
+            );
+        }
+        // A modulus that divides 2^64 evenly wastes nothing at all.
+        assert_eq!(acceptance_bound(8), 1u128 << 64);
+        assert_eq!(acceptance_bound(2), 1u128 << 64);
+    }
+
+    #[test]
+    fn words_in_the_discard_region_are_skipped_rather_than_reduced() {
+        // Alphabet of 89. The discard region is [bound, 2^64), which is the
+        // top `2^64 mod 89` words. Feed one of those first and prove the
+        // character comes from the *second* word instead.
+        let policy = PasswordPolicyV1::new(13, CharacterClassesV1::all(), false).unwrap();
+        let modulus = u64::try_from(policy.alphabet().len()).unwrap();
+        let bound = acceptance_bound(modulus);
+        let discarded = u64::MAX;
+        assert!(
+            u128::from(discarded) >= bound,
+            "u64::MAX must fall in the discard region for 89"
+        );
+
+        let mut with_discard = Vec::new();
+        with_discard.extend_from_slice(&discarded.to_be_bytes());
+        let mut baseline = Vec::new();
+        // 13 usable words, all distinct so the comparison is not accidental.
+        for index in 0..13_u64 {
+            let word = index.wrapping_mul(0x0100_0000_0000_0001);
+            assert!(u128::from(word) < bound);
+            with_discard.extend_from_slice(&word.to_be_bytes());
+            baseline.extend_from_slice(&word.to_be_bytes());
+        }
+        let padding = policy.required_entropy_bytes();
+        with_discard.resize(padding, 0);
+        baseline.resize(padding, 0);
+
+        let skipped = generate_password(&policy, &with_discard).unwrap();
+        let plain = generate_password(&policy, &baseline).unwrap();
+        assert_eq!(
+            skipped.as_str(),
+            plain.as_str(),
+            "a discarded word must contribute nothing at all"
+        );
+        // And a biased implementation *would* have used it, visibly: reducing
+        // the discarded word instead of skipping it selects an ordinary index,
+        // and a different one than the word that actually got used. So this
+        // test would fail against a `word % n` sampler rather than passing by
+        // luck.
+        let biased_index = usize::try_from(discarded % modulus).unwrap();
+        let honest_index = usize::try_from(0_u64 % modulus).unwrap();
+        assert_ne!(
+            policy.alphabet()[biased_index],
+            policy.alphabet()[honest_index],
+            "the discarded word must not select the same character as the used one"
+        );
+        assert_eq!(plain.as_bytes()[0], policy.alphabet()[honest_index]);
+    }
+
+    #[test]
+    fn an_exhausted_reserve_fails_instead_of_falling_back() {
+        let policy = PasswordPolicyV1::new(13, CharacterClassesV1::all(), false).unwrap();
+        // Every single word lands in the discard region, spares included.
+        let reserve = vec![0xff; policy.required_entropy_bytes()];
+        assert_eq!(
+            refusal(generate_password(&policy, &reserve)),
+            PasswordPolicyError::EntropyExhausted
+        );
+    }
+
+    #[test]
+    fn the_spare_words_absorb_discards_up_to_their_count() {
+        let policy = PasswordPolicyV1::new(13, CharacterClassesV1::all(), false).unwrap();
+        let mut reserve = Vec::new();
+        for _ in 0..SPARE_ENTROPY_WORDS {
+            reserve.extend_from_slice(&u64::MAX.to_be_bytes());
+        }
+        reserve.resize(policy.required_entropy_bytes(), 0);
+        let password = generate_password(&policy, &reserve).expect("eight discards are survivable");
+        assert_eq!(password.len(), 13);
+
+        // One more discard than there are spares is one too many.
+        let mut over = Vec::new();
+        for _ in 0..=SPARE_ENTROPY_WORDS {
+            over.extend_from_slice(&u64::MAX.to_be_bytes());
+        }
+        over.resize(policy.required_entropy_bytes(), 0);
+        assert_eq!(
+            refusal(generate_password(&policy, &over)),
+            PasswordPolicyError::EntropyExhausted
+        );
+    }
+
+    #[test]
+    fn output_is_not_obviously_non_random() {
+        let policy = PasswordPolicyV1::new(64, CharacterClassesV1::all(), false).unwrap();
+        let alphabet_len = policy.alphabet().len();
+        let samples = 400_usize;
+        let mut stream = SplitMix64(0xdead_beef_cafe_0042);
+        let mut counts = [0_usize; 128];
+        let mut distinct = BTreeSet::new();
+
+        for _ in 0..samples {
+            let reserve = stream.bytes(policy.required_entropy_bytes());
+            let password = generate_password(&policy, &reserve).unwrap();
+            assert_eq!(password.len(), 64);
+            for byte in password.as_bytes() {
+                counts[usize::from(*byte)] += 1;
+            }
+            // Consecutive outputs must differ, and no single output may be a
+            // short repeating cycle — the two shapes a broken generator that
+            // "looks random" most often takes.
+            for period in 1..=8 {
+                let repeats = password
+                    .as_bytes()
+                    .windows(period + 1)
+                    .all(|window| window[0] == window[period]);
+                assert!(!repeats, "output cycles with period {period}");
+            }
+            assert!(distinct.insert(password.as_str().to_owned()), "repeat draw");
+        }
+
+        let drawn = samples * 64;
+        let expected = drawn / alphabet_len;
+        for member in policy.alphabet() {
+            let observed = counts[usize::from(*member)];
+            assert!(observed > 0, "{member} never appeared in {drawn} draws");
+            assert!(
+                observed * 2 > expected && observed < expected * 2,
+                "{member} appeared {observed} times against an expectation of {expected}"
+            );
+        }
+        // Nothing outside the alphabet was ever emitted.
+        let emitted: usize = counts.iter().sum();
+        let inside: usize = policy
+            .alphabet()
+            .iter()
+            .map(|member| counts[usize::from(*member)])
+            .sum();
+        assert_eq!(emitted, inside);
+    }
+
+    #[test]
+    fn errors_are_payload_free_and_displayable() {
+        let messages = [
+            PasswordPolicyError::NoCharacterClass,
+            PasswordPolicyError::LengthOutOfRange,
+            PasswordPolicyError::EntropyFloorNotMet,
+            PasswordPolicyError::EntropyBlockSizeMismatch,
+            PasswordPolicyError::EntropyExhausted,
+        ];
+        let mut seen = BTreeSet::new();
+        for error in messages {
+            let rendered = error.to_string();
+            assert!(rendered.starts_with("vault-pm password policy: "));
+            assert!(rendered.is_ascii());
+            assert!(seen.insert(rendered), "two errors share one message");
+        }
+        assert_eq!(
+            format!("{:?}", PasswordPolicyError::EntropyExhausted),
+            "EntropyExhausted"
+        );
+    }
+
+    #[test]
+    fn class_selection_helpers_behave() {
+        assert!(CharacterClassesV1::all().any());
+        assert!(!classes(false, false, false, false).any());
+        assert!(classes(false, false, false, true).any());
+        assert_eq!(CharacterClassesV1::default(), CharacterClassesV1::all());
+    }
+}

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+- The shipped executable can now mint a password: `vault-pm password generate
+  [policy flags] (--reveal|--copy)`. This crate's own sources are unchanged;
+  the ceremony lives in `coding_adventures_vault_pm_cli` under
+  `code/specs/VLT-PM44-cli-password-generate.md`, and it is recorded here
+  because it changes what this binary does.
+
+  It is the first verb this executable accepts that opens no vault: it takes no
+  `--vault` selector, collects no passphrase, and runs on a home directory
+  where `init` has never happened.
+
+  Two real-process tests were added to `local_cli_e2e.rs`, and they check
+  things the in-process tests structurally cannot. The first starts from an
+  untouched home, drives the confirmation and the delivery over a real
+  pseudo-terminal, and asserts that the password arrives on `/dev/tty` while
+  captured standard output stays empty, that `config`, `data`, and `cache` are
+  all still empty afterwards, and that two runs of the identical command
+  produce *different* passwords — which is the only end-to-end evidence that
+  the operating-system CSPRNG is genuinely wired in rather than a fixed buffer
+  being formatted convincingly. It also drives a narrowed policy and checks the
+  alphabet of what comes back. The second proves the refusals: a confirmation
+  answered `no` delivers nothing, an under-strength policy fails with the
+  entropy-floor message before the terminal is touched at all, disabling every
+  character class and passing a `--vault` selector are invalid, and `--copy`
+  exits with the unsupported class.
+
+  Both send the same standard-input injection every other reveal test sends, so
+  a generated password can neither be influenced by nor leak through an
+  attacker-controlled stdin.
+
 - The shipped executable can now change its master passphrase:
   `vault-pm [--vault NAME] passphrase rotate`. This crate's own sources are
   unchanged; the ceremony lives in `coding_adventures_vault_pm_cli` under

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -18,6 +18,9 @@ vault-pm [--vault NAME] audit list
 vault-pm [--vault NAME] audit show TRACE
 vault-pm [--vault NAME] doctor [--unlock]
 vault-pm [--vault NAME] passphrase rotate
+vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase]
+                           [--no-digits] [--no-symbols] [--exclude-ambiguous]
+                           (--reveal|--copy)
 vault-pm [--vault NAME] export FILE
 vault-pm [--vault NAME] import FILE
 vault-pm --vault NAME restore FILE
@@ -47,6 +50,12 @@ vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION
 ```
+
+`password generate` is the one exception to everything below: it opens no
+vault, takes no `--vault` selector, collects no passphrase, and runs on a home
+directory where `init` has never happened. It still needs a controlling
+terminal, because its confirmation and its one line of output both go there and
+nowhere else.
 
 `init` and every authenticated command require a controlling terminal even
 when stdin is redirected. No passphrase flag, environment variable, config

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -1030,6 +1030,157 @@ fn real_cli_creates_redacts_and_separately_reveals_a_totp_seed() {
     assert_tree_excludes(&home.0, TOTP_RAW_SECRET);
 }
 
+/// VLT-PM44 §8 gate 9, against the real executable.
+///
+/// The generator is the one command in this product that must work before
+/// `vault-pm init` has ever run, because the most common moment to want a
+/// generated password is while signing up for something. This test therefore
+/// starts from an untouched home, generates twice, and checks four things the
+/// unit tests cannot: that the process really does reach `/dev/tty` for both
+/// the confirmation and the delivery, that its ordinary standard output stays
+/// empty, that no vault state appears on disk, and that two runs of the same
+/// command produce different passwords — which is the only end-to-end evidence
+/// that the operating-system CSPRNG is genuinely wired in.
+#[test]
+fn real_cli_generates_a_password_without_a_vault_and_delivers_it_only_on_the_terminal() {
+    let home = TestHome::new();
+    let (status, transcript, stdout) =
+        run_password_generate_in_pty(&home, &["password", "generate", "--reveal"], b"yes");
+    assert!(status.success(), "{transcript}");
+    assert!(
+        stdout.is_empty(),
+        "a generated password must never reach standard output"
+    );
+
+    let generated = extract_revealed_secret(&transcript);
+    assert_eq!(generated.len(), 24, "{transcript}");
+    assert!(generated.is_ascii());
+    for character in generated.chars() {
+        assert!(
+            character.is_ascii_graphic() && character != '"' && character != '\\',
+            "{character} is outside the generated alphabet"
+        );
+    }
+    assert_transcript_excludes_secrets(&transcript);
+
+    // Nothing about the request is echoed, and no vault was created or opened.
+    assert!(!transcript.contains("vault-pm:"), "{transcript}");
+    for child in ["config", "data", "cache"] {
+        assert_eq!(
+            fs::read_dir(home.0.join(child)).unwrap().count(),
+            0,
+            "the generator must leave {child} untouched"
+        );
+    }
+
+    // A second run draws again from the operating-system CSPRNG.
+    let (second_status, second_transcript, second_stdout) =
+        run_password_generate_in_pty(&home, &["password", "generate", "--reveal"], b"yes");
+    assert!(second_status.success(), "{second_transcript}");
+    assert!(second_stdout.is_empty());
+    let second = extract_revealed_secret(&second_transcript);
+    assert_ne!(
+        generated, second,
+        "two runs producing the same password would mean the CSPRNG is not wired in"
+    );
+
+    // A narrowed policy is honoured end to end.
+    let (narrow_status, narrow_transcript, narrow_stdout) = run_password_generate_in_pty(
+        &home,
+        &[
+            "password",
+            "generate",
+            "--length",
+            "40",
+            "--no-symbols",
+            "--exclude-ambiguous",
+            "--reveal",
+        ],
+        b"yes",
+    );
+    assert!(narrow_status.success(), "{narrow_transcript}");
+    assert!(narrow_stdout.is_empty());
+    let narrowed = extract_revealed_secret(&narrow_transcript);
+    assert_eq!(narrowed.len(), 40);
+    for character in narrowed.chars() {
+        assert!(character.is_ascii_alphanumeric(), "{character} is a symbol");
+        assert!(!"01IOl|".contains(character), "{character} is ambiguous");
+    }
+}
+
+/// A refused confirmation mints nothing, and an under-strength policy is
+/// refused before the terminal is ever touched.
+#[test]
+fn real_cli_refuses_weak_password_policies_and_unconfirmed_reveals() {
+    let home = TestHome::new();
+
+    let (status, transcript, stdout) =
+        run_password_generate_in_pty(&home, &["password", "generate", "--reveal"], b"no");
+    assert_eq!(status.code(), Some(2), "{transcript}");
+    assert!(stdout.is_empty());
+    assert!(
+        !transcript.contains("Secret: "),
+        "a refused reveal must deliver nothing: {transcript}"
+    );
+
+    // Parse-time refusals never reach the terminal at all, so they need no
+    // pseudo-terminal to observe.
+    let weak = run_plain(
+        &home,
+        &["password", "generate", "--length", "12", "--reveal"],
+    );
+    assert_eq!(weak.status.code(), Some(2));
+    assert!(weak.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&weak.stderr),
+        "vault-pm: password policy below the minimum entropy floor\n"
+    );
+
+    // One character more clears the 80-bit floor, so the refusal is the floor
+    // talking and not a blanket rejection of `--length`.
+    let all_classes_disabled = run_plain(
+        &home,
+        &[
+            "password",
+            "generate",
+            "--no-lowercase",
+            "--no-uppercase",
+            "--no-digits",
+            "--no-symbols",
+            "--reveal",
+        ],
+    );
+    assert_eq!(all_classes_disabled.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8_lossy(&all_classes_disabled.stderr),
+        "vault-pm: invalid command\n"
+    );
+
+    // `--copy` is recognized but has no adapter behind it yet.
+    let copied = run_plain(&home, &["password", "generate", "--copy"]);
+    assert_eq!(copied.status.code(), Some(8));
+    assert!(copied.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&copied.stderr),
+        "vault-pm: unsupported capability\n"
+    );
+
+    // A selector names a target this command never opens.
+    let selected = run_plain(
+        &home,
+        &["--vault", "personal", "password", "generate", "--reveal"],
+    );
+    assert_eq!(selected.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8_lossy(&selected.stderr),
+        "vault-pm: invalid command\n"
+    );
+
+    for child in ["config", "data", "cache"] {
+        assert_eq!(fs::read_dir(home.0.join(child)).unwrap().count(), 0);
+    }
+}
+
 fn run_export_in_pty(home: &TestHome, destination: &Path) -> (ExitStatus, String) {
     let (mut master, slave) = open_pty();
     let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
@@ -1685,6 +1836,83 @@ fn extract_audit_trace(transcript: &str, action: &str) -> String {
         .and_then(|line| line.split('\t').next())
         .expect("canonical audit trace")
         .to_string()
+}
+
+/// Run one `password generate --reveal` against a real controlling terminal.
+///
+/// Unlike every other pseudo-terminal helper here this one never sends a
+/// passphrase, because the command it drives never asks for one: VLT-PM44 §1
+/// makes the generator vault-free, so the only terminal interaction is the
+/// reveal confirmation.
+fn run_password_generate_in_pty(
+    home: &TestHome,
+    arguments: &[&str],
+    confirmation: &[u8],
+) -> (ExitStatus, String, Vec<u8>) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(arguments);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDERR_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    // A generated password must not be influenced by, or leak through, an
+    // attacker-controlled standard input.
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(
+        &mut master,
+        &mut transcript,
+        b"Reveal secret on this terminal? Type yes to continue: ",
+    );
+    master.write_all(confirmation).unwrap();
+    master.write_all(b"\n").unwrap();
+    drain_pty(&mut master, &mut transcript);
+    drop(master);
+    let status = child.wait().unwrap();
+    let mut stdout = Vec::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_end(&mut stdout)
+        .unwrap();
+    (
+        status,
+        String::from_utf8_lossy(&transcript).into_owned(),
+        stdout,
+    )
+}
+
+/// Pull the one quoted secret line out of a terminal transcript.
+///
+/// The generator's alphabet contains neither `"` nor `\`, so the debug quoting
+/// the host applies is exactly a pair of quotes around the raw value and the
+/// closing quote is unambiguous.
+fn extract_revealed_secret(transcript: &str) -> String {
+    let start = transcript
+        .find("Secret: \"")
+        .expect("the terminal must receive one quoted secret line")
+        + "Secret: \"".len();
+    let rest = &transcript[start..];
+    let end = rest.find('"').expect("the secret line must be closed");
+    rest[..end].to_owned()
 }
 
 fn run_plain(home: &TestHome, arguments: &[&str]) -> std::process::Output {

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -889,7 +889,9 @@ vault-pm history list ITEM
 vault-pm history show ITEM REV [--copy|--reveal]
 vault-pm history restore ITEM REV
 
-vault-pm password generate [policy flags] [--copy|--reveal]
+vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase]
+                           [--no-digits] [--no-symbols] [--exclude-ambiguous]
+                           (--reveal|--copy)
 vault-pm totp code ITEM [--copy|--reveal]
 
 vault-pm attachment add ITEM PATH
@@ -920,6 +922,14 @@ portable export, audit verification, and `doctor`. `password generate`,
 `totp code`, and the attachment commands are Phase 1B daily-use conveniences
 (§23 item 11), as are the import adapters (§23 item 13).
 Cloud/storage migration commands activate in Phase 2.
+
+`password generate` has since shipped as the first of item 11, specified by
+`VLT-PM44-cli-password-generate.md`. It is the one command in this table that
+takes no `--vault` selector *and* opens no vault: it mints a password from the
+operating-system CSPRNG, refuses a policy below an 80-bit entropy floor, and
+delivers the result only through the §14.6 reveal path. Its `--copy` mode is
+recognized and refused with the unsupported class until item 11's clipboard
+ceremony provides an adapter.
 
 ### 14.5 Unlock experience
 
@@ -1779,6 +1789,18 @@ changelog, focused build, and downstream validation.
 ### Phase 1B — daily local use
 
 11. password generator, TOTP display, clipboard, attachments and packing.
+      The **password generator has shipped**, as
+      `VLT-PM44-cli-password-generate.md`: `vault-pm password generate` mints a
+      password from the operating-system CSPRNG by exactly uniform rejection
+      sampling, refuses any policy worth fewer than 80 bits of entropy, and
+      delivers the result only to the confirmed controlling terminal. It opens
+      no vault, requires no unlock, and publishes no audit event, for the
+      reasons that document's §1 records. That closes the half of §14.4 that
+      named a signature without naming a strength.
+      TOTP display, clipboard delivery, and attachments remain open. The
+      generator's `--copy` mode is recognized and refused with the unsupported
+      class until the clipboard ceremony lands, since no clipboard adapter
+      exists in this product yet.
 12. local agent/IPC and auto-lock.
 13. Bitwarden/KDBX/browser CSV import adapters.
 14. removable/synced-folder mode and mirror decorator.

--- a/code/specs/VLT-PM44-cli-password-generate.md
+++ b/code/specs/VLT-PM44-cli-password-generate.md
@@ -1,0 +1,437 @@
+# VLT-PM44 — CLI Password Generation
+
+## Status
+
+Normative Phase 1B contract for minting a new password that the vault never
+stores, through the local CLI and controlling terminal.
+
+`VLT-PM00-local-first-password-manager.md` §23 item 11 bundles four daily-use
+conveniences — "password generator, TOTP display, clipboard, attachments and
+packing". This document is the generator, and only the generator. TOTP display,
+clipboard delivery, and attachments remain separate ceremonies.
+
+§23 item 10c settled which phase the generator belongs to. It did not settle
+what the generator *does*: §14.4 names the signature
+
+```text
+vault-pm password generate [policy flags] [--copy|--reveal]
+```
+
+and says nothing about how strong the result must be or where its randomness
+comes from. A password manager whose generator is underspecified in exactly
+those two places is a password manager with a latent vulnerability, because
+"policy flags" is precisely the surface through which a person can ask for a
+password that is too weak to be worth storing. §3 and §4 below close that gap,
+and they are the load-bearing half of this contract.
+
+## 1. What this command is, and what it is not
+
+This is a **generate-only** command. It creates one password, delivers it once,
+and forgets it. It opens no vault, unlocks nothing, reads no item, writes no
+item, and publishes no audit event. It is usable on a machine where
+`vault-pm init` has never run.
+
+That is a deliberate scoping choice, not an omission, and three of this
+product's own rules force it:
+
+1. **There is nothing to audit.** `VLT-PM15-operation-audit.md` §2 defines the
+   audit boundary as "one user-visible application action" against a vault, and
+   names the exceptions explicitly: "Locked `status`, help, and grammar
+   rejection reveal no vault content and do not require an event." A generation
+   reveals no vault content either — there is no vault in the picture. Worse, a
+   vault-scoped event *would* be a new disclosure: an audit chain that recorded
+   "a password was generated at 14:02" tells a later reader of the chain
+   something the vault did not previously know, and correlates that instant
+   with whichever item is created next. The audit trail is supposed to make
+   vault operations attributable, not to accumulate a diary of things that
+   never touched the vault.
+2. **An unlock would be a lie about what happened.** Every command that calls
+   `authenticated_access` collects the master passphrase. Requiring one here
+   would mean prompting for the vault's most valuable secret in order to
+   perform an operation that never opens the vault — training the person to
+   type the master passphrase at prompts that do not need it, which is the
+   habit every phishing attack against a password manager depends on.
+3. **`init` must not be a prerequisite.** The single most common moment to want
+   a generated password is while signing up for something, which is frequently
+   before the vault exists.
+
+**Deferred, deliberately.** `password generate` does not offer to store its
+result into a new or existing item. That would make it a mutation — vault
+access, unlock, audit event, publication ordering, conflict handling, the
+entire `item add` ceremony — with a generated value substituted for one prompt.
+It is a strictly larger contract than this one and belongs in its own document.
+The composition that exists today is that a person reveals a generated password
+and pastes it into the `item add login` password prompt, which is one extra
+step and requires nothing new.
+
+## 2. Command surface
+
+```text
+vault-pm password generate [policy flags] (--reveal | --copy)
+```
+
+where the policy flags are exactly:
+
+```text
+--length N
+--no-lowercase
+--no-uppercase
+--no-digits
+--no-symbols
+--exclude-ambiguous
+```
+
+### 2.1 Closed grammar
+
+`generate` is the only verb under the `password` noun. Every flag above may
+appear at most once, in any order, and no other token is accepted. A repeated
+flag, an unknown flag, a positional argument, an `--flag=value` spelling, or a
+missing `--length` value fails before any host work with the invalid class.
+
+`--length N` takes exactly one following argument: one to three ASCII decimal
+digits with no sign, no underscore, no whitespace, and no leading zero. `007`
+is rejected rather than read as seven, because a grammar that accepts two
+spellings of one number is a grammar where a typo can silently mean something
+else.
+
+### 2.2 No vault selector
+
+The leading `--vault NAME` selector is **rejected** for this command, exactly as
+it is for `init`, `vault create`, and `help`. VLT-PM00 §14.4 permits the
+selector on commands "that operate on an existing vault", and this command
+operates on none. Accepting and ignoring it would be a small false statement —
+the person would have named a target that had no effect on anything.
+
+The interactive shell binds one vault at session start and prefixes every
+delegated command with that selector. Because this command refuses the
+selector, the shell must delegate `password` **without** prefixing it. That is
+the shell's job, not a reason to weaken the grammar: the generator is useful
+inside a session, so refusing the verb in the shell would be worse than
+teaching the shell that one verb is vault-free. A session's retained
+authenticator is not consulted, which is correct — nothing here authenticates.
+
+### 2.3 Exactly one output mode
+
+One of `--reveal` or `--copy` is **required**. Neither, or both, is invalid.
+
+There is no default output mode and no plain-stdout mode, because VLT-PM00
+§14.6 makes ordinary output redacted and this command has nothing *but* a
+secret to say. A `password generate` that printed to stdout by default would
+put a live credential into shell history files, terminal scrollback,
+`tee` pipelines, and CI logs the first time anyone redirected it.
+
+`--copy` is **recognized and refused** in this slice, with the unsupported
+class and the fixed message `vault-pm: unsupported capability`. No clipboard
+adapter exists anywhere in this product — `clipboard_clear_seconds` is a
+configuration value with no writer behind it — and building one is §23 item
+11's clipboard ceremony, not this one. Recognizing the flag and refusing it is
+better than treating it as an unknown token: §14.4 documents `--copy` as part
+of this command's signature, so a person who reads the spec and types it
+deserves "not yet", not "invalid command". When the clipboard ceremony lands,
+this refusal becomes a delivery path and nothing else about this document
+changes.
+
+## 3. Character classes and the alphabet
+
+Four classes are selected by default. Each `--no-*` flag removes one. Removing
+all four is invalid.
+
+| Class | Members | Size |
+|---|---|---:|
+| lowercase | `abcdefghijklmnopqrstuvwxyz` | 26 |
+| uppercase | `ABCDEFGHIJKLMNOPQRSTUVWXYZ` | 26 |
+| digits | `0123456789` | 10 |
+| symbols | `!#$%&()*+,-.:;<=>?@[]^_{|}~` | 27 |
+
+The symbol set is the 32 printable US-ASCII punctuation characters minus `"`,
+`'`, `` ` ``, `\`, and `/`; the space character is printable but is not
+punctuation and was never a candidate. The exclusions are not aesthetic. Quote and backslash characters are the
+ones that most often survive a round trip through a shell, a CSV import, a JSON
+blob, or a hand-written SQL string as *something other than themselves*; a
+generated password that a downstream system silently mangles is a password the
+person can no longer log in with, and they will not know why. Space is excluded
+because it is invisible at both ends of a value and is stripped by a large
+fraction of login forms.
+
+`--exclude-ambiguous` removes the six characters that are routinely misread
+when a password is copied off a screen or read aloud:
+
+| Removed | Class | Confused with |
+|---|---|---|
+| `0` | digits | `O` |
+| `1` | digits | `l`, `I` |
+| `I` | uppercase | `1`, `l` |
+| `O` | uppercase | `0` |
+| `l` | lowercase | `1`, `I` |
+| `|` | symbols | `l`, `I`, `1` |
+
+Every removed character belongs to exactly one class, so the flag can never
+empty a selected class. The resulting sizes are lowercase 25, uppercase 24,
+digits 8, symbols 26; all four classes selected gives 83 rather than 89.
+
+### 3.1 No forced class inclusion
+
+Every character is drawn independently and uniformly from the whole selected
+alphabet. The generator does **not** guarantee that at least one character of
+each selected class appears.
+
+This is the security-relevant choice it looks like, and it is made in the
+strong direction. A "must contain at least one digit" rule is a constraint on
+the output, and constraining the output of a uniform sampler always removes
+entropy — the sampler is no longer uniform over |alphabet|^length, so the
+entropy claim in §4 would stop being true and would have to be replaced by a
+smaller number that is much harder to state exactly. Since the floor in §4 is
+enforced against that claim, an inflated claim would let an under-strength
+policy through. Independent uniform sampling is the one construction whose
+strength can be stated exactly, so it is the one whose strength can be
+enforced exactly.
+
+The practical cost is nil at the default: the chance that a 24-character draw
+from the 89-character alphabet omits the digits entirely is
+`(79/89)^24 ≈ 5.7 × 10^-2`… which is *not* nil, and stating it honestly is the
+point. A person facing a site that demands a digit re-runs the command, or
+narrows the alphabet with `--no-symbols` so the site accepts the result at all.
+A "minimum one of each class" flag is a reasonable later addition; it belongs
+with an entropy accounting that is correct for constrained sampling, and this
+slice does not pretend to have one.
+
+## 4. The entropy floor and the randomness source
+
+### 4.1 Where the randomness comes from
+
+Every byte consumed by this command comes from the operating-system CSPRNG,
+reached through the path this product already uses for vault key material:
+
+```text
+password generate
+  └─ CliHost::fill_entropy
+       └─ coding_adventures_vault_pm_cli_host::OsEntropy::fill
+            └─ coding_adventures_csprng::fill_random
+                 └─ getrandom(2) / getentropy(2) / BCryptGenRandom
+```
+
+No general-purpose RNG is acceptable here and none is used. `coding_adventures_csprng`
+is a fail-closed wrapper with no fallback chain: if the OS source is
+unavailable it returns an error, which this command surfaces as the provider
+class rather than substituting a weaker source. A generated password is
+long-lived key material for whatever it protects, and the same reasoning that
+makes a vault root key come from the OS CSPRNG makes this come from the OS
+CSPRNG.
+
+### 4.2 Uniform selection without modulo bias
+
+Naïvely reducing a random word modulo the alphabet size is biased toward the
+low end of the alphabet, and although the bias is tiny for a 64-bit word it is
+avoidable at no cost, so it is avoided.
+
+Randomness is consumed as 8-byte big-endian words. For an alphabet of size `n`,
+the acceptance region is `floor(2^64 / n) * n`, the largest multiple of `n`
+that fits in a 64-bit word. A word inside the region selects
+`alphabet[word mod n]`; a word outside it is **discarded** and the next word is
+read. This is exactly uniform, not approximately uniform.
+
+The command therefore reserves `(length + 8) * 8` bytes in one call: one word
+per character plus eight spare words. The reserve is not decoration. Discarding
+is what makes the sampler exact, and a sampler that can discard must be able to
+run out. With `n ≤ 89` the chance that any one word is discarded is at most
+`88 / 2^64 ≈ 4.8 × 10^-18`, so exhausting eight spares is far below any
+probability worth naming; if it ever happened the command **fails** with the
+provider class rather than falling back to a biased draw. Failing closed on an
+impossible event is cheap. Silently becoming biased on it is not.
+
+### 4.3 The floor
+
+**The minimum is 80 bits of entropy, and the command refuses to generate below
+it.**
+
+The entropy of one generated password is exactly `length × log2(|alphabet|)`
+bits, which §3.1 is what buys. The refusal is evaluated as an exact integer
+comparison — `|alphabet|^length ≥ 2^80` — rather than in floating point,
+because a security boundary decided by rounding is a security boundary that
+differs between platforms.
+
+80 bits is chosen against the threat this product actually faces, which is not
+online guessing but **offline** attack on a credential database that leaked
+from the far end. Sites that store passwords under a fast unsalted hash are
+attacked today at roughly `10^12`–`10^14` guesses per second on commodity GPU
+farms. `2^80 ≈ 1.2 × 10^24`, which is about 380 years at `10^14/s`; the next
+power of ten of attacker capability still leaves decades. Below 80 the margin
+collapses quickly rather than degrading gracefully — 64 bits is under a day at
+`10^14/s` — which is what makes 80 a floor rather than a preference.
+
+The floor is not the recommendation. The default is 24 characters over all four
+classes, which is **155 bits**, comfortably past the 128-bit bar at which the
+password stops being the weakest part of any system it is typed into. The floor
+exists only to catch policies a person deliberately narrowed, and it is
+deliberately set low enough that it never argues with a reasonable request.
+
+Minimum lengths implied by the floor, for the policies people actually ask for:
+
+| Policy | Alphabet | Minimum length | Bits at that length |
+|---|---:|---:|---:|
+| all four classes | 89 | 13 | 84.2 |
+| all four, `--exclude-ambiguous` | 83 | 13 | 82.9 |
+| `--no-symbols` | 62 | 14 | 83.4 |
+| `--no-digits --no-symbols` | 52 | 15 | 85.5 |
+| `--no-uppercase --no-symbols` | 36 | 16 | 82.7 |
+| lowercase only | 26 | 18 | 84.6 |
+| digits only (a PIN) | 10 | 25 | 83.0 |
+| digits only, `--exclude-ambiguous` | 8 | 27 | 81.0 |
+
+Two rows are worth reading twice. A 12-character password using every class is
+77.7 bits and **is refused**, one character short; the deficit is real and the
+remedy costs one keystroke. And "digits only" needs 25 of them, which is the
+floor correctly reporting that a numeric PIN is not a password — the command
+will produce one, but only at a length that actually earns the name.
+
+There is no override flag in this slice. A site with a hostile maximum-length
+cap is a real problem and deserves a real answer — a flag that names the cap,
+says out loud how many bits the result has, and refuses to pretend otherwise —
+and that answer is a later addition. Shipping the escape hatch before the floor
+would mean shipping only the escape hatch.
+
+Length is additionally bounded to `1 ≤ N ≤ 128`. The upper bound exists so the
+one entropy reservation this command makes is bounded (at most 1088 bytes), not
+because 128 characters is meaningful.
+
+## 5. Ceremony and ordering
+
+```text
+1. parse and validate the policy      -- no host call yet
+2. refuse if the policy is under the floor
+3. host.confirm_secret_reveal()       -- exact lowercase `yes`
+4. host.fill_entropy(reserve)         -- OS CSPRNG, one call
+5. generate                           -- uniform draw, §4.2
+6. host.write_revealed_text(password) -- controlling terminal only
+7. wipe
+```
+
+The order is the contract, not an implementation detail.
+
+**Validation precedes every host call** (steps 1–2 before 3), so a request that
+was never going to be honoured costs no prompt, no terminal interaction, and no
+entropy.
+
+**Confirmation precedes generation** (step 3 before 4–5). VLT-PM00 §14.6
+requires an interactive TTY confirmation before `--reveal`, and this command
+uses the same fixed prompt and the same exact-`yes` rule as
+`VLT-PM25-cli-secret-reveal.md` §3 rather than inventing a second confirmation
+ceremony with its own wording. Putting it first has a property the item-reveal
+ordering cannot have: on refusal **no password is ever created**. There is no
+secret to wipe because none existed. A generator that minted a value and then
+discarded it on refusal would be strictly worse for no benefit, since unlike
+`item reveal` there is no audit event that needs to be published before the
+answer is known.
+
+**Delivery is terminal-only** (step 6). The generated password never enters
+`CliOutput`, process stdout, process stderr, argv, an environment variable, a
+configuration file, a `Debug` rendering, or any cloneable value owned by the
+command result. It is written by the same host adapter `item reveal` uses,
+which reopens the controlling terminal directly, quotes and control-escapes the
+value so it cannot inject terminal control sequences, and wipes its temporary
+buffers. One line is written:
+
+```text
+Secret: "QUOTED AND ESCAPED VALUE"
+```
+
+Ordinary stdout and stderr are empty on success. Nothing echoes the requested
+length, the alphabet, or the entropy bits — those are properties of a live
+credential and belong in this document, not in a transcript.
+
+**Wiping** (step 7). The entropy reserve and the generated password are both
+held in wipe-on-drop buffers for their whole lifetime and are wiped when the
+command ends, including on the failure paths. The password string is allocated
+once at its exact final capacity so that appending a character can never
+reallocate and strand an unwiped copy of a prefix on the heap.
+
+A terminal write that fails after step 6 began is reported with the provider
+class. Unlike `item reveal`, there is no truthfulness problem to resolve: no
+event claimed anything, and the value is wiped either way.
+
+## 6. Failure classes
+
+| Situation | Class | Exit |
+|---|---|---:|
+| unknown verb, unknown/repeated flag, bad `--length` spelling, missing or doubled output mode, `--vault` selector, all classes disabled, length outside 1–128 | invalid | 2 |
+| policy below the 80-bit floor | invalid | 2 |
+| confirmation answered with anything but `yes` | invalid | 2 |
+| `--copy` | unsupported | 8 |
+| OS CSPRNG unavailable | provider | 7 |
+| entropy reserve exhausted by discards (§4.2) | provider | 7 |
+| controlling terminal unavailable or unwritable | provider | 7 |
+| no audited terminal adapter for the platform | unsupported | 8 |
+
+The floor refusal carries its own fixed, payload-free message —
+`vault-pm: password policy below the minimum entropy floor` — rather than the
+generic invalid-command text. It is the one rejection in this command that a
+person will hit while doing something entirely reasonable, and "invalid
+command" would send them looking for a typo that is not there. The message
+still names no length, alphabet, or bit count: it says which rule was broken,
+and this document says what the rule is.
+
+## 7. Where the code lives
+
+The generator's policy and sampler are a **pure** library,
+`coding_adventures_vault_pm_password_policy`, with no clock, storage, terminal,
+process, or entropy source of its own. It validates a policy, states how many
+bytes that policy needs, and turns caller-supplied bytes into a password. It
+cannot generate anything by itself, which is what makes every property in §3
+and §4 testable against fixed byte vectors rather than against a random source.
+
+The CLI owns the two things that are not pure: reserving randomness from the
+host, and delivering the result to the controlling terminal. The application
+layer is not involved at all, for the reasons in §1.
+
+## 8. Acceptance gates
+
+The slice is complete only when tests prove:
+
+1. the grammar accepts exactly the flags in §2 and rejects unknown flags,
+   repeated flags, positional arguments, `--flag=value`, a missing `--length`
+   value, non-canonical numbers, neither output mode, both output modes, and a
+   leading `--vault` selector;
+2. the alphabet for every class combination is exactly the table in §3, and
+   `--exclude-ambiguous` removes exactly the six characters in §3, leaving
+   every selected class non-empty;
+3. the floor accepts and refuses exactly at the boundary in §4.3, checked on
+   both sides of every row of that table, by exact integer comparison;
+4. generation from a fixed byte vector is deterministic and reproducible, every
+   output character is in the selected alphabet, no excluded character appears,
+   and the output has exactly the requested length;
+5. a word in the rejection region is discarded rather than reduced, and an
+   exhausted reserve fails rather than falling back;
+6. over many samples the output is not obviously non-random: every alphabet
+   member appears, no member is wildly over-represented, and consecutive
+   outputs do not repeat or cycle;
+7. `--reveal` delivers only through the terminal adapter, with empty stdout and
+   stderr, and a refused confirmation delivers nothing at all;
+8. `--copy` fails unsupported, and an unavailable CSPRNG fails provider, with
+   no value delivered in either case;
+9. the real executable, driven under a pseudo-terminal, receives the password
+   on `/dev/tty` while its captured stdout stays empty, refuses an
+   under-strength policy, and never writes a generated value to any ordinary
+   stream; and
+10. formatting, Clippy, rustdoc, and the policy/CLI/executable test suites pass.
+
+## 9. References
+
+### Internal
+
+- `VLT-PM00-local-first-password-manager.md` §2.1, §14.4, §14.6, §14.7, §23
+  items 10c and 11 — command surface, secret-output policy, exit classes, and
+  the phase resolution this document implements.
+- `VLT-PM15-operation-audit.md` §2 — the audit boundary, and the named
+  exceptions that put this command outside it.
+- `VLT-PM25-cli-secret-reveal.md` §3, §5 — the confirmation prompt and the
+  terminal delivery adapter reused unchanged.
+- `VLT-PM40-cli-interactive-shell.md` — the session host that must delegate
+  this verb without a vault selector.
+
+### Code
+
+- `code/packages/rust/vault-pm-password-policy` — the pure policy and sampler.
+- `code/packages/rust/vault-pm-cli` — grammar, ceremony, and composition.
+- `code/packages/rust/vault-pm-cli-host` — `OsEntropy`, `confirm_secret_reveal`,
+  `write_revealed_text`.
+- `code/packages/rust/csprng` — the operating-system CSPRNG wrapper.


### PR DESCRIPTION
Implements the password generator: the first of VLT-PM00 §23 item 11, specified
by the new `code/specs/VLT-PM44-cli-password-generate.md`.

```text
vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase]
                           [--no-digits] [--no-symbols] [--exclude-ambiguous]
                           (--reveal|--copy)
```

§23 item 10c settled which *phase* the generator belongs to. It did not settle
what the generator does: §14.4 named a signature and said nothing about how
strong the result must be or where its randomness comes from — which is exactly
the pair of gaps through which a password manager ships a weak generator. The
two decisions that close them are the point of this PR.

## The entropy floor is 80 bits, and it is integer arithmetic

A policy is accepted when `alphabet^length >= 2^80`, computed by multiplying and
stopping early — never by comparing `length * log2(n)` against `80.0`. Two of
the eight documented policy rows land within 0.2 bits of the line (52 characters
at length 14 is 79.81 bits; 26 at length 17 is 79.91), so a floating-point check
would put rounding in charge of a security boundary and could answer differently
on different platforms.

80 is argued against offline attack on a leaked credential database at
10^12–10^14 guesses/second, where 2^80 is centuries and 64 bits is under a day.
It is a floor, not a recommendation: the default is 24 characters over all four
classes, **155 bits**, so the floor only ever bites on a policy someone
deliberately narrowed.

| Policy | Alphabet | Min length | Bits |
|---|---:|---:|---:|
| all four classes | 89 | 13 | 84.2 |
| all four, `--exclude-ambiguous` | 83 | 13 | 82.9 |
| `--no-symbols` | 62 | 14 | 83.4 |
| lowercase only | 26 | 18 | 84.6 |
| digits only | 10 | 25 | 83.0 |

A 12-character all-class password is 77.7 bits and is **refused**, one character
short. That is stated in the spec rather than hidden, and it gets its own fixed
message — `vault-pm: password policy below the minimum entropy floor` — because
it is the one rejection here a person hits while doing something entirely
reasonable, and "invalid command" would send them hunting for a typo that is not
there.

## Selection is exactly uniform, from the OS CSPRNG

Randomness reaches the sampler through the path this product already uses for
vault key material, in one reservation, into a wipe-on-drop buffer:

```text
CliHost::fill_entropy -> OsEntropy::fill -> csprng::fill_random
                      -> getrandom(2) / getentropy(2) / BCryptGenRandom
```

No `rand`, no thread-local generator, no new adapter. That path is fail-closed:
an unavailable source is a provider failure, never a weaker draw.

Bytes are consumed as 8-byte big-endian words. A word below
`floor(2^64 / n) * n` selects `alphabet[word mod n]`; a word at or above it is
**discarded** and the next is read. The bound is computed in `u128` because the
span being divided is `2^64`, which a `u64` cannot hold — doing it in 64-bit
arithmetic is the classic way to be wrong by exactly one block. Eight spare
words cover discards (each word discards with probability below 4.8e-18), and
exhausting them is an error rather than a fallback to a biased draw, so the
branch nobody ever exercises is not the branch that silently weakens the output.

**No forced class inclusion.** Constraining a uniform sampler's output removes
entropy, which would make the strength claim the floor is checked against
untrue — and the floor is only as good as the claim it checks. The honest cost
(a default draw contains no digit about 5.7% of the time) is in the spec, not
buried.

## Scope: generate-only, no vault

This is the first verb in the grammar that opens no vault. It is dispatched
beside `help`, before `execute`: no platform layout resolved, no cross-process
writer lock, no passphrase, no audit event. It runs where `init` has never
happened, which is the most common moment to want a generated password.

VLT-PM44 §1 argues that rather than assuming it. VLT-PM15 §2 already exempts
operations that reveal no vault content; beyond that, a vault-scoped audit event
would be a *new* disclosure, correlating an instant with whichever item is
created next, and requiring the master passphrase for an operation that never
opens the vault would train a person to type it at prompts that do not need it.
"Generate directly into an item" is deferred as its own contract, because it is
a mutation.

## Output

Exactly one mode is required and there is no plain-stdout mode: §14.6 makes
ordinary output redacted and this command has nothing but a secret to say, so a
default stdout mode would put a live credential into shell history, scrollback,
`tee` pipelines, and CI logs the first time anyone redirected it.

`--reveal` reuses `item reveal`'s fixed prompt and terminal adapter unchanged.
Confirmation runs **before** generation, which buys a property `item reveal`
cannot have: on refusal no password is ever created, so there is no secret to
wipe. Nothing forces the other order here, because unlike a stored-secret reveal
there is no audit event that must be published before the answer is known.

`--copy` is recognized and refused with the unsupported class. No clipboard
adapter exists in this product — `clipboard_clear_seconds` is a config value
with no writer behind it — and §14.4 documents the flag, so someone who reads
the spec and types it deserves "not yet" rather than "invalid command".

The `--vault` selector is refused, joining `init`, `vault create`, and `help`.
The shell prefixes every delegated command with its bound vault, so it now asks
`takes_no_vault_selector` first and delegates this one verb unprefixed —
refusing the verb in a session would have been the smaller change and the worse
one.

## Layering

The policy and sampler live in a new pure crate,
`coding_adventures_vault_pm_password_policy`, which sources **no randomness at
all**: there is no entry point that produces a password without being handed
bytes first. That forces the CLI to name its entropy source out loud, and turns
every security property into an assertion about specific bytes rather than a
statistical hope. `required_capabilities.json` is empty; the only dependency is
`zeroize`.

## Tests

- 19 unit tests + 1 doctest in the policy crate: class tables and disjointness,
  alphabet composition across twelve class/ambiguity combinations, **both sides
  of every entropy-floor row**, degenerate alphabets, validation ordering,
  determinism, reserve-size mismatch in both directions, the acceptance bound's
  maximality, reserve exhaustion, spare-word absorption at exactly its limit,
  and a distribution check over 25,600 draws that also rejects short-period
  cycles and repeated outputs. The discard test is written so it would **fail**
  against a plain `word % n` sampler rather than pass by luck.
- 10 new CLI unit tests and 25 new closed-parser rows (81 total in the crate).
- 2 real-process PTY tests. These check what the in-process tests structurally
  cannot: the password arrives on `/dev/tty` while captured stdout stays empty,
  `config`/`data`/`cache` are all still empty afterwards, and two runs of the
  identical command produce **different** passwords — the only end-to-end
  evidence that the OS CSPRNG is genuinely wired in rather than a fixed buffer
  being formatted convincingly.

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and
`RUSTDOCFLAGS="-D warnings" cargo doc` are clean on every touched crate.

## Security review

`/security-review` passed clean on the first round, verifying all five claims
(CSPRNG fail-closed, no modulo bias including the `n | 2^64` case, floor exact
and unbypassable across every CLI-reachable alphabet, secret zeroized and
absent from stdout/stderr/argv/`Debug`, parser closed) and confirming every
`expect`/`unreachable!` is unreachable from user input.

It raised one **pre-existing, out-of-scope** observation, filed separately:
`escaped_revealed_text` in `vault-pm-cli-host` builds its display string with
`format!`, which grows from zero capacity and leaves unwiped copies of secret
prefixes on the heap. That is unchanged code already on the `item reveal` and
`conflict reveal` paths and is not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
