### PR TITLE
fix(mosaic-emit-xaml): emit Content for HostButton labels from row expressions

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — HostButton labels from row expressions
+
+A `HostButton` whose `label` is a row expression emitted **no `Content`
+attribute at all**, so the button rendered blank.
+
+The `label` match handled `SlotRef`, `String` and `Keyword`; `label: ( row[1] )`
+parses as `LayoutPropValue::Expr`, which had no arm, and the trailing `_ => {}`
+swallowed it silently. Adding the `Expr` arm routes it through
+`lower_expr_for_xbind` — the same helper the `Text` lowering already used
+successfully two elements away inside the same template.
+
+This was not a binding-mode problem. There was no attribute for a mode to
+apply to.
+
+**Scope.** Every `HostButton` inside a `For`. In the generated TaskApp that
+meant the task name, the completion toggle, every project-rail row and every
+notes row rendered as empty buttons. It read as a styling gap for weeks
+because an empty button is invisible rather than obviously broken.
+
+Verified live: the UI Automation tree went from listing only `Delete` for a
+task row to listing `[○]`, `[Ship the XAML fix]` and `[Delete]`, and the
+project rail from a blank row to `[Inbox]`.
+
+`host_button_with_row_expression_label_emits_content` guards it, asserting
+both that the binding is emitted and — more generally — that no emitted
+`<Button>` lacks `Content`.
+
 ## [Unreleased] — every x:Bind declares its mode
 
 `x:Bind` defaults to **OneTime** in WinUI, and each emission site chose its

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -7092,6 +7092,26 @@ fn emit_host_button(
                 attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
             }
         }
+        // An expression label — `label: ( row[1] )` is the common shape.
+        //
+        // This arm was missing, and the catch-all below swallowed it, so a
+        // button whose label came from a row expression emitted NO Content
+        // attribute at all. That is why every task row, project-rail row and
+        // notes row rendered a blank button: not a binding-mode problem, the
+        // attribute simply never existed. The Text lowering already routes
+        // expressions through the same helper successfully two elements away
+        // in the same template.
+        Some(LayoutPropValue::Expr(src)) => match lower_expr_for_xbind(src, ctx) {
+            ExprLowering::Bindable(path) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {path}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Helper(call) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {call}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Unsupported(reason) => {
+                return Err(PipelineEmitError::UnsupportedExpression(reason));
+            }
+        },
         _ => {}
     }
 
@@ -12611,6 +12631,72 @@ mod tests {
              them to OneTime and whatever they render freezes after the first \
              pass:\n{}",
             offenders.join("\n")
+        );
+    }
+
+    /// A `HostButton` whose label is a row expression must emit `Content`.
+    ///
+    /// `label: ( row[1] )` lands on `LayoutPropValue::Expr`, and that arm was
+    /// missing from the label match — the catch-all swallowed it, so the
+    /// button emitted no `Content` attribute at all and rendered blank. It
+    /// looked like a styling gap for weeks because an empty button is
+    /// invisible rather than obviously broken; it affected every task row,
+    /// project-rail row and notes row.
+    #[test]
+    fn host_button_with_row_expression_label_emits_content() {
+        let c = component(
+            "Foo",
+            vec![slot(
+                "rows",
+                // list<list<text>> — a list of rows, each a list of cells,
+                // which is the shape task-rows actually has.
+                SlotType::List(Box::new(ListInnerType::List(Box::new(
+                    ListInnerType::Text,
+                )))),
+                true,
+            )],
+            vec![],
+        );
+        let l = layout_with_root(
+            "Foo",
+            LayoutNode {
+                tag: "Column".to_string(),
+                part_name: None,
+                props: Vec::new(),
+                children: vec![for_node(
+                    LayoutPropValue::SlotRef("rows".to_string()),
+                    "row",
+                    None,
+                    vec![LayoutNode {
+                        tag: "HostButton".to_string(),
+                        part_name: None,
+                        props: vec![LayoutProp {
+                            name: "label".to_string(),
+                            value: LayoutPropValue::Expr("row[1]".to_string()),
+                        }],
+                        children: Vec::new(),
+                    }],
+                )],
+            },
+        );
+        let r = compile(&c, &l, &empty_style("Foo"));
+
+        // Every emitted Button must carry a Content attribute — a button that
+        // renders empty is the failure mode this guards against.
+        for line in r.xaml.lines() {
+            let t = line.trim();
+            if t.starts_with("<Button ") {
+                assert!(
+                    t.contains("Content="),
+                    "emitted a Button with no Content, which renders blank:\n{t}\n\nfull XAML:\n{}",
+                    r.xaml
+                );
+            }
+        }
+        assert!(
+            r.xaml.contains("Content=\"{x:Bind"),
+            "row-expression label should lower to a binding, got:\n{}",
+            r.xaml
         );
     }
 


### PR DESCRIPTION
Closes #12020. Part of #12017.

A `HostButton` whose `label` is a row expression emitted **no `Content` attribute at all**, so the button rendered blank.

The `label` match handled `SlotRef`, `String` and `Keyword`. `label: ( row[1] )` parses as `LayoutPropValue::Expr`, which had no arm, and the trailing `_ => {}` swallowed it silently. The new arm routes through `lower_expr_for_xbind` — the same helper the `Text` lowering already used successfully **two elements away inside the same `DataTemplate`**.

This was not a binding-mode problem. There was no attribute for a mode to apply to, which is why #12036 did not fix it.

## Scope

Every `HostButton` inside a `For`. In the generated TaskApp that meant **the task name, the completion toggle, every project-rail row and every notes row** rendered as empty buttons.

It read as a styling gap for weeks, because an empty button is invisible rather than obviously broken — I attributed the blank project rail to missing styles in an earlier session.

## How it was found

The issue was filed under a different hypothesis: that the row template indexed past the end of the row and `x:Bind` swallowed the exception. Dumping a real `task-rows` row over the C ABI **killed that outright** — rows carry 15 cells and the template's highest read is `T[5]`, so nothing throws:

```
row[0] cells=15  [0]=○  [1]=Ship the XAML fix  [2]=  …
```

What the dump showed instead is that `row[0]` is the toggle glyph and `row[1]` the name — matching [`TaskApp.mll:474-476`](../blob/main/code/programs/mosaic/task-app/src/TaskApp.mll) exactly. Engine and layout agreed, which pointed at the lowering.

## Verification

Rebuilt from `mosaic-compile` output with no hand-patching, on Windows 11. The UI Automation tree for a task row:

| before | after |
|---|---|
| `[Delete]` | `[○]` `[Ship the XAML fix]` `[Delete]` |
| project rail: *(blank)* | `[Inbox]` |

Emitted XAML now has **zero** `<Button>` without `Content`, down from four distinct blank-button sites.

213 tests pass across all 7 targets (`--no-fail-fast`, unfiltered).

## The guard

`host_button_with_row_expression_label_emits_content` asserts both that the row-expression label lowers to a binding and — more usefully — that **no emitted `<Button>` lacks `Content`**. The general form is the half that matters: a control that renders empty is exactly the failure mode that hid this.

## Security review

Passed first round. The reviewer traced the value end-to-end: `lower_expr_for_xbind` output derives only from `ExprTok::Name`, and `tokenise_expr` rejects every byte outside `[A-Za-z0-9_-]` plus a fixed operator set, so no quote or brace can reach the attribute. The arm is identical in guarding to the already-merged `Expr` arms in `emit_text` and `emit_component_reference`. The change is also fail-closed — an unlowerable expression now returns `Err` where it previously emitted nothing silently.

## Follow-up not folded in

The sibling `label` match in the `HostRadio`/`HostCheckbox` lowering has the same missing `Expr` arm. Not fixed here because nothing exercises it yet and I have not verified the shape — I'd rather not change code I can't test. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
