### PR TITLE
fix(mosaic-emit-xaml): refuse CSS length units XAML cannot parse

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — reject CSS units XAML cannot parse
+
+The length path stripped `px` and rejected `%`, but every other CSS unit fell
+straight through into the emitted attribute. The generated TaskApp shipped
+
+    <StackPanel Orientation="Horizontal" MinHeight="100vh">
+
+`vh` is a CSS viewport unit; WinUI lengths are `Double`, so that value is
+unparseable. It was silent at build time.
+
+Two changes:
+
+- `100vh` / `100vw` on a size setter now lower to `VerticalAlignment="Stretch"`
+  / `HorizontalAlignment="Stretch"`. In a desktop app the window is the
+  viewport, so "fill the viewport" and "fill the parent" coincide.
+- Any other unparseable unit (`em`, `rem`, `ch`, `pt`, fractional `vh`) is
+  refused rather than emitted, so an element is sized by its parent instead of
+  carrying an attribute the runtime cannot read.
+
+**This does not fix the app's layout.** Verified by screenshot before and
+after: identical. XAML was evidently already discarding the bad value, so
+removing it changed nothing visible. It is a correctness fix — no invalid
+attribute in generated output — not the fix for the window-filling symptom,
+which remains open.
+
 ## [Unreleased] — width/height 100% become stretch alignments
 
 `width: 100%` is a *sizing* property in CSS but an *alignment* in XAML: WinUI's

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -1499,14 +1499,42 @@ fn edge_thickness(edge: &str, value: &str) -> String {
 /// those still drop rather than being approximated.
 fn stretch_alignment_for(key: &str, value: &str) -> Option<&'static str> {
     let v = value.trim();
-    if v != "100%" {
-        return None;
-    }
-    match key {
-        "Width" => Some("HorizontalAlignment"),
-        "Height" => Some("VerticalAlignment"),
+    match (key, v) {
+        // Percentage of the parent.
+        ("Width", "100%") => Some("HorizontalAlignment"),
+        ("Height", "100%") => Some("VerticalAlignment"),
+
+        // Viewport units. `min-height: 100vh` is how a web shell says "fill
+        // the window", and it was reaching XAML verbatim as
+        // `MinHeight="100vh"` — not a Double, so the shell never got a
+        // height. In a desktop app the window IS the viewport, so filling it
+        // is the same stretch.
+        ("Height" | "MinHeight" | "MaxHeight", "100vh") => Some("VerticalAlignment"),
+        ("Width" | "MinWidth" | "MaxWidth", "100vw") => Some("HorizontalAlignment"),
         _ => None,
     }
+}
+
+/// Reject a length carrying a CSS unit XAML cannot parse.
+///
+/// The length path strips `px` and rejects `%`, but every other CSS unit fell
+/// straight through into the emitted attribute — `MinHeight="100vh"` shipped
+/// this way. WinUI lengths are `Double`, so such a value is not merely wrong,
+/// it is unparseable, and the failure is silent at build time.
+///
+/// Anything ending in an alphabetic suffix that is not `px` is refused here.
+/// Callers drop the property, which is the honest outcome: better an element
+/// sized by its parent than an attribute the runtime cannot read.
+fn has_unsupported_length_unit(value: &str) -> bool {
+    let v = value.trim();
+    let Some(first_alpha) = v.find(|c: char| c.is_ascii_alphabetic()) else {
+        return false;
+    };
+    // A leading-alpha value is a keyword (`Auto`, `Stretch`), not a length.
+    if first_alpha == 0 {
+        return false;
+    }
+    !v[first_alpha..].eq_ignore_ascii_case("px")
 }
 
 /// Translate a mosstyle CSS *value* into the form the WinUI 3 XAML
@@ -1555,6 +1583,13 @@ fn translate_xaml_value(key: &str, raw: &str) -> Option<String> {
         // Doubles. Drop the whole property; the layout container
         // (StackPanel / Grid `*`) sizes the element instead.
         if trimmed.ends_with('%') {
+            return None;
+        }
+        // Any other CSS unit (`vh`, `vw`, `em`, `rem`, `ch`, …) is equally
+        // unparseable as a Double, and previously fell straight through into
+        // the attribute. `MinHeight="100vh"` shipped that way, which is how
+        // the generated shell lost its full-window height.
+        if has_unsupported_length_unit(trimmed) {
             return None;
         }
         return Some(strip_px_units(trimmed));
@@ -12709,6 +12744,60 @@ mod tests {
         // Only the two size setters map this way.
         assert_eq!(stretch_alignment_for("FontSize", "100%"), None);
         assert_eq!(stretch_alignment_for("Padding", "100%"), None);
+    }
+
+    /// `min-height: 100vh` is how a web shell says "fill the window", and it
+    /// was reaching XAML verbatim as `MinHeight="100vh"` — not a Double, so
+    /// the generated shell silently lost its full-window height. This is the
+    /// single declaration the whole TaskApp shell relies on for its height.
+    #[test]
+    fn viewport_units_become_stretch_alignments() {
+        assert_eq!(
+            stretch_alignment_for("MinHeight", "100vh"),
+            Some("VerticalAlignment")
+        );
+        assert_eq!(
+            stretch_alignment_for("Height", "100vh"),
+            Some("VerticalAlignment")
+        );
+        assert_eq!(
+            stretch_alignment_for("MinWidth", "100vw"),
+            Some("HorizontalAlignment")
+        );
+        // A viewport unit that is not the full viewport is proportional
+        // sizing, not a stretch — it must not be approximated.
+        assert_eq!(stretch_alignment_for("MinHeight", "50vh"), None);
+    }
+
+    /// CSS units XAML cannot parse must be refused, not emitted.
+    ///
+    /// WinUI lengths are `Double`. Before this, only `px` and `%` were
+    /// handled and every other unit fell through into the attribute, so the
+    /// failure was silent at build time and only visible as a mis-laid-out
+    /// window.
+    #[test]
+    fn unsupported_length_units_are_refused() {
+        for bad in ["100vh", "50vw", "2em", "1.5rem", "10ch", "3pt"] {
+            assert!(
+                has_unsupported_length_unit(bad),
+                "{bad} should be refused as a XAML length"
+            );
+            assert_eq!(
+                translate_xaml_value("MinHeight", bad),
+                None,
+                "{bad} must not reach the emitted attribute"
+            );
+        }
+        // Plain numbers and px are fine.
+        for ok in ["100", "12.5", "34px", " 8 "] {
+            assert!(
+                !has_unsupported_length_unit(ok),
+                "{ok} should be accepted as a XAML length"
+            );
+        }
+        // Keywords are not lengths and must not be mistaken for one.
+        assert!(!has_unsupported_length_unit("Auto"));
+        assert!(!has_unsupported_length_unit("Stretch"));
     }
 
     /// End-to-end: a part declaring `width: 100%` emits a stretch alignment


### PR DESCRIPTION
Part of #12017. Refines #12021.

The length path stripped `px` and rejected `%`, but **every other CSS unit fell straight through** into the emitted attribute. The generated TaskApp shipped:

```xml
<StackPanel Orientation="Horizontal" MinHeight="100vh">
```

`vh` is a CSS viewport unit; WinUI lengths are `Double`, so that attribute is unparseable. Nothing flagged it — not the markup compiler, not the degradation report, not any test.

## Changes

- `100vh` / `100vw` on a size setter lower to `VerticalAlignment="Stretch"` / `HorizontalAlignment="Stretch"`. In a desktop app the window *is* the viewport, so "fill the viewport" and "fill the parent" coincide.
- Any other unparseable unit (`em`, `rem`, `ch`, `pt`, fractional `vh`) is **refused** rather than emitted. An element sized by its parent beats an attribute the runtime can't read.

## This does not fix the layout

I found this while diagnosing why the generated window doesn't fill, and expected it to be the cause — the shell's only full-height instruction being garbage is a compelling story.

**Screenshots before and after are identical.** XAML was already discarding the value, so removing it changed nothing visible.

So this lands as a correctness fix, and the window-filling symptom stays open. I'd rather say that than let the PR title imply a fix it doesn't deliver.

## What the screenshots did tell me

The remaining problem is **horizontal**, not vertical. The shell's top-level Row places the rail and main content side by side, each sized to content, leaving the right half of the window empty. That *is* the `flex-grow` case — so the Grid lowering is needed after all, but narrowly: only for containers that actually declare `flex-grow`, which is two of them. That's a far smaller change than converting all ~82 `StackPanel` sites, and I've recorded it on #12021.

## Verification

217 tests across all 7 targets (`--no-fail-fast`, unfiltered). Smoke test from #12048 passes. Emitted output: `100vh` occurrences 1 → 0, `VerticalAlignment="Stretch"` 0 → 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
