### PR TITLE
feat(cowsay): route C# port through paint-vm-ascii (spec + pilot for #1611)

### DIFF
--- a/code/programs/csharp/cowsay/.gitignore
+++ b/code/programs/csharp/cowsay/.gitignore
@@ -1,0 +1,5 @@
+**/bin/
+**/obj/
+**/.dotnet/
+**/.artifacts/
+**/coverage.json

--- a/code/programs/csharp/cowsay/BUILD
+++ b/code/programs/csharp/cowsay/BUILD
@@ -1,0 +1,1 @@
+mkdir -p .dotnet .dotnet/tmp .artifacts && TMPDIR="$PWD/.dotnet/tmp" HOME="$PWD/.dotnet" DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 DOTNET_CLI_HOME="$PWD/.dotnet" dotnet test tests/CodingAdventures.Cowsay.Tests/CodingAdventures.Cowsay.Tests.csproj --disable-build-servers --artifacts-path .artifacts /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[cowsay]*"

--- a/code/programs/csharp/cowsay/BUILD_windows
+++ b/code/programs/csharp/cowsay/BUILD_windows
@@ -1,0 +1,1 @@
+dotnet test tests/CodingAdventures.Cowsay.Tests/CodingAdventures.Cowsay.Tests.csproj --disable-build-servers /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line "/p:Include=[cowsay]*"

--- a/code/programs/csharp/cowsay/CHANGELOG.md
+++ b/code/programs/csharp/cowsay/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.1.0
+
+- add the C# port of `cowsay`, parsing `code/specs/cowsay.json` via
+  `cli-builder` and rendering `code/specs/cows/*.cow` templates
+- first program in the repository to render through `paint-vm-ascii`: the
+  composed bubble+cow text is converted into a `PaintScene` of
+  `PaintGlyphRun` instructions and rendered via `PaintVmAscii.RenderToAscii`
+  instead of being printed directly (see
+  `code/specs/cowsay-paintvm-pipeline.md`)
+- support eyes/tongue/cowfile/nowrap/width/think flags and the eight mood
+  shortcuts (`--borg`, `--dead`, `--greedy`, `--paranoid`, `--stoned`,
+  `--tired`, `--wired`, `--youthful`)
+- support `--list` to enumerate available `.cow` files

--- a/code/programs/csharp/cowsay/Cowsay.cs
+++ b/code/programs/csharp/cowsay/Cowsay.cs
@@ -225,13 +225,31 @@ public static class CowsayRenderer
     /// default.cow when the requested file doesn't exist. The template is a Perl
     /// heredoc (`$the_cow = &lt;&lt;EOC; ... EOC`); only the body between the heredoc
     /// markers is returned.
+    ///
+    /// <paramref name="cowName"/> comes from the user-supplied -f/--file flag, so it
+    /// is treated as untrusted: only a bare filename (no directory separators, no
+    /// rooted/absolute path) is accepted, and the resolved path is verified to stay
+    /// inside <paramref name="cowsDir"/> before it's read — otherwise this falls back
+    /// to default.cow instead of reading an arbitrary file the caller pointed at via
+    /// "..", a rooted override, or similar. A rooted `cowName` matters because
+    /// Path.Combine ignores its first argument entirely when the second is already
+    /// rooted (e.g. "C:\Windows\win" + ".cow"), which would otherwise let a crafted
+    /// -f value escape cowsDir outright, not just traverse out of it.
     /// </summary>
     public static string LoadCow(string cowName, string cowsDir)
     {
-        var cowPath = Path.Combine(cowsDir, cowName + ".cow");
-        if (!File.Exists(cowPath))
+        var cowsRoot = Path.GetFullPath(cowsDir);
+        var safeName = Path.GetFileName(cowName);
+        var cowPath = safeName.Length > 0 && !Path.IsPathRooted(cowName)
+            ? Path.GetFullPath(Path.Combine(cowsRoot, safeName + ".cow"))
+            : null;
+
+        var isWithinCowsDir = cowPath is not null &&
+            cowPath.StartsWith(cowsRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+
+        if (cowPath is null || !isWithinCowsDir || !File.Exists(cowPath))
         {
-            cowPath = Path.Combine(cowsDir, "default.cow");
+            cowPath = Path.Combine(cowsRoot, "default.cow");
         }
 
         var content = File.ReadAllText(cowPath);

--- a/code/programs/csharp/cowsay/Cowsay.cs
+++ b/code/programs/csharp/cowsay/Cowsay.cs
@@ -1,0 +1,403 @@
+// cowsay — routed through paint-vm-ascii
+//
+// This is the first program in the repository that renders through the
+// paint-vm-ascii backend (see code/specs/cowsay-paintvm-pipeline.md for the
+// full design rationale). Everything up through composing the bubble+cow
+// text block is ordinary string formatting, ported from the reference
+// implementation at code/programs/go/cowsay/main.go. The one thing that's
+// different from that reference: instead of printing the composed text
+// directly, BuildScene converts it into a PaintScene of PaintGlyphRun
+// instructions (one glyph placement per non-space character, positioned on
+// an 8x16 character grid), and PaintVmAscii.RenderToAscii turns that scene
+// back into the terminal string we print. The round trip must reproduce the
+// same bytes a direct print would have produced.
+using System.Text.RegularExpressions;
+using CodingAdventures.PaintInstructions;
+using CodingAdventures.PaintVmAscii;
+
+namespace CodingAdventures.Cowsay;
+
+/// <summary>
+/// The resolved set of inputs needed to render one cowsay invocation, after
+/// CLI flags and mode shortcuts have been reconciled into concrete values.
+/// </summary>
+public sealed record CowsayInvocation(
+    string Message,
+    string Eyes,
+    string Tongue,
+    IReadOnlyList<string> ActiveModes,
+    bool NoWrap,
+    int Width,
+    bool Think,
+    string CowFile);
+
+public static class CowsayRenderer
+{
+    // paint-vm-ascii's documented default scale factors (P2D02-paint-vm-ascii.md).
+    public const double ScaleX = 8.0;
+    public const double ScaleY = 16.0;
+
+    private static readonly IReadOnlyDictionary<string, (string Eyes, string? Tongue)> ModeOverrides =
+        new Dictionary<string, (string, string?)>(StringComparer.Ordinal)
+        {
+            ["borg"] = ("==", null),
+            ["dead"] = ("XX", "U "),
+            ["greedy"] = ("$$", null),
+            ["paranoid"] = ("@@", null),
+            ["stoned"] = ("xx", "U "),
+            ["tired"] = ("--", null),
+            ["wired"] = ("OO", null),
+            ["youthful"] = ("..", null),
+        };
+
+    /// <summary>
+    /// Splits text into lines no longer than <paramref name="width"/>, breaking on word
+    /// boundaries. A single word longer than the width is kept whole (never split mid-word).
+    /// </summary>
+    public static IReadOnlyList<string> WrapText(string text, int width)
+    {
+        if (text.Length <= width)
+        {
+            return [text];
+        }
+
+        var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+        {
+            return [""];
+        }
+
+        var lines = new List<string>();
+        var current = "";
+        foreach (var word in words)
+        {
+            if (current.Length + word.Length + 1 <= width)
+            {
+                current = current.Length == 0 ? word : $"{current} {word}";
+            }
+            else
+            {
+                if (current.Length > 0)
+                {
+                    lines.Add(current);
+                }
+
+                current = word;
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            lines.Add(current);
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Draws the speech/thought bubble around the given lines. A single line gets
+    /// "&lt; ... &gt;" (or "( ... )" for a thought bubble); multiple lines get
+    /// "/ ... \", "| ... |", "\ ... /" (or "( ... )" on every line for a thought bubble).
+    /// </summary>
+    public static string FormatBubble(IReadOnlyList<string> lines, bool isThink)
+    {
+        if (lines.Count == 0)
+        {
+            return "";
+        }
+
+        var maxLen = lines.Max(line => line.Length);
+        var borderTop = " " + new string('_', maxLen + 2);
+        var borderBottom = " " + new string('-', maxLen + 2);
+
+        var result = new List<string> { borderTop };
+
+        if (lines.Count == 1)
+        {
+            var (start, end) = isThink ? ("(", ")") : ("<", ">");
+            result.Add($"{start} {lines[0].PadRight(maxLen)} {end}");
+        }
+        else
+        {
+            for (var i = 0; i < lines.Count; i++)
+            {
+                string start, end;
+                if (isThink)
+                {
+                    (start, end) = ("(", ")");
+                }
+                else if (i == 0)
+                {
+                    (start, end) = ("/", "\\");
+                }
+                else if (i == lines.Count - 1)
+                {
+                    (start, end) = ("\\", "/");
+                }
+                else
+                {
+                    (start, end) = ("|", "|");
+                }
+
+                result.Add($"{start} {lines[i].PadRight(maxLen)} {end}");
+            }
+        }
+
+        result.Add(borderBottom);
+        return string.Join("\n", result);
+    }
+
+    /// <summary>
+    /// Pads or truncates a mode string (eyes/tongue) to exactly two characters,
+    /// matching cowsay's convention that eyes/tongue are always a 2-char glyph.
+    /// </summary>
+    public static string NormalizeTwoChars(string value)
+    {
+        if (value.Length < 2)
+        {
+            return (value + "  ")[..2];
+        }
+
+        return value.Length > 2 ? value[..2] : value;
+    }
+
+    /// <summary>
+    /// Applies mode shortcuts (--borg, --dead, etc.) on top of the base eyes/tongue
+    /// flag values, then normalizes both to two characters. Modes are mutually
+    /// exclusive per cowsay.json, but this accepts any set for robustness.
+    /// </summary>
+    public static (string Eyes, string Tongue) ResolveEyesAndTongue(
+        string baseEyes, string baseTongue, IEnumerable<string> activeModes)
+    {
+        var eyes = baseEyes;
+        var tongue = baseTongue;
+
+        foreach (var mode in activeModes)
+        {
+            if (!ModeOverrides.TryGetValue(mode, out var overrideValue))
+            {
+                continue;
+            }
+
+            eyes = overrideValue.Eyes;
+            if (overrideValue.Tongue is not null)
+            {
+                tongue = overrideValue.Tongue;
+            }
+        }
+
+        return (NormalizeTwoChars(eyes), NormalizeTwoChars(tongue));
+    }
+
+    /// <summary>
+    /// Walks up from <paramref name="startDir"/> looking for CLAUDE.md, the repo-root
+    /// sentinel file. CLAUDE.md (not code/specs/cowsay.json itself) is used deliberately —
+    /// it's a more robust marker than reaching for the very file being located, and this
+    /// exact fix was called out as a lesson from a prior, reverted cowsay Lua port's CI
+    /// pathing problems (PR #1535).
+    /// </summary>
+    public static string FindRepoRoot(string startDir)
+    {
+        var dir = startDir;
+        for (var i = 0; i < 24; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "CLAUDE.md")))
+            {
+                return dir;
+            }
+
+            var parent = Directory.GetParent(dir);
+            if (parent is null)
+            {
+                break;
+            }
+
+            dir = parent.FullName;
+        }
+
+        return startDir;
+    }
+
+    private static readonly Regex CowBodyPattern = new(@"<<EOC;\n(.*?)EOC", RegexOptions.Singleline);
+
+    /// <summary>
+    /// Loads a .cow template's body from <paramref name="cowsDir"/>, falling back to
+    /// default.cow when the requested file doesn't exist. The template is a Perl
+    /// heredoc (`$the_cow = &lt;&lt;EOC; ... EOC`); only the body between the heredoc
+    /// markers is returned.
+    /// </summary>
+    public static string LoadCow(string cowName, string cowsDir)
+    {
+        var cowPath = Path.Combine(cowsDir, cowName + ".cow");
+        if (!File.Exists(cowPath))
+        {
+            cowPath = Path.Combine(cowsDir, "default.cow");
+        }
+
+        var content = File.ReadAllText(cowPath);
+        var match = CowBodyPattern.Match(content);
+        return match.Success ? match.Groups[1].Value : content;
+    }
+
+    /// <summary>
+    /// Composes the full bubble+cow text block for one invocation — everything up
+    /// to (but not including) the paint-vm-ascii render step.
+    /// </summary>
+    public static string ComposeContent(CowsayInvocation invocation, string cowsDir)
+    {
+        var (eyes, tongue) = ResolveEyesAndTongue(invocation.Eyes, invocation.Tongue, invocation.ActiveModes);
+
+        var lines = new List<string>();
+        foreach (var rawLine in invocation.Message.Split('\n'))
+        {
+            if (rawLine.Length == 0)
+            {
+                lines.Add("");
+            }
+            else if (invocation.NoWrap)
+            {
+                lines.Add(rawLine);
+            }
+            else
+            {
+                lines.AddRange(WrapText(rawLine, invocation.Width));
+            }
+        }
+
+        var thoughts = invocation.Think ? "o" : "\\";
+        var bubble = FormatBubble(lines, invocation.Think);
+
+        var cowTemplate = LoadCow(invocation.CowFile, cowsDir);
+        var cow = cowTemplate
+            .Replace("$eyes", eyes)
+            .Replace("$tongue", tongue)
+            .Replace("$thoughts", thoughts)
+            .Replace("\\\\", "\\");
+
+        return bubble + "\n" + cow;
+    }
+
+    /// <summary>
+    /// Converts a composed text block into a PaintScene: one PaintGlyphRun per
+    /// line, one PaintGlyphPlacement per non-space character. See
+    /// code/specs/cowsay-paintvm-pipeline.md §3 for the full contract, including
+    /// why glyph_id is a literal Unicode code point here (an ASCII-backend-only
+    /// relaxation of the general PaintGlyphRun contract).
+    /// </summary>
+    public static PaintScene BuildScene(string text)
+    {
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        var instructions = new List<PaintInstructionBase>();
+        var maxWidth = 0;
+
+        for (var row = 0; row < lines.Length; row++)
+        {
+            var line = lines[row];
+            if (line.Length > maxWidth)
+            {
+                maxWidth = line.Length;
+            }
+
+            var placements = new List<PaintGlyphPlacement>();
+            for (var col = 0; col < line.Length; col++)
+            {
+                var ch = line[col];
+                if (ch == ' ')
+                {
+                    continue;
+                }
+
+                placements.Add(new PaintGlyphPlacement(ch, col * ScaleX, row * ScaleY));
+            }
+
+            if (placements.Count > 0)
+            {
+                instructions.Add(new PaintGlyphRun(placements, "terminal-mono", ScaleY) { Fill = "#000000" });
+            }
+        }
+
+        var width = Math.Max(1, maxWidth) * ScaleX;
+        var height = Math.Max(1, lines.Length) * ScaleY;
+        return new PaintScene(width, height, "transparent", instructions);
+    }
+
+    /// <summary>
+    /// End-to-end: compose the bubble+cow text, build a PaintScene from it, and
+    /// render that scene through paint-vm-ascii.
+    /// </summary>
+    public static string Render(CowsayInvocation invocation, string cowsDir)
+    {
+        var content = ComposeContent(invocation, cowsDir);
+        var scene = BuildScene(content);
+        return CodingAdventures.PaintVmAscii.PaintVmAscii.RenderToAscii(scene, new AsciiOptions { ScaleX = ScaleX, ScaleY = ScaleY });
+    }
+}
+
+/// <summary>
+/// The CLI-facing glue between a CliBuilder ParseResult's flags/arguments dictionaries
+/// and CowsayRenderer's typed inputs. Pulled out of Program.cs so it's directly
+/// unit-testable without spawning a process or driving a real Parser.
+/// </summary>
+public static class CowsayCli
+{
+    private static readonly string[] ModeFlagIds =
+        ["borg", "dead", "greedy", "paranoid", "stoned", "tired", "wired", "youthful"];
+
+    public static bool IsListRequested(IReadOnlyDictionary<string, object?> flags) =>
+        flags.TryGetValue("list", out var listFlag) && listFlag is true;
+
+    /// <summary>Cow file basenames under <paramref name="cowsDir"/>, sorted ordinally.</summary>
+    public static IReadOnlyList<string> ListCowFiles(string cowsDir) =>
+        Directory.EnumerateFiles(cowsDir, "*.cow")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(name => name is not null)
+            .Select(name => name!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// Resolves the message from the parsed "message" positional argument. Returns
+    /// null when no message was given on argv — the caller should fall back to stdin.
+    /// </summary>
+    public static string? ResolveMessageFromArguments(IReadOnlyDictionary<string, object?> arguments)
+    {
+        if (arguments.TryGetValue("message", out var messageValue) &&
+            messageValue is List<object?> { Count: > 0 } messageParts)
+        {
+            return string.Join(" ", messageParts.Select(part => part?.ToString() ?? ""));
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds a CowsayInvocation from a resolved message and the parsed flags
+    /// dictionary, applying cowsay.json's documented defaults for any flag that
+    /// wasn't explicitly set.
+    /// </summary>
+    public static CowsayInvocation BuildInvocation(string message, IReadOnlyDictionary<string, object?> flags)
+    {
+        var eyes = flags.TryGetValue("eyes", out var eyesValue) && eyesValue is string eyesString ? eyesString : "oo";
+        var tongue = flags.TryGetValue("tongue", out var tongueValue) && tongueValue is string tongueString ? tongueString : "  ";
+        var cowFile = flags.TryGetValue("cowfile", out var cowFileValue) && cowFileValue is string cowFileString ? cowFileString : "default";
+        var noWrap = flags.TryGetValue("nowrap", out var noWrapValue) && noWrapValue is true;
+        var think = flags.TryGetValue("think", out var thinkValue) && thinkValue is true;
+
+        var width = 40;
+        if (flags.TryGetValue("width", out var widthValue))
+        {
+            width = widthValue switch
+            {
+                long longWidth => (int)Math.Clamp(longWidth, 1, int.MaxValue),
+                int intWidth => Math.Max(1, intWidth),
+                _ => width,
+            };
+        }
+
+        var activeModes = ModeFlagIds
+            .Where(mode => flags.TryGetValue(mode, out var modeValue) && modeValue is true)
+            .ToArray();
+
+        return new CowsayInvocation(message, eyes, tongue, activeModes, noWrap, width, think, cowFile);
+    }
+}

--- a/code/programs/csharp/cowsay/Program.cs
+++ b/code/programs/csharp/cowsay/Program.cs
@@ -1,0 +1,83 @@
+// cowsay (C#) — entry point
+//
+// Thin CLI wiring: parse argv against code/specs/cowsay.json via CliBuilder,
+// resolve the parsed flags/arguments into a CowsayInvocation, and hand off to
+// CowsayRenderer (Cowsay.cs) for the actual formatting + paint-vm-ascii
+// render. See code/specs/cowsay-paintvm-pipeline.md for the design.
+using CodingAdventures.CliBuilder;
+using CodingAdventures.Cowsay;
+
+var repoRoot = CowsayRenderer.FindRepoRoot(Directory.GetCurrentDirectory());
+var specPath = Path.Combine(repoRoot, "code", "specs", "cowsay.json");
+var cowsDir = Path.Combine(repoRoot, "code", "specs", "cows");
+
+// CliBuilder's Parser follows the C/Go argv convention, where index 0 is the
+// program name and real arguments start at index 1 (see Parser.Parse(),
+// "for (var index = 1; index < _argv.Count; index++)"). C#'s top-level
+// `args` does NOT include the program name, so it must be prepended here —
+// passing `args` directly silently drops the first real argument.
+var argv = new List<string> { "cowsay" };
+argv.AddRange(args);
+
+ParserResult result;
+try
+{
+    var parser = new Parser(specPath, argv);
+    result = parser.Parse();
+}
+catch (CliBuilderError error)
+{
+    Console.Error.WriteLine(error.Message);
+    Environment.Exit(1);
+    return;
+}
+
+switch (result)
+{
+    case HelpResult help:
+        Console.WriteLine(help.Text);
+        return;
+
+    case VersionResult version:
+        Console.WriteLine(version.Version);
+        return;
+
+    case ParseResult parseResult:
+        Run(parseResult, cowsDir);
+        return;
+}
+
+static void Run(ParseResult result, string cowsDir)
+{
+    var flags = result.Flags;
+    var arguments = result.Arguments;
+
+    if (CowsayCli.IsListRequested(flags))
+    {
+        foreach (var name in CowsayCli.ListCowFiles(cowsDir))
+        {
+            Console.WriteLine(name);
+        }
+
+        return;
+    }
+
+    var message = CowsayCli.ResolveMessageFromArguments(arguments);
+    if (message is null)
+    {
+        if (!Console.IsInputRedirected)
+        {
+            return;
+        }
+
+        message = Console.In.ReadToEnd().Trim();
+    }
+
+    if (message.Length == 0)
+    {
+        return;
+    }
+
+    var invocation = CowsayCli.BuildInvocation(message, flags);
+    Console.WriteLine(CowsayRenderer.Render(invocation, cowsDir));
+}

--- a/code/programs/csharp/cowsay/README.md
+++ b/code/programs/csharp/cowsay/README.md
@@ -1,0 +1,54 @@
+# cowsay (C#)
+
+A configurable ASCII cow that speaks or thinks — the C# port of `cowsay`, and
+the first program in the repository that renders through the `paint-vm-ascii`
+backend instead of printing formatted text directly.
+
+See [`code/specs/cowsay-paintvm-pipeline.md`](../../../specs/cowsay-paintvm-pipeline.md)
+for the full design: why this port routes through PaintVM-ASCII, how the
+composed bubble+cow text becomes a `PaintScene`, and the rollout plan for the
+other languages still missing `cowsay`.
+
+## What it does
+
+Parses its CLI spec from [`code/specs/cowsay.json`](../../../specs/cowsay.json)
+via `CodingAdventures.CliBuilder`, formats a message into a speech or thought
+bubble above an ASCII cow loaded from
+[`code/specs/cows/*.cow`](../../../specs/cows/), and prints the result — same
+behavior as the existing python/go/rust/typescript/ruby/elixir ports.
+
+The one thing this port does differently: instead of printing the composed
+text directly, it builds a `PaintScene` (one `PaintGlyphRun` per line, one
+`PaintGlyphPlacement` per non-space character) and renders that scene through
+`CodingAdventures.PaintVmAscii.RenderToAscii`. The output is byte-identical to
+what a direct print would have produced — this program exists to prove that
+round trip holds, not to change cowsay's behavior.
+
+## Dependencies
+
+- `cli-builder`
+- `paint-instructions` (transitively, via `paint-vm-ascii`)
+- `paint-vm-ascii`
+
+## Usage
+
+```bash
+dotnet run --project code/programs/csharp/cowsay -- "Hello, World!"
+dotnet run --project code/programs/csharp/cowsay -- --think -f tux "beep boop"
+dotnet run --project code/programs/csharp/cowsay -- --borg -f dragon "resistance is futile"
+dotnet run --project code/programs/csharp/cowsay -- -l
+```
+
+Flags match `code/specs/cowsay.json`: `-e/--eyes`, `-T/--tongue`,
+`-f/--file` (cow name), `-l/--list`, `-n/--nowrap`, `-W/--width`,
+`--think`, and the mood shortcuts `-b/--borg`, `-d/--dead`, `-g/--greedy`,
+`-p/--paranoid`, `-s/--stoned`, `-t/--tired`, `-w/--wired`, `-y/--youthful`.
+
+## Development
+
+```bash
+bash BUILD
+```
+
+Runs the test suite with an 80% line-coverage gate via coverlet, same as
+every other C# package/program in this repo.

--- a/code/programs/csharp/cowsay/cowsay.csproj
+++ b/code/programs/csharp/cowsay/cowsay.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>cowsay</AssemblyName>
+    <RootNamespace>CodingAdventures.Cowsay</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <EmbeddedResource Remove="tests\**" />
+    <None Remove="tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../packages/csharp/cli-builder/CodingAdventures.CliBuilder.csproj" />
+    <ProjectReference Include="../../../packages/csharp/paint-vm-ascii/CodingAdventures.PaintVmAscii.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CodingAdventures.Cowsay.Tests.csproj
+++ b/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CodingAdventures.Cowsay.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <ProjectReference Include="../../cowsay.csproj" />
+  </ItemGroup>
+</Project>

--- a/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CowsayRendererTests.cs
+++ b/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CowsayRendererTests.cs
@@ -1,0 +1,508 @@
+using CodingAdventures.CliBuilder;
+using CodingAdventures.Cowsay;
+using CodingAdventures.PaintInstructions;
+
+namespace CodingAdventures.Cowsay.Tests;
+
+/// <summary>
+/// Regression test for a real bug this port's manual verification caught: CliBuilder's
+/// Parser follows the C/Go argv convention (index 0 = program name, real tokens start
+/// at index 1). C#'s `args` doesn't include the program name, so `Program.cs` must
+/// prepend a placeholder before constructing Parser — otherwise the first real CLI
+/// token is silently dropped. See the "C#" entry in lessons.md. This test drives the
+/// actual Parser end-to-end (unlike the CowsayCli tests, which hand-build the
+/// flags/arguments dictionaries and never touch Parser at all), because that's exactly
+/// the gap that let the bug through unit tests the first time.
+/// </summary>
+public class ProgramArgvConventionTests
+{
+    private static readonly string SpecPath = Path.Combine(
+        CowsayRenderer.FindRepoRoot(AppContext.BaseDirectory), "code", "specs", "cowsay.json");
+
+    [Fact]
+    public void SingleWordMessageIsNotDroppedWhenProgramNameIsPrepended()
+    {
+        var argv = new List<string> { "cowsay", "hello" };
+        var result = Assert.IsType<ParseResult>(new Parser(SpecPath, argv).Parse());
+
+        var message = CowsayCli.ResolveMessageFromArguments(result.Arguments);
+
+        Assert.Equal("hello", message);
+    }
+
+    [Fact]
+    public void MultiWordMessageKeepsItsFirstWordWhenProgramNameIsPrepended()
+    {
+        var argv = new List<string> { "cowsay", "hello", "world" };
+        var result = Assert.IsType<ParseResult>(new Parser(SpecPath, argv).Parse());
+
+        var message = CowsayCli.ResolveMessageFromArguments(result.Arguments);
+
+        Assert.Equal("hello world", message);
+    }
+}
+
+public class WrapTextTests
+{
+    [Fact]
+    public void ShortTextIsNotWrapped()
+    {
+        Assert.Equal(["hello"], CowsayRenderer.WrapText("hello", 40));
+    }
+
+    [Fact]
+    public void LongTextWrapsAtWordBoundaries()
+    {
+        var result = CowsayRenderer.WrapText("the quick brown fox jumps over", 10);
+        Assert.Equal(["the quick", "brown fox", "jumps over"], result);
+    }
+
+    [Fact]
+    public void EmptyTextReturnsEmptyLine()
+    {
+        Assert.Equal([""], CowsayRenderer.WrapText("", 40));
+    }
+
+    [Fact]
+    public void SingleWordLongerThanWidthStaysWhole()
+    {
+        var result = CowsayRenderer.WrapText("supercalifragilisticexpialidocious", 5);
+        Assert.Equal(["supercalifragilisticexpialidocious"], result);
+    }
+
+    [Fact]
+    public void WhitespaceOnlyTextReturnsEmptyLine()
+    {
+        var result = CowsayRenderer.WrapText("     ", 3);
+        Assert.Equal([""], result);
+    }
+}
+
+public class FormatBubbleTests
+{
+    [Fact]
+    public void EmptyLinesReturnsEmptyString()
+    {
+        Assert.Equal("", CowsayRenderer.FormatBubble([], isThink: false));
+    }
+
+    [Fact]
+    public void SingleLineSpeechBubble()
+    {
+        var result = CowsayRenderer.FormatBubble(["hi"], isThink: false);
+        Assert.Equal(" ____\n< hi >\n ----", result);
+    }
+
+    [Fact]
+    public void SingleLineThoughtBubble()
+    {
+        var result = CowsayRenderer.FormatBubble(["hi"], isThink: true);
+        Assert.Equal(" ____\n( hi )\n ----", result);
+    }
+
+    [Fact]
+    public void MultiLineSpeechBubbleUsesSlashPipeBackslashBorders()
+    {
+        var result = CowsayRenderer.FormatBubble(["one", "two", "three"], isThink: false);
+        Assert.Equal(
+            " _______\n" +
+            "/ one   \\\n" +
+            "| two   |\n" +
+            "\\ three /\n" +
+            " -------",
+            result);
+    }
+
+    [Fact]
+    public void MultiLineThoughtBubbleUsesParensOnEveryLine()
+    {
+        var result = CowsayRenderer.FormatBubble(["one", "two"], isThink: true);
+        Assert.Equal(
+            " _____\n" +
+            "( one )\n" +
+            "( two )\n" +
+            " -----",
+            result);
+    }
+}
+
+public class NormalizeTwoCharsTests
+{
+    [Theory]
+    [InlineData("o", "o ")]
+    [InlineData("", "  ")]
+    [InlineData("oo", "oo")]
+    [InlineData("ooo", "oo")]
+    public void NormalizesToExactlyTwoCharacters(string input, string expected)
+    {
+        Assert.Equal(expected, CowsayRenderer.NormalizeTwoChars(input));
+    }
+}
+
+public class ResolveEyesAndTongueTests
+{
+    [Fact]
+    public void NoActiveModesKeepsBaseValues()
+    {
+        var (eyes, tongue) = CowsayRenderer.ResolveEyesAndTongue("oo", "  ", []);
+        Assert.Equal("oo", eyes);
+        Assert.Equal("  ", tongue);
+    }
+
+    [Theory]
+    [InlineData("borg", "==", "  ")]
+    [InlineData("dead", "XX", "U ")]
+    [InlineData("greedy", "$$", "  ")]
+    [InlineData("paranoid", "@@", "  ")]
+    [InlineData("stoned", "xx", "U ")]
+    [InlineData("tired", "--", "  ")]
+    [InlineData("wired", "OO", "  ")]
+    [InlineData("youthful", "..", "  ")]
+    public void EachModeOverridesEyesAndSometimesTongue(string mode, string expectedEyes, string expectedTongue)
+    {
+        var (eyes, tongue) = CowsayRenderer.ResolveEyesAndTongue("oo", "  ", [mode]);
+        Assert.Equal(expectedEyes, eyes);
+        Assert.Equal(expectedTongue, tongue);
+    }
+
+    [Fact]
+    public void UnknownModeIsIgnored()
+    {
+        var (eyes, tongue) = CowsayRenderer.ResolveEyesAndTongue("oo", "  ", ["not-a-real-mode"]);
+        Assert.Equal("oo", eyes);
+        Assert.Equal("  ", tongue);
+    }
+}
+
+public class LoadCowTests : IDisposable
+{
+    private readonly string _tempDir = Directory.CreateTempSubdirectory("cowsay-tests-").FullName;
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void LoadsBodyBetweenHeredocMarkers()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "default.cow"),
+            "$the_cow = <<EOC;\n  $thoughts   ^__^\n   ($eyes)\nEOC\n");
+
+        var body = CowsayRenderer.LoadCow("default", _tempDir);
+
+        Assert.Equal("  $thoughts   ^__^\n   ($eyes)\n", body);
+    }
+
+    [Fact]
+    public void FallsBackToDefaultWhenNamedCowIsMissing()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "default.cow"), "$the_cow = <<EOC;\nfallback\nEOC\n");
+
+        var body = CowsayRenderer.LoadCow("does-not-exist", _tempDir);
+
+        Assert.Equal("fallback\n", body);
+    }
+}
+
+public class ComposeContentTests : IDisposable
+{
+    private readonly string _tempDir = Directory.CreateTempSubdirectory("cowsay-tests-").FullName;
+
+    public ComposeContentTests()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "default.cow"), "$the_cow = <<EOC;\n$thoughts $eyes $tongue\nEOC\n");
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void ComposesBubbleAndCowWithSubstitutions()
+    {
+        var invocation = new CowsayInvocation(
+            Message: "hi",
+            Eyes: "oo",
+            Tongue: "  ",
+            ActiveModes: [],
+            NoWrap: false,
+            Width: 40,
+            Think: false,
+            CowFile: "default");
+
+        var content = CowsayRenderer.ComposeContent(invocation, _tempDir);
+
+        Assert.Equal(" ____\n< hi >\n ----\n\\ oo   \n", content);
+    }
+
+    [Fact]
+    public void ThinkModeUsesOForThoughtsAndParenBubble()
+    {
+        var invocation = new CowsayInvocation(
+            Message: "hi",
+            Eyes: "oo",
+            Tongue: "  ",
+            ActiveModes: [],
+            NoWrap: false,
+            Width: 40,
+            Think: true,
+            CowFile: "default");
+
+        var content = CowsayRenderer.ComposeContent(invocation, _tempDir);
+
+        Assert.Equal(" ____\n( hi )\n ----\no oo   \n", content);
+    }
+
+    [Fact]
+    public void ModeFlagOverridesEyesInCowTemplate()
+    {
+        var invocation = new CowsayInvocation(
+            Message: "hi",
+            Eyes: "oo",
+            Tongue: "  ",
+            ActiveModes: ["dead"],
+            NoWrap: false,
+            Width: 40,
+            Think: false,
+            CowFile: "default");
+
+        var content = CowsayRenderer.ComposeContent(invocation, _tempDir);
+
+        Assert.Equal(" ____\n< hi >\n ----\n\\ XX U \n", content);
+    }
+}
+
+public class BuildSceneTests
+{
+    [Fact]
+    public void OneGlyphRunPerNonBlankLineWithCorrectPlacements()
+    {
+        var scene = CowsayRenderer.BuildScene("hi\n\nyo");
+
+        var glyphRuns = scene.Instructions.Cast<PaintGlyphRun>().ToList();
+        Assert.Equal(2, glyphRuns.Count);
+
+        Assert.Equal(2, glyphRuns[0].Glyphs.Count);
+        Assert.Equal(new PaintGlyphPlacement('h', 0, 0), glyphRuns[0].Glyphs[0]);
+        Assert.Equal(new PaintGlyphPlacement('i', CowsayRenderer.ScaleX, 0), glyphRuns[0].Glyphs[1]);
+
+        Assert.Equal(2, glyphRuns[1].Glyphs.Count);
+        Assert.Equal(new PaintGlyphPlacement('y', 0, 2 * CowsayRenderer.ScaleY), glyphRuns[1].Glyphs[0]);
+        Assert.Equal(new PaintGlyphPlacement('o', CowsayRenderer.ScaleX, 2 * CowsayRenderer.ScaleY), glyphRuns[1].Glyphs[1]);
+    }
+
+    [Fact]
+    public void SpacesAreSkippedNotPlaced()
+    {
+        var scene = CowsayRenderer.BuildScene("a b");
+
+        var glyphRun = Assert.Single(scene.Instructions.Cast<PaintGlyphRun>());
+        Assert.Equal(2, glyphRun.Glyphs.Count);
+        Assert.Equal('a', (char)glyphRun.Glyphs[0].GlyphId);
+        Assert.Equal('b', (char)glyphRun.Glyphs[1].GlyphId);
+    }
+
+    [Fact]
+    public void SceneDimensionsCoverAllLines()
+    {
+        var scene = CowsayRenderer.BuildScene("abc\nde");
+
+        Assert.Equal(3 * CowsayRenderer.ScaleX, scene.Width);
+        Assert.Equal(2 * CowsayRenderer.ScaleY, scene.Height);
+    }
+}
+
+public class RenderRoundTripTests
+{
+    [Theory]
+    [InlineData("hi")]
+    [InlineData("hello\nworld")]
+    [InlineData(" ____\n< hi >\n ----\n\\   ^__^\n")]
+    public void RenderingThroughPaintVmAsciiReproducesTheOriginalText(string content)
+    {
+        var rendered = CowsayRenderer.BuildScene(content);
+        var output = CodingAdventures.PaintVmAscii.PaintVmAscii.RenderToAscii(rendered);
+
+        var expectedLines = content.Split('\n').Select(line => line.TrimEnd());
+        var expected = string.Join("\n", expectedLines).TrimEnd('\n');
+
+        Assert.Equal(expected, output);
+    }
+}
+
+public class CowsayCliTests
+{
+    [Fact]
+    public void IsListRequestedTrueWhenFlagPresent()
+    {
+        Assert.True(CowsayCli.IsListRequested(new Dictionary<string, object?> { ["list"] = true }));
+    }
+
+    [Theory]
+    [MemberData(nameof(NotListRequestedCases))]
+    public void IsListRequestedFalseOtherwise(IReadOnlyDictionary<string, object?> flags)
+    {
+        Assert.False(CowsayCli.IsListRequested(flags));
+    }
+
+    public static IEnumerable<object[]> NotListRequestedCases()
+    {
+        yield return [new Dictionary<string, object?>()];
+        yield return [new Dictionary<string, object?> { ["list"] = false }];
+    }
+
+    [Fact]
+    public void ResolveMessageJoinsPositionalWords()
+    {
+        var arguments = new Dictionary<string, object?>
+        {
+            ["message"] = new List<object?> { "hello", "there" },
+        };
+
+        Assert.Equal("hello there", CowsayCli.ResolveMessageFromArguments(arguments));
+    }
+
+    [Theory]
+    [MemberData(nameof(NoMessageCases))]
+    public void ResolveMessageReturnsNullWhenNoPositionalMessage(IReadOnlyDictionary<string, object?> arguments)
+    {
+        Assert.Null(CowsayCli.ResolveMessageFromArguments(arguments));
+    }
+
+    public static IEnumerable<object[]> NoMessageCases()
+    {
+        yield return [new Dictionary<string, object?>()];
+        yield return [new Dictionary<string, object?> { ["message"] = new List<object?>() }];
+    }
+
+    [Fact]
+    public void BuildInvocationUsesDefaultsWhenNoFlagsSet()
+    {
+        var invocation = CowsayCli.BuildInvocation("hi", new Dictionary<string, object?>());
+
+        Assert.Equal("hi", invocation.Message);
+        Assert.Equal("oo", invocation.Eyes);
+        Assert.Equal("  ", invocation.Tongue);
+        Assert.Equal("default", invocation.CowFile);
+        Assert.False(invocation.NoWrap);
+        Assert.False(invocation.Think);
+        Assert.Equal(40, invocation.Width);
+        Assert.Empty(invocation.ActiveModes);
+    }
+
+    [Fact]
+    public void BuildInvocationHonorsExplicitFlags()
+    {
+        var flags = new Dictionary<string, object?>
+        {
+            ["eyes"] = "^^",
+            ["tongue"] = "vv",
+            ["cowfile"] = "dragon",
+            ["nowrap"] = true,
+            ["think"] = true,
+            ["width"] = 20,
+            ["borg"] = true,
+        };
+
+        var invocation = CowsayCli.BuildInvocation("hi", flags);
+
+        Assert.Equal("^^", invocation.Eyes);
+        Assert.Equal("vv", invocation.Tongue);
+        Assert.Equal("dragon", invocation.CowFile);
+        Assert.True(invocation.NoWrap);
+        Assert.True(invocation.Think);
+        Assert.Equal(20, invocation.Width);
+        Assert.Equal(["borg"], invocation.ActiveModes);
+    }
+
+    [Fact]
+    public void BuildInvocationAcceptsLongWidthAndClampsToPositive()
+    {
+        var flags = new Dictionary<string, object?> { ["width"] = 99_999_999_999L };
+        Assert.Equal(int.MaxValue, CowsayCli.BuildInvocation("hi", flags).Width);
+
+        var negativeFlags = new Dictionary<string, object?> { ["width"] = -5L };
+        Assert.Equal(1, CowsayCli.BuildInvocation("hi", negativeFlags).Width);
+    }
+
+    [Fact]
+    public void ListCowFilesReturnsSortedBasenames()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("cowsay-cli-tests-").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "tux.cow"), "");
+            File.WriteAllText(Path.Combine(tempDir, "default.cow"), "");
+            File.WriteAllText(Path.Combine(tempDir, "dragon.cow"), "");
+
+            Assert.Equal(["default", "dragon", "tux"], CowsayCli.ListCowFiles(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}
+
+public class EndToEndGoldenTests
+{
+    private static readonly string CowsDir = Path.Combine(
+        CowsayRenderer.FindRepoRoot(AppContext.BaseDirectory), "code", "specs", "cows");
+
+    [Fact]
+    public void FindRepoRootLocatesTheRealCowsDirectory()
+    {
+        Assert.True(Directory.Exists(CowsDir), $"expected cows dir at {CowsDir}; BaseDirectory={AppContext.BaseDirectory}");
+        Assert.True(File.Exists(Path.Combine(CowsDir, "default.cow")));
+    }
+
+    [Fact]
+    public void DefaultCowSpeakingHelloWorld()
+    {
+        var invocation = new CowsayInvocation(
+            Message: "Hello, World!",
+            Eyes: "oo",
+            Tongue: "  ",
+            ActiveModes: [],
+            NoWrap: false,
+            Width: 40,
+            Think: false,
+            CowFile: "default");
+
+        var output = CowsayRenderer.Render(invocation, CowsDir);
+
+        Assert.Equal(
+            " _______________\n" +
+            "< Hello, World! >\n" +
+            " ---------------\n" +
+            "        \\   ^__^\n" +
+            "         \\  (oo)\\_______\n" +
+            "            (__)\\       )\\/\\\n" +
+            "                ||----w |\n" +
+            "                ||     ||",
+            output);
+    }
+
+    [Fact]
+    public void BorgModeThinkingWithDefaultCow()
+    {
+        var invocation = new CowsayInvocation(
+            Message: "beep",
+            Eyes: "oo",
+            Tongue: "  ",
+            ActiveModes: ["borg"],
+            NoWrap: false,
+            Width: 40,
+            Think: true,
+            CowFile: "default");
+
+        var output = CowsayRenderer.Render(invocation, CowsDir);
+
+        Assert.Equal(
+            " ______\n" +
+            "( beep )\n" +
+            " ------\n" +
+            "        o   ^__^\n" +
+            "         o  (==)\\_______\n" +
+            "            (__)\\       )\\/\\\n" +
+            "                ||----w |\n" +
+            "                ||     ||",
+            output);
+    }
+}

--- a/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CowsayRendererTests.cs
+++ b/code/programs/csharp/cowsay/tests/CodingAdventures.Cowsay.Tests/CowsayRendererTests.cs
@@ -200,6 +200,49 @@ public class LoadCowTests : IDisposable
 
         Assert.Equal("fallback\n", body);
     }
+
+    [Theory]
+    [InlineData("../../../../../../etc/passwd")]
+    [InlineData("..\\..\\..\\secret")]
+    [InlineData("../outside")]
+    public void FallsBackToDefaultInsteadOfEscapingCowsDirViaTraversal(string maliciousCowName)
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "default.cow"), "$the_cow = <<EOC;\nfallback\nEOC\n");
+        var outsideDir = Directory.CreateTempSubdirectory("cowsay-outside-").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(outsideDir, "secret.cow"), "$the_cow = <<EOC;\nSECRET\nEOC\n");
+            File.WriteAllText(Path.Combine(outsideDir, "outside.cow"), "$the_cow = <<EOC;\nSECRET\nEOC\n");
+
+            var body = CowsayRenderer.LoadCow(maliciousCowName, _tempDir);
+
+            Assert.Equal("fallback\n", body);
+        }
+        finally
+        {
+            Directory.Delete(outsideDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FallsBackToDefaultInsteadOfFollowingARootedPathOverride()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "default.cow"), "$the_cow = <<EOC;\nfallback\nEOC\n");
+        var outsideDir = Directory.CreateTempSubdirectory("cowsay-outside-").FullName;
+        try
+        {
+            var rootedTarget = Path.Combine(outsideDir, "win");
+            File.WriteAllText(rootedTarget + ".cow", "$the_cow = <<EOC;\nSECRET\nEOC\n");
+
+            var body = CowsayRenderer.LoadCow(rootedTarget, _tempDir);
+
+            Assert.Equal("fallback\n", body);
+        }
+        finally
+        {
+            Directory.Delete(outsideDir, recursive: true);
+        }
+    }
 }
 
 public class ComposeContentTests : IDisposable

--- a/code/specs/cowsay-paintvm-pipeline.md
+++ b/code/specs/cowsay-paintvm-pipeline.md
@@ -1,0 +1,193 @@
+# Cowsay on PaintVM-ASCII
+
+A design decision and technical contract for routing `cowsay` ports through
+the `paint-vm-ascii` backend, resolving the open question raised in issue
+#1611.
+
+---
+
+## 1. Background
+
+`cowsay` ships on six languages today (python, go, rust, typescript, ruby,
+elixir), each hand-rolling its own bubble-border and cow-template rendering
+directly to a string that gets printed to stdout. Issue #1611 asked whether
+the remaining ports should keep doing that, or route through the existing
+`paint-vm-ascii` backend (`P2D02-paint-vm-ascii.md`), which already exists
+as the text-mode target of the shared PaintInstructions IR
+(`P2D00-paint-instructions.md`):
+
+```
+cli_builder (parse argv)
+  -> cowsay text formatting (word wrap, bubble border, cow template)
+  -> paint-instructions (PaintScene of PaintGlyphRun instructions)
+  -> paint-vm-ascii (render to a character-grid string)
+  -> terminal
+```
+
+**Decision: every new `cowsay` port routes through `paint-vm-ascii`.** This
+makes `paint-vm-ascii` a real, exercised backend instead of a set of
+library-only packages nobody calls, and it means the bubble/cow rendering
+logic that already exists in seven other languages' `paint-vm-ascii`
+packages doesn't get re-invented a ninth and tenth time as hand-rolled string
+code.
+
+Whether the existing six ports get migrated onto the same pipeline, and
+whether they get the `BUILD`/tests/README/CHANGELOG they're currently
+missing, is an explicit follow-up — not part of this decision.
+
+---
+
+## 2. Corrected coverage matrix
+
+Issue #1611's own coverage matrix was stale by the time this spec was
+written. The state below was verified directly against the repository
+(`ls code/packages/*/paint-vm-ascii`, `code/packages/*/paint-instructions`,
+`code/programs/*/cowsay`, and a grep for `glyph_run`/`GlyphRun` inside each
+`paint-vm-ascii` package):
+
+| Language   | cowsay | paint-instructions | paint-vm-ascii | paint-vm-ascii implements `glyph_run` |
+|------------|:------:|:-------------------:|:---------------:|:---------------------------------------:|
+| python     | ✅     | ✅                   | ✅               | ❌ (rect-only)                          |
+| go         | ✅     | ✅                   | ✅               | ❌ (rect-only)                          |
+| rust       | ✅     | ✅                   | ✅               | ✅                                       |
+| typescript | ✅     | ✅                   | ✅               | ✅                                       |
+| ruby       | ✅     | ❌                   | ❌               | —                                        |
+| elixir     | ✅     | ❌                   | ❌               | —                                        |
+| csharp     | ❌     | ✅                   | ✅               | ✅                                       |
+| fsharp     | ❌     | ✅                   | ✅               | ✅                                       |
+| perl       | ❌     | ✅                   | ✅               | ❌ (rect-only)                          |
+| haskell    | ❌     | ✅                   | ✅               | ❌ (rect-only)                          |
+| java       | ❌     | ✅                   | ❌               | —                                        |
+| kotlin     | ❌     | ✅                   | ❌               | —                                        |
+| dart       | ❌     | ✅                   | ❌               | —                                        |
+| lua        | ❌     | ❌                   | ❌               | —                                        |
+| swift      | ❌     | ❌                   | ❌               | —                                        |
+
+Notes on the issue's original matrix:
+
+- **"dotnet" is not a distinct language.** `code/programs/dotnet/` only holds
+  the shared `hello-world-csharp` / `hello-world-fsharp` / build-tool
+  bootstrap programs. Real csharp/fsharp feature programs (including this
+  one) live under `code/programs/csharp/` and `code/programs/fsharp/`
+  directly, same as every other language.
+- **"wasm" is explicitly out of scope**, per the issue's own text (terminal
+  output through a wasm program is a separate design problem).
+- That leaves **9 real target languages**: lua, perl, swift, haskell, csharp,
+  fsharp, java, kotlin, dart.
+- No program anywhere in the repository currently consumes any
+  `paint-vm-ascii` package. This is a first-of-its-kind wiring.
+
+---
+
+## 3. The technical contract
+
+Cowsay's own formatting logic — word wrap, eyes/tongue/mode substitution,
+bubble border characters (`_`/`-`/`<`/`>`/`\`/`/`/`|`/`(`/`)`), and `.cow`
+template substitution (`$eyes`, `$tongue`, `$thoughts`) — is plain text
+formatting, language-agnostic, and does not change. Port it faithfully from
+the existing reference implementation, `code/programs/go/cowsay/main.go`
+(`wrapText`, `formatBubble`, `loadCow`, and the mode-flag-to-eyes/tongue
+table).
+
+What changes is the last step: instead of printing the composed text block
+directly, build a `PaintScene` from it and render that scene through
+`paint-vm-ascii`.
+
+### 3.1 Text lines to glyph placements
+
+Given the composed bubble+cow text as a list of lines:
+
+1. For each line at row index `r`, for each character at column index `c`
+   that is not a space, create a glyph placement at
+   `x = c * scale_x, y = r * scale_y`, with `glyph_id` set to the character's
+   Unicode code point. Skip space characters — unaddressed cells default to
+   blank in the ASCII backend's character grid.
+2. Use `paint-vm-ascii`'s default scale factors, `scale_x = 8, scale_y = 16`
+   (`P2D02-paint-vm-ascii.md`), unless a port's convenience API defaults to
+   something else — always pass the scale explicitly if there's any doubt.
+
+**Important deviation from the general `PaintGlyphRun` contract:** per
+`P2D00-paint-instructions.md`, `glyph_id` is normally a font-internal glyph
+index (not a Unicode code point), resolved through a real font's `cmap`
+table. `P2D02-paint-vm-ascii.md` explicitly relaxes this for the ASCII
+backend only: "`glyph_run` is rendered by converting each `glyph_id` into a
+Unicode scalar value ... This backend is best suited to glyph runs whose
+`glyph_id` values are already ordinary Unicode code points." Every cowsay
+port must rely on this backend-specific relaxation — do not attempt real
+glyph-ID resolution for a terminal target.
+
+### 3.2 Glyph placements to a scene
+
+Group the placements into one or more `PaintGlyphRun` instructions (one per
+line is simplest and matches the natural row-major structure of the text).
+`font_ref`, `font_size`, and `fill` are required fields on `PaintGlyphRun`
+but are explicitly ignored by the ASCII backend — any placeholder value
+(e.g. `font_ref: "terminal-mono"`) is correct.
+
+Wrap the glyph runs in a `PaintScene`:
+
+```
+{
+  width: (longest line length) * scale_x,
+  height: (line count) * scale_y,
+  background: "transparent",
+  instructions: [ <PaintGlyphRun>, <PaintGlyphRun>, ... ]
+}
+```
+
+### 3.3 Rendering
+
+Call the language's `paint-vm-ascii` render entry point (e.g. C#'s
+`PaintVmAscii.RenderToAscii(scene)`, or the equivalent `render(scene,
+options?)` convenience function called out in `P2D02-paint-vm-ascii.md` §
+"Public API") and print the returned string.
+
+### 3.4 Output identity requirement
+
+`paint-vm-ascii` trims trailing spaces on each line and trailing blank lines
+at the end of the document (spec-mandated). Cowsay's own output has never
+depended on trailing whitespace for visible content, so routing through this
+pipeline must reproduce **byte-identical** output to the direct-print
+approach used by the existing six ports. Any port added under this contract
+should be checked against another existing port for the same flags and
+message, and the two outputs must match exactly.
+
+---
+
+## 4. Rollout phases
+
+Each phase is its own set of small, focused PRs — never bundled into one
+PR per the repo's stated convention (issue #1611's own "suggested next
+steps," and the general small-PR discipline in `CLAUDE.md`).
+
+- **Phase 1 (this PR)** — **C#**. `code/packages/csharp/paint-vm-ascii` is
+  the only fully spec-compliant implementation found (rect, line, glyph_run,
+  group, clip, layer all registered against a real dispatch-table VM). C#
+  also already has `cli-builder` and `paint-instructions`. This phase needs
+  zero backend work — it exists purely to prove the pipeline described in
+  §3 holds together end-to-end, before investing in the backend work the
+  later phases need.
+- **Phase 2** — **F#** (already has full `glyph_run` support — same pattern
+  as C#, no backend work needed); **Perl** and **Haskell** (need `glyph_run`
+  added to their existing rect-only `paint-vm-ascii` packages first, then
+  cowsay on top).
+- **Phase 3** — **Java, Kotlin, Dart**. These have `paint-instructions`
+  already but no `paint-vm-ascii` package at all — build one from scratch
+  implementing the full `P2D02-paint-vm-ascii.md` contract (not just rect),
+  then add cowsay.
+- **Phase 4** — **Lua, Swift**. Neither has `paint-instructions` nor
+  `paint-vm-ascii` — both packages need to be built from scratch before
+  cowsay can land.
+
+---
+
+## 5. Explicitly out of scope
+
+- Migrating the existing six hand-rolled `cowsay` ports onto this pipeline.
+  This is a real question (raised in issue #1611 itself) but is independent
+  of adding the missing languages and is left for a future decision.
+- Giving the existing six `cowsay` programs the `BUILD`/tests/README/
+  CHANGELOG they currently lack. They have none today — none of them are
+  wired into CI. This is a pre-existing gap unrelated to the languages this
+  spec adds, called out here so it isn't mistaken for something this spec
+  fixed.

--- a/lessons.md
+++ b/lessons.md
@@ -142,6 +142,10 @@ A condensed quick-reference of mistakes made during development, grouped by cate
 - **Redeclaring a `let` binding** (e.g. when adding overflow-safe `multipliedReportingOverflow` for `bLen`) fails compile — remove the original.
 - **F# interpolated strings break on quoted literals inside expressions.** Bind with `let` first, or switch to `sprintf` for dense XML/HTML attributes.
 
+## C#
+
+- **`CliBuilder.Parser`'s `argv` follows the C/Go convention where index 0 is the program name** (`Parser.Parse()` sets `program = argv[0]` and starts real token parsing at `index = 1`). C#'s top-level `args` array does **not** include the program name — passing it straight to `new Parser(specPath, args)` silently drops the first real CLI token (single-arg invocations parse zero positional arguments; multi-arg invocations lose the first one). Symptom is silent: no exception, just an empty/short result. Fix: prepend a placeholder before calling, `var argv = new List<string> { "<program-name>" }; argv.AddRange(args);`. Found while wiring the C# `cowsay` port to `cli-builder` (first C# consumer of `Parser` outside its own test suite) — verify with an end-to-end run (`dotnet run -- <realistic args>`), not just unit tests that call `Parser` with a hand-built `argv` list, since it's easy to hand-build the list "correctly" (with a leading program name) in a test and then get the real entry point wrong.
+
 ## TypeScript / JavaScript
 
 - **JS bitwise ops are signed 32-bit.** `1 << 32 === 1` (shifts are mod 32) — guard `bitWidth >= 32` separately. `0xFFFFFFFF & 0xFFFFFFFF === -1` — use `>>> 0` to convert to unsigned: `(value & mask) >>> 0`. Critical for register files / ALU / addressing.


### PR DESCRIPTION
## Summary

Closes the design question raised in #1611: should new `cowsay` ports render through the existing `paint-vm-ascii` backend, or stay hand-rolled like the current six? This PR lands the decision plus a pilot proving it out — **not** all 9 remaining languages, which is scoped as follow-up PRs (see the phased rollout in the spec).

- Adds `code/specs/cowsay-paintvm-pipeline.md`: the design decision (route everything through `paint-vm-ascii`), a corrected coverage matrix (the issue's own matrix was stale — e.g. Haskell already has a working `paint-vm-ascii`, only csharp/fsharp/rust/typescript actually implement `glyph_run`), the technical contract for converting composed cowsay text into a `PaintScene` of `PaintGlyphRun` instructions, and a 4-phase rollout plan for the other 8 languages.
- Lands the pilot: `code/programs/csharp/cowsay`, the **first program in the repo that actually consumes `paint-vm-ascii`** (no prior program did, despite 8 languages having the package). C# was picked because its `paint-vm-ascii` is the only fully spec-compliant implementation found (rect/line/glyph_run/group/clip/layer), so the pilot needed zero backend work — pure proof that the pipeline holds end-to-end.
- Verified byte-identical output against the Go reference port (`code/programs/go/cowsay`) across several flag combinations (default cow, `--think`, mode shortcuts, `-f dragon`), modulo `paint-vm-ascii`'s spec-mandated trailing-blank-line trimming.
- Found and fixed two real bugs along the way (documented in `lessons.md`):
  - `CliBuilder.Parser` expects `argv[0]` to be the program name (C/Go convention); C#'s `args` omits it, so passing it straight through silently dropped the first CLI token. Added a regression test that drives the real `Parser`.
  - `/security-review` caught a path-traversal / `Path.Combine` rooted-path-override issue in `LoadCow` via the `-f`/`--file` flag — fixed with filename-only validation + containment check, with regression tests.
- 54 tests, 80.7% line coverage (repo's 80% gate for programs).

## Test plan

- [x] `dotnet build` and `dotnet test` pass locally (54/54, 80.7% line coverage, meets the package's 80% coverlet gate)
- [x] Manual byte-diff against `code/programs/go/cowsay` for multiple flag combinations — identical modulo documented trailing-blank-line trimming
- [x] `/security-review` — one MEDIUM finding (path traversal), fixed, second round passed clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)