### PR TITLE
fix(hl-c238): romanize seventeen more words a reader had no way to say

### DIFF
--- a/code/learning/human-languages/bengali/book/chapters/ch11-friend-family-brother-sister.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch11-friend-family-brother-sister.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:da9153764c563267
+% canonical-source-hash: fnv1a64:89cb40fe92cb7cd8
 % canonical-lessons: BN-C11-bondhu, BN-C11-poribar, BN-C11-bhai, BN-C11-bon
 
 \chapter{Friend, Family, Brother, and Sister}
@@ -134,7 +134,7 @@ Give \textquotedblleft{}my brother\textquotedblright{} in Bengali. (\textbf{\bn{
 
 
 \begin{quote}
-\bn{ভাই} turned out to be the very word \textquotedblleft{}brother.\textquotedblright{} This one does not — and where it comes from instead is the surprise this chapter has been saving.
+\bn{ভাই} (\emph{bhāi}) turned out to be the very word \textquotedblleft{}brother.\textquotedblright{} This one does not — and where it comes from instead is the surprise this chapter has been saving.
 \end{quote}
 
 \subsection*{You'll want to know: \bn{বোন}}

--- a/code/learning/human-languages/bengali/book/chapters/ch12-eye-mouth-nose-heart.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch12-eye-mouth-nose-heart.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d262da98de3a941e
+% canonical-source-hash: fnv1a64:4a8bfadfeee7db35
 % canonical-lessons: BN-C12-chokh, BN-C12-mukh, BN-C12-nak, BN-C12-hridoy
 
 \chapter{Eye, Mouth, Nose, and Heart}
@@ -57,7 +57,7 @@ Give \textquotedblleft{}my eye\textquotedblright{} in Bengali. (\textbf{\bn{আ�
 
 
 \begin{quote}
-\bn{চোখ} was half old sound, half new. This word is a full tatsama again — and its own history is a real, unresolved argument among linguists.
+\bn{চোখ} (\emph{chokh}) was half old sound, half new. This word is a full tatsama again — and its own history is a real, unresolved argument among linguists.
 \end{quote}
 
 \subsection*{You'll want to know: \bn{মুখ}}

--- a/code/learning/human-languages/bengali/lessons/BN-C11-bon.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C11-bon.md
@@ -34,7 +34,7 @@ reviews_of: [BN-C11-bhai, BN-C11-poribar, BN-C11-bondhu, BN-C10-bhat, BN-C06-num
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-C11-BHAI-01] -->
 
-[PAUSE 2s] ভাই turned out to be the very word "brother." This one does not —
+[PAUSE 2s] ভাই (*bhāi*) turned out to be the very word "brother." This one does not —
 and where it comes from instead is the surprise this chapter has been saving.
 
 ## You'll want to know: বোন

--- a/code/learning/human-languages/bengali/lessons/BN-C12-mukh.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C12-mukh.md
@@ -34,7 +34,7 @@ reviews_of: [BN-C12-chokh, BN-C11-bon]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-C12-CHOKH-01] -->
 
-[PAUSE 2s] চোখ was half old sound, half new. This word is a full tatsama again
+[PAUSE 2s] চোখ (*chokh*) was half old sound, half new. This word is a full tatsama again
 — and its own history is a real, unresolved argument among linguists.
 
 ## You'll want to know: মুখ

--- a/code/learning/human-languages/bengali/narration/ch11.json
+++ b/code/learning/human-languages/bengali/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Friend, Family, Brother, and Sister",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:3f28f826b9058a0d",
+  "sourceHash": "fnv1a64:08a61c259a749e99",
   "lessons": [
     {
       "id": "BN-C11-bondhu",
@@ -455,7 +455,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8e3696b8355f72cb",
+      "sourceHash": "fnv1a64:572bd690f1dfa551",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/bengali/narration/ch12.json
+++ b/code/learning/human-languages/bengali/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Eye, Mouth, Nose, and Heart",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:4917f65a4dae0f72",
+  "sourceHash": "fnv1a64:6f56ed66ba6d8ddf",
   "lessons": [
     {
       "id": "BN-C12-chokh",
@@ -166,7 +166,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4d222701aedec1af",
+      "sourceHash": "fnv1a64:52d0908b20971d13",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -410,7 +410,7 @@
     {
       "language": "bengali",
       "chapter": 11,
-      "sourceHash": "fnv1a64:da9153764c563267",
+      "sourceHash": "fnv1a64:89cb40fe92cb7cd8",
       "lessonIds": [
         "BN-C11-bondhu",
         "BN-C11-poribar",
@@ -422,7 +422,7 @@
     {
       "language": "bengali",
       "chapter": 12,
-      "sourceHash": "fnv1a64:d262da98de3a941e",
+      "sourceHash": "fnv1a64:4a8bfadfeee7db35",
       "lessonIds": [
         "BN-C12-chokh",
         "BN-C12-mukh",
@@ -936,7 +936,7 @@
     {
       "language": "gujarati",
       "chapter": 11,
-      "sourceHash": "fnv1a64:5dd5ff86739e3787",
+      "sourceHash": "fnv1a64:90845aa5f84cb894",
       "lessonIds": [
         "GU-C11-mitra",
         "GU-C11-kutumb",
@@ -948,7 +948,7 @@
     {
       "language": "gujarati",
       "chapter": 12,
-      "sourceHash": "fnv1a64:db5e43033a15f566",
+      "sourceHash": "fnv1a64:54121385f25ba2ae",
       "lessonIds": [
         "GU-C12-aankh",
         "GU-C12-kaan",
@@ -1289,7 +1289,7 @@
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:3e43fc6e37fee09e",
+      "sourceHash": "fnv1a64:cc6e26d6a1c42403",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -1874,7 +1874,7 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:1205af27f6675fc9",
+      "sourceHash": "fnv1a64:76726ad2b2b0b3b1",
       "lessonIds": [
         "JA-C01-hai",
         "JA-C01-iie",
@@ -1963,7 +1963,7 @@
     {
       "language": "kannada",
       "chapter": 9,
-      "sourceHash": "fnv1a64:32858450485fd597",
+      "sourceHash": "fnv1a64:ec35d557249d21ff",
       "lessonIds": [
         "KA-C09-kshamisi",
         "KA-S04-vowel-sign-i",
@@ -3126,7 +3126,7 @@
     {
       "language": "malayalam",
       "chapter": 17,
-      "sourceHash": "fnv1a64:fd01cd124320768d",
+      "sourceHash": "fnv1a64:d2e305459a1f26fc",
       "lessonIds": [
         "ML-C17-ucha-paathira",
         "ML-C17-paathira",
@@ -4246,7 +4246,7 @@
     {
       "language": "punjabi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:90434f8563da1fad",
+      "sourceHash": "fnv1a64:2eff3cda40a2abe1",
       "lessonIds": [
         "PA-C11-dost",
         "PA-C11-parivar",
@@ -4544,7 +4544,7 @@
     {
       "language": "sanskrit",
       "chapter": 12,
-      "sourceHash": "fnv1a64:96a077f1b0ce86eb",
+      "sourceHash": "fnv1a64:4bdbdac42bdd01f3",
       "lessonIds": [
         "SA-C12-akshi",
         "SA-C12-karnah",
@@ -4717,7 +4717,7 @@
     {
       "language": "sanskrit",
       "chapter": 25,
-      "sourceHash": "fnv1a64:4a1b5cabfc1c1b24",
+      "sourceHash": "fnv1a64:e4ff3ac7e40d4494",
       "lessonIds": [
         "SA-C25-hand",
         "SA-C25-foot",
@@ -8966,7 +8966,7 @@
     {
       "language": "telugu",
       "chapter": 48,
-      "sourceHash": "fnv1a64:9d9015125c43497d",
+      "sourceHash": "fnv1a64:773cdd3fd7a20474",
       "lessonIds": [
         "TE-C48-teacher",
         "TE-C48-student",
@@ -8992,7 +8992,7 @@
     {
       "language": "telugu",
       "chapter": 50,
-      "sourceHash": "fnv1a64:869a2a5ed96f0517",
+      "sourceHash": "fnv1a64:204d311254d96d78",
       "lessonIds": [
         "TE-C50-now",
         "TE-C50-day-after",
@@ -9198,7 +9198,7 @@
     {
       "language": "urdu",
       "chapter": 9,
-      "sourceHash": "fnv1a64:933a4f5b3b96125d",
+      "sourceHash": "fnv1a64:340213801ea754ca",
       "lessonIds": [
         "UR-C09-bhai",
         "UR-C09-bahan",
@@ -9231,7 +9231,7 @@
     {
       "language": "urdu",
       "chapter": 12,
-      "sourceHash": "fnv1a64:5206e3ae83221d48",
+      "sourceHash": "fnv1a64:7ef0e0f99ce1e9ae",
       "lessonIds": [
         "UR-C12-pani",
         "UR-C12-chai",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -753,7 +753,7 @@
     {
       "language": "bengali",
       "chapter": 11,
-      "sourceHash": "fnv1a64:3f28f826b9058a0d",
+      "sourceHash": "fnv1a64:08a61c259a749e99",
       "lessonIds": [
         "BN-C11-bondhu",
         "BN-C11-poribar",
@@ -765,12 +765,12 @@
       "text": "bengali/narration/ch11.txt",
       "json": "bengali/narration/ch11.json",
       "textHash": "fnv1a64:306694d81f9b00c1",
-      "jsonHash": "fnv1a64:c50ca8cd06d4c02a"
+      "jsonHash": "fnv1a64:2651e904ca27e3d1"
     },
     {
       "language": "bengali",
       "chapter": 12,
-      "sourceHash": "fnv1a64:4917f65a4dae0f72",
+      "sourceHash": "fnv1a64:6f56ed66ba6d8ddf",
       "lessonIds": [
         "BN-C12-chokh",
         "BN-C12-mukh",
@@ -782,7 +782,7 @@
       "text": "bengali/narration/ch12.txt",
       "json": "bengali/narration/ch12.json",
       "textHash": "fnv1a64:2215af79a7520ca2",
-      "jsonHash": "fnv1a64:d95226aa272442ef"
+      "jsonHash": "fnv1a64:cf1404081dab3b7d"
     },
     {
       "language": "bengali",
@@ -2146,7 +2146,7 @@
     {
       "language": "gujarati",
       "chapter": 11,
-      "sourceHash": "fnv1a64:268df2f35691414a",
+      "sourceHash": "fnv1a64:b8d449da74c1452e",
       "lessonIds": [
         "GU-C11-mitra",
         "GU-C11-kutumb",
@@ -2158,12 +2158,12 @@
       "text": "gujarati/narration/ch11.txt",
       "json": "gujarati/narration/ch11.json",
       "textHash": "fnv1a64:fabda219f9c195c8",
-      "jsonHash": "fnv1a64:c2370f24eca9ae58"
+      "jsonHash": "fnv1a64:a428713ffe4edf75"
     },
     {
       "language": "gujarati",
       "chapter": 12,
-      "sourceHash": "fnv1a64:dd6356418ad747f7",
+      "sourceHash": "fnv1a64:b4450287fa203285",
       "lessonIds": [
         "GU-C12-aankh",
         "GU-C12-kaan",
@@ -2174,8 +2174,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch12.txt",
       "json": "gujarati/narration/ch12.json",
-      "textHash": "fnv1a64:a41b8946aab1a71c",
-      "jsonHash": "fnv1a64:2d898857829749aa"
+      "textHash": "fnv1a64:e8e47f30baafeb2b",
+      "jsonHash": "fnv1a64:3bbe02bb1b16b3b3"
     },
     {
       "language": "gujarati",
@@ -2774,7 +2774,7 @@
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:6b415dff491322be",
+      "sourceHash": "fnv1a64:21e94bfc2692c481",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -2785,8 +2785,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch36.txt",
       "json": "hindi/narration/ch36.json",
-      "textHash": "fnv1a64:94c23af56b5bca5a",
-      "jsonHash": "fnv1a64:bb27ed8786b62894"
+      "textHash": "fnv1a64:5a67d1c7fef3b179",
+      "jsonHash": "fnv1a64:249dcc39108ef541"
     },
     {
       "language": "hindi",
@@ -3621,7 +3621,7 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:61da3ea5036d0e14",
+      "sourceHash": "fnv1a64:9927b0eced7c6fcf",
       "lessonIds": [
         "JA-C01-hai",
         "JA-C01-iie",
@@ -3637,7 +3637,7 @@
       "text": "japanese/narration/ch01.txt",
       "json": "japanese/narration/ch01.json",
       "textHash": "fnv1a64:e9d826f7652f1fcf",
-      "jsonHash": "fnv1a64:24c475c85fc84b70"
+      "jsonHash": "fnv1a64:3425b1b2b383325f"
     },
     {
       "language": "japanese",
@@ -3835,7 +3835,7 @@
     {
       "language": "kannada",
       "chapter": 9,
-      "sourceHash": "fnv1a64:6174957c2ce0d6b9",
+      "sourceHash": "fnv1a64:153be3bf12dc9139",
       "lessonIds": [
         "KA-C09-kshamisi",
         "KA-S04-vowel-sign-i",
@@ -3845,8 +3845,8 @@
       "drivablePrefix": 1,
       "text": "kannada/narration/ch09.txt",
       "json": "kannada/narration/ch09.json",
-      "textHash": "fnv1a64:bdacf879fd72adf3",
-      "jsonHash": "fnv1a64:4b40eb6c0e2b94d4"
+      "textHash": "fnv1a64:1e02493cffbf8c9f",
+      "jsonHash": "fnv1a64:db3e148e1efa5154"
     },
     {
       "language": "kannada",
@@ -5653,7 +5653,7 @@
     {
       "language": "malayalam",
       "chapter": 17,
-      "sourceHash": "fnv1a64:96c9978d515355d7",
+      "sourceHash": "fnv1a64:610a0729798efa47",
       "lessonIds": [
         "ML-C17-ucha-paathira",
         "ML-C17-paathira",
@@ -5664,7 +5664,7 @@
       "text": "malayalam/narration/ch17.txt",
       "json": "malayalam/narration/ch17.json",
       "textHash": "fnv1a64:9911aaba91af0be8",
-      "jsonHash": "fnv1a64:b4910dc37812a9cd"
+      "jsonHash": "fnv1a64:86f15f4edbf2612a"
     },
     {
       "language": "malayalam",
@@ -7495,7 +7495,7 @@
     {
       "language": "punjabi",
       "chapter": 11,
-      "sourceHash": "fnv1a64:6bda23565e753403",
+      "sourceHash": "fnv1a64:c6c833e1d1a6b395",
       "lessonIds": [
         "PA-C11-dost",
         "PA-C11-parivar",
@@ -7507,7 +7507,7 @@
       "text": "punjabi/narration/ch11.txt",
       "json": "punjabi/narration/ch11.json",
       "textHash": "fnv1a64:3d762a82365f5292",
-      "jsonHash": "fnv1a64:b8a70915952b1f42"
+      "jsonHash": "fnv1a64:ce5df93b051fd97c"
     },
     {
       "language": "punjabi",
@@ -8051,7 +8051,7 @@
     {
       "language": "sanskrit",
       "chapter": 12,
-      "sourceHash": "fnv1a64:c2e5f8208860ac10",
+      "sourceHash": "fnv1a64:71d9e91f007f92f2",
       "lessonIds": [
         "SA-C12-akshi",
         "SA-C12-karnah",
@@ -8064,7 +8064,7 @@
       "text": "sanskrit/narration/ch12.txt",
       "json": "sanskrit/narration/ch12.json",
       "textHash": "fnv1a64:5074a2fd286695b0",
-      "jsonHash": "fnv1a64:218e09a3acbc02d0"
+      "jsonHash": "fnv1a64:406dd6c1f765f6a6"
     },
     {
       "language": "sanskrit",
@@ -8289,7 +8289,7 @@
     {
       "language": "sanskrit",
       "chapter": 25,
-      "sourceHash": "fnv1a64:af646fe1e249bbd9",
+      "sourceHash": "fnv1a64:68be4c4a02fc726e",
       "lessonIds": [
         "SA-C25-hand",
         "SA-C25-foot",
@@ -8301,8 +8301,8 @@
       "drivablePrefix": 5,
       "text": "sanskrit/narration/ch25.txt",
       "json": "sanskrit/narration/ch25.json",
-      "textHash": "fnv1a64:27bf8b0926e5cd1c",
-      "jsonHash": "fnv1a64:0dcff8bcc3ca7215"
+      "textHash": "fnv1a64:10e936a884296d74",
+      "jsonHash": "fnv1a64:37a045a8ef8e9efe"
     },
     {
       "language": "sanskrit",
@@ -14778,7 +14778,7 @@
     {
       "language": "telugu",
       "chapter": 48,
-      "sourceHash": "fnv1a64:8f31aa85f30163fb",
+      "sourceHash": "fnv1a64:e22e97c39f8b3a48",
       "lessonIds": [
         "TE-C48-teacher",
         "TE-C48-student",
@@ -14790,8 +14790,8 @@
       "drivablePrefix": 2,
       "text": "telugu/narration/ch48.txt",
       "json": "telugu/narration/ch48.json",
-      "textHash": "fnv1a64:69effc2f0194ed19",
-      "jsonHash": "fnv1a64:1faa6f1b9239dca0"
+      "textHash": "fnv1a64:4924ba5a55588581",
+      "jsonHash": "fnv1a64:79a9778597286b90"
     },
     {
       "language": "telugu",
@@ -14814,7 +14814,7 @@
     {
       "language": "telugu",
       "chapter": 50,
-      "sourceHash": "fnv1a64:c8dd55defa59b40a",
+      "sourceHash": "fnv1a64:d7882d1a74054ce4",
       "lessonIds": [
         "TE-C50-now",
         "TE-C50-day-after",
@@ -14827,7 +14827,7 @@
       "text": "telugu/narration/ch50.txt",
       "json": "telugu/narration/ch50.json",
       "textHash": "fnv1a64:9eabdaafd89d516e",
-      "jsonHash": "fnv1a64:6cacbaaa175c5a86"
+      "jsonHash": "fnv1a64:f50ee049b06f10b7"
     },
     {
       "language": "telugu",
@@ -15131,7 +15131,7 @@
     {
       "language": "urdu",
       "chapter": 9,
-      "sourceHash": "fnv1a64:a24f7fd7207d0a03",
+      "sourceHash": "fnv1a64:03400f396e06b4be",
       "lessonIds": [
         "UR-C09-bhai",
         "UR-C09-bahan",
@@ -15142,8 +15142,8 @@
       "drivablePrefix": 0,
       "text": "urdu/narration/ch09.txt",
       "json": "urdu/narration/ch09.json",
-      "textHash": "fnv1a64:cb00f151ae104c18",
-      "jsonHash": "fnv1a64:9d977a1fc69923d6"
+      "textHash": "fnv1a64:7dbdce5a025257a1",
+      "jsonHash": "fnv1a64:e330411758dce9b7"
     },
     {
       "language": "urdu",
@@ -15179,7 +15179,7 @@
     {
       "language": "urdu",
       "chapter": 12,
-      "sourceHash": "fnv1a64:404672bf9b8f91e1",
+      "sourceHash": "fnv1a64:e9210dac6052faaf",
       "lessonIds": [
         "UR-C12-pani",
         "UR-C12-chai",
@@ -15190,8 +15190,8 @@
       "drivablePrefix": 1,
       "text": "urdu/narration/ch12.txt",
       "json": "urdu/narration/ch12.json",
-      "textHash": "fnv1a64:4c1be6db2c4ff184",
-      "jsonHash": "fnv1a64:6dcf3e6fadf06d89"
+      "textHash": "fnv1a64:c5574458caf84a4f",
+      "jsonHash": "fnv1a64:413658fe2bd63126"
     },
     {
       "language": "urdu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:79d8e51e0b335384",
+  "sourceHash": "fnv1a64:cf70534ef7fdbaa2",
   "summary": {
     "totalLessons": 3070,
     "voice": 2161,
@@ -19525,7 +19525,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8e3696b8355f72cb",
+      "sourceHash": "fnv1a64:572bd690f1dfa551",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -19567,7 +19567,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4d222701aedec1af",
+      "sourceHash": "fnv1a64:52d0908b20971d13",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25671,7 +25671,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c39f2e29b360abd1",
+      "sourceHash": "fnv1a64:f359800e0ad34bc1",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25692,7 +25692,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5d350bffe10b8cc4",
+      "sourceHash": "fnv1a64:4704038cd28045da",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25734,7 +25734,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bd4ab774acbdc9cc",
+      "sourceHash": "fnv1a64:908a428d5d9ba832",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25776,7 +25776,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:211a5716175a85c3",
+      "sourceHash": "fnv1a64:d21dd2c664d5e91f",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -28419,7 +28419,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ece8edc0c8ff0a94",
+      "sourceHash": "fnv1a64:bf4ccc0cb3c4a4b6",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -32329,7 +32329,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8f23a1be663b2b64",
+      "sourceHash": "fnv1a64:30364ffdc03370b8",
       "detachableSegments": [
         "Script — kanji, and the readings problem"
       ]
@@ -33778,7 +33778,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:35ace1cd966ef652"
+      "sourceHash": "fnv1a64:a85c6449433ef6c2"
     },
     {
       "id": "KA-S04-vowel-sign-i",
@@ -40183,7 +40183,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5e5d3423d223860c"
+      "sourceHash": "fnv1a64:d7efb9f6cdc7e7e2"
     },
     {
       "id": "ML-S116-letter-u",
@@ -48473,7 +48473,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:edc886bfb095835d",
+      "sourceHash": "fnv1a64:ac3e35f497e92e49",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -51826,7 +51826,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:06be3f898bcc6470",
+      "sourceHash": "fnv1a64:65afbb8a807510b4",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -53104,7 +53104,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cdf0549300c973c1"
+      "sourceHash": "fnv1a64:575f1f3418a0e14d"
     },
     {
       "id": "SA-C25-foot",
@@ -72614,7 +72614,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:50fec0361dfbb03f"
+      "sourceHash": "fnv1a64:d8f002c8510516bb"
     },
     {
       "id": "TE-C48-guest",
@@ -72794,7 +72794,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5498826f1751796e"
+      "sourceHash": "fnv1a64:c0f84523cc3f570c"
     },
     {
       "id": "TE-C50-farewell",
@@ -74300,7 +74300,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5db80ac0bcb513ca"
+      "sourceHash": "fnv1a64:735012b737d6b7ac"
     },
     {
       "id": "UR-C09-khandan",
@@ -74453,7 +74453,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fe7ad4ec6aa386c2",
+      "sourceHash": "fnv1a64:2e7a8df8a1a0d160",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/gujarati/book/chapters/ch11-friend-and-family.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch11-friend-and-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5dd5ff86739e3787
+% canonical-source-hash: fnv1a64:90845aa5f84cb894
 % canonical-lessons: GU-C11-mitra, GU-C11-kutumb, GU-C11-bhai, GU-C11-bahen
 
 \chapter{Friend and Family}
@@ -57,7 +57,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%AA\%AE\%E0\%AA\%BF\%E0\%AA\%
 
 
 \begin{quote}
-\textbf{\gu{મિત્ર}} reached Gujarati the long way, worn down through Prakrit like nearly every word you own. The word for the group a friend gets folded into took a different road entirely.
+\textbf{\gu{મિત્ર}} (\emph{mitra}) reached Gujarati the long way, worn down through Prakrit like nearly every word you own. The word for the group a friend gets folded into took a different road entirely.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -97,7 +97,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%AA\%95\%E0\%AB\%81\%E0\%AA\%
 
 
 \begin{quote}
-\textbf{\gu{કુટુંબ}} was taken up whole, close to the finished Sanskrit shape. The two words for its members run the opposite way — worn all the way down, the ordinary path nearly every Gujarati word has followed.
+\textbf{\gu{કુટુંબ}} (\emph{kuṭumb}) was taken up whole, close to the finished Sanskrit shape. The two words for its members run the opposite way — worn all the way down, the ordinary path nearly every Gujarati word has followed.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/gujarati/book/chapters/ch12-face-parts.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch12-face-parts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:db5e43033a15f566
+% canonical-source-hash: fnv1a64:54121385f25ba2ae
 % canonical-lessons: GU-C12-aankh, GU-C12-kaan, GU-C12-modhu, GU-C12-naak
 
 \chapter{Eye, Ear, Mouth, and Nose}
@@ -19,7 +19,7 @@ The chapter closes on \gu{નાક}, completing the face: the reader produces \
 
 
 \begin{quote}
-\textbf{\gu{બહેન}} closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about.
+\textbf{\gu{બહેન}} (\emph{bahen}) closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}
@@ -95,7 +95,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%AA\%95\%E0\%AA\%BE\%E0\%AA\%
 
 
 \begin{quote}
-\textbf{\gu{કાન}}'s own gender shifted away from Sanskrit's. The next body part wears its gender in plain sight — the same nasalized ending you have heard on nearly every verb in this book.
+\textbf{\gu{કાન}} (\emph{kān})'s own gender shifted away from Sanskrit's. The next body part wears its gender in plain sight — the same nasalized ending you have heard on nearly every verb in this book.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/gujarati/lessons/GU-C11-bhai.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C11-bhai.md
@@ -34,7 +34,7 @@ reviews_of: [GU-C11-kutumb, GU-C11-mitra]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-KUTUMB] -->
 
-[PAUSE 2s] **કુટુંબ** was taken up whole, close to the finished Sanskrit
+[PAUSE 2s] **કુટુંબ** (*kuṭumb*) was taken up whole, close to the finished Sanskrit
 shape. The two words for its members run the opposite way — worn all the way
 down, the ordinary path nearly every Gujarati word has followed.
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C11-kutumb.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C11-kutumb.md
@@ -34,7 +34,7 @@ reviews_of: [GU-C11-mitra, GU-C06-number-histories]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-MITRA] -->
 
-[PAUSE 2s] **મિત્ર** reached Gujarati the long way, worn down through Prakrit
+[PAUSE 2s] **મિત્ર** (*mitra*) reached Gujarati the long way, worn down through Prakrit
 like nearly every word you own. The word for the group a friend gets folded
 into took a different road entirely.
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C12-aankh.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C12-aankh.md
@@ -34,7 +34,7 @@ reviews_of: [GU-C11-bahen, GU-C08-vanchvun]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-BAHEN] -->
 
-[PAUSE 2s] **બહેન** closed a chapter about people. This chapter checks on how
+[PAUSE 2s] **બહેન** (*bahen*) closed a chapter about people. This chapter checks on how
 someone is — starting with the parts of the body a friend might actually ask
 about.
 

--- a/code/learning/human-languages/gujarati/lessons/GU-C12-modhu.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C12-modhu.md
@@ -34,7 +34,7 @@ reviews_of: [GU-C12-kaan, GU-C07-jaanvun]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[GU-LEX-KAAN] -->
 
-[PAUSE 2s] **કાન**'s own gender shifted away from Sanskrit's. The next body
+[PAUSE 2s] **કાન** (*kān*)'s own gender shifted away from Sanskrit's. The next body
 part wears its gender in plain sight — the same nasalized ending you have
 heard on nearly every verb in this book.
 

--- a/code/learning/human-languages/gujarati/narration/ch11.json
+++ b/code/learning/human-languages/gujarati/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Friend and Family",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:268df2f35691414a",
+  "sourceHash": "fnv1a64:b8d449da74c1452e",
   "lessons": [
     {
       "id": "GU-C11-mitra",
@@ -165,7 +165,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c39f2e29b360abd1",
+      "sourceHash": "fnv1a64:f359800e0ad34bc1",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -318,7 +318,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5d350bffe10b8cc4",
+      "sourceHash": "fnv1a64:4704038cd28045da",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch12.json
+++ b/code/learning/human-languages/gujarati/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Eye, Ear, Mouth, and Nose",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:dd6356418ad747f7",
+  "sourceHash": "fnv1a64:b4450287fa203285",
   "lessons": [
     {
       "id": "GU-C12-aankh",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bd4ab774acbdc9cc",
+      "sourceHash": "fnv1a64:908a428d5d9ba832",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -45,7 +45,7 @@
             },
             {
               "kind": "speech",
-              "text": "બહેન closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about."
+              "text": "બહેન (bahen) closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about."
             }
           ]
         },
@@ -313,7 +313,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:211a5716175a85c3",
+      "sourceHash": "fnv1a64:d21dd2c664d5e91f",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch12.txt
+++ b/code/learning/human-languages/gujarati/narration/ch12.txt
@@ -9,7 +9,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-બહેન closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about.
+બહેન (bahen) closed a chapter about people. This chapter checks on how someone is — starting with the parts of the body a friend might actually ask about.
 
 You'll want to know first — one word.
 આંખ — āṅkh — eye.

--- a/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3e43fc6e37fee09e
+% canonical-source-hash: fnv1a64:cc6e26d6a1c42403
 % canonical-lessons: HI-C36-ghar, HI-C36-darvaaza, HI-C36-kamra, HI-C36-kursi
 
 \chapter{One House, Four Languages}
@@ -81,7 +81,7 @@ A nuqta is a small confession in ink: \emph{this sound came from somewhere else.
 
 Here is your first piece of help. A noun ending in long \textbf{-ā} is usually masculine, and \emph{darvāzā} ends in \textbf{-\hi{ा}}. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
 
-\textbf{\hi{घर}} ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
+\textbf{\hi{घर}} (\emph{ghar}) ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
 \end{grammarlens}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
@@ -57,7 +57,7 @@ A nuqta is a small confession in ink: *this sound came from somewhere else.*
 Here is your first piece of help. A noun ending in long **-ā** is usually
 masculine, and *darvāzā* ends in **-ा**. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
 
-**घर** ends in a consonant and is masculine too — so a consonant ending tells
+**घर** (*ghar*) ends in a consonant and is masculine too — so a consonant ending tells
 you nothing at all. That one you simply learn.
 
 ## The word, taken apart: दरवाज़ा

--- a/code/learning/human-languages/hindi/narration/ch36.json
+++ b/code/learning/human-languages/hindi/narration/ch36.json
@@ -4,7 +4,7 @@
   "chapter": 36,
   "title": "One House, Four Languages",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6b415dff491322be",
+  "sourceHash": "fnv1a64:21e94bfc2692c481",
   "lessons": [
     {
       "id": "HI-C36-ghar",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ece8edc0c8ff0a94",
+      "sourceHash": "fnv1a64:bf4ccc0cb3c4a4b6",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -249,7 +249,7 @@
             },
             {
               "kind": "speech",
-              "text": "घर ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn."
+              "text": "घर (ghar) ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn."
             }
           ]
         },

--- a/code/learning/human-languages/hindi/narration/ch36.txt
+++ b/code/learning/human-languages/hindi/narration/ch36.txt
@@ -59,7 +59,7 @@ A nuqta is a small confession in ink: this sound came from somewhere else.
 Grammar Lens: the shape that usually tells you.
 दरवाज़ा (darvāzā) = "door," and it is masculine — so मेरा दरवाज़ा.
 Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
-घर ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
+घर (ghar) ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
 
 The word, taken apart: दरवाज़ा.
 दरवाज़ा is Persian, دروازه (darvāza), and its first syllable is where this gets remarkable. Persian در (dar) means "door," and it descends from the ancient root dʰwer- — as do English door, Latin forēs, Greek thúrā and Sanskrit द्वार (dvāra).

--- a/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:1205af27f6675fc9
+% canonical-source-hash: fnv1a64:76726ad2b2b0b3b1
 % canonical-lessons: JA-C01-hai, JA-C01-iie, JA-C01-konnichiwa, JA-C01-nihongo, JA-C01-koohii, JA-C01-arigatou, JA-C01-gozaimasu, JA-C01-practice
 
 \chapter{Three Writing Systems in One Doorway}
@@ -137,7 +137,7 @@ Source: \href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%A
 
 
 \begin{quote}
-Say \textbf{\ja{こんにちは}}. Its history hid two characters, \ja{今日}, that hiragana cannot show you. This lesson opens that second system by naming the language itself.
+Say \textbf{\ja{こんにちは}} (\emph{konnichiwa}). Its history hid two characters, \ja{今日}, that hiragana cannot show you. This lesson opens that second system by naming the language itself.
 \end{quote}
 
 \subsection*{Script — kanji, and the readings problem}

--- a/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
@@ -34,7 +34,7 @@ reviews_of: [JA-C01-konnichiwa]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA] -->
 
-[PAUSE 2s] Say **こんにちは**. Its history hid two characters, 今日, that
+[PAUSE 2s] Say **こんにちは** (*konnichiwa*). Its history hid two characters, 今日, that
 hiragana cannot show you. This lesson opens that second system by naming the
 language itself.
 

--- a/code/learning/human-languages/japanese/narration/ch01.json
+++ b/code/learning/human-languages/japanese/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Three Writing Systems in One Doorway",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:61da3ea5036d0e14",
+  "sourceHash": "fnv1a64:9927b0eced7c6fcf",
   "lessons": [
     {
       "id": "JA-C01-hai",
@@ -485,7 +485,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8f23a1be663b2b64",
+      "sourceHash": "fnv1a64:30364ffdc03370b8",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/kannada/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch09-sorry.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:32858450485fd597
+% canonical-source-hash: fnv1a64:ec35d557249d21ff
 % canonical-lessons: KA-C09-kshamisi, KA-S04-vowel-sign-i, KA-S113-letter-lla
 
 \chapter{Sorry}
@@ -19,7 +19,7 @@ Say \kn{ಕ್ಷಮಿಸಿ}, trace it back through kṣamisu to Sanskrit kṣ
 
 
 \begin{quote}
-You already know \textbf{\kn{ದಯವಿಟ್ಟು}}, \textquotedblleft{}please.\textquotedblright{} Kannada's \textquotedblleft{}sorry\textquotedblright{} reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb.
+You already know \textbf{\kn{ದಯವಿಟ್ಟು}} (\emph{dayaviṭṭu}), \textquotedblleft{}please.\textquotedblright{} Kannada's \textquotedblleft{}sorry\textquotedblright{} reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb.
 \end{quote}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C09-kshamisi.md
@@ -33,7 +33,7 @@ variety: standard-colloquial
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[KA-ETYMON-C08-DAYAVITTU-01, KA-ETYMON-C08-DAYAVITTU-02, KA-PRAGMATICS-C08-DAYAVITTU-03, KA-SCRIPT-C08-DAYAVITTU-04] -->
 
-[PAUSE 2s] You already know **ದಯವಿಟ್ಟು**, "please." Kannada's "sorry" reuses
+[PAUSE 2s] You already know **ದಯವಿಟ್ಟು** (*dayaviṭṭu*), "please." Kannada's "sorry" reuses
 a trick you'll see everywhere in this language: taking a Sanskrit noun and
 turning it into a working Kannada verb.
 

--- a/code/learning/human-languages/kannada/narration/ch09.json
+++ b/code/learning/human-languages/kannada/narration/ch09.json
@@ -4,7 +4,7 @@
   "chapter": 9,
   "title": "Sorry",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:6174957c2ce0d6b9",
+  "sourceHash": "fnv1a64:153be3bf12dc9139",
   "lessons": [
     {
       "id": "KA-C09-kshamisi",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:35ace1cd966ef652",
+      "sourceHash": "fnv1a64:a85c6449433ef6c2",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "You already know ದಯವಿಟ್ಟು, \"please.\" Kannada's \"sorry\" reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb."
+              "text": "You already know ದಯವಿಟ್ಟು (dayaviṭṭu), \"please.\" Kannada's \"sorry\" reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb."
             }
           ]
         },

--- a/code/learning/human-languages/kannada/narration/ch09.txt
+++ b/code/learning/human-languages/kannada/narration/ch09.txt
@@ -7,7 +7,7 @@ Lesson 1 of 3.
 
 Warm-up.
 [pause 2 seconds]
-You already know ದಯವಿಟ್ಟು, "please." Kannada's "sorry" reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb.
+You already know ದಯವಿಟ್ಟು (dayaviṭṭu), "please." Kannada's "sorry" reuses a trick you'll see everywhere in this language: taking a Sanskrit noun and turning it into a working Kannada verb.
 
 The word, taken apart.
 ಕ್ಷಮಾ (kṣamā) = "patience, forbearance, forgiveness" — a Sanskrit noun, unchanged.

--- a/code/learning/human-languages/malayalam/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch17-noon-and-midnight.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:fd01cd124320768d
+% canonical-source-hash: fnv1a64:d2e305459a1f26fc
 % canonical-lessons: ML-C17-ucha-paathira, ML-C17-paathira, ML-S116-letter-u
 
 \chapter{Noon and Midnight}
@@ -48,7 +48,7 @@ Is \textbf{\ml{ഉച്ച}} a Sanskrit \textquotedblleft{}middle\textquotedblr
 
 
 \begin{quote}
-\textbf{\ml{ഉച്ച}} named noon by the sun’s height. Malayalam builds midnight with a different spatial idea: cut the night in half.
+\textbf{\ml{ഉച്ച}} (\emph{ucca}) named noon by the sun’s height. Malayalam builds midnight with a different spatial idea: cut the night in half.
 \end{quote}
 
 \subsection*{What to know first}

--- a/code/learning/human-languages/malayalam/lessons/ML-C17-paathira.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C17-paathira.md
@@ -33,7 +33,7 @@ reviews_of: [ML-C17-ucha-paathira]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] **ഉച്ച** named noon by the sun’s height. Malayalam builds midnight
+[PAUSE 2s] **ഉച്ച** (*ucca*) named noon by the sun’s height. Malayalam builds midnight
 with a different spatial idea: cut the night in half.
 
 ## You'll want to know

--- a/code/learning/human-languages/malayalam/narration/ch17.json
+++ b/code/learning/human-languages/malayalam/narration/ch17.json
@@ -4,7 +4,7 @@
   "chapter": 17,
   "title": "Noon and Midnight",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:96c9978d515355d7",
+  "sourceHash": "fnv1a64:610a0729798efa47",
   "lessons": [
     {
       "id": "ML-C17-ucha-paathira",
@@ -124,7 +124,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5e5d3423d223860c",
+      "sourceHash": "fnv1a64:d7efb9f6cdc7e7e2",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/punjabi/book/chapters/ch11-friend-and-family.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch11-friend-and-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:90434f8563da1fad
+% canonical-source-hash: fnv1a64:2eff3cda40a2abe1
 % canonical-lessons: PA-C11-dost, PA-C11-parivar, PA-C11-bhara, PA-C11-bhain
 
 \chapter{Friend, Family, Brother, and Sister}
@@ -57,7 +57,7 @@ Sources: \href{https://en.wiktionary.org/wiki/\%E0\%A8\%A6\%E0\%A9\%8B\%E0\%A8\%
 
 
 \begin{quote}
-\textbf{\pa{ਦੋਸਤ}} named one person, chosen. This word names the group you never chose at all.
+\textbf{\pa{ਦੋਸਤ}} (\emph{dost}) named one person, chosen. This word names the group you never chose at all.
 \end{quote}
 
 \subsection*{You'll want to know first — one word}

--- a/code/learning/human-languages/punjabi/lessons/PA-C11-parivar.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C11-parivar.md
@@ -34,7 +34,7 @@ reviews_of: [PA-C11-dost, PA-C10-roti]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[PA-LEX-DOST, PA-ETYMON-DOST-CHOOSE] -->
 
-[PAUSE 2s] **ਦੋਸਤ** named one person, chosen. This word names the group you
+[PAUSE 2s] **ਦੋਸਤ** (*dost*) named one person, chosen. This word names the group you
 never chose at all.
 
 ## You'll want to know first — one word

--- a/code/learning/human-languages/punjabi/narration/ch11.json
+++ b/code/learning/human-languages/punjabi/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Friend, Family, Brother, and Sister",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6bda23565e753403",
+  "sourceHash": "fnv1a64:c6c833e1d1a6b395",
   "lessons": [
     {
       "id": "PA-C11-dost",
@@ -165,7 +165,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:edc886bfb095835d",
+      "sourceHash": "fnv1a64:ac3e35f497e92e49",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/sanskrit/book/chapters/ch12-face-nouns-1.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch12-face-nouns-1.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:96a077f1b0ce86eb
+% canonical-source-hash: fnv1a64:4bdbdac42bdd01f3
 % canonical-lessons: SA-C12-akshi, SA-C12-karnah, SA-C12-mukham, SA-S05-sign-virama, SA-S111-letter-ka
 
 \chapter{The Face, Part One}
@@ -84,7 +84,7 @@ Masculine, unlike \sk{अक्षि}.
 \textbf{\sk{कर्}} is \emph{kar}, the \emph{r} you have sounded since \textbf{\sk{संस्कृत}}. \textbf{\sk{ण}} is the curled-back retroflex \emph{n}, familiar from \textbf{\sk{गृह्णाति}}. The final \textbf{\sk{ः}}, a \emph{visarga}, breathes the word out on an echo of its own vowel: \emph{kar-ṇa-ḥ}, the same puff first heard closing \textbf{\sk{नमस्ते}}.
 
 \begin{cousinweb}
-Where \sk{अक्षि}'s ancestry runs clean back to PIE, \sk{कर्णः}'s does not run anywhere agreed. Proposed roots mean \textquotedblleft{}a defect,\textquotedblright{} \textquotedblleft{}a point,\textquotedblright{} \textquotedblleft{}a handle,\textquotedblright{} and \textquotedblleft{}to hear\textquotedblright{} — and no single account has won out over the others.
+Where \sk{अक्षि} (\emph{akṣi})'s ancestry runs clean back to PIE, \sk{कर्णः}'s does not run anywhere agreed. Proposed roots mean \textquotedblleft{}a defect,\textquotedblright{} \textquotedblleft{}a point,\textquotedblright{} \textquotedblleft{}a handle,\textquotedblright{} and \textquotedblleft{}to hear\textquotedblright{} — and no single account has won out over the others.
 
 What is certain is where it went. \sk{कर्णः} wore down through Prakrit \textbf{kaṇṇa} into Gujarati \emph{kān} — and changed gender on the way: masculine in Sanskrit, feminine in Gujarati. A word can cross a language boundary and lose the very grammar that first classified it.
 \end{cousinweb}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch25-hand-and-foot.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch25-hand-and-foot.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4a1b5cabfc1c1b24
+% canonical-source-hash: fnv1a64:e4ff3ac7e40d4494
 % canonical-lessons: SA-C25-hand, SA-C25-foot, SA-C25-head, SA-C25-tooth, SA-C25-hair
 
 \chapter{The Hand and the Foot}
@@ -25,7 +25,7 @@ Before the new word: what did \emph{dīpaḥ} mean?
 \subsection*{You'll want to know: \sk{हस्तः}}
 \textbf{\sk{हस्तः}} (\emph{hastaḥ}) — \textquotedblleft{}hand\textquotedblright{}.
 
-You have \sk{अक्षि}, \sk{कर्णः}, \sk{मुखम्}, \sk{नासिका} and \sk{हृदयम्}. \textbf{\sk{हस्तः}} adds the hand.
+You have \sk{अक्षि}, \sk{कर्णः}, \sk{मुखम्}, \sk{नासिका} and \sk{हृदयम्} (\emph{akṣi, karṇaḥ, mukham, nāsikā, hṛdayam}). \textbf{\sk{हस्तः}} adds the hand.
 
 Its cousins run west rather than into Europe: Avestan \emph{zasta}, Old Persian \emph{dasta}, and modern Persian \emph{dast}, all \textquotedblleft{}hand\textquotedblright{}. Latin went its own way with \emph{manus} and shares nothing with this word at all — a reminder that the family tree branches, and that two languages can both be cousins of Sanskrit without being cousins of each other in any given word.
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C12-karnah.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C12-karnah.md
@@ -59,7 +59,7 @@ the same puff first heard closing **नमस्ते**.
 ## The word, taken apart — no agreed parent
 <!-- hl-knowledge: introduces=[SA-ETYMON-KARNA-DISPUTED]; assesses=[SA-LEX-AKSHI-EYE, SA-ETYMON-OKW-EYE] -->
 
-Where अक्षि's ancestry runs clean back to PIE, कर्णः's does not run anywhere
+Where अक्षि (*akṣi*)'s ancestry runs clean back to PIE, कर्णः's does not run anywhere
 agreed. Proposed roots mean "a defect," "a point," "a handle," and "to
 hear" — and no single account has won out over the others.
 

--- a/code/learning/human-languages/sanskrit/lessons/SA-C25-hand.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C25-hand.md
@@ -40,7 +40,7 @@ reviews_of: [SA-C24-lamp]
 
 **हस्तः** (*hastaḥ*) — "hand".
 
-You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम्. **हस्तः** adds the hand.
+You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम् (*akṣi, karṇaḥ, mukham, nāsikā, hṛdayam*). **हस्तः** adds the hand.
 
 Its cousins run west rather than into Europe: Avestan *zasta*, Old Persian *dasta*, and modern Persian *dast*, all "hand". Latin went its own way with *manus* and shares nothing with this word at all — a reminder that the family tree branches, and that two languages can both be cousins of Sanskrit without being cousins of each other in any given word.
 

--- a/code/learning/human-languages/sanskrit/narration/ch12.json
+++ b/code/learning/human-languages/sanskrit/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "The Face, Part One",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:c2e5f8208860ac10",
+  "sourceHash": "fnv1a64:71d9e91f007f92f2",
   "lessons": [
     {
       "id": "SA-C12-akshi",
@@ -171,7 +171,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:06be3f898bcc6470",
+      "sourceHash": "fnv1a64:65afbb8a807510b4",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/sanskrit/narration/ch25.json
+++ b/code/learning/human-languages/sanskrit/narration/ch25.json
@@ -4,7 +4,7 @@
   "chapter": 25,
   "title": "The Hand and the Foot",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:af646fe1e249bbd9",
+  "sourceHash": "fnv1a64:68be4c4a02fc726e",
   "lessons": [
     {
       "id": "SA-C25-hand",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cdf0549300c973c1",
+      "sourceHash": "fnv1a64:575f1f3418a0e14d",
       "notice": null,
       "blocks": [
         {
@@ -50,7 +50,7 @@
             },
             {
               "kind": "speech",
-              "text": "You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम्. हस्तः (hastaḥ) adds the hand."
+              "text": "You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम् (akṣi, karṇaḥ, mukham, nāsikā, hṛdayam). हस्तः (hastaḥ) adds the hand."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/sanskrit/narration/ch25.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch25.txt
@@ -11,7 +11,7 @@ Before the new word: what did dīpaḥ mean?
 
 You'll want to know: हस्तः.
 हस्तः (hastaḥ) — "hand".
-You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम्. हस्तः (hastaḥ) adds the hand.
+You have अक्षि, कर्णः, मुखम्, नासिका and हृदयम् (akṣi, karṇaḥ, mukham, nāsikā, hṛdayam). हस्तः (hastaḥ) adds the hand.
 Its cousins run west rather than into Europe: Avestan zasta, Old Persian dasta, and modern Persian dast, all "hand". Latin went its own way with manus and shares nothing with this word at all — a reminder that the family tree branches, and that two languages can both be cousins of Sanskrit without being cousins of each other in any given word.
 
 What you've built.

--- a/code/learning/human-languages/telugu/book/chapters/ch48-roles.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch48-roles.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9d9015125c43497d
+% canonical-source-hash: fnv1a64:773cdd3fd7a20474
 % canonical-lessons: TE-C48-teacher, TE-C48-student, TE-C48-doctor, TE-C48-farmer, TE-C48-guest
 
 \chapter{Naming Who Someone Is}
@@ -129,7 +129,7 @@ Before the new one: what did \emph{vaidyuḍu} mean?
 
 \te{రైతు} came the long way round. Arabic \emph{raʿiyyah} meant a flock, then the people a ruler answers for. Persian and Urdu carried it into India as \emph{raʿīyat}, the subject, the tenant; the revenue clerks of the Deccan wrote it on their rolls; and Telugu kept it for the person who works the land.
 
-That is a second arrival from the north-west, after \te{రోజు} and \te{పుస్తకం}. The words that travel are the words that follow paperwork and trade.
+That is a second arrival from the north-west, after \te{రోజు} (\emph{rōju}) and \te{పుస్తకం}. The words that travel are the words that follow paperwork and trade.
 
 \begin{grammarlens}[title={What you've built}]
 Four.

--- a/code/learning/human-languages/telugu/book/chapters/ch50-taking-leave.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch50-taking-leave.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:869a2a5ed96f0517
+% canonical-source-hash: fnv1a64:204d311254d96d78
 % canonical-lessons: TE-C50-now, TE-C50-day-after, TE-C50-journey, TE-C50-set-out, TE-C50-farewell
 
 \chapter{Taking Your Leave}
@@ -129,7 +129,7 @@ Before the new one: what did \emph{prayāṇaṁ} mean?
 
 Native, and a picture rather than an abstraction. \te{బయలు} is open ground, the outside; \te{దేరు} is to rise, to come forth. To set out is to come out into the open.
 
-Set it beside \te{ప్రయాణం} and you have two languages building the same idea from opposite ends: Sanskrit from the going, Telugu from the doorstep.
+Set it beside \te{ప్రయాణం} (\emph{prayāṇaṁ}) and you have two languages building the same idea from opposite ends: Sanskrit from the going, Telugu from the doorstep.
 
 \begin{grammarlens}[title={What you've built}]
 Four.

--- a/code/learning/human-languages/telugu/lessons/TE-C48-farmer.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C48-farmer.md
@@ -42,7 +42,7 @@ reviews_of: [TE-C48-doctor]
 
 రైతు came the long way round. Arabic *raʿiyyah* meant a flock, then the people a ruler answers for. Persian and Urdu carried it into India as *raʿīyat*, the subject, the tenant; the revenue clerks of the Deccan wrote it on their rolls; and Telugu kept it for the person who works the land.
 
-That is a second arrival from the north-west, after రోజు and పుస్తకం. The words that travel are the words that follow paperwork and trade.
+That is a second arrival from the north-west, after రోజు (*rōju*) and పుస్తకం. The words that travel are the words that follow paperwork and trade.
 
 ## What you've built
 <!-- hl-knowledge: introduces=[]; assesses=[] -->

--- a/code/learning/human-languages/telugu/lessons/TE-C50-set-out.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C50-set-out.md
@@ -42,7 +42,7 @@ reviews_of: [TE-C50-journey]
 
 Native, and a picture rather than an abstraction. బయలు is open ground, the outside; దేరు is to rise, to come forth. To set out is to come out into the open.
 
-Set it beside ప్రయాణం and you have two languages building the same idea from opposite ends: Sanskrit from the going, Telugu from the doorstep.
+Set it beside ప్రయాణం (*prayāṇaṁ*) and you have two languages building the same idea from opposite ends: Sanskrit from the going, Telugu from the doorstep.
 
 ## What you've built
 <!-- hl-knowledge: introduces=[]; assesses=[] -->

--- a/code/learning/human-languages/telugu/narration/ch48.json
+++ b/code/learning/human-languages/telugu/narration/ch48.json
@@ -4,7 +4,7 @@
   "chapter": 48,
   "title": "Naming Who Someone Is",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:8f31aa85f30163fb",
+  "sourceHash": "fnv1a64:e22e97c39f8b3a48",
   "lessons": [
     {
       "id": "TE-C48-teacher",
@@ -392,7 +392,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:50fec0361dfbb03f",
+      "sourceHash": "fnv1a64:d8f002c8510516bb",
       "notice": null,
       "blocks": [
         {
@@ -427,7 +427,7 @@
             },
             {
               "kind": "speech",
-              "text": "That is a second arrival from the north-west, after రోజు and పుస్తకం. The words that travel are the words that follow paperwork and trade."
+              "text": "That is a second arrival from the north-west, after రోజు (rōju) and పుస్తకం. The words that travel are the words that follow paperwork and trade."
             }
           ]
         },

--- a/code/learning/human-languages/telugu/narration/ch48.txt
+++ b/code/learning/human-languages/telugu/narration/ch48.txt
@@ -101,7 +101,7 @@ Before the new one: what did vaidyuḍu mean?
 You'll want to know: రైతు.
 రైతు (raitu) — "a farmer".
 రైతు (raitu) came the long way round. Arabic raʿiyyah meant a flock, then the people a ruler answers for. Persian and Urdu carried it into India as raʿīyat, the subject, the tenant; the revenue clerks of the Deccan wrote it on their rolls; and Telugu kept it for the person who works the land.
-That is a second arrival from the north-west, after రోజు and పుస్తకం. The words that travel are the words that follow paperwork and trade.
+That is a second arrival from the north-west, after రోజు (rōju) and పుస్తకం. The words that travel are the words that follow paperwork and trade.
 
 What you've built.
 Four.

--- a/code/learning/human-languages/telugu/narration/ch50.json
+++ b/code/learning/human-languages/telugu/narration/ch50.json
@@ -4,7 +4,7 @@
   "chapter": 50,
   "title": "Taking Your Leave",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:c8dd55defa59b40a",
+  "sourceHash": "fnv1a64:d7882d1a74054ce4",
   "lessons": [
     {
       "id": "TE-C50-now",
@@ -385,7 +385,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5498826f1751796e",
+      "sourceHash": "fnv1a64:c0f84523cc3f570c",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/urdu/book/chapters/ch09-people.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch09-people.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:933a4f5b3b96125d
+% canonical-source-hash: fnv1a64:340213801ea754ca
 % canonical-lessons: UR-C09-bhai, UR-C09-bahan, UR-C09-dost, UR-C09-khandan
 
 \chapter{People You'd Introduce}
@@ -138,7 +138,7 @@ Back in Chapter 3 you learned three Urdu words for \textquotedblleft{}you\textqu
 Persian's own word for \textquotedblleft{}ask,\textquotedblright{} \textbf{porsīdan}, turned out to share one root with Urdu's inherited \textbf{\ur{پوچھنا}}. \textbf{\ur{دوست}} is not that kind of cousin — Urdu has no inherited word from \emph{*ǵews-} to compare it against — but it is the same general shape: an old Indo-European root, arriving in Urdu by the Persian road alone.
 \end{cousinweb}
 
-\begin{grammarlens}[title={Grammar Lens: where \ur{تم} actually lives}]
+\begin{grammarlens}[title={Grammar Lens: where \ur{تم} (\emph{tum}) actually lives}]
 Chapter 3 taught \textbf{āp / tum / tū} and told you to move to \textbf{tum} once familiarity is safe. A \textbf{\ur{دوست}} is exactly that relationship: someone you have moved off \textbf{āp} for. You do not need a new rule — just the word for the person the old rule was describing.
 \end{grammarlens}
 

--- a/code/learning/human-languages/urdu/book/chapters/ch12-food-words.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch12-food-words.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5206e3ae83221d48
+% canonical-source-hash: fnv1a64:7ef0e0f99ce1e9ae
 % canonical-lessons: UR-C12-pani, UR-C12-chai, UR-C12-doodh, UR-C12-roti
 
 \chapter{Water, Tea, Milk, Bread}

--- a/code/learning/human-languages/urdu/lessons/UR-C09-dost.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C09-dost.md
@@ -71,7 +71,7 @@ Urdu has no inherited word from *\*ǵews-* to compare it against — but it is
 the same general shape: an old Indo-European root, arriving in Urdu by the
 Persian road alone.
 
-## Grammar Lens: where تم actually lives
+## Grammar Lens: where تم (*tum*) actually lives
 <!-- hl-knowledge: introduces=[]; assesses=[UR-LEX-AAP-TUM-TU, UR-SCRIPT-AAP-TUM-TU, UR-PRAGMATICS-YOU-REGISTER] -->
 
 Chapter 3 taught **āp / tum / tū** and told you to move to **tum** once

--- a/code/learning/human-languages/urdu/lessons/UR-C12-chai.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C12-chai.md
@@ -56,7 +56,7 @@ letter **بھائی** introduced; then **ے**, broad final *e* from *kaise*.
 **چائے**'s **ئ** does the same job it did in **بھائی**: keeping **ā** and
 the vowel after it from colliding.
 
-## The word, taken apart — the same road as خدا and حافظ
+## The word, taken apart — the same road as خدا and حافظ (*hāfiz*)
 <!-- hl-knowledge: introduces=[UR-ETYMON-CHAI-SILKROAD]; assesses=[UR-LEX-CHAI, UR-ETYMON-KHUDA-PERSIAN] -->
 
 **چائے** is borrowed from Classical Persian **چای** (*chāy*), which traces

--- a/code/learning/human-languages/urdu/narration/ch09.json
+++ b/code/learning/human-languages/urdu/narration/ch09.json
@@ -4,7 +4,7 @@
   "chapter": 9,
   "title": "People You'd Introduce",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:a24f7fd7207d0a03",
+  "sourceHash": "fnv1a64:03400f396e06b4be",
   "lessons": [
     {
       "id": "UR-C09-bhai",
@@ -350,7 +350,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5db80ac0bcb513ca",
+      "sourceHash": "fnv1a64:735012b737d6b7ac",
       "notice": null,
       "blocks": [
         {
@@ -414,7 +414,7 @@
         {
           "index": 4,
           "type": "grammar",
-          "title": "Grammar Lens: where تم actually lives",
+          "title": "Grammar Lens: where تم (tum) actually lives",
           "segments": [
             {
               "kind": "speech",

--- a/code/learning/human-languages/urdu/narration/ch09.txt
+++ b/code/learning/human-languages/urdu/narration/ch09.txt
@@ -98,7 +98,7 @@ The word, taken apart — a friend is someone chosen.
 dost is Persian, inherited from Old Persian dauštā, from Proto-Iranian jawštā́, from Proto-Indo-European ǵews-, "to taste, to choose, to enjoy." That root also gave English choose and Latin gustus — behind English gusto. A friend, on this history, is someone tasted and chosen, the same picture as lenā's worn-down "take."
 Persian's own word for "ask," porsīdan, turned out to share one root with Urdu's inherited پوچھنا. دوست (dost) is not that kind of cousin — Urdu has no inherited word from ǵews- to compare it against — but it is the same general shape: an old Indo-European root, arriving in Urdu by the Persian road alone.
 
-Grammar Lens: where تم actually lives.
+Grammar Lens: where تم (tum) actually lives.
 Chapter 3 taught āp / tum / tū and told you to move to tum once familiarity is safe. A دوست (dost) is exactly that relationship: someone you have moved off āp for. You do not need a new rule — just the word for the person the old rule was describing.
 
 Guided Practice.

--- a/code/learning/human-languages/urdu/narration/ch12.json
+++ b/code/learning/human-languages/urdu/narration/ch12.json
@@ -4,7 +4,7 @@
   "chapter": 12,
   "title": "Water, Tea, Milk, Bread",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:404672bf9b8f91e1",
+  "sourceHash": "fnv1a64:e9210dac6052faaf",
   "lessons": [
     {
       "id": "UR-C12-pani",
@@ -150,7 +150,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fe7ad4ec6aa386c2",
+      "sourceHash": "fnv1a64:2e7a8df8a1a0d160",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -212,7 +212,7 @@
         {
           "index": 3,
           "type": "etymology",
-          "title": "The word, taken apart — the same road as خدا and حافظ",
+          "title": "The word, taken apart — the same road as خدا and حافظ (hāfiz)",
           "segments": [
             {
               "kind": "speech",

--- a/code/learning/human-languages/urdu/narration/ch12.txt
+++ b/code/learning/human-languages/urdu/narration/ch12.txt
@@ -51,7 +51,7 @@ You'll want to know first — one word.
 The letters in this word.
 From the right edge: چ ch, already yours from sochnā and samajhnā; then ا long ā; then ئ, hamza-ye, the vowel-glide letter بھائی introduced; then ے, broad final e from kaise. چائے (chāy)'s ئ does the same job it did in بھائی: keeping ā and the vowel after it from colliding.
 
-The word, taken apart — the same road as خدا and حافظ.
+The word, taken apart — the same road as خدا and حافظ (hāfiz).
 چائے is borrowed from Classical Persian چای (chāy), which traces back to Northern Chinese chá, carried overland through Central Asia into Persian before Urdu ever had it. That is the same road خدا and دل travelled in earlier chapters — Persian into Urdu — just with a Chinese starting point this time instead of one further west.
 Tea that instead reached Europe by sea kept a different form, from southern coastal Chinese, which is why English says tea and French says thé instead of chai. One drink, two words, sorted by whether it travelled by land or by water.
 


### PR DESCRIPTION
Seventeen lessons across nine tracks — Bengali, Gujarati, Urdu, Japanese, Sanskrit, Kannada, Punjabi, Malayalam, Hindi, Telugu. **Truly-unreachable words fall 53 → 34.**

Every romanization is attested elsewhere in its own track. That claim *is* the PR — this touches nine scripts and I can't eyeball nine scripts, so the review was pointed at sourcing above everything else.

## I almost shipped an invented pronunciation, and the review caught it

I wrote `jijñāsā karā` for জিজ্ঞাসা করা. The Bengali track spells the inherent vowel **ô**, not *a* — `kôrā` appears **126 times, `karā` zero** — and `bengali/README.md` states that as the track's fingerprint.

Worse, **the premise was false**: the same lesson already romanizes the phrase twice, and the generated book carried `(jijñāsā kôrā)` before I touched it. So my edit produced

> জিজ্ঞাসা করা **(jijñāsā kôrā) (jijñāsā karā)**

in the narration script — the phrase read aloud twice, with two conflicting pronunciations, one of them wrong. Reverted; the lesson needed nothing.

**That's the third time this run I've written a romanization contradicting one already in the same lesson** — Marathi's `Mira`, Russian's `pozhálusta`, now Bengali's `karā`. Same cause each time: searching for the word standalone and missing it inside a longer phrase or an undelimited cue.

## Before that, the extractor itself was wrong three times

Its first version matched **English prose** after a bolded word and would have written `জিজ্ঞাসা -> is` and `घर -> ends in a consonant` into lessons *as pronunciations*. Requiring explicit `*` or `(` delimiters fixed that; adding table-row extraction and widening the Latin range to U+1E00 (Tamil's `ṉ`/`ṟ`) recovered the rest. Sourced coverage went **30 → 32 → 35 of 48** as each gap closed.

The residue isn't missing data — it's **morphology**. Punjabi's `-ਦਾ/-ਦੀ` suffixes, Kannada's `ಉತ್ತ` infix, Bengali's `করি/করে/করেন` endings appear only inside grammatical decomposition, where "a word the reader cannot say" doesn't apply. Left alone deliberately rather than glossed for the sake of a number.

## Verification

**Fifteen of the sixteen** regenerated chapters carry a real content change rather than a hash-only one, so these edits reach the page rather than only the source. No doubled glosses remain (checked across all generated output).

**804 + 1231 + 725 tests pass**, five gates clean, validator clean, no corpus pin moved, no lesson over the 299s ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)