### PR TITLE
fix(mosaic-emit-xaml): lower width/height 100% to a stretch alignment

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — width/height 100% become stretch alignments
+
+`width: 100%` is a *sizing* property in CSS but an *alignment* in XAML: WinUI's
+`Width` is an absolute `Double` with no percentage form, and the way an element
+fills its parent's cross axis is `HorizontalAlignment="Stretch"`.
+
+Value translation alone could not express that, so the property was dropped
+outright and the element fell back to sizing itself to its content.
+
+Deliberately narrow: only `100%` maps this cleanly. Other percentages need
+proportional (star) sizing, which is a `Grid` change of a different magnitude —
+those still drop rather than being approximated.
+
+In the generated TaskApp this turns 0 stretch alignments into 14. Visible
+effect is real but modest — the project rail rows now fill their column instead
+of collapsing to a sliver. It does **not** fix the app hugging the top-left of
+an empty window; that needs the flex→Grid lowering.
+
 ## [Unreleased] — HostButton labels from row expressions
 
 A `HostButton` whose `label` is a row expression emitted **no `Content`

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -1397,6 +1397,24 @@ fn build_style_fragment(props: &[mosstyle_compiler::StyleProp]) -> String {
             Some(k) => k,
             None => continue,
         };
+
+        // `width: 100%` / `height: 100%` express "fill the cross axis", and
+        // XAML says that with an alignment, not a length. Translating the
+        // value alone cannot do this — WinUI's Width/Height are absolute
+        // Doubles — so the percentage was previously dropped entirely and the
+        // element fell back to sizing itself to its content. That is a large
+        // part of why generated apps hug the top-left of an otherwise empty
+        // window instead of filling it.
+        //
+        // Only 100% maps this cleanly. Any other percentage needs
+        // proportional sizing (a Grid with star columns), which is a
+        // different and much larger change — those keep being dropped rather
+        // than guessed at.
+        if let Some(alignment_key) = stretch_alignment_for(&key, &p.value) {
+            upsert_style_attr(&mut parts, alignment_key.to_string(), "Stretch".to_string());
+            continue;
+        }
+
         // X5: translate the *value* into the form the WinUI 3 markup
         // compiler accepts. `translate_xaml_value` may return `None`
         // when the whole property must be dropped (e.g. a percentage
@@ -1465,6 +1483,29 @@ fn edge_thickness(edge: &str, value: &str) -> String {
         "bottom" => format!("0,0,0,{value}"),
         "left" => format!("{value},0,0,0"),
         _ => value.to_string(),
+    }
+}
+
+/// Map a full-width/full-height declaration onto the XAML alignment that
+/// expresses it, or `None` when this is not that case.
+///
+/// `width: 100%` is a *sizing* property in CSS but an *alignment* in XAML:
+/// WinUI's `Width` is an absolute `Double` with no percentage form, and the
+/// way an element fills its parent's cross axis is
+/// `HorizontalAlignment="Stretch"`.
+///
+/// Deliberately narrow. Percentages other than 100% need proportional
+/// sizing — a `Grid` with star columns — which is a much larger change;
+/// those still drop rather than being approximated.
+fn stretch_alignment_for(key: &str, value: &str) -> Option<&'static str> {
+    let v = value.trim();
+    if v != "100%" {
+        return None;
+    }
+    match key {
+        "Width" => Some("HorizontalAlignment"),
+        "Height" => Some("VerticalAlignment"),
+        _ => None,
     }
 }
 
@@ -12631,6 +12672,81 @@ mod tests {
              them to OneTime and whatever they render freezes after the first \
              pass:\n{}",
             offenders.join("\n")
+        );
+    }
+
+    /// `width: 100%` must become an alignment, not vanish.
+    ///
+    /// CSS treats full-width as a sizing property; XAML treats it as an
+    /// alignment, because WinUI's `Width` is an absolute `Double` with no
+    /// percentage form. Translating the value alone therefore could not
+    /// express it, and the property was dropped outright — leaving the
+    /// element to size itself to its content, which is a large part of why
+    /// generated apps hug the top-left of an empty window.
+    #[test]
+    fn full_width_and_height_become_stretch_alignments() {
+        assert_eq!(
+            stretch_alignment_for("Width", "100%"),
+            Some("HorizontalAlignment")
+        );
+        assert_eq!(
+            stretch_alignment_for("Height", "100%"),
+            Some("VerticalAlignment")
+        );
+        // Tolerate incidental whitespace from the stylesheet.
+        assert_eq!(
+            stretch_alignment_for("Width", " 100% "),
+            Some("HorizontalAlignment")
+        );
+
+        // Other percentages need proportional (star) sizing, which is a
+        // different change — they must NOT be silently approximated to
+        // "fill the parent".
+        assert_eq!(stretch_alignment_for("Width", "50%"), None);
+        assert_eq!(stretch_alignment_for("Height", "33%"), None);
+        // Absolute lengths are unaffected.
+        assert_eq!(stretch_alignment_for("Width", "34"), None);
+        // Only the two size setters map this way.
+        assert_eq!(stretch_alignment_for("FontSize", "100%"), None);
+        assert_eq!(stretch_alignment_for("Padding", "100%"), None);
+    }
+
+    /// End-to-end: a part declaring `width: 100%` emits a stretch alignment
+    /// rather than nothing at all.
+    #[test]
+    fn part_with_full_width_emits_stretch_not_nothing() {
+        let c = component("Foo", vec![], vec![]);
+        let l = layout_with_root(
+            "Foo",
+            LayoutNode {
+                tag: "Box".to_string(),
+                part_name: Some("panel".to_string()),
+                props: Vec::new(),
+                children: Vec::new(),
+            },
+        );
+        let s = StyleDef {
+            component_name: "Foo".to_string(),
+            parts: vec![PartStyle {
+                name: "panel".to_string(),
+                base: vec![StyleProp {
+                    name: "width".to_string(),
+                    value: "100%".to_string(),
+                }],
+                transitions: Vec::new(),
+                states: Vec::new(),
+            }],
+        };
+        let r = compile(&c, &l, &s);
+        assert!(
+            r.xaml.contains("HorizontalAlignment=\"Stretch\""),
+            "expected a stretch alignment, got:\n{}",
+            r.xaml
+        );
+        assert!(
+            !r.xaml.contains("Width=\"100%\""),
+            "must not emit a percentage as an absolute Width:\n{}",
+            r.xaml
         );
     }
 


### PR DESCRIPTION
Partial progress on #12021. Part of #12017.

`width: 100%` is a **sizing** property in CSS but an **alignment** in XAML. WinUI's `Width` is an absolute `Double` with no percentage form, and the way an element fills its parent's cross axis is `HorizontalAlignment="Stretch"`.

`translate_xaml_value` can only rewrite a *value*, not change which attribute is emitted — so the percentage was dropped entirely and the element fell back to sizing itself to its content.

## Deliberately narrow

Only `100%` maps cleanly to an alignment. Any other percentage needs proportional star sizing, which is the flex→`Grid` change and much larger. Those keep dropping rather than being approximated — guessing "fill the parent" for `width: 50%` would be worse than emitting nothing.

## A correction to my own earlier claim

I measured before writing this, because I'd overstated the impact in the backlog. task-app actually declares:

| | count |
|---|---|
| `width: 100%` | 4 |
| `flex-grow` | 2 |
| `justify-content` | **0** |
| `align-items` | **0** |

So the dropped-percentage problem is real but **small**, and the "everything clumps in the corner" symptom is *not* mostly explained by it. #12021's framing — mine — implied otherwise. Saying so plainly rather than letting this PR imply it fixes the layout.

## Effect

0 stretch alignments in the generated TaskApp before, **14** after. The project rail rows now fill their column instead of collapsing to a sliver.

The app **still hugs the top-left of an empty window.** That needs the Grid lowering, which #12021 stays open for.

## Verification

First use of the smoke test from #12048 to check a *subsequent* change, which is what it was built for:

```
window is up
summary updated: 1 task(s) · 0 done · projected finish 2026-01-05
task row rendered: CI smoke task
```

215 tests pass across all 7 targets (`--no-fail-fast`, unfiltered). **No golden churn** — itself evidence the change is as narrow as intended. Screenshot compared before and after.

Security review passed. The emitted key and value are both compile-time constants (`stretch_alignment_for` returns `Option<&'static str>`; the value is the literal `"Stretch"`), so no stylesheet bytes reach the attribute. The reviewer also confirmed the branch is strictly non-worsening for the pre-existing unescaped-attribute issue tracked in #12025, and that `HorizontalAlignment`/`VerticalAlignment` have no other producer, so upsert semantics can't clobber an emitter-set value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
