### PR TITLE
feat(hl-c248): convert the three unblocked hand-written chapters to generated

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -133,7 +133,7 @@ enter cross-language review only after focused retrieval.
 | Language | Family / script | Canonical lessons | Mapped lessons | Book progress |
 |---|---|---:|---:|---|
 | [Spanish](./spanish/README.md) | Romance / Latin | 549 | 549 | 295 chapters; through Ch. 295; 295 generated |
-| [Latin](./latin/README.md) | Italic / Latin | 108 | 108 | 47 chapters; through Ch. 47; 46 generated |
+| [Latin](./latin/README.md) | Italic / Latin | 108 | 108 | 47 chapters; through Ch. 47; 47 generated |
 | [French](./french/README.md) | Romance / Latin | 118 | 104 | 33 chapters; through Ch. 33; 17 generated |
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
@@ -150,8 +150,8 @@ enter cross-language review only after focused retrieval.
 | [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati | 69 | 65 | 13 chapters; through Ch. 13; 8 generated |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | 84 | 76 | 15 chapters; through Ch. 15; 13 generated |
 | [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari | 231 | 228 | 44 chapters; through Ch. 44; 39 generated |
-| [Persian](./persian/README.md) | Iranian / Perso-Arabic | 69 | 69 | 15 chapters; through Ch. 15; 13 generated |
-| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu-Nastaliq | 68 | 68 | 16 chapters; through Ch. 16; 14 generated |
+| [Persian](./persian/README.md) | Iranian / Perso-Arabic | 69 | 69 | 15 chapters; through Ch. 15; 14 generated |
+| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu-Nastaliq | 68 | 68 | 16 chapters; through Ch. 16; 15 generated |
 | [Mandarin Chinese](./chinese/README.md) | Sinitic / Chinese | 63 | 63 | 11 chapters; through Ch. 11; 11 generated |
 | [Japanese](./japanese/README.md) | Japonic / Japanese | 29 | 29 | 3 chapters; through Ch. 3; 3 generated |
 <!-- END GENERATED TRACK PROGRESS -->

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1816,6 +1816,11 @@
     },
     {
       "language": "latin",
+      "chapter": 1,
+      "output": "latin/book/chapters/ch01-greetings.tex"
+    },
+    {
+      "language": "latin",
       "chapter": 2,
       "output": "latin/book/chapters/ch02-numbers-1-10.tex"
     },
@@ -2430,6 +2435,13 @@
       "output": "marathi/book/chapters/ch14-script-first.tex",
       "unicodeScript": "Devanagari",
       "scriptCommand": "mr"
+    },
+    {
+      "language": "persian",
+      "chapter": 2,
+      "output": "persian/book/chapters/ch02-give-your-name.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
     },
     {
       "language": "persian",
@@ -5114,6 +5126,13 @@
     },
     {
       "language": "urdu",
+      "chapter": 2,
+      "output": "urdu/book/chapters/ch02-give-your-name.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    },
+    {
+      "language": "urdu",
       "chapter": 3,
       "output": "urdu/book/chapters/ch03-ask-and-answer-names.tex",
       "unicodeScript": "Arabic",
@@ -5697,11 +5716,6 @@
       "output": "kannada/book/chapters/ch05-first-verbs.tex"
     },
     {
-      "language": "latin",
-      "chapter": 1,
-      "output": "latin/book/chapters/ch01-greetings.tex"
-    },
-    {
       "language": "malayalam",
       "chapter": 1,
       "output": "malayalam/book/chapters/ch01-greetings.tex"
@@ -5755,11 +5769,6 @@
       "language": "persian",
       "chapter": 1,
       "output": "persian/book/chapters/ch01-greetings-and-responses.tex"
-    },
-    {
-      "language": "persian",
-      "chapter": 2,
-      "output": "persian/book/chapters/ch02-give-your-name.tex"
     },
     {
       "language": "portuguese",
@@ -5880,11 +5889,6 @@
       "language": "urdu",
       "chapter": 1,
       "output": "urdu/book/chapters/ch01-greetings-and-responses.tex"
-    },
-    {
-      "language": "urdu",
-      "chapter": 2,
-      "output": "urdu/book/chapters/ch02-give-your-name.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2649,6 +2649,20 @@
     },
     {
       "language": "latin",
+      "chapter": 1,
+      "sourceHash": "fnv1a64:fc742a0558a5aef5",
+      "lessonIds": [
+        "LA-C01-salve",
+        "LA-C01-ave",
+        "LA-C01-vale",
+        "LA-C01-gratias",
+        "LA-C01-ita-non",
+        "LA-C01-practice"
+      ],
+      "tex": "latin/book/chapters/ch01-greetings.tex"
+    },
+    {
+      "language": "latin",
       "chapter": 2,
       "sourceHash": "fnv1a64:e487ced01dcb7f2f",
       "lessonIds": [
@@ -3841,6 +3855,15 @@
         "MR-W01-namaskar-read"
       ],
       "tex": "marathi/book/chapters/ch14-script-first.tex"
+    },
+    {
+      "language": "persian",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:497f80f61dd5767f",
+      "lessonIds": [
+        "FA-C02-esm-e-man"
+      ],
+      "tex": "persian/book/chapters/ch02-give-your-name.tex"
     },
     {
       "language": "persian",
@@ -9323,6 +9346,15 @@
         "TE-C66-harvest"
       ],
       "tex": "telugu/book/chapters/ch66-the-field.tex"
+    },
+    {
+      "language": "urdu",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:cfca1c3146b05ede",
+      "lessonIds": [
+        "UR-C02-mera-naam"
+      ],
+      "tex": "urdu/book/chapters/ch02-give-your-name.tex"
     },
     {
       "language": "urdu",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -15296,7 +15296,7 @@
     {
       "language": "urdu",
       "chapter": 2,
-      "sourceHash": "fnv1a64:d3efc74a56512410",
+      "sourceHash": "fnv1a64:d7e6c7d21186e200",
       "lessonIds": [
         "UR-C02-mera-naam"
       ],
@@ -15304,8 +15304,8 @@
       "drivablePrefix": 1,
       "text": "urdu/narration/ch02.txt",
       "json": "urdu/narration/ch02.json",
-      "textHash": "fnv1a64:62f95e1e2a34f5c1",
-      "jsonHash": "fnv1a64:3cc911c9f78d0d11"
+      "textHash": "fnv1a64:b51d3358d9b6bb75",
+      "jsonHash": "fnv1a64:ea3231d5c2ec1fbe"
     },
     {
       "language": "urdu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:ecce86212d2bd4c0",
+  "sourceHash": "fnv1a64:c3922faa9a470bf4",
   "summary": {
     "totalLessons": 3147,
     "voice": 2221,
@@ -75465,7 +75465,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c9b79da0c62dcb0a"
+      "sourceHash": "fnv1a64:f7dd6fcae0bd7124"
     },
     {
       "id": "UR-C03-aap-tum-tu",

--- a/code/learning/human-languages/latin/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch01-greetings.tex
@@ -1,166 +1,238 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:fc742a0558a5aef5
+% canonical-lessons: LA-C01-salve, LA-C01-ave, LA-C01-vale, LA-C01-gratias, LA-C01-ita-non, LA-C01-practice
+
 \chapter{Greetings}
 \label{ch:greetings}
 \hlchaptermodality{1}
 
-The Latin greetings --- and why they matter more than most first words. Latin is
-a \textbf{taproot}: these five salutations are the ancestors of the greetings of
-Spanish, Italian, French, and Portuguese, \emph{and} the etymons of a
-surprising slice of English's polite vocabulary. Learn \emph{valē} and you have
-already half-learned \emph{value}, \emph{valid}, and \emph{prevail}. Each lesson
-introduces the sounds its word needs.
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can greet someone in Latin, thank them, answer yes or no, and say goodbye.}
 
-\section{\textit{salv\=e} / \textit{salv\=ete} --- ``hello'' (be well)}
-\label{lesson:salve}
+The whole doorway sequence on cue: salvē or avē on arrival, grātiās tibi agō, ita or nōn, and valē on the way out.
+\end{chapteropening}
+
+\section[salvē / salvēte]{salvē / salvēte — \textquotedblleft{}hello\textquotedblright{} (be well)}
+
+\label{lesson:LA-C01-salve}
+
+
+
+\begin{quote}
+The first Latin word — and it already contains \emph{save}, \emph{safe}, and \emph{salute}.
+\end{quote}
 
 \begin{sounds}
-Latin is read as written, every letter sounded. A \textbf{macron} (\=a, \=e,
-\=\i, \=o, \=u) marks a \emph{long} vowel --- held longer, never changing its
-quality. \=V is like English ``way'' before a vowel. \textit{salv\=e} $=$
-\emph{SAL-weh}. The classical \textit{v} was a \textbf{w}: Romans said
-\emph{SAL-weh}, not ``sal-vay.''
+Latin is read as written, every letter sounded. A \textbf{macron} (ā ē ī ō ū) marks a \emph{long} vowel — held longer, same quality. Classical \textbf{v = w}. So \emph{salvē} = \textbf{SAL-weh}, not \textquotedblleft{}sal-vay.\textquotedblright{}
 \end{sounds}
 
 \begin{cousinweb}
-\textit{Salv\=e} (to one person) / \textit{salv\=ete} (to several) is the
-imperative of \textit{salv\=ere}, ``to be in good health,'' from \textit{salvus}
-``safe, sound, whole.'' To greet someone in Latin is to \emph{wish them health}.
-That one root \textit{salvus}/\textit{salv\=are} fans out enormously into
-English: \textbf{save}, \textbf{safe}, \textbf{salvage}, \textbf{salvation},
-\textbf{salute}, \textbf{salubrious}, and the toast \textbf{``salut!''} And into
-the Romance children as the very word for health --- Spanish \emph{salud},
-Italian \emph{salute}, French \emph{salut} (which became a greeting again, having
-started as one).
+\emph{Salvē} (to one person) / \emph{salvēte} (to several) is the imperative of \emph{salvēre}, \textquotedblleft{}to be in good health,\textquotedblright{} from \emph{salvus} \textquotedblleft{}safe, sound, whole.\textquotedblright{} To greet in Latin is to \textbf{wish someone health}. That root fans out into English — \textbf{save, safe, salvage, salvation, salute, salubrious}, the toast \textbf{\textquotedblleft{}salut!\textquotedblright{}} — and into the Romance children as the word for health itself: Spanish \emph{salud}, Italian \emph{salute}, French \emph{salut}.
 \end{cousinweb}
 
-\begin{grammarlens}
-Notice \textit{salv\=e} vs. \textit{salv\=ete}: Latin changes the \emph{ending}
-to mark one listener versus many (\emph{-e} singular, \emph{-\=ete} plural). This
-is your first taste of the feature that defines Latin --- meaning carried in
-\textbf{endings}, not word order or extra words. English lost almost all of this;
-its Romance grandchildren kept some. You will meet it in every chapter.
+\begin{grammarlens}[title={Grammar Lens}]
+\emph{salvē} vs. \emph{salvēte}: Latin changes the \textbf{ending} to mark one listener (\emph{-e}) versus many (\emph{-ēte}). This is the feature that defines Latin — meaning carried in endings, not in word order or extra words. English lost almost all of it; its Romance grandchildren kept some. You will meet it in every chapter.
 \end{grammarlens}
 
-\section{\textit{av\=e} / \textit{av\=ete} --- ``hail'' (a formal greeting)}
-\label{lesson:ave}
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item greet one friend — \emph{salvē} (SAL-weh)
+  \item greet a whole room — \emph{salvēte}
+  \item two English words from \emph{salvus} (save, safe, salute, salvation…)
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \emph{salvē} literally wish, and how do you greet more than one person? (\textquotedblleft{}Be well / be in good health\textquotedblright{}; \emph{salvēte}, with the plural \emph{-ēte} ending.)
+\end{tcolorbox}
+\section[avē / avēte]{avē / avēte — \textquotedblleft{}hail\textquotedblright{} (a formal greeting)}
+
+\label{lesson:LA-C01-ave}
+
+
+
+\begin{quote}
+The ceremonious greeting — the one you still hear in \emph{Ave Maria}.
+\end{quote}
 
 \begin{sounds}
-\textit{Av\=e} $=$ \emph{AH-weh} (again the \emph{w}-sound for \textit{v}). Two
-syllables, the second long.
+\emph{Avē} = \textbf{AH-weh} (again the \emph{w}-sound for \emph{v}). Two syllables, the second long.
 \end{sounds}
 
 \begin{cousinweb}
-\textit{Av\=e} is the more ceremonious greeting --- ``hail'' --- from
-\textit{av\=ere} ``to fare well, to be eager.'' It survives in English essentially
-unchanged inside the prayer \textbf{``Ave Maria''} (``Hail, Mary''), and stands
-in the famous salute \emph{av\=e atque val\=e} --- ``hail and farewell'' ---
-Catullus's words at his brother's grave, pairing the greeting you say on arrival
-with the one you say on leaving (next lesson).
+\emph{Avē} is the more formal greeting — \textquotedblleft{}hail\textquotedblright{} — from \emph{avēre} \textquotedblleft{}to fare well, to be eager.\textquotedblright{} It survives in English essentially unchanged inside the prayer \textbf{\textquotedblleft{}Ave Maria\textquotedblright{}} (\textquotedblleft{}Hail, Mary\textquotedblright{}), and stands in Catullus's famous \emph{avē atque valē} — \textquotedblleft{}hail and farewell\textquotedblright{} — spoken at his brother's grave, pairing the word you say on arrival with the one you say on leaving (next lesson).
 \end{cousinweb}
 
 \begin{culture}
-\emph{Av\=e} carried a whiff of rank and ritual --- addressed to emperors and
-gods (\emph{av\=e, Caesar}). For an everyday ``hi,'' Romans reached for
-\textit{salv\=e}; \emph{av\=e} was the bow, not the wave.
+\emph{Avē} carried rank and ritual — addressed to emperors and gods (\emph{avē, Caesar}). For an everyday \textquotedblleft{}hi,\textquotedblright{} Romans reached for \emph{salvē}; \emph{avē} was the bow, not the wave.
 \end{culture}
 
-\section{\textit{val\=e} / \textit{val\=ete} --- ``goodbye'' (be strong)}
-\label{lesson:vale}
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item read it — AH-weh
+  \item where English still uses it (\emph{Ave Maria}, \textquotedblleft{}Hail Mary\textquotedblright{})
+  \item which is more formal, \emph{avē} or \emph{salvē}? (\emph{avē})
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What register does \emph{avē} carry, and in what famous phrase does English keep it? (Formal / ceremonial, for emperors and gods; \emph{Ave Maria}.)
+\end{tcolorbox}
+\section[valē / valēte]{valē / valēte — \textquotedblleft{}goodbye\textquotedblright{} (be strong)}
+
+\label{lesson:LA-C01-vale}
+
+
+
+\begin{quote}
+Latin's goodbye wishes you \emph{strength} — and hides inside \emph{value}, \emph{valid}, and \emph{prevail}.
+\end{quote}
 
 \begin{sounds}
-\textit{Val\=e} $=$ \emph{WAH-leh}. As with \textit{salv\=e}, a
-health-and-strength wish frozen into a command.
+\emph{Valē} = \textbf{WAH-leh}. Like \emph{salvē}, a health-and-strength wish frozen into a command.
 \end{sounds}
 
 \begin{cousinweb}
-\textit{Val\=e} (singular) / \textit{val\=ete} (plural) is the imperative of
-\textit{val\=ere}, ``to be strong, to be well'' --- so goodbye in Latin literally
-wishes you \emph{strength}. The root \textit{val\=ere} is another English gold
-mine: \textbf{value}, \textbf{valid}, \textbf{valiant}, \textbf{valour},
-\textbf{valence}, \textbf{prevail}, \textbf{convalesce}, \textbf{ambivalent} (to
-be ``strong both ways''). And the Romance children carry \textit{val\=ere} as
-their verb ``to be worth'' --- Spanish \emph{valer}, Italian \emph{valere},
-French \emph{valoir}.
+\emph{Valē} (singular) / \emph{valēte} (plural) is the imperative of \emph{valēre}, \textquotedblleft{}to be strong, to be well.\textquotedblright{} So goodbye in Latin literally wishes you \textbf{strength}. The root is an English gold mine: \textbf{value, valid, valiant, valour, valence, prevail, convalesce, ambivalent} (\textquotedblleft{}strong both ways\textquotedblright{}). And the Romance children carry \emph{valēre} as their verb \textquotedblleft{}to be worth\textquotedblright{}: Spanish \emph{valer}, Italian \emph{valere}, French \emph{valoir}.
 \end{cousinweb}
 
-\begin{grammarlens}
-Three of these greetings --- \textit{salv\=e}, \textit{av\=e}, \textit{val\=e} ---
-are the same grammatical shape: a bare \textbf{imperative}, a command form of a
-verb about health or strength. Latin doesn't say ``hello''; it \emph{orders} you
-to thrive. Feel how the \emph{-\=e}/\emph{-\=ete} pair recurs: once you know it,
-you can address one friend or a whole room.
+\begin{grammarlens}[title={Grammar Lens}]
+\emph{salvē}, \emph{avē}, \emph{valē} are all the same shape — a bare \textbf{imperative}, a command form of a verb about health or strength. Latin doesn't say \textquotedblleft{}hello/goodbye\textquotedblright{}; it \emph{orders} you to thrive. Feel the \emph{-ē} / \emph{-ēte} pair recur: know it once, and you can address one friend or a whole room in any of the three.
 \end{grammarlens}
 
-\section{\textit{gr\=ati\=as ag\=o} --- ``thank you'' (I give thanks)}
-\label{lesson:gratias}
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item say goodbye to one person — \emph{valē} (WAH-leh)
+  \item to several — \emph{valēte}
+  \item the whole \textquotedblleft{}hail and farewell\textquotedblright{} — \emph{avē atque valē}
+  \item two English words from \emph{valēre} (value, valid, valiant, prevail…)
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \emph{valē} literally wish, and what everyday English noun comes straight from its root? (\textquotedblleft{}Be strong / be well\textquotedblright{}; \emph{value} — from \emph{valēre} \textquotedblleft{}to be worth.\textquotedblright{})
+\end{tcolorbox}
+\section[grātiās (tibi) agō]{grātiās (tibi) agō — \textquotedblleft{}thank you\textquotedblright{} (I give thanks)}
+
+\label{lesson:LA-C01-gratias}
+
+
+
+\begin{quote}
+Say this and you have said \emph{grace}, \emph{gratitude}, \emph{gracias}, and \emph{grazie} all at once.
+\end{quote}
 
 \begin{sounds}
-\textit{Gr\=ati\=as} $=$ \emph{GRAH-tee-\=as}; \textit{ag\=o} $=$ \emph{AH-go}.
-The \textit{c}/\textit{t} before \textit{i} are hard in classical Latin ---
-\emph{GRA-tee}, not ``GRA-shee.''
+\emph{Grātiās} = \textbf{GRAH-tee-ās}; \emph{agō} = \textbf{AH-go}. In classical Latin \emph{c} and \emph{t} before \emph{i} stay hard — \textbf{GRA-tee}, never \textquotedblleft{}GRA-shee.\textquotedblright{}
 \end{sounds}
 
 \begin{cousinweb}
-The full phrase is \textit{gr\=ati\=as tibi ag\=o} --- literally ``\textbf{I give
-thanks to you}'' (\textit{gr\=ati\=as} ``thanks,'' \textit{tibi} ``to you,''
-\textit{ag\=o} ``I do/drive''). The noun \textit{gr\=atia} means ``favour, grace,
-gratitude,'' from \textit{gr\=atus} ``pleasing, thankful.'' Into English:
-\textbf{grace}, \textbf{gratitude}, \textbf{gratis}, \textbf{grateful},
-\textbf{gracious}, \textbf{ingratiate}, \textbf{congratulate}. And straight into
-the Romance ``thank you'' you already learned --- Italian \emph{grazie}, Spanish
-\emph{gracias}, Portuguese \emph{gra\c{c}as} --- all just the plural
-\textit{gr\=ati\=as}, ``thanks,'' worn smooth by time.
+The full phrase is \emph{grātiās tibi agō} — literally \textquotedblleft{}\textbf{I give thanks to you}\textquotedblright{} (\emph{grātiās} \textquotedblleft{}thanks,\textquotedblright{} \emph{tibi} \textquotedblleft{}to you,\textquotedblright{} \emph{agō} \textquotedblleft{}I do/drive\textquotedblright{}). The noun \emph{grātia} means \textquotedblleft{}favour, grace, gratitude,\textquotedblright{} from \emph{grātus} \textquotedblleft{}pleasing, thankful.\textquotedblright{} Into English: \textbf{grace, gratitude, gratis, grateful, gracious, ingratiate, congratulate}. And straight into the Romance \textquotedblleft{}thank you\textquotedblright{} you already learned — Italian \emph{grazie}, Spanish \emph{gracias}, Portuguese \emph{graças} — all just the plural \emph{grātiās}, \textquotedblleft{}thanks,\textquotedblright{} worn smooth.
 \end{cousinweb}
 
-\begin{grammarlens}
-\textit{Ag\=o} means ``I do'': the \emph{-\=o} ending \emph{is} ``I,'' so no
-separate word for the pronoun is needed. This is Latin's other great habit ---
-the verb ending tells you \emph{who} acts. \textit{Ag\=o} itself is another root
-you know: \textbf{agent}, \textbf{act}, \textbf{agenda} (``things to be done''),
-\textbf{agile}, \textbf{navigate}.
+\begin{grammarlens}[title={Grammar Lens}]
+\emph{agō} means \textquotedblleft{}I do\textquotedblright{} — the \emph{-ō} ending \textbf{is} \textquotedblleft{}I,\textquotedblright{} so no separate pronoun is needed. This is Latin's great habit: the verb ending tells you \emph{who} acts. \emph{Agō} itself is a root you know: \textbf{agent, act, agenda} (\textquotedblleft{}things to be done\textquotedblright{}), \textbf{agile, navigate}.
 \end{grammarlens}
 
-\section{\textit{ita} / \textit{n\=on} --- ``yes'' and ``no''}
-\label{lesson:ita-non}
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the phrase — \emph{grātiās tibi agō}
+  \item the Romance descendants of \emph{grātiās} (grazie, gracias, graças)
+  \item what the \emph{-ō} on \emph{agō} already means (the pronoun \textquotedblleft{}I\textquotedblright{})
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+\emph{Grātiās agō} literally says what, and why is there no word for \textquotedblleft{}I\textquotedblright{}? (\textquotedblleft{}I give thanks\textquotedblright{}; the \emph{-ō} verb-ending already carries \textquotedblleft{}I.\textquotedblright{})
+\end{tcolorbox}
+\section[ita / nōn]{ita / nōn — \textquotedblleft{}yes\textquotedblright{} and \textquotedblleft{}no\textquotedblright{}}
+
+\label{lesson:LA-C01-ita-non}
+
+
+
+\begin{quote}
+A surprise: Latin had no plain word for \textquotedblleft{}yes.\textquotedblright{} Here is what Romans said instead.
+\end{quote}
 
 \begin{sounds}
-\textit{Ita} $=$ \emph{IH-tah}; \textit{n\=on} $=$ \emph{n\=one}, with a long
-\=o.
+\emph{Ita} = \textbf{IH-tah}; \emph{nōn} = \textbf{nōne}, with a long ō.
 \end{sounds}
 
 \begin{cousinweb}
-Here is a surprise: \textbf{classical Latin had no plain word for ``yes.''} To
-agree you said \textit{ita} (``thus, so''), \textit{sīc} (``so, in this way''),
-\textit{certē} (``certainly''), or simply \emph{repeated the verb} --- asked
-``are you coming?'' you answered ``I'm coming.'' It was \textit{sīc} that hardened
-into the Romance ``yes'': Spanish and Italian \textbf{\emph{s\'{\i}}}, French
-\emph{si} (the emphatic yes). ``No'' is easier: \textit{n\=on} (``not''), from
-older \textit{ne-oenum} ``not one thing'' --- the ancient negative \textit{ne-}
-that also gives English \textbf{no}, \textbf{not}, \textbf{none}, \textbf{never},
-and which you will meet again as Sanskrit \textit{na}.
+Classical Latin had \textbf{no simple \textquotedblleft{}yes.\textquotedblright{}} To agree you said \emph{ita} (\textquotedblleft{}thus, so\textquotedblright{}), \emph{sīc} (\textquotedblleft{}so, in this way\textquotedblright{}), \emph{certē} (\textquotedblleft{}certainly\textquotedblright{}), or you just \textbf{repeated the verb} — asked \textquotedblleft{}are you coming?\textquotedblright{}, you answered \textquotedblleft{}I'm coming.\textquotedblright{} It was \emph{sīc} that hardened into the Romance \textquotedblleft{}yes\textquotedblright{}: Spanish and Italian \textbf{sí / sì}, French \emph{si} (the emphatic yes). \textquotedblleft{}No\textquotedblright{} is easier: \emph{nōn} (\textquotedblleft{}not\textquotedblright{}), from older \emph{ne-oenum} \textquotedblleft{}not one thing\textquotedblright{} — the ancient negative \textbf{ne-} that also gives English \textbf{no, not, none, never}, and which you will meet again as Sanskrit \emph{na} and Hindi \emph{nahīṇ}.
 \end{cousinweb}
 
-\section{Recap}
-\label{lesson:practice}
+\begin{culture}
+A language that carries so much in its verb endings barely needs a \textquotedblleft{}yes\textquotedblright{} word — the verb \emph{is} the answer. This is a real window into how Latin thinks: agreement lives in the sentence, not in a little particle bolted on.
+\end{culture}
 
-\begin{center}
-\begin{tabular}{@{}lll@{}}
-\toprule
-Latin & & Meaning \\
-\midrule
-\textit{salv\=e} / \textit{salv\=ete} & \emph{be well} & hello \\
-\textit{av\=e} / \textit{av\=ete} & \emph{fare well} & hail (formal) \\
-\textit{val\=e} / \textit{val\=ete} & \emph{be strong} & goodbye \\
-\textit{gr\=ati\=as (tibi) ag\=o} & \emph{I give thanks to you} & thank you \\
-\textit{ita} / \textit{n\=on} & \emph{thus / not} & yes / no \\
-\bottomrule
-\end{tabular}
-\end{center}
+\subsection*{Your turn}
+Say these aloud:
 
-Latin greets you by \emph{commanding your health}: \textit{salv\=e} ``be well,''
-\textit{val\=e} ``be strong.'' Those two roots alone --- \textit{salvus} and
-\textit{val\=ere} --- seeded \emph{save, safe, salute, salvation} and \emph{value,
-valid, valiant, prevail}, and became the Romance words for health and worth. This
-is the whole reason to learn Latin: it is the root Spanish, Italian, French, and
-Portuguese keep pointing back to, and a root of English besides. Next chapter: \textit{quis es?} (``who are you?''),
-\textit{n\=omen mihi est\ldots} (``my name is\ldots''), and the endings that let
-Latin drop pronouns entirely.
+\begin{itemize}
+\raggedright
+  \item three Latin ways to say \textquotedblleft{}yes\textquotedblright{} (\emph{ita}, \emph{sīc}, \emph{certē})
+  \item which one became Spanish/Italian \emph{sí/sì}? (\emph{sīc})
+  \item the English cousins of \emph{nōn} (no, not, none, never)
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How did Romans say \textquotedblleft{}yes,\textquotedblright{} and what Romance word grew out of \emph{sīc}? (With \emph{ita}/\emph{sīc}/\emph{certē} or by repeating the verb; \emph{sí} / \emph{sì}.)
+\end{tcolorbox}
+\section[Practice]{Chapter 1 — Practice and Recall}
+
+\label{lesson:LA-C01-practice}
+
+
+
+\begin{quote}
+No new words. Just the greetings — and the English and Romance words they secretly contain.
+\end{quote}
+
+\subsection*{Your turn: Rapid recall}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item hello, one person — \emph{salvē}
+  \item hail, formally — \emph{avē}
+  \item goodbye, one person — \emph{valē}
+  \item thank you — \emph{grātiās tibi agō}
+  \item \textquotedblleft{}thus\textquotedblright{} (a way to say yes) and \textquotedblleft{}not\textquotedblright{} — \emph{ita} / \emph{nōn}
+\end{itemize}
+
+\begin{cousinweb}
+Each greeting is an etymological hub. Trace them:
+
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item which greeting root gives \emph{save, safe, salute}? (\emph{salvus}, from \emph{salvē})
+  \item which gives \emph{value, valid, prevail}? (\emph{valēre}, from \emph{valē})
+  \item which gives \emph{grace, gratitude, grazie, gracias}? (\emph{grātia}, from \emph{grātiās})
+\end{itemize}
+\end{cousinweb}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+\begin{itemize}
+\raggedright
+  \item \emph{salvus} \textquotedblleft{}safe\textquotedblright{} $\to$ \textbf{save, safe, salvage, salvation, salute}
+  \item \emph{valēre} \textquotedblleft{}be strong\textquotedblright{} $\to$ \textbf{value, valid, valiant, prevail, convalesce}
+  \item \emph{grātia} \textquotedblleft{}grace\textquotedblright{} $\to$ \textbf{grace, gratitude, gratis, congratulate}; Romance \emph{grazie/gracias}
+  \item \emph{nōn} $\leftarrow$ \emph{ne-} $\to$ English \textbf{no, not, none}; cousin of Sanskrit \emph{na}
+\end{itemize}
+\end{tcolorbox}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Catullus wrote \emph{avē atque valē} at his brother's grave. Translate it, and say what each verb literally wishes. (\textquotedblleft{}Hail and farewell\textquotedblright{}; \emph{avē} \textquotedblleft{}fare well\textquotedblright{} on meeting, \emph{valē} \textquotedblleft{}be strong\textquotedblright{} on parting.)
+\end{tcolorbox}

--- a/code/learning/human-languages/persian/book/chapters/ch02-give-your-name.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch02-give-your-name.tex
@@ -1,55 +1,67 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:497f80f61dd5767f
+% canonical-lessons: FA-C02-esm-e-man
+
 \chapter{Give your name}
 \label{ch:persian-name}
 \hlchaptermodality{2}
 
-The first chapter supplied social moves. This one adds a single sentence and a
-single grammar idea: Persian's linking vowel, \emph{ezafe}.
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say my name in Persian in one careful sentence, and I can hear the small linking -e that ties the name to its owner.}
 
-\section{\texorpdfstring{\fa{اسم من ... است}}{esm-e man ... ast}
-  \emph{(esm-e man ... ast)} --- my name is ...}
+One careful sentence with a slot for your own name: esm-e man ... ast, with the spoken ezafe doing the linking.
+\end{chapteropening}
 
-Read the Persian phrase from right to left while keeping its spoken word order:
+\section[esm-e man ... ast]{\fa{اسم} \fa{من} ... \fa{است} — my name is ...}
 
-\begin{center}
-  \Large\fa{اسم من سارا است}
+\label{lesson:FA-C02-esm-e-man}
 
-  \normalsize\emph{esm-e man S\^ar\^a ast} --- My name is Sara.
-\end{center}
 
-\begin{scriptstep}
-The phrase reuses more than it appears to. In \fa{اسم} \emph{esm}, you already
-recognize \fa{ا}, \fa{س}, and \fa{م}. In \fa{من} \emph{man}, both letters came
-from \fa{ممنون}. The final word \fa{است} \emph{ast} begins with familiar
-\fa{ا} and \fa{س}; only \fa{ت} $t$ is new. Short vowels remain mostly implicit.
-\end{scriptstep}
 
-\begin{usage}
-Assemble four pieces:
-\begin{enumerate}
-  \item \fa{اسم} \emph{esm} --- name;
-  \item a spoken \emph{-e} --- the linker called \textbf{ezafe};
-  \item \fa{من} \emph{man} --- I/me, interpreted here as the owner;
-  \item your name, followed by \fa{است} \emph{ast} --- is.
-\end{enumerate}
-Only one reusable pattern is due: \textbf{noun + -e + owner}. Do not expand it
-into a table of possessive grammar yet.
-\end{usage}
+\begin{quote}
+Greet once, then answer yes and no. The next line gives you one careful sentence for your own name.
+\end{quote}
 
-\begin{rootweb}
-The sentence displays two historical layers side by side. \emph{Esm} is an
-Arabic loan related to Arabic \emph{ism}. \emph{Man} and \emph{ast} belong to
-Persian's inherited Iranian core. Borrowed nouns and inherited grammar now work
-together as one Persian sentence.
-\end{rootweb}
+\subsection*{The exchange}
+Read the phrase from right to left, but say its words in this order:
 
-\begin{checkpoint}
-What links \emph{esm} to \emph{man}? Say the normally unwritten \emph{-e}.
-Then replace Sara with your own name and produce the full careful sentence once.
-\end{checkpoint}
+\begin{quote}
+\textbf{\fa{اسمِ} \fa{من} ... \fa{است}} — \emph{esm-e man ... ast}
+\end{quote}
 
-\section*{What is deliberately deferred}
+\begin{itemize}
+\raggedright
+  \item \textbf{\fa{اسم}} \emph{esm} = name. You already recognize \textbf{\fa{ا}}, \textbf{\fa{س}}, and \textbf{\fa{م}}.
+  \item The small spoken \textbf{-e} after \emph{esm} links “name” to its owner. This linker is called \textbf{ezafe}. It is often not written in ordinary text.
+  \item \textbf{\fa{من}} \emph{man} = I / me; after the linker it means “my.”
+  \item \textbf{\fa{است}} \emph{ast} = is.
+\end{itemize}
 
-Everyday speech often shortens the final copula, and Persian has familiar and
-polite ways to ask another person's name. Those are later lessons. Keeping the
-full \fa{است} visible here lets a new reader account for every part before
-conversational reductions begin.
+\begin{cousinweb}
+\textbf{esm} is an Arabic loan related to Arabic \emph{ism}, while \textbf{man} and \textbf{ast} belong to Persian's inherited Iranian core. One tiny sentence can therefore show two major layers of Persian vocabulary.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: one spoken link}]
+Only one grammar idea is new: \textbf{noun + -e + owner}. The spoken \textbf{-e} links “name” to its owner, so \emph{esm-e man} is literally “name-of me.” Do not turn that one pattern into a full grammar table yet.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Replace the dots with your name:
+
+\begin{quote}
+\textbf{\fa{اسم} \fa{من} \fa{سارا} \fa{است}.} — \emph{esm-e man Sârâ ast.} — My name is Sara.
+\end{quote}
+
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{esm-e man Sârâ ast}
+  \item replace \textbf{Sârâ} with your own name
+\end{itemize}
+
+In everyday speech, the ending is often shortened. Keep the careful full form for now; it makes every part visible.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What links \emph{esm} to \emph{man}? The spoken \textbf{-e}, or ezafe. Say “My name is …” once with your own name.
+\end{tcolorbox}

--- a/code/learning/human-languages/urdu/book/chapters/ch02-give-your-name.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch02-give-your-name.tex
@@ -1,57 +1,57 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:cfca1c3146b05ede
+% canonical-lessons: UR-C02-mera-naam
+
 \chapter{Give your name}
 \label{ch:urdu-name}
 \hlchaptermodality{2}
 
-The first chapter supplied social moves. This one adds one sentence and one
-word-order fact: Urdu places the present copula at the end.
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say my name in Urdu in one sentence, keeping hai at the end where Urdu puts it.}
 
-\section{\texorpdfstring{\ur{میرا نام ... ہے}}{mera nam ... hai} --- my name is ...}
+One sentence with a slot for your own name: merā nām ... hai, with the copula held to the end of the line.
+\end{chapteropening}
 
-Read the Urdu phrase from right to left while keeping its spoken word order:
+\section[merā nām ... hai]{\ur{میرا} \ur{نام} ... \ur{ہے} — my name is ...}
 
-\begin{center}
-  \Large\ur{میرا نام سارا ہے۔}
+\label{lesson:UR-C02-mera-naam}
 
-  \normalsize\emph{mer\={a} n\={a}m S\={a}r\={a} hai} --- My name is Sara.
-\end{center}
 
-\begin{scriptstep}
-Nearly every shape is recycled. \ur{میرا} begins with \ur{م} from
-\ur{سلام}, then reuses \ur{ی}, \ur{ر}, and \ur{ا}. \ur{نام} reuses
-\ur{ن}, \ur{ا}, and \ur{م}. In final \ur{ہے}, the only new form is
-\ur{ے}, called \emph{ba\d{r}\={i} ye}; here the whole word is pronounced
-\emph{hai}. Learn that diphthong with the word.
-\end{scriptstep}
 
-\begin{usage}
-Assemble four slots:
-\begin{enumerate}
-  \item \ur{میرا} \emph{mer\={a}} --- my;
-  \item \ur{نام} \emph{n\={a}m} --- name;
-  \item your name;
-  \item \ur{ہے} \emph{hai} --- is.
-\end{enumerate}
-The reusable pattern is \textbf{my + name + NAME + is}. Urdu places
-\emph{hai} at the end. Replace Sara with your name and keep every other slot.
-\end{usage}
+\begin{quote}
+Greet once, then answer yes and no. The next line gives you one reliable Urdu sentence for your own name.
+\end{quote}
 
-\begin{rootweb}
-\emph{N\={a}m} continues an old Indo-Aryan form related to Sanskrit
-\emph{n\={a}man} and, much farther back, English \emph{name}. The possessive
-\emph{mer\={a}} and copula \emph{hai} also belong to Urdu's inherited grammar.
-The sentence therefore follows the Indo-Aryan layer that Urdu shares closely
-with Hindi, even though Urdu writes it in the Perso-Arabic script.
-\end{rootweb}
+\subsection*{The exchange}
+Read the line right to left, but keep its spoken order:
 
-\begin{checkpoint}
-Where does ``is'' go? At the end. Point to \ur{ہے}, then replace Sara with your
-own name and say the full four-slot sentence once.
-\end{checkpoint}
+\begin{quote}
+\textbf{\ur{میرا} | \ur{نام} | ... | \ur{ہے}} — \emph{merā nām ... hai}
+\end{quote}
 
-\section*{What is deliberately deferred}
+\begin{itemize}
+\raggedright
+  \item \textbf{\ur{میرا}} \emph{merā} = my
+  \item \textbf{\ur{نام}} \emph{nām} = name
+  \item your name goes in the open slot
+  \item \textbf{\ur{ہے}} \emph{hai} = is
+\end{itemize}
 
-Urdu possessives agree with the noun they describe; \emph{mer\={a}} has this
-form because \emph{n\={a}m} is grammatically masculine, not because of the
-speaker's gender. That rule, other possessive forms, and the rest of the copula
-paradigm belong to later lessons. The fixed introduction works for every
-speaker now.
+The word \textbf{nām} is an old Indo-Aryan relative of Sanskrit \emph{nāman} and distant English \emph{name}. \textbf{merā} and \textbf{hai} show Urdu's inherited grammatical core, shared closely with Hindi even though the two languages use different scripts.
+
+Nearly every shape here is one you have already met. \textbf{\ur{میرا}} opens with \textbf{\ur{م}}, the letter that begins \emph{salām}, then reuses \textbf{\ur{ی}}, \textbf{\ur{ر}} and \textbf{\ur{ا}}. \textbf{\ur{نام}} is \textbf{\ur{ن}} plus that same \textbf{\ur{ا}} and \textbf{\ur{م}}. Only the final \textbf{\ur{ے}} in \textbf{\ur{ہے}} is new — it is called \emph{baṛī ye}, the \textquotedblleft{}big ye\textquotedblright{}, and here the whole word is said \emph{hai}. Learn that vowel with this word and you will meet it again everywhere.
+
+\begin{grammarlens}[title={Grammar Lens: the verb waits}]
+Urdu puts \textbf{hai} at the end. That is the only sentence-pattern fact to learn now: \textbf{my + name + NAME + is}. Keep this one frame; broader word-order and agreement rules can wait.
+\end{grammarlens}
+
+\subsection*{Your turn}
+\begin{quote}
+\textbf{\ur{میرا} \ur{نام} \ur{سارا} \ur{ہے۔}} — \emph{merā nām Sārā hai.} — My name is Sara.
+\end{quote}
+
+Replace \textbf{Sārā} with your own name. Do not add agreement rules yet; this exact frame is enough for the introduction.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Where does “is” go in this Urdu sentence? At the end. Say the four slots, then say the full sentence with your name.
+\end{tcolorbox}

--- a/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C02-mera-naam.md
@@ -53,6 +53,12 @@ The word **nām** is an old Indo-Aryan relative of Sanskrit *nāman* and distant
 English *name*. **merā** and **hai** show Urdu's inherited grammatical core,
 shared closely with Hindi even though the two languages use different scripts.
 
+Nearly every shape here is one you have already met. **میرا** opens with **م**,
+the letter that begins *salām*, then reuses **ی**, **ر** and **ا**. **نام** is
+**ن** plus that same **ا** and **م**. Only the final **ے** in **ہے** is new — it
+is called *baṛī ye*, the "big ye", and here the whole word is said *hai*. Learn
+that vowel with this word and you will meet it again everywhere.
+
 ## Grammar Lens: the verb waits
 <!-- hl-knowledge: introduces=[UR-GRAMMAR-COPULA-FINAL]; assesses=[] -->
 

--- a/code/learning/human-languages/urdu/narration/ch02.json
+++ b/code/learning/human-languages/urdu/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Give your name",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:d3efc74a56512410",
+  "sourceHash": "fnv1a64:d7e6c7d21186e200",
   "lessons": [
     {
       "id": "UR-C02-mera-naam",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c9b79da0c62dcb0a",
+      "sourceHash": "fnv1a64:f7dd6fcae0bd7124",
       "notice": null,
       "blocks": [
         {
@@ -71,6 +71,10 @@
             {
               "kind": "speech",
               "text": "The word nām is an old Indo-Aryan relative of Sanskrit nāman and distant English name. merā and hai show Urdu's inherited grammatical core, shared closely with Hindi even though the two languages use different scripts."
+            },
+            {
+              "kind": "speech",
+              "text": "Nearly every shape here is one you have already met. میرا opens with م, the letter that begins salām, then reuses ی, ر and ا. نام is ن plus that same ا and م. Only the final ے in ہے is new — it is called baṛī ye, the \"big ye\", and here the whole word is said hai. Learn that vowel with this word and you will meet it again everywhere."
             }
           ]
         },

--- a/code/learning/human-languages/urdu/narration/ch02.txt
+++ b/code/learning/human-languages/urdu/narration/ch02.txt
@@ -17,6 +17,7 @@ Read the line right to left, but keep its spoken order:
 your name goes in the open slot.
 ہے hai = is.
 The word nām is an old Indo-Aryan relative of Sanskrit nāman and distant English name. merā and hai show Urdu's inherited grammatical core, shared closely with Hindi even though the two languages use different scripts.
+Nearly every shape here is one you have already met. میرا opens with م, the letter that begins salām, then reuses ی, ر and ا. نام is ن plus that same ا and م. Only the final ے in ہے is new — it is called baṛī ye, the "big ye", and here the whole word is said hai. Learn that vowel with this word and you will meet it again everywhere.
 
 Grammar Lens: the verb waits.
 Urdu puts hai at the end. That is the only sentence-pattern fact to learn now: my + name + NAME + is. Keep this one frame; broader word-order and agreement rules can wait.


### PR DESCRIPTION
Closes the only part of #12049 that isn't blocked by #12072.

## The problem

**93 book chapters across 19 tracks are hand-written `.tex` files that shadow canonical lessons which already exist.** Nothing generates them, so nothing measures them — the five-minute limit is enforced on *lessons*, but a hand-written chapter is one undivided unit, and **57 of the 93 run over five minutes** as a single read. `check:books` passes *precisely because* the generator never sees these files, so the gate is structurally incapable of catching the drift.

## What this PR does

Converts the three that are convertible today, because every lesson behind them is already `schema_version: 2`:

| Chapter | Printed words before | After |
|---|---|---|
| `latin/ch01-greetings` | 1094 | **1501** |
| `persian/ch02-give-your-name` | 306 | **347** |
| `urdu/ch02-give-your-name` | 342 | **363** |

The other 90 are blocked: `renderBookChapter` rejects any lesson that isn't v2, and **510 of the 538 lessons behind those chapters — 94% — are still v1**. Filed as #12072 with per-track counts; every per-track issue now carries its own blocker status.

## Two things learned that the issues have been corrected with

**The conversion is a *move*, not an add.** `core/book-generation.json` has both a `targets` list and a `handwritten` list, and a chapter registered in both fails with `duplicate chapter`. The entry moves between them; the output path is unchanged, so the generator overwrites the hand-written file in place and nothing needs deleting.

**Urdu initially lost 59 words.** Its hand-written `.tex` carried a script step the lesson didn't have — which letters of میرا نام ہے are recycled from سلام, and that the final ے is *baṛī ye*. That's real script pedagogy, so it was folded into `UR-C02-mera-naam` before converting rather than dropped. This is the procedure the issues prescribe: where the `.tex` has prose the lessons lack, move it into a lesson **first**. Only one chapter in all 93 has more than 200 such words — `french/ch16-etre` at +397, flagged in #12050.

## Related finding

Hand-written chapters also push script macros into the TOC with no short form — `\section{\ta{வணக்கம்} ...}` where generated chapters emit `\section[short]{long}`. **252 such titles across 13 tracks**, including the three whose broken TOCs were reported. Detail and a testable prediction in #12069; converting a chapter fixes it for free.

## Verification

No pins moved — the lessons didn't change except for the Urdu addition, only which file the book prints from. human-language-data 45/45 files and 804 tests, script-ductus 3/3 and 1231, language-ladder 34/34 and 727, five gates, plus language-ladder's build and bundle check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)