### PR TITLE
fix(hl-c249): print chapters before the back matter, not after it

### DIFF
--- a/code/learning/human-languages/hindi/book/book.tex
+++ b/code/learning/human-languages/hindi/book/book.tex
@@ -156,14 +156,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch39-people-around-you}
 \input{chapters/ch40-pointing-and-asking}
 \input{chapters/ch41-describing-things}
-
-\backmatter
-
-\input{chapters/appendix-pronunciation}
-\input{chapters/appendix-glossary}
-\input{chapters/appendix-answer-key}
-
-\input{chapters/appendix-index}
 \input{chapters/ch42-more-verbs}
 \input{chapters/ch43-see-say}
 \input{chapters/ch44-sons-daughters}
@@ -182,5 +174,13 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch57-a-gift-and-a-feast}
 \input{chapters/ch58-inside-the-house}
 \input{chapters/ch59-script-second-wave}
+
+\backmatter
+
+\input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
+
+\input{chapters/appendix-index}
 
 \end{document}

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -127,14 +127,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch40-a-meal}
 \input{chapters/ch41-pointing-and-asking}
 \input{chapters/ch42-describing-things}
-
-\backmatter
-
-\input{chapters/appendix-pronunciation}
-\input{chapters/appendix-glossary}
-\input{chapters/appendix-answer-key}
-
-\input{chapters/appendix-index}
 \input{chapters/ch43-more-verbs}
 \input{chapters/ch44-see-say}
 \input{chapters/ch45-older-generation}
@@ -152,5 +144,13 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch57-more-of-the-body}
 \input{chapters/ch58-more-short-replies}
 \input{chapters/ch59-weather-and-ground}
+
+\backmatter
+
+\input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
+
+\input{chapters/appendix-index}
 
 \end{document}

--- a/code/learning/human-languages/malayalam/book/book.tex
+++ b/code/learning/human-languages/malayalam/book/book.tex
@@ -163,14 +163,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch40-the-meal}
 \input{chapters/ch41-pointing-and-asking}
 \input{chapters/ch42-describing-things}
-
-\backmatter
-
-\input{chapters/appendix-pronunciation}
-\input{chapters/appendix-glossary}
-\input{chapters/appendix-answer-key}
-
-\input{chapters/appendix-index}
 \input{chapters/ch43-more-verbs}
 \input{chapters/ch44-see-say}
 \input{chapters/ch45-grandparents}
@@ -188,5 +180,13 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch57-five-more-of-the-body}
 \input{chapters/ch58-five-more-short-answers}
 \input{chapters/ch59-what-the-air-carries}
+
+\backmatter
+
+\input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
+
+\input{chapters/appendix-index}
 
 \end{document}

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -116,6 +116,30 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch18-asking}
 \input{chapters/ch19-numbers}
 \input{chapters/ch20-people}
+\input{chapters/ch21-more-verbs}
+\input{chapters/ch22-more-verbs}
+\input{chapters/ch23-kinship}
+\input{chapters/ch24-things-you-ask-for}
+\input{chapters/ch25-hand-and-foot}
+\input{chapters/ch26-roles}
+\input{chapters/ch27-replies}
+\input{chapters/ch28-taking-leave}
+\input{chapters/ch29-courtesy}
+\input{chapters/ch30-welcoming-a-guest}
+\input{chapters/ch31-the-sky}
+\input{chapters/ch32-the-tree}
+\input{chapters/ch33-river-and-road}
+\input{chapters/ch34-more-of-the-body}
+\input{chapters/ch35-in-the-house}
+\input{chapters/ch36-more-short-replies}
+\input{chapters/ch37-more-courtesy}
+\input{chapters/ch38-fire-and-stone}
+\input{chapters/ch39-animals}
+\input{chapters/ch40-in-the-kitchen}
+\input{chapters/ch41-things-people-make}
+\input{chapters/ch42-more-replies}
+\input{chapters/ch43-good-manners}
+\input{chapters/ch44-colours}
 
 \backmatter
 
@@ -124,32 +148,5 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/appendix-answer-key}
 
 \input{chapters/appendix-index}
-\input{chapters/ch21-more-verbs}
-\input{chapters/ch22-more-verbs}
-\input{chapters/ch23-kinship}
-
-\input{chapters/ch24-things-you-ask-for}
-\input{chapters/ch25-hand-and-foot}
-\input{chapters/ch26-roles}
-\input{chapters/ch27-replies}
-\input{chapters/ch28-taking-leave}
-\input{chapters/ch29-courtesy}
-\input{chapters/ch30-welcoming-a-guest}
-
-\input{chapters/ch31-the-sky}
-\input{chapters/ch32-the-tree}
-\input{chapters/ch33-river-and-road}
-\input{chapters/ch34-more-of-the-body}
-\input{chapters/ch35-in-the-house}
-\input{chapters/ch36-more-short-replies}
-\input{chapters/ch37-more-courtesy}
-
-\input{chapters/ch38-fire-and-stone}
-\input{chapters/ch39-animals}
-\input{chapters/ch40-in-the-kitchen}
-\input{chapters/ch41-things-people-make}
-\input{chapters/ch42-more-replies}
-\input{chapters/ch43-good-manners}
-\input{chapters/ch44-colours}
 
 \end{document}

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -131,14 +131,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch39-asking-for-what-you-want}
 \input{chapters/ch40-pointing-and-asking}
 \input{chapters/ch41-describing-things}
-
-\backmatter
-
-\input{chapters/appendix-pronunciation}
-\input{chapters/appendix-glossary}
-\input{chapters/appendix-answer-key}
-
-\input{chapters/appendix-index}
 \input{chapters/ch42-more-verbs}
 \input{chapters/ch43-household}
 \input{chapters/ch44-things-you-ask-for}
@@ -155,5 +147,13 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch55-the-rest-of-you}
 \input{chapters/ch56-how-much}
 \input{chapters/ch57-wind-and-fire}
+
+\backmatter
+
+\input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
+
+\input{chapters/appendix-index}
 
 \end{document}

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -128,14 +128,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch40-a-meal}
 \input{chapters/ch41-pointing-and-asking}
 \input{chapters/ch42-describing-things}
-
-\backmatter
-
-\input{chapters/appendix-pronunciation}
-\input{chapters/appendix-glossary}
-\input{chapters/appendix-answer-key}
-
-\input{chapters/appendix-index}
 \input{chapters/ch43-more-verbs}
 \input{chapters/ch44-see-say}
 \input{chapters/ch45-grandparents}
@@ -160,5 +152,13 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch64-joining-words}
 \input{chapters/ch65-more-good-manners}
 \input{chapters/ch66-the-field}
+
+\backmatter
+
+\input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
+
+\input{chapters/appendix-index}
 
 \end{document}

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -777,6 +777,46 @@ describe("the manifest covers the corpus", () => {
   });
 });
 
+describe("chapter order against the back matter", () => {
+  const root = defaultCurriculumRoot();
+
+  // Six books printed chapters AFTER \backmatter and after all four appendices:
+  // hindi 18, sanskrit 24, telugu 24, kannada 17, malayalam 17, tamil 16 -- 116
+  // chapters in all. Every one of them began at a "more-verbs" chapter, so a single
+  // tranche appended past the back matter and every later tranche inherited the
+  // mistake by appending after it in turn.
+  //
+  // The reader saw the pronunciation guide, glossary, answer key and index wedged
+  // between two chapters, and `book`'s \backmatter also strips chapter numbering,
+  // so those 116 chapters printed unnumbered. Nothing caught it: book.tex is
+  // hand-maintained, and every gate here reads the CHAPTER FILES rather than the
+  // order the entrypoint inputs them in.
+  it("inputs every chapter before the back matter, in ascending order", () => {
+    const registry = JSON.parse(
+      readFileSync(join(root, "core", "languages.json"), "utf8"),
+    ) as { languages: Array<{ id: string }> };
+    expect(registry.languages.length).toBeGreaterThan(0);
+    for (const { id } of registry.languages) {
+      const lines = readFileSync(join(root, id, "book", "book.tex"), "utf8").split("\n");
+      const backmatter = lines.findIndex((line) => line.trim() === "\\backmatter");
+      if (backmatter < 0) continue;
+      const isChapter = (line: string) => line.startsWith("\\input{chapters/ch");
+      const stranded = lines.slice(backmatter).filter(isChapter);
+      expect(stranded, `${id}: chapters input after \\backmatter`).toEqual([]);
+
+      // Ascending, and parsed as a full integer -- reading only two digits makes
+      // ch100 sort as ch10 and reports a false failure on the long tracks.
+      const numbers = lines
+        .slice(0, backmatter)
+        .filter(isChapter)
+        .map((line) => Number(/\/ch(\d+)/.exec(line)?.[1]));
+      expect(numbers, `${id}: chapter inputs out of order`).toEqual(
+        [...numbers].sort((left, right) => left - right),
+      );
+    }
+  });
+});
+
 describe("chapter label validation", () => {
   // `label` is interpolated RAW into \label{...} by the generator -- the only
   // author-controlled field in chapters.json that had no guard. A security review


### PR DESCRIPTION
Fixes the user-reported symptom that **the appendices appear wedged between chapter titles**. Very likely the whole of #12069.

## What was wrong

Six books input chapters *after* `\backmatter` and after all four appendices, so the pronunciation guide, glossary, answer key and index printed in the middle of the chapter sequence:

| Track | Stranded | Range |
|---|---|---|
| sanskrit | 24 | `ch21-more-verbs` .. `ch44-colours` |
| telugu | 24 | `ch43-more-verbs` .. `ch66-the-field` |
| hindi | 18 | `ch42-more-verbs` .. `ch59-script-second-wave` |
| kannada | 17 | `ch43-more-verbs` .. `ch59-weather-and-ground` |
| malayalam | 17 | `ch43-more-verbs` .. `ch59-what-the-air-carries` |
| tamil | 16 | `ch42-more-verbs` .. `ch57-wind-and-fire` |

**116 chapters in all.** Every one of the six begins at a "more-verbs" chapter, which says how it happened: one tranche appended its `\input` lines to the end of `book.tex` instead of inserting them before `\backmatter`, and every later tranche appended after *that* and inherited the mistake.

**The damage is worse than ordering.** In the `book` class, `\backmatter` also stops chapter numbering — so those 116 chapters printed **unnumbered** as well as out of place. That's more than a third of the Tamil book and over a third of Telugu's.

## Why nothing caught it

`book.tex` is hand-maintained, and every existing gate reads the **chapter files** — their hashes, their modality, their labels — rather than the order the entrypoint inputs them in. The one artefact that decides what a reader sees, and in what order, was the one artefact nothing checked.

The new test asserts, for every registered book, that no chapter is input at or after `\backmatter` and that the chapter numbers before it ascend.

**Self-tested against a dirty control:** stranding `tamil` ch57 after `\backmatter` makes it fail with `tamil: chapters input after \backmatter`, and it passes again once restored.

The ascending check parses the chapter number as a full integer deliberately — my first version read two digits, which makes `ch100` sort as `ch10` and reported a false failure against Spanish's 295 chapters. The test comment says so, since the next person will be tempted by the same shortcut.

## Relationship to #12069

All three tracks you reported are in this list, and an appendix appearing mid-list *is* the broken table of contents. The 252 TOC-unsafe `\section` titles noted on that issue are a separate, smaller matter, and are fixed for free by the conversion work in #12049.

## Verification

human-language-data 45/45 files and 805 tests, script-ductus 3/3 and 1231, language-ladder 34/34 and 727, five gates, plus the bundle check. **No pins moved** — no lesson content changed, only the order the books input their chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)