### PR TITLE
ci(mosaic): launch the generated TaskApp and assert the screen reacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1630,6 +1630,23 @@ jobs:
           }
           Write-Host "Built generated WinUI executable at $($executable.FullName)"
 
+          # Launch the app and assert the SCREEN reacts to a real event.
+          #
+          # The runtime-conformance harness below asserts on the component
+          # object's properties, which passes even when the app is broken --
+          # props do reach the object. Three shipped defects were green under
+          # that arrangement: a startup crash (missing PRI), a UI frozen after
+          # first render (x:Bind defaulting to OneTime), and every row button
+          # emitting no Content. Each was caught only by a human looking at the
+          # window. This is that check, automated.
+          #
+          # UI Automation does not need a foreground window, so no interactive
+          # desktop session is required.
+          pwsh -NoProfile -ExecutionPolicy Bypass -File code/scripts/taskapp-xaml-smoke.ps1 -ExePath $executable.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "TaskApp XAML smoke test failed with exit code $LASTEXITCODE"
+          }
+
           $taskHarness = Join-Path $env:RUNNER_TEMP 'mosaic-xaml-taskapp-runtime-conformance'
           New-Item -ItemType Directory -Path $taskHarness -Force | Out-Null
           Copy-Item 'code/packages/rust/task-mosaic-app/conformance/xaml/*' $taskHarness -Recurse

--- a/code/scripts/taskapp-xaml-smoke.ps1
+++ b/code/scripts/taskapp-xaml-smoke.ps1
@@ -1,0 +1,187 @@
+<#
+.SYNOPSIS
+    Launch the generated WinUI TaskApp and assert the screen reacts to a real event.
+
+.DESCRIPTION
+    CI builds the generated XAML app and runs a headless ABI conformance harness
+    that asserts on the component *object's* properties. Those assertions pass
+    even when the app is completely broken, because props really do reach the
+    object -- nothing checks that the screen reflects them, and nothing launches
+    the GUI.
+
+    Three separate shipped defects were green under that arrangement:
+
+      1. The app crashed before drawing a pixel (missing app PRI ->
+         E_XAMLPARSEFAILED).
+      2. The app rendered once and froze (118/153 bindings defaulting to
+         x:Bind's OneTime).
+      3. Every button inside a For rendered blank (no Content attribute
+         emitted at all).
+
+    Each was found by a human launching the app and looking at it. This script
+    is that loop, automated. It drives the real window through UI Automation
+    and asserts on rendered values, so all three classes fail here rather than
+    shipping.
+
+    UI Automation does not require a visible foreground window, so this runs on
+    an ordinary hosted runner -- it does not need an interactive desktop
+    session.
+
+.PARAMETER ExePath
+    Path to the built TaskApp.exe.
+
+.PARAMETER TimeoutSeconds
+    How long to wait for the window and for each dispatched event to land.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ExePath,
+    [int]$TimeoutSeconds = 30
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+
+if (-not (Test-Path $ExePath)) {
+    Write-Error "TaskApp executable not found at $ExePath"
+    exit 1
+}
+
+$proc = $null
+$failures = @()
+
+function Get-Descendants($root, $controlType) {
+    $cond = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $controlType)
+    return $root.FindAll([System.Windows.Automation.TreeScope]::Descendants, $cond)
+}
+
+function Get-TextValues($root) {
+    $out = @()
+    foreach ($e in Get-Descendants $root ([System.Windows.Automation.ControlType]::Text)) {
+        if ($e.Current.Name) { $out += $e.Current.Name }
+    }
+    return $out
+}
+
+function Get-ButtonNames($root) {
+    $out = @()
+    foreach ($e in Get-Descendants $root ([System.Windows.Automation.ControlType]::Button)) {
+        if ($e.Current.Name) { $out += $e.Current.Name }
+    }
+    return $out
+}
+
+function Find-ByName($root, $name, $controlType) {
+    $cond = New-Object System.Windows.Automation.AndCondition(
+        (New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::NameProperty, $name)),
+        (New-Object System.Windows.Automation.PropertyCondition(
+            [System.Windows.Automation.AutomationElement]::ControlTypeProperty, $controlType)))
+    return $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $cond)
+}
+
+try {
+    # ── 1. It launches at all ────────────────────────────────────────────
+    #
+    # A missing app PRI made this fail with E_XAMLPARSEFAILED while the build
+    # stayed green, so "the process is still alive" is itself an assertion.
+    Write-Host "Launching $ExePath"
+    $proc = Start-Process -FilePath $ExePath -PassThru
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+        $proc.Refresh()
+        if ($proc.HasExited) {
+            throw "TaskApp exited during startup with code $($proc.ExitCode). It did not render."
+        }
+        if ($proc.MainWindowHandle -ne [IntPtr]::Zero) { break }
+    }
+    $proc.Refresh()
+    if ($proc.MainWindowHandle -eq [IntPtr]::Zero) {
+        throw "TaskApp never produced a window within $TimeoutSeconds seconds."
+    }
+    Write-Host "  window is up (pid $($proc.Id))"
+
+    $root = [System.Windows.Automation.AutomationElement]::FromHandle($proc.MainWindowHandle)
+
+    # ── 2. The initial render reached the screen ─────────────────────────
+    $before = Get-TextValues $root
+    $summaryBefore = $before | Where-Object { $_ -like '*task(s)*' } | Select-Object -First 1
+    if (-not $summaryBefore) {
+        $failures += "No summary text rendered. Visible text: $($before -join ' | ')"
+    } else {
+        Write-Host "  initial summary: $summaryBefore"
+    }
+
+    # ── 3. A dispatched event changes what is on screen ──────────────────
+    #
+    # This is the assertion the headless harness cannot make. Props reaching
+    # the component object is not the same as the screen updating: with
+    # x:Bind defaulting to OneTime, the object was correct and the window was
+    # frozen.
+    $composer = Find-ByName $root 'What needs doing?' ([System.Windows.Automation.ControlType]::Edit)
+    if (-not $composer) {
+        throw "Could not find the task composer input. Buttons present: $((Get-ButtonNames $root) -join ', ')"
+    }
+    $taskName = 'CI smoke task'
+    $composer.GetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern).SetValue($taskName)
+    Start-Sleep -Seconds 2
+
+    $addButton = Find-ByName $root 'Add task' ([System.Windows.Automation.ControlType]::Button)
+    if (-not $addButton) {
+        throw "Could not find the 'Add task' button."
+    }
+    $addButton.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke()
+
+    $summaryAfter = $null
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds 500
+        $summaryAfter = Get-TextValues $root | Where-Object { $_ -like '*task(s)*' } | Select-Object -First 1
+        if ($summaryAfter -and $summaryAfter -ne $summaryBefore) { break }
+    }
+
+    if (-not $summaryAfter -or $summaryAfter -eq $summaryBefore) {
+        $failures += "Adding a task did not change the rendered summary (still '$summaryBefore'). " +
+                     "The engine ran but the UI is frozen -- this is the x:Bind OneTime class of bug."
+    } else {
+        Write-Host "  summary updated: $summaryAfter"
+    }
+
+    # ── 4. The new row actually rendered its content ─────────────────────
+    #
+    # A HostButton whose label came from a row expression emitted no Content
+    # at all, so rows appeared as invisible empty buttons while every other
+    # signal looked healthy.
+    $buttons = Get-ButtonNames $root
+    if ($buttons -notcontains $taskName) {
+        $failures += "The new task row did not render its name. Expected a control named '$taskName'. " +
+                     "Buttons present: $($buttons -join ', ')"
+    } else {
+        Write-Host "  task row rendered: $taskName"
+    }
+}
+catch {
+    $failures += $_.Exception.Message
+}
+finally {
+    if ($proc -and -not $proc.HasExited) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'TaskApp XAML smoke test FAILED:' -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host "  - $f" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'TaskApp XAML smoke test passed: the app launched, and a dispatched event changed the screen.'
+exit 0


### PR DESCRIPTION
Closes #12023. Part of #12017.

CI built the generated XAML app and ran a headless ABI conformance harness that asserts on the component **object's** properties. Those assertions pass even when the app is completely broken, because props really do reach the object — nothing checked that the *screen* reflected them, and nothing launched the GUI.

**Three separate shipped defects were green under that arrangement:**

1. The app **crashed before drawing a pixel** — missing app PRI, so WinUI couldn't resolve themeresources and startup died with `E_XAMLPARSEFAILED`.
2. The app **rendered once and froze** — 118 of 153 bindings defaulted to `x:Bind`'s OneTime. Every event reached the Rust engine, the engine computed correctly, and none of it reached the screen.
3. **Every button inside a `For` rendered blank** — the label match had no `Expr` arm, so no `Content` attribute was emitted at all.

Each was found by a human launching the app and looking at it. I've now done that loop manually three times across this effort. This automates it.

## What it asserts

`code/scripts/taskapp-xaml-smoke.ps1` drives the real window through UI Automation:

| assertion | catches |
|---|---|
| process produces a window, doesn't exit during startup | #1 |
| a summary renders at all | — |
| adding a task **changes** the rendered summary | #2 |
| the new row renders its name as a real control | #3 |

Written as a committed script rather than inline YAML so it can be run locally against any build — which is also how it was verified.

## Verified in both directions

An assertion that cannot fail is decoration, so I checked it bites:

**Against the current build — passes:**
```
initial summary: 0 task(s) · 0 done · projected finish —
summary updated: 1 task(s) · 0 done · projected finish 2026-01-05
task row rendered: CI smoke task
```

**Against a pre-#12045 build — fails, with the precise diagnostic:**
```
The new task row did not render its name. Expected a control named 'CI smoke task'.
Buttons present: +, + Sub-project, ..., Add task, Delete
```

## Notes

UI Automation does **not** require a foreground window, so this runs on an ordinary hosted runner — it does not need the interactive Windows worker that visible launch was previously deferred to.

Security review passed first round. Confirmed the workflow triggers on plain `pull_request` (not `pull_request_target`), declares `permissions: contents: read`, references no secrets, and that running a PR-built binary was already this job's baseline (`cargo run`, `dotnet build`, and an existing conformance `.dll` all execute PR-authored code). Process cleanup is `finally`-guarded and hang risk is bounded by both the script's own deadline and the step's `timeout-minutes: 15`.

**For whoever extends this:** the other native backends (Qt, Flutter, Compose, SwiftUI) currently assert only "still alive after 8 seconds" — which all three failures above would have passed. Their green checks are not evidence those backends render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
