### PR TITLE
fix(mosaic-emit-xaml): generated WinUI apps launch and stay live

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -1497,9 +1497,14 @@ fn translate_xaml_value(key: &str, raw: &str) -> Option<String> {
         return Some(raw.to_string());
     }
 
-    // Color setters: hand off to the X4 PascalCasing pass.
+    // Color setters: hand off to the X4 PascalCasing pass. It returns
+    // `None` for CSS-only color forms that have no XAML literal
+    // (`currentColor`), which drops the property rather than emitting a
+    // value the XAML *runtime* rejects with E_XAMLPARSEFAILED. Note the
+    // markup compiler does not validate brush literals, so an
+    // unconvertible color builds cleanly and crashes on launch.
     if is_color_setter(key) {
-        return Some(normalize_xaml_color_value(raw));
+        return normalize_xaml_color_value(raw);
     }
 
     // Length setters: strip CSS `px` units (and reject percentages,
@@ -1646,21 +1651,37 @@ fn is_color_setter(setter: &str) -> bool {
 /// with the WinUI 3 `Microsoft.UI.Colors` set.  Most of them are
 /// identical PascalCased forms (`red`â†’`Red`); a few â€” `darkgray`
 /// vs `DarkGray` â€” also normalise to PascalCase.
-fn normalize_xaml_color_value(s: &str) -> String {
+fn normalize_xaml_color_value(s: &str) -> Option<String> {
     let trimmed = s.trim();
     if trimmed.starts_with('#') {
-        return s.to_string();
+        return Some(s.to_string());
+    }
+    // `rgb()` / `rgba()` are CSS *functions*, not XAML literals. Convert
+    // them to the `#AARRGGBB` form XAML understands rather than passing
+    // the call syntax through (which parses at build time and throws
+    // at runtime).
+    if let Some(hex) = css_rgb_function_to_xaml_hex(trimmed) {
+        return Some(hex);
+    }
+    // `currentColor` is a CSS *cascade* keyword — "whatever the
+    // inherited text color is". XAML has no equivalent: a Brush must
+    // resolve to an actual color, and there is no ambient inherited
+    // value to read at parse time. Drop it and let the element keep its
+    // theme default; inventing a color here would silently diverge from
+    // the authored design.
+    if trimmed.eq_ignore_ascii_case("currentcolor") {
+        return None;
     }
     // `{x:Bind â€¦}` / `{Binding â€¦}` markup extensions or any string with
     // braces â€” keep verbatim.  These aren't color literals.
     if trimmed.starts_with('{') {
-        return s.to_string();
+        return Some(s.to_string());
     }
     // Already PascalCased (or starts with an uppercase letter)?  Treat
     // as XAML-native and pass through.
     let first = trimmed.chars().next();
     if matches!(first, Some(c) if c.is_ascii_uppercase()) {
-        return s.to_string();
+        return Some(s.to_string());
     }
     // All-lowercase identifier â€” PascalCase it.  `transparent` â†’
     // `Transparent`, `red` â†’ `Red`, etc.  We don't gate on a known
@@ -1670,11 +1691,59 @@ fn normalize_xaml_color_value(s: &str) -> String {
     if trimmed.chars().all(|c| c.is_ascii_lowercase()) {
         let mut chars = trimmed.chars();
         match chars.next() {
-            Some(c) => return c.to_ascii_uppercase().to_string() + chars.as_str(),
-            None => return s.to_string(),
+            Some(c) => return Some(c.to_ascii_uppercase().to_string() + chars.as_str()),
+            None => return Some(s.to_string()),
         }
     }
-    s.to_string()
+    Some(s.to_string())
+}
+
+/// Convert a CSS `rgb()` / `rgba()` function call into the `#RRGGBB` /
+/// `#AARRGGBB` literal XAML expects.
+///
+/// XAML brushes accept only hex literals and named colors, so the CSS
+/// call syntax has to be evaluated at emit time. The alpha channel is
+/// CSS's `0.0..=1.0` fraction (commonly written with a leading dot, as
+/// in `rgba(20,17,13,.28)`) and becomes XAML's leading `AA` byte.
+///
+/// Returns `None` for anything that isn't a well-formed 3- or 4-argument
+/// `rgb`/`rgba` call with integer channels in `0..=255`, so malformed
+/// input falls through to the caller's other branches rather than
+/// producing a bogus color.
+fn css_rgb_function_to_xaml_hex(s: &str) -> Option<String> {
+    let lower = s.trim().to_ascii_lowercase();
+    let inner = lower
+        .strip_prefix("rgba(")
+        .or_else(|| lower.strip_prefix("rgb("))?
+        .strip_suffix(')')?;
+
+    let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+    if parts.len() != 3 && parts.len() != 4 {
+        return None;
+    }
+
+    let mut channels = [0u8; 3];
+    for (slot, raw) in channels.iter_mut().zip(parts.iter()) {
+        *slot = raw.parse::<u16>().ok().filter(|v| *v <= 255)? as u8;
+    }
+
+    let alpha = match parts.get(3) {
+        None => 255u8,
+        Some(raw) => {
+            let fraction = raw.parse::<f64>().ok()?;
+            if !(0.0..=1.0).contains(&fraction) {
+                return None;
+            }
+            // Round rather than truncate so `.28` lands on 71 (0x47),
+            // matching how browsers rasterize the same value.
+            (fraction * 255.0).round() as u8
+        }
+    };
+
+    Some(format!(
+        "#{:02X}{:02X}{:02X}{:02X}",
+        alpha, channels[0], channels[1], channels[2]
+    ))
 }
 
 /// Map a mosstyle CSS property name to its XAML setter property name.
@@ -2718,9 +2787,13 @@ fn emit_text(
             if !is_safe_identifier(&property) {
                 return Err(PipelineEmitError::UnsafeSlotName(property));
             }
+            // A slot-backed accessible name tracks the component's live
+            // prop value, so it must be OneWay. `x:Bind` defaults to
+            // OneTime, which would freeze the announced name at whatever
+            // the slot held when the template was first realized.
             write!(
                 accessibility_attrs,
-                " AutomationProperties.Name=\"{{x:Bind {}}}\"",
+                " AutomationProperties.Name=\"{{x:Bind {}, Mode=OneWay}}\"",
                 ctx.slot_xbind_path(slot)
             )
             .unwrap();
@@ -2746,7 +2819,14 @@ fn emit_text(
             if !is_safe_identifier(&property) {
                 return Err(PipelineEmitError::UnsafeSlotName(property));
             }
-            format!(" Text=\"{{x:Bind {}}}\"", ctx.slot_xbind_path(slot))
+            // Slot-backed text is the component's live prop value and
+            // must be OneWay. `x:Bind`'s default is OneTime, which
+            // renders the value once and never again — the defect that
+            // froze every label in the generated TaskApp.
+            format!(
+                " Text=\"{{x:Bind {}, Mode=OneWay}}\"",
+                ctx.slot_xbind_path(slot)
+            )
         }
         Some(LayoutPropValue::String(s)) => {
             let escaped = escape_xaml_attr(s);
@@ -2768,9 +2848,18 @@ fn emit_text(
         Some(LayoutPropValue::Number(n)) => format!(" Text=\"{n}\""),
         Some(LayoutPropValue::Expr(src)) => {
             // PR-2: route through ExprLowerer.
+            // An expression can read component slots (directly or via a
+            // generated helper), so it must be OneWay for the same
+            // reason as the SlotRef arm above. Row-VM-only expressions
+            // are re-evaluated when the item is rebuilt regardless, so
+            // OneWay is never wrong here — only occasionally redundant.
             match lower_expr_for_xbind(src, ctx) {
-                ExprLowering::Bindable(path) => format!(" Text=\"{{x:Bind {path}}}\""),
-                ExprLowering::Helper(call) => format!(" Text=\"{{x:Bind {call}}}\""),
+                ExprLowering::Bindable(path) => {
+                    format!(" Text=\"{{x:Bind {path}, Mode=OneWay}}\"")
+                }
+                ExprLowering::Helper(call) => {
+                    format!(" Text=\"{{x:Bind {call}, Mode=OneWay}}\"")
+                }
                 ExprLowering::Unsupported(reason) => {
                     return Err(PipelineEmitError::UnsupportedExpression(reason));
                 }
@@ -5137,7 +5226,7 @@ fn emit_csproj(_name: &str, options: &EmitOptions) -> String {
              <UseWinUI>true</UseWinUI>\n\
              <EnableMsixTooling>false</EnableMsixTooling>\n\
              <WindowsPackageType>None</WindowsPackageType>\n\
-             <EnableCoreMrtTooling>false</EnableCoreMrtTooling>\n\
+             <EnableCoreMrtTooling>true</EnableCoreMrtTooling>\n\
              <Nullable>enable</Nullable>\n\
              <ImplicitUsings>enable</ImplicitUsings>\n\
              <LangVersion>latest</LangVersion>\n\
@@ -5150,11 +5239,21 @@ fn emit_csproj(_name: &str, options: &EmitOptions) -> String {
                   removed from the default graph. UseRidGraph=true restores\n\
                   support for them. -->\n\
              <UseRidGraph>true</UseRidGraph>\n\
-             <!-- Unpackaged WinUI does not need MrtCore PRI generation or MSIX\n\
-                  packaging targets for this host shell. Keeping them disabled\n\
-                  lets `dotnet build` work on SDK-only machines. -->\n\
-             <AppxGeneratePriEnabled>false</AppxGeneratePriEnabled>\n\
-             <EnableDefaultPriItems>false</EnableDefaultPriItems>\n\
+             <!-- MSIX packaging targets stay OFF above (EnableMsixTooling):\n\
+                  they need the VS-shipped Microsoft.Build.AppxPackage.* tasks,\n\
+                  absent on SDK-only machines — see hello-dialog-xaml\n\
+                  ISSUES.md C1.\n\
+             \n\
+                  PRI generation is a SEPARATE subsystem and must stay ON. The\n\
+                  original C1 mitigation disabled both together, which was too\n\
+                  broad: makepri.exe ships inside the Microsoft.Windows.SDK.BuildTools\n\
+                  package referenced below, so PRI needs no Visual Studio.\n\
+                  Without the app PRI, WinUI cannot resolve\n\
+                  ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml and the\n\
+                  app dies at startup with E_XAMLPARSEFAILED (0x802B000A) — it\n\
+                  builds cleanly and then cannot launch. -->\n\
+             <AppxGeneratePriEnabled>true</AppxGeneratePriEnabled>\n\
+             <EnableDefaultPriItems>true</EnableDefaultPriItems>\n\
            </PropertyGroup>\n\
          \n\
            <ItemGroup>\n\
@@ -9495,7 +9594,7 @@ mod tests {
             },
         );
         let out = compile(&c, &l, &empty_style("Title")).xaml;
-        assert!(out.contains("AutomationProperties.Name=\"{x:Bind SpokenTitle}\""));
+        assert!(out.contains("AutomationProperties.Name=\"{x:Bind SpokenTitle, Mode=OneWay}\""));
         assert!(out.contains("AutomationProperties.HeadingLevel=\"Level2\""));
 
         let hidden = layout_with_root(
@@ -9578,7 +9677,8 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
-            r.xaml.contains("<TextBlock Text=\"{x:Bind Greeting}\""),
+            r.xaml
+                .contains("<TextBlock Text=\"{x:Bind Greeting, Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -9604,7 +9704,7 @@ mod tests {
             },
         );
         let r = compile(&c, &l, &empty_style("Foo"));
-        assert!(r.xaml.contains("{x:Bind DisplayName}"));
+        assert!(r.xaml.contains("{x:Bind DisplayName, Mode=OneWay}"));
     }
 
     #[test]
@@ -11862,7 +11962,7 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Grid"));
         assert!(
-            r.xaml.contains("Text=\"{x:Bind Owner.Title}\""),
+            r.xaml.contains("Text=\"{x:Bind Owner.Title, Mode=OneWay}\""),
             "component slots inside a typed template must route through Owner:\n{}",
             r.xaml
         );
@@ -12361,6 +12461,56 @@ mod tests {
         assert!(r.xaml.contains("Padding=\"8\""), "got:\n{}", r.xaml);
     }
 
+    /// CSS `rgb()`/`rgba()` are function calls, not XAML literals. They
+    /// must be evaluated at emit time into `#AARRGGBB`, because the XAML
+    /// markup compiler does NOT validate brush literals — an
+    /// unconverted value builds cleanly and then throws
+    /// E_XAMLPARSEFAILED when the runtime loads the page.
+    #[test]
+    fn css_rgb_functions_convert_to_xaml_hex() {
+        // Opaque 3-arg form gets a fully opaque alpha byte.
+        assert_eq!(
+            css_rgb_function_to_xaml_hex("rgb(20,17,13)").as_deref(),
+            Some("#FF14110D")
+        );
+        // 4-arg form with CSS's leading-dot fraction: .28 * 255 = 71.4 â†’ 0x47.
+        assert_eq!(
+            css_rgb_function_to_xaml_hex("rgba(20,17,13,.28)").as_deref(),
+            Some("#4714110D")
+        );
+        assert_eq!(
+            css_rgb_function_to_xaml_hex("rgba(255, 255, 255, 1)").as_deref(),
+            Some("#FFFFFFFF")
+        );
+        // Malformed / out-of-range input falls through rather than
+        // producing a bogus color.
+        assert_eq!(css_rgb_function_to_xaml_hex("rgb(300,0,0)"), None);
+        assert_eq!(css_rgb_function_to_xaml_hex("rgba(1,2,3,9)"), None);
+        assert_eq!(css_rgb_function_to_xaml_hex("#ffffff"), None);
+    }
+
+    /// `currentColor` is a CSS cascade keyword with no XAML equivalent,
+    /// so the color normalizer drops the property instead of emitting a
+    /// literal the runtime rejects.
+    #[test]
+    fn current_color_is_dropped_not_emitted() {
+        assert_eq!(normalize_xaml_color_value("currentColor"), None);
+        assert_eq!(normalize_xaml_color_value("currentcolor"), None);
+        // Ordinary values still normalize as before.
+        assert_eq!(
+            normalize_xaml_color_value("transparent").as_deref(),
+            Some("Transparent")
+        );
+        assert_eq!(
+            normalize_xaml_color_value("#1e1e1e").as_deref(),
+            Some("#1e1e1e")
+        );
+        assert_eq!(
+            normalize_xaml_color_value("rgba(20,17,13,.28)").as_deref(),
+            Some("#4714110D")
+        );
+    }
+
     // â”€â”€ unused-flag placeholders â”€â”€
 
     /// `EmitOptions::emit_project = false` (default) â†’ `project` is
@@ -12394,8 +12544,15 @@ mod tests {
         assert!(p
             .csproj
             .contains("<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>"));
-        assert!(p.csproj.contains("AppxGeneratePriEnabled>false"));
-        assert!(p.csproj.contains("EnableCoreMrtTooling>false"));
+        // PRI generation must be ON — makepri.exe comes from the
+        // Microsoft.Windows.SDK.BuildTools package reference, and
+        // without an app PRI the built app cannot resolve WinUI's
+        // themeresources and dies at startup. MSIX tooling stays off
+        // separately (that is the part which needs Visual Studio).
+        assert!(p.csproj.contains("AppxGeneratePriEnabled>true"));
+        assert!(p.csproj.contains("EnableDefaultPriItems>true"));
+        assert!(p.csproj.contains("EnableCoreMrtTooling>true"));
+        assert!(p.csproj.contains("EnableMsixTooling>false"));
         assert!(p.csproj.contains("UseRidGraph>true"));
         assert!(p.csproj.contains("FlattenNativeRuntimeDlls"));
         assert!(p.csproj.contains("CopyMosaicNativeHostLibraries"));

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -1653,6 +1653,20 @@ fn is_color_setter(setter: &str) -> bool {
 /// vs `DarkGray` â€” also normalise to PascalCase.
 fn normalize_xaml_color_value(s: &str) -> Option<String> {
     let trimmed = s.trim();
+    // Defence in depth. Several arms below fall through to returning the
+    // stylesheet value verbatim, and the base-style-fragment path that
+    // consumes it does not XML-escape (unlike the `<Setter>` path, which
+    // wraps values in `escape_xaml_attr`). A value carrying `"`, `<`, `>`
+    // or `&` can therefore terminate the attribute it is written into and
+    // inject markup. mosstyle's own token validation permits all four.
+    //
+    // No legitimate colour literal contains any of them, so refusing them
+    // here costs nothing and closes this function as an injection source.
+    // The general fix — escaping at every attribute sink — is broader than
+    // this change and tracked separately.
+    if trimmed.contains(['"', '<', '>', '&']) {
+        return None;
+    }
     if trimmed.starts_with('#') {
         return Some(s.to_string());
     }
@@ -1717,7 +1731,12 @@ fn css_rgb_function_to_xaml_hex(s: &str) -> Option<String> {
         .or_else(|| lower.strip_prefix("rgb("))?
         .strip_suffix(')')?;
 
-    let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+    // `splitn(5, ..)` caps the allocation: a hostile value like
+    // `rgb(` + 100k commas + `)` would otherwise materialize one slice per
+    // field before the arity check rejects it. Commas are legal in mosstyle
+    // token values, so this input is reachable from a third-party package.
+    // Five is enough to still distinguish "4 fields" from "too many".
+    let parts: Vec<&str> = inner.splitn(5, ',').map(str::trim).collect();
     if parts.len() != 3 && parts.len() != 4 {
         return None;
     }
@@ -12509,6 +12528,34 @@ mod tests {
             normalize_xaml_color_value("rgba(20,17,13,.28)").as_deref(),
             Some("#4714110D")
         );
+    }
+
+    /// A colour value carrying XML metacharacters is refused rather than
+    /// echoed into an attribute. Several arms of the normalizer return the
+    /// stylesheet value verbatim, and the base-style-fragment sink does not
+    /// XML-escape, so a value like `x" Foo="bar` would otherwise close the
+    /// attribute and inject markup. mosstyle token validation permits these
+    /// characters, so a third-party package can supply them.
+    #[test]
+    fn color_values_with_xml_metacharacters_are_refused() {
+        assert_eq!(normalize_xaml_color_value(r#"x" Foo="bar"#), None);
+        assert_eq!(normalize_xaml_color_value("a<b"), None);
+        assert_eq!(normalize_xaml_color_value("a>b"), None);
+        assert_eq!(normalize_xaml_color_value("a&b"), None);
+        // A quoted value (mosstyle STRING tokens retain their quotes) is
+        // refused for the same reason.
+        assert_eq!(normalize_xaml_color_value("\"red\""), None);
+        // Legitimate literals are unaffected.
+        assert_eq!(normalize_xaml_color_value("#1e1e1e").as_deref(), Some("#1e1e1e"));
+        assert_eq!(normalize_xaml_color_value("Transparent").as_deref(), Some("Transparent"));
+    }
+
+    /// A hostile `rgb(` value with a huge field count must not allocate one
+    /// slice per field before the arity check rejects it.
+    #[test]
+    fn rgb_parser_bounds_its_field_split() {
+        let hostile = format!("rgb({})", ",".repeat(100_000));
+        assert_eq!(css_rgb_function_to_xaml_hex(&hostile), None);
     }
 
     // â”€â”€ unused-flag placeholders â”€â”€


### PR DESCRIPTION
Generated WinUI apps built cleanly and were non-functional at runtime: they crashed on launch, and once past that, rendered exactly once and never updated again.

CI never caught either. The Windows job builds the XAML and runs a headless ABI conformance harness that asserts on the component object's properties — nothing launches the GUI or checks that the screen reflects those props. An app that crashed on startup and an app frozen after first paint both passed.

## Three defects, all in the emitter

**1. PRI generation was disabled, so the app could not launch at all.** Without an app PRI, WinUI cannot resolve `ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml` and startup dies with `E_XAMLPARSEFAILED` (0x802B000A).

This came from the `hello-dialog-xaml` ISSUES.md **C1** mitigation, which disabled MSIX tooling *and* PRI generation together. That was too broad: the C1 failure is the VS-shipped `Microsoft.Build.AppxPackage.*` tasks, which `EnableMsixTooling=false` already handles on its own. PRI is a separate subsystem whose `makepri.exe` ships inside the `Microsoft.Windows.SDK.BuildTools` package the csproj already references — so it needs no Visual Studio, and C1 does not regress.

**2. `x:Bind` defaults to OneTime.** The `Text=` and `AutomationProperties.Name=` emission sites omitted `Mode=OneWay` while `Content=`/`IsEnabled=` included it. `Text` is the most common binding in a generated app, so **118 of 153 bindings were frozen** after first render. Every event still reached the Rust engine and the engine computed correctly; none of it reached the screen.

**3. CSS-only colour values reached XAML as Brush literals.** The markup compiler does not validate brushes, so `currentColor` and `rgba(20,17,13,.28)` built cleanly and threw at runtime. `rgb()`/`rgba()` now convert to `#AARRGGBB`; `currentColor` is a CSS cascade keyword with no XAML equivalent and is dropped rather than guessed at.

## Verification

Built straight from `mosaic-compile` output with **no hand-patching**, on Windows 11 / WindowsAppSDK 1.8. The app launches, and adding a task updates the summary from `0 task(s) · projected finish —` to `1 task(s) · projected finish 2026-01-05`, with the row and its group count badge appearing. Previously the summary was frozen at 0 tasks forever.

220 tests pass across all 7 targets (`--no-fail-fast`, unfiltered — per the lessons.md note that cargo skips remaining targets after a failure). `clippy --all-targets -- -D warnings` is clean.

## Security review

Two findings, both addressed in the second commit:

- **LOW (this PR):** the `rgb()` parser collected every comma-separated field before checking arity — `rgb(` + 100k commas + `)` allocated one slice per field. Now `splitn(5, ..)`.
- **HIGH (pre-existing, on lines this PR rewrites):** several arms of `normalize_xaml_color_value` return the stylesheet value verbatim, and the base-style-fragment sink does not XML-escape (unlike the `<Setter>` path, which uses `escape_xaml_attr`). A value like `x" Foo="bar` terminates its attribute and injects markup; mosstyle's `validate_token_map` blocks only `{ } ; NUL CR LF`, so `"`, `<`, `>`, `&` all pass. The normalizer now refuses those characters outright — free, since it already returns `Option`.

The general fix (escape at every attribute sink; remove the C-string backslash round-trip in `build_style_fragment`) is wider than this PR and is tracked as follow-up. The reviewer also flagged a pre-existing DLL-planting primitive in the `CopyMosaicNativeHostLibraries` target, untouched here and likewise tracked.

## Known gaps, not addressed here

- Task rows render their toggle and Delete button but the **name cell is blank**.
- `Visibility=` bindings are a separate emission site and are **still OneTime**, so conditional UI stays frozen.
- Layout and styling (StackPanel vs Grid, dropped shadows) are deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
