### PR TITLE
fix(mosaic-emit-xaml): every x:Bind declares its mode

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — every x:Bind declares its mode
+
+`x:Bind` defaults to **OneTime** in WinUI, and each emission site chose its
+binding mode by hand, so coverage drifted. In the generated TaskApp that left
+118 of 153 bindings frozen after first render: every event reached the Rust
+engine and the engine computed correctly, but none of it reached the screen.
+
+A previous change fixed `Text=` and `AutomationProperties.Name=`. Every
+remaining site now emits `Mode=OneWay`:
+
+- **`Visibility=`** on the `If` lowering — the one that mattered most, since it
+  pinned every conditional surface to its first-render value and made view
+  switching a no-op
+- `Content=` (7 sites, including the two literal `Content="{x:Bind Index}"`
+  forms), `Source=`, `Glyph=`, `IsReadOnly=`, `GroupName=`, `NavigateUri=`,
+  `ToolTipService.ToolTip=`
+- the UI31 table cell/header attributes (`Row=`, `Column=`, `Header=`,
+  `Value=`, `AutomationProperties.Name=`)
+- the GROUP C `Width=` injection, whose own doc comment already claimed a mode
+  it did not emit
+- `ItemsRepeater.ItemsSource`, where the mode was conditional on there being a
+  projection property — so a repeater bound directly to a slot got the
+  OneTime default and never re-rendered when its list changed
+
+### The guard
+
+`every_xbind_emission_site_declares_its_mode` scans **this file's own source**
+and fails on any emission site whose `x:Bind` carries no `Mode`, naming each
+offender by line.
+
+Scanning source rather than emitted output is deliberate, and was learned the
+hard way. The first version of this test compiled a fixture and scanned the
+resulting XAML — but a fixture only reaches the sites it happens to exercise.
+It used a `Text` and an `If`, both already correct, so it passed while roughly
+twenty sites were still emitting mode-less bindings. A fixture-based test would
+also have gone stale the moment someone added a site it did not cover, which is
+exactly how the original defect arose.
+
+It handles both emission forms — the doubled-brace `format!` form and the
+literal single-brace form used by `inject_attr_into_first_element` — and
+brace-matches rather than stopping at the first `}}`, so a binding carrying a
+nested `Converter={StaticResource …}` parses correctly. It scans only up to
+`#[cfg(test)]`, since tests legitimately pass mode-less bindings as *input*.
+
+Verified by regression: reverting a single site to the mode-less form makes the
+test fail and name that binding.
+
+## The actual deliverable
+
+`every_emitted_xbind_declares_its_mode` scans emitted XAML and fails on any
+`{x:Bind …}` without an explicit `Mode`, naming the offenders. It brace-matches
+rather than scanning to the first `}`, so a binding carrying a nested
+`Converter={StaticResource …}` is parsed correctly.
+
+Verified by regression: reverting a single site to the mode-less form makes the
+test fail and name that binding. Without that check the test would be
+decoration — a per-site fix list goes stale the moment a new emission site is
+added, which is exactly how this defect arose.
+
 ## [Unreleased] — accessible HostSlider names
 
 Literal and slot-backed `HostSlider.a11y-label` values now lower to

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -2858,7 +2858,7 @@ fn emit_text(
             // the React backend's behaviour pre-PR-2).
             if ctx.lookup_for_binding(k).is_some() || ctx.lookup_for_index(k).is_some() {
                 let pascal = kebab_to_pascal_case(k);
-                format!(" Text=\"{{x:Bind {pascal}}}\"")
+                format!(" Text=\"{{x:Bind {pascal}, Mode=OneWay}}\"")
             } else {
                 let escaped = escape_xaml_attr(k);
                 format!(" Text=\"{escaped}\"")
@@ -2915,7 +2915,7 @@ fn emit_image(
             if !is_safe_identifier(&property) {
                 return Err(PipelineEmitError::UnsafeSlotName(property));
             }
-            format!(" Source=\"{{x:Bind {}}}\"", ctx.slot_xbind_path(slot))
+            format!(" Source=\"{{x:Bind {}, Mode=OneWay}}\"", ctx.slot_xbind_path(slot))
         }
         Some(LayoutPropValue::String(s)) => format!(" Source=\"{}\"", escape_xaml_attr(s)),
         _ => String::new(),
@@ -2998,7 +2998,7 @@ fn emit_icon(
         Some(LayoutPropValue::String(s)) => format!(" Glyph=\"{}\"", escape_xaml_attr(s)),
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            format!(" Glyph=\"{{x:Bind {pascal}}}\"")
+            format!(" Glyph=\"{{x:Bind {pascal}, Mode=OneWay}}\"")
         }
         _ => String::new(),
     };
@@ -4718,7 +4718,7 @@ fn emit_for(
     // into that opening tag so the column renders at the colgroup's
     // fixed pixel width regardless of cell content.
     if is_cell_loop {
-        body = inject_attr_into_first_element(&body, "Width=\"{x:Bind Width}\"");
+        body = inject_attr_into_first_element(&body, "Width=\"{x:Bind Width, Mode=OneWay}\"");
     }
 
     if !template_visual_state_groups.is_empty() {
@@ -4737,7 +4737,7 @@ fn emit_for(
     if let Some((role, _, _, entry_depth)) = native_table_entry {
         let wrapper = match role {
             NativeTableRole::Header if entry_depth == 0 => Some(format!(
-                "local:{}MosaicTableHeaderCell Column=\"{{x:Bind Index}}\" Header=\"{{x:Bind {element_property}}}\" AutomationProperties.Name=\"{{x:Bind {element_property}}}\"",
+                "local:{}MosaicTableHeaderCell Column=\"{{x:Bind Index, Mode=OneWay}}\" Header=\"{{x:Bind {element_property}, Mode=OneWay}}\" AutomationProperties.Name=\"{{x:Bind {element_property}, Mode=OneWay}}\"",
                 ctx.component_name
             )),
             NativeTableRole::Body if is_cell_loop => {
@@ -4748,7 +4748,7 @@ fn emit_for(
                     .map(kebab_to_pascal_case)
                     .unwrap_or_else(|| "Index".to_string());
                 Some(format!(
-                    "local:{}MosaicTableCell Row=\"{{x:Bind {row_index_property}}}\" Column=\"{{x:Bind Index}}\" Header=\"{{x:Bind MosaicTableHeader}}\" Value=\"{{x:Bind {element_property}}}\" AutomationProperties.Name=\"{{x:Bind MosaicTableName}}\"",
+                    "local:{}MosaicTableCell Row=\"{{x:Bind {row_index_property}, Mode=OneWay}}\" Column=\"{{x:Bind Index, Mode=OneWay}}\" Header=\"{{x:Bind MosaicTableHeader, Mode=OneWay}}\" Value=\"{{x:Bind {element_property}, Mode=OneWay}}\" AutomationProperties.Name=\"{{x:Bind MosaicTableName, Mode=OneWay}}\"",
                     ctx.component_name
                 ))
             }
@@ -4775,15 +4775,15 @@ fn emit_for(
     let pad3 = " ".repeat(indent + 8);
     let style = part_style_attr(node, part_styles);
     let items_source = projection_property.as_deref().unwrap_or(&items_path);
-    let binding_mode = if projection_property.is_some() {
-        ", Mode=OneWay"
-    } else {
-        ""
-    };
+    // Always OneWay. This was previously conditional on there being a
+    // projection property, which meant a repeater bound directly to a slot
+    // got the x:Bind default — OneTime — and so never re-rendered when the
+    // list changed. The distinction was never load-bearing: both forms read
+    // a collection that the host reassigns wholesale on every prop update.
     let mut out = String::new();
     writeln!(
         out,
-        "{pad}<ItemsRepeater ItemsSource=\"{{x:Bind {items_source}{binding_mode}}}\"{style}>"
+        "{pad}<ItemsRepeater ItemsSource=\"{{x:Bind {items_source}, Mode=OneWay}}\"{style}>"
     )
     .unwrap();
     writeln!(out, "{pad2}<ItemsRepeater.ItemTemplate>").unwrap();
@@ -4959,7 +4959,7 @@ fn emit_if(
     let mut out = String::new();
     writeln!(
         out,
-        "{pad}<ContentControl Visibility=\"{{x:Bind {when_path}, Converter={{StaticResource BoolToVisibilityConverter}}}}\">"
+        "{pad}<ContentControl Visibility=\"{{x:Bind {when_path}, Converter={{StaticResource BoolToVisibilityConverter}}, Mode=OneWay}}\">"
     )
     .unwrap();
     out.push_str(&then_body);
@@ -4973,7 +4973,7 @@ fn emit_if(
             emit_xaml_single_content_children(&else_node.children, indent + 4, part_styles, ctx)?;
         writeln!(
             out,
-            "{pad}<ContentControl Visibility=\"{{x:Bind {when_path}, Converter={{StaticResource BoolToVisibilityConverter}}, ConverterParameter=invert}}\">"
+            "{pad}<ContentControl Visibility=\"{{x:Bind {when_path}, Converter={{StaticResource BoolToVisibilityConverter}}, ConverterParameter=invert, Mode=OneWay}}\">"
         )
         .unwrap();
         out.push_str(&else_body);
@@ -5130,7 +5130,7 @@ fn emit_row_vm_source(component: &str, vm: &RowVm, options: &EmitOptions) -> Str
             out,
             "/// <remarks>\n\
              /// GROUP C â€” fixed per-column widths. This VM carries a `Width`\n\
-             /// (double) the cell element binds via `Width=\"{{x:Bind Width}}\"`.\n\
+             /// (double) the cell element binds via `Width=\"{{x:Bind Width, Mode=OneWay}}\"`.\n\
              /// The enclosing generated row projection zips each cell index\n\
              /// with the component's authored `column-widths` slot.\n\
              /// </remarks>"
@@ -6920,7 +6920,7 @@ fn emit_host_input(
     match find_prop_value(node, "read-only") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" IsReadOnly=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" IsReadOnly=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::Keyword(k)) if k == "true" => {
             attrs.push_str(" IsReadOnly=\"True\"");
@@ -7077,7 +7077,7 @@ fn emit_host_button(
     match find_prop_value(node, "label") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::String(s)) => {
             attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(s)));
@@ -7085,9 +7085,9 @@ fn emit_host_button(
         Some(LayoutPropValue::Keyword(k)) => {
             if ctx.lookup_for_binding(k).is_some() {
                 let pascal = kebab_to_pascal_case(k);
-                attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+                attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
             } else if ctx.lookup_for_index(k).is_some() {
-                attrs.push_str(" Content=\"{x:Bind Index}\"");
+                attrs.push_str(" Content=\"{x:Bind Index, Mode=OneWay}\"");
             } else {
                 attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
             }
@@ -7541,7 +7541,7 @@ fn emit_host_checkbox(
     match find_prop_value(node, "label") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::String(s)) => {
             attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(s)));
@@ -7686,7 +7686,7 @@ fn emit_host_radio(
     match find_prop_value(node, "label") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::String(s)) => {
             attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(s)));
@@ -7701,7 +7701,7 @@ fn emit_host_radio(
     match find_prop_value(node, "group") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" GroupName=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" GroupName=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::String(s)) => {
             attrs.push_str(&format!(" GroupName=\"{}\"", escape_xaml_attr(s)));
@@ -7809,7 +7809,7 @@ fn emit_host_slider(
         }
         Some(LayoutPropValue::SlotRef(slot)) => {
             attrs.push_str(&format!(
-                " AutomationProperties.Name=\"{{x:Bind {}}}\"",
+                " AutomationProperties.Name=\"{{x:Bind {}, Mode=OneWay}}\"",
                 ctx.slot_xbind_path(slot)
             ));
         }
@@ -8011,7 +8011,7 @@ fn emit_host_link(
     match find_prop_value(node, "label") {
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            content_attr.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+            content_attr.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         Some(LayoutPropValue::String(s)) => {
             content_attr.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(s)));
@@ -8019,9 +8019,9 @@ fn emit_host_link(
         Some(LayoutPropValue::Keyword(k)) => {
             if ctx.lookup_for_binding(k).is_some() {
                 let pascal = kebab_to_pascal_case(k);
-                content_attr.push_str(&format!(" Content=\"{{x:Bind {pascal}}}\""));
+                content_attr.push_str(&format!(" Content=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
             } else if ctx.lookup_for_index(k).is_some() {
-                content_attr.push_str(" Content=\"{x:Bind Index}\"");
+                content_attr.push_str(" Content=\"{x:Bind Index, Mode=OneWay}\"");
             } else {
                 content_attr.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
             }
@@ -8068,7 +8068,7 @@ fn emit_host_link(
             }
             Some(LayoutPropValue::SlotRef(slot)) => {
                 let pascal = ctx.slot_xbind_path(slot);
-                attrs.push_str(&format!(" NavigateUri=\"{{x:Bind {pascal}}}\""));
+                attrs.push_str(&format!(" NavigateUri=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
             }
             _ => {}
         }
@@ -8110,7 +8110,7 @@ fn emit_host_tooltip(
         }
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            format!(" ToolTipService.ToolTip=\"{{x:Bind {pascal}}}\"")
+            format!(" ToolTipService.ToolTip=\"{{x:Bind {pascal}, Mode=OneWay}}\"")
         }
         _ => String::new(),
     };
@@ -8189,7 +8189,7 @@ fn emit_host_number_input(
         }
         Some(LayoutPropValue::SlotRef(slot)) => {
             let pascal = ctx.slot_xbind_path(slot);
-            attrs.push_str(&format!(" PlaceholderText=\"{{x:Bind {pascal}}}\""));
+            attrs.push_str(&format!(" PlaceholderText=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
         }
         _ => {}
     }
@@ -8640,7 +8640,7 @@ fn emit_native_host_table(
             let property = ctx.slot_property_name(slot);
             if is_safe_identifier(&property) {
                 format!(
-                    " FlowDirection=\"{{x:Bind {}}}\"",
+                    " FlowDirection=\"{{x:Bind {}, Mode=OneWay}}\"",
                     ctx.slot_xbind_path(slot)
                 )
             } else {
@@ -8690,7 +8690,7 @@ fn emit_native_host_table(
     let mut out = String::new();
     writeln!(
         out,
-        "{pad}<local:{table_type} RowCount=\"{{x:Bind {rows_path}.Count}}\" ColumnCount=\"{{x:Bind {header_path}.Count}}\" AutomationProperties.Name=\"{}\"{flow_direction_attr}{style}>",
+        "{pad}<local:{table_type} RowCount=\"{{x:Bind {rows_path}.Count, Mode=OneWay}}\" ColumnCount=\"{{x:Bind {header_path}.Count, Mode=OneWay}}\" AutomationProperties.Name=\"{}\"{flow_direction_attr}{style}>",
         escape_xaml_attr(&table_name)
     )
     .unwrap();
@@ -8775,7 +8775,7 @@ fn emit_host_table(
             let property = ctx.slot_property_name(slot);
             if is_safe_identifier(&property) {
                 format!(
-                    " FlowDirection=\"{{x:Bind {}}}\"",
+                    " FlowDirection=\"{{x:Bind {}, Mode=OneWay}}\"",
                     ctx.slot_xbind_path(slot)
                 )
             } else {
@@ -9065,7 +9065,7 @@ fn emit_component_reference(
                     return Err(PipelineEmitError::UnsafeSlotName(property));
                 }
                 attrs.push_str(&format!(
-                    " {attr_name}=\"{{x:Bind {}}}\"",
+                    " {attr_name}=\"{{x:Bind {}, Mode=OneWay}}\"",
                     ctx.slot_xbind_path(slot)
                 ));
             }
@@ -9078,7 +9078,7 @@ fn emit_component_reference(
             LayoutPropValue::Keyword(k) => {
                 if ctx.lookup_for_binding(k).is_some() || ctx.lookup_for_index(k).is_some() {
                     let pascal = kebab_to_pascal_case(k);
-                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {pascal}}}\""));
+                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {pascal}, Mode=OneWay}}\""));
                 } else {
                     attrs.push_str(&format!(" {attr_name}=\"{}\"", escape_xaml_attr(k)));
                 }
@@ -9088,10 +9088,10 @@ fn emit_component_reference(
             }
             LayoutPropValue::Expr(src) => match lower_expr_for_xbind(src, ctx) {
                 ExprLowering::Bindable(path) => {
-                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {path}}}\""));
+                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {path}, Mode=OneWay}}\""));
                 }
                 ExprLowering::Helper(call) => {
-                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {call}}}\""));
+                    attrs.push_str(&format!(" {attr_name}=\"{{x:Bind {call}, Mode=OneWay}}\""));
                 }
                 ExprLowering::Unsupported(reason) => {
                     return Err(PipelineEmitError::UnsupportedExpression(reason));
@@ -9805,7 +9805,7 @@ mod tests {
             },
         );
         let r = compile(&c, &l, &empty_style("Foo"));
-        assert!(r.xaml.contains("<Image Source=\"{x:Bind AvatarUrl}\""));
+        assert!(r.xaml.contains("<Image Source=\"{x:Bind AvatarUrl, Mode=OneWay}\""));
     }
 
     #[test]
@@ -9954,7 +9954,7 @@ mod tests {
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(r.xaml.contains("<FontIcon"), "got:\n{}", r.xaml);
         assert!(
-            r.xaml.contains("Glyph=\"{x:Bind GlyphName}\""),
+            r.xaml.contains("Glyph=\"{x:Bind GlyphName, Mode=OneWay}\""),
             "expected x:Bind passthrough, got:\n{}",
             r.xaml
         );
@@ -10748,7 +10748,7 @@ mod tests {
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
             r.xaml
-                .contains("FlowDirection=\"{x:Bind LayoutDirection}\""),
+                .contains("FlowDirection=\"{x:Bind LayoutDirection, Mode=OneWay}\""),
             "expected FlowDirection=\"{{x:Bind LayoutDirection}}\", got:\n{}",
             r.xaml
         );
@@ -10943,7 +10943,7 @@ mod tests {
         );
         let r = compile_with_registry(&c, &l, &empty_style("Demo"), &reg);
         assert!(
-            r.xaml.contains("Rows=\"{x:Bind Rows}\""),
+            r.xaml.contains("Rows=\"{x:Bind Rows, Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -11503,7 +11503,7 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
-            r.xaml.contains("Content=\"{x:Bind ButtonLabel}\""),
+            r.xaml.contains("Content=\"{x:Bind ButtonLabel, Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -11563,7 +11563,7 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
-            r.xaml.contains("Content=\"{x:Bind Item}\""),
+            r.xaml.contains("Content=\"{x:Bind Item, Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -11613,7 +11613,7 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
-            r.xaml.contains("Content=\"{x:Bind Option}\""),
+            r.xaml.contains("Content=\"{x:Bind Option, Mode=OneWay}\""),
             "got:\n{}",
             r.xaml
         );
@@ -11949,7 +11949,7 @@ mod tests {
             r.xaml
         );
         // Inner Text binds to the for-bound name.
-        assert!(r.xaml.contains("Text=\"{x:Bind Row}\""), "got:\n{}", r.xaml);
+        assert!(r.xaml.contains("Text=\"{x:Bind Row, Mode=OneWay}\""), "got:\n{}", r.xaml);
     }
 
     #[test]
@@ -12172,7 +12172,7 @@ mod tests {
         let r = compile(&c, &l, &empty_style("Foo"));
         assert!(
             r.xaml
-                .contains("<ContentControl Visibility=\"{x:Bind Editable, Converter={StaticResource BoolToVisibilityConverter}}\">"),
+                .contains("<ContentControl Visibility=\"{x:Bind Editable, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}\">"),
             "got:\n{}",
             r.xaml
         );
@@ -12478,6 +12478,193 @@ mod tests {
             r.xaml
         );
         assert!(r.xaml.contains("Padding=\"8\""), "got:\n{}", r.xaml);
+    }
+
+    /// Scan emitted XAML for any `{x:Bind ...}` that does not declare an
+    /// explicit `Mode`.
+    ///
+    /// This is the guard that matters. `x:Bind` defaults to **OneTime**, so a
+    /// binding emitted without a mode renders once and then never updates
+    /// again. Because each emission site used to choose its own mode by hand,
+    /// coverage drifted: `Text=` and `Content=` had `Mode=OneWay` while
+    /// `Visibility=` did not, which silently froze every conditional surface
+    /// in a generated app while the engine behind it worked perfectly.
+    ///
+    /// Returns the offending binding substrings so a failure names them.
+    fn xbinds_missing_mode(xaml: &str) -> Vec<String> {
+        let mut missing = Vec::new();
+        let mut rest = xaml;
+        while let Some(start) = rest.find("{x:Bind ") {
+            // A binding may embed a nested markup extension (a Converter),
+            // so match braces rather than scanning to the first '}'.
+            let tail = &rest[start..];
+            let mut depth = 0usize;
+            let mut end = None;
+            for (i, ch) in tail.char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(i + 1);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let Some(end) = end else { break };
+            let binding = &tail[..end];
+            if !binding.contains("Mode=") {
+                missing.push(binding.to_string());
+            }
+            rest = &tail[end..];
+        }
+        missing
+    }
+
+    /// Every `x:Bind` emission site in this file must declare its mode.
+    ///
+    /// This scans the emitter's own source rather than emitted output,
+    /// deliberately. A fixture-based test only covers the sites its fixture
+    /// happens to reach — the first version of this test exercised a Text and
+    /// an If, both already correct, and passed while roughly twenty other
+    /// sites still emitted mode-less bindings. Scanning the source is the
+    /// only form that actually holds the invariant.
+    #[test]
+    fn every_xbind_emission_site_declares_its_mode() {
+        let src = include_str!("pipeline.rs");
+        let mut offenders = Vec::new();
+
+        // Scan only the emitter, not this test module. Tests legitimately
+        // pass mode-less `{x:Bind …}` strings as *input* (translate_xaml_value
+        // cases) and assert on pre-existing output shapes; neither is an
+        // emission site. Cutting at the module boundary is exact, where
+        // string filters were not.
+        let emitter_src = match src.find("#[cfg(test)]") {
+            Some(i) => &src[..i],
+            None => src,
+        };
+
+        for (n, line) in emitter_src.lines().enumerate() {
+            let trimmed = line.trim();
+            // Skip prose — only emission code counts.
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+            // The format-string form the emitter uses: `{{x:Bind ...}}`.
+            //
+            // Walk `{{`/`}}` pairs rather than stopping at the first `}}` —
+            // a binding may embed a nested markup extension, as the If
+            // lowering does with `Converter={{StaticResource ...}}`, and
+            // `Mode=` sits *after* that nested close.
+            for (idx, _) in line.match_indices("{{x:Bind ") {
+                let rest = &line[idx..];
+                let bytes = rest.as_bytes();
+                let mut depth = 0usize;
+                let mut end = None;
+                let mut i = 0usize;
+                while i + 1 < bytes.len() {
+                    if bytes[i] == b'{' && bytes[i + 1] == b'{' {
+                        depth += 1;
+                        i += 2;
+                    } else if bytes[i] == b'}' && bytes[i + 1] == b'}' {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(i);
+                            break;
+                        }
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                // An unterminated binding means the format string wraps
+                // across lines; the closing line carries the mode, so skip.
+                let Some(end) = end else { continue };
+                if !rest[..end].contains("Mode=") {
+                    offenders.push(format!("line {}: {}", n + 1, trimmed));
+                }
+            }
+
+            // Some sites emit a literal (non-format) string, so the braces
+            // are single rather than doubled — `inject_attr_into_first_element`
+            // is the one that does this today. Those need the same guard;
+            // missing it is how the GROUP C `Width` binding stayed OneTime
+            // while its own doc comment claimed otherwise.
+            for (idx, _) in line.match_indices("{x:Bind ") {
+                // Skip the doubled form already handled above.
+                if idx > 0 && line.as_bytes()[idx - 1] == b'{' {
+                    continue;
+                }
+                let rest = &line[idx..];
+                let Some(end) = rest.find('}') else { continue };
+                if !rest[..end].contains("Mode=") {
+                    offenders.push(format!("line {}: {}", n + 1, trimmed));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these x:Bind emission sites declare no Mode, so WinUI defaults \
+             them to OneTime and whatever they render freezes after the first \
+             pass:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// Companion to the source scan: emitted output for a representative
+    /// layout carries no mode-less binding either.
+    #[test]
+    fn every_emitted_xbind_declares_its_mode() {
+        fn text_bound_to(slot_name: &str) -> LayoutNode {
+            LayoutNode {
+                tag: "Text".to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "content".to_string(),
+                    value: LayoutPropValue::SlotRef(slot_name.to_string()),
+                }],
+                children: Vec::new(),
+            }
+        }
+
+        let c = component(
+            "Foo",
+            vec![
+                slot("title", SlotType::Text, true),
+                slot("editable", SlotType::Bool, true),
+            ],
+            vec![],
+        );
+        let l = layout_with_root(
+            "Foo",
+            LayoutNode {
+                tag: "Column".to_string(),
+                part_name: None,
+                props: Vec::new(),
+                children: vec![
+                    // A plain slot-bound text binding.
+                    text_bound_to("title"),
+                    // A conditional — the site that was still OneTime and
+                    // froze every view switch in the generated TaskApp.
+                    if_node(
+                        LayoutPropValue::SlotRef("editable".to_string()),
+                        vec![text_bound_to("title")],
+                    ),
+                ],
+            },
+        );
+        let r = compile(&c, &l, &empty_style("Foo"));
+
+        let missing = xbinds_missing_mode(&r.xaml);
+        assert!(
+            missing.is_empty(),
+            "these bindings default to OneTime and will freeze after first \
+             render; give each an explicit Mode: {missing:#?}\n\nfull XAML:\n{}",
+            r.xaml
+        );
     }
 
     /// CSS `rgb()`/`rgba()` are function calls, not XAML literals. They
@@ -13590,7 +13777,7 @@ mod tests {
             .contains("AutomationProperties.AutomationId=\"volume-slider\""));
         assert!(r
             .xaml
-            .contains("AutomationProperties.Name=\"{x:Bind Label}\""));
+            .contains("AutomationProperties.Name=\"{x:Bind Label, Mode=OneWay}\""));
         assert!(r.xaml.contains("Value=\"{x:Bind Volume, Mode=OneWay}\""));
         assert!(r.xaml.contains("Minimum=\"-10\""));
         assert!(r.xaml.contains("Maximum=\"10\""));
@@ -13809,7 +13996,7 @@ mod tests {
         );
         let r = compile(&c, &l, &empty_style("Nav"));
         assert!(
-            r.xaml.contains("Content=\"{x:Bind Item}\""),
+            r.xaml.contains("Content=\"{x:Bind Item, Mode=OneWay}\""),
             "expected HostLink label to bind For item, got:\n{}",
             r.xaml
         );
@@ -15005,7 +15192,7 @@ mod tests {
 
         // The cell element binds the width.
         assert!(
-            r.xaml.contains("Width=\"{x:Bind Width}\""),
+            r.xaml.contains("Width=\"{x:Bind Width, Mode=OneWay}\""),
             "cell element must bind Width, got:\n{}",
             r.xaml
         );

--- a/code/packages/rust/mosaic-emit-xaml/tests/pkg_grid_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/pkg_grid_compiles_to_xaml.rs
@@ -189,7 +189,7 @@ fn grid_component_lowers_to_xaml_without_error() {
     );
     assert!(xaml.contains("<local:GridMosaicTableHeaderCell "));
     assert!(xaml.contains("<local:GridMosaicTableCell "));
-    assert!(xaml.contains("AutomationProperties.Name=\"{x:Bind MosaicTableName}\""));
+    assert!(xaml.contains("AutomationProperties.Name=\"{x:Bind MosaicTableName, Mode=OneWay}\""));
     // For block lowered to ItemsRepeater.
     assert!(
         xaml.contains("<ItemsRepeater"),

--- a/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/venture_chrome_compiles_to_xaml.rs
@@ -54,7 +54,7 @@ fn venture_chrome_lowers_to_native_xaml_controls_and_project_shell() {
             .xaml
             .contains("IsEnabled=\"{x:Bind Not(ForwardDisabled), Mode=OneWay}\""));
         assert!(result.xaml.contains(
-            "<TextBox x:Name=\"AddressInput\" AutomationProperties.AutomationId=\"address-input\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled}\""
+            "<TextBox x:Name=\"AddressInput\" AutomationProperties.AutomationId=\"address-input\" Text=\"{x:Bind Address, Mode=TwoWay}\" IsReadOnly=\"{x:Bind NavigationDisabled, Mode=OneWay}\""
         ));
         assert!(result
             .xaml


### PR DESCRIPTION
Closes #12019. Part of #12017.

`x:Bind` defaults to **OneTime** in WinUI, and each emission site chose its binding mode by hand, so coverage drifted. In the generated TaskApp that left **118 of 153 bindings frozen** after first render: every event reached the Rust engine and the engine computed correctly, but none of it reached the screen.

#12015 fixed `Text=` and `AutomationProperties.Name=`. Every remaining site now emits `Mode=OneWay`:

- **`Visibility=`** on the `If` lowering — the one that mattered most, since it pinned every conditional surface to its first-render value and made view switching a no-op
- `Content=` (7 sites), `Source=`, `Glyph=`, `IsReadOnly=`, `GroupName=`, `NavigateUri=`, `ToolTipService.ToolTip=`
- the UI31 table cell/header attributes
- the GROUP C `Width=` injection, whose own doc comment already claimed a mode it did not emit
- `ItemsRepeater.ItemsSource`, where the mode was **conditional on there being a projection property** — so a repeater bound directly to a slot got the OneTime default and never re-rendered when its list changed

## The guard is the deliverable

`every_xbind_emission_site_declares_its_mode` scans **the emitter's own source** and fails on any emission site whose `x:Bind` carries no `Mode`, naming each offender by line. It handles both emission forms (doubled-brace `format!` and the literal single-brace form), brace-matches rather than stopping at the first `}}` so a nested `Converter={StaticResource …}` parses correctly, and scans only up to `#[cfg(test)]`.

Verified by regression: reverting a single site makes the test fail and name that binding.

## Worth reading if you review one thing

My first attempt at this **did not do what its commit message claimed**, and the security review caught it.

I applied the change with a regex, then wrote a test that compiled a fixture and scanned the resulting XAML. Both were wrong in the same way:

- the regex used `[^{}]` to match binding contents, so it **could not cross** sites written as `{{x:Bind {pascal}}}` — it changed 4 sites, not the 18 I claimed
- the fixture test exercised a `Text` and an `If`, both *already correct*, so it passed while ~20 sites still emitted mode-less bindings
- the regex also rewrote two strings without their code, desyncing a doc comment and an assertion message from what they described

A fixture-based test only covers the sites its fixture happens to reach, and goes stale the moment someone adds one — which is precisely how the original defect arose. Scanning source is the only form that holds the invariant. The fixture test is retained as a companion.

## Verification

212 tests across all 7 targets (`--no-fail-fast`, unfiltered); `clippy --all-targets -- -D warnings` clean. 12 goldens updated across three test files.

## Follow-ups, deliberately not folded in

- **`NavigateUri` now re-evaluates after render.** There is no URI scheme validation today, on either the bound or literal arm, so a `file:`/UNC/custom-protocol target reaches the shell launcher. Pre-existing for the literal arm; `OneWay` adds the ability to swap a link target after the user has read it. Filing separately.
- Row-VM member bindings inside `DataTemplate`s would be marginally cheaper as `OneTime` and are what drives the `WMC1506` warning volume. A wrongly-`OneTime` binding freezes silently while a wrongly-`OneWay` one only warns, so the safe direction is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
