### PR TITLE
fix(mosaic-emit-xaml): repair double-encoded characters in the generated host

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — fix double-encoded characters in the generated host
+
+Every generated WinUI app displayed a mojibake title bar:
+
+    TaskApp â€” Mosaic â†’ XAML demo
+
+The em dash and arrow were double-encoded **in the emitter's own source
+literal** — UTF-8 bytes reinterpreted as Latin-1 and re-encoded — so the
+corruption shipped to every consumer. The status text carried the same defect
+in its ellipsis (`waiting for dispatchâ€¦`).
+
+Four literals fixed across both `RootShape` variants. Guarded by an assertion
+on the generated `MainWindow.xaml` that it contains real U+2014/U+2192 and no
+U+00E2 — the tell-tale of a Latin-1 round trip.
+
+Verified on the running app: the live window title's non-ASCII code points are
+now exactly `U+2014` and `U+2192`.
+
+Worth noting for anyone re-checking this: `Get-Content` and many terminals
+default to ANSI and will *display* correct UTF-8 as mojibake. Both the earlier
+misdiagnosis and the verification here needed a byte-level or code-point-level
+check, not a visual one.
 ## [Unreleased] — reject CSS units XAML cannot parse
 
 The length path stripped `px` and rejected `%`, but every other CSS unit fell

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -5441,7 +5441,7 @@ fn emit_main_window_xaml(name: &str, options: &EmitOptions, shape: RootShape) ->
                      xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n    \
                      xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n    \
                      xmlns:local=\"using:{ns}\"\n    \
-                     Title=\"{name} â€” Mosaic â†’ XAML demo\">\n    \
+                     Title=\"{name} — Mosaic → XAML demo\">\n    \
                      <Grid>\n        \
                          <Grid.RowDefinitions>\n            \
                              <RowDefinition Height=\"*\"/>\n            \
@@ -5450,7 +5450,7 @@ fn emit_main_window_xaml(name: &str, options: &EmitOptions, shape: RootShape) ->
                          <TextBlock Grid.Row=\"0\" Margin=\"40\" FontSize=\"18\" TextWrapping=\"Wrap\"\n                   \
                                     Text=\"Mosaic-authored {name} dialog. Click the button to open it.\"/>\n        \
                          <TextBlock Grid.Row=\"1\" Margin=\"40,0,40,20\" x:Name=\"StatusText\" Foreground=\"#888\"\n                   \
-                                    Text=\"Status: waiting for dispatchâ€¦\"/>\n        \
+                                    Text=\"Status: waiting for dispatch…\"/>\n        \
                          <Button Grid.Row=\"1\" HorizontalAlignment=\"Right\" Margin=\"0,0,40,20\"\n                \
                                  x:Name=\"OpenButton\" Content=\"Open the dialog\" Click=\"OnOpenButtonClick\"/>\n    \
                      </Grid>\n\
@@ -5466,7 +5466,7 @@ fn emit_main_window_xaml(name: &str, options: &EmitOptions, shape: RootShape) ->
                      xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\"\n    \
                      xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n    \
                      xmlns:gen=\"using:{ns}\"\n    \
-                     Title=\"{name} â€” Mosaic â†’ XAML demo\">\n    \
+                     Title=\"{name} — Mosaic → XAML demo\">\n    \
                      <Grid>\n        \
                          <Grid.RowDefinitions>\n            \
                              <RowDefinition Height=\"*\"/>\n            \
@@ -5474,7 +5474,7 @@ fn emit_main_window_xaml(name: &str, options: &EmitOptions, shape: RootShape) ->
                          </Grid.RowDefinitions>\n        \
                          <gen:{name} Grid.Row=\"0\" x:Name=\"Component\"/>\n        \
                          <TextBlock Grid.Row=\"1\" Margin=\"20\" x:Name=\"StatusText\" Foreground=\"#888\"\n                   \
-                                    Text=\"Status: waiting for dispatchâ€¦\"/>\n    \
+                                    Text=\"Status: waiting for dispatch…\"/>\n    \
                      </Grid>\n\
                  </Window>\n"
             )
@@ -13082,6 +13082,31 @@ mod tests {
         assert!(p.csproj.contains("FlattenNativeRuntimeDlls"));
         assert!(p.csproj.contains("CopyMosaicNativeHostLibraries"));
         assert!(p.csproj.contains("$(MSBuildProjectDirectory)\\*.dll"));
+        // The window title must be correctly encoded UTF-8.
+        //
+        // Every generated WinUI app displayed `TaskApp â€" Mosaic â†' XAML
+        // demo` in its title bar: the em dash and arrow were double-encoded
+        // in the emitter's own source literal, so the mojibake shipped to
+        // every consumer. It survived because nothing asserted on the
+        // title's bytes -- cosmetic, always visible, easy to stop noticing.
+        assert!(
+            p.main_window_xaml.contains('\u{2014}'),
+            "title should carry a real em dash (U+2014), got:\n{}",
+            p.main_window_xaml
+        );
+        assert!(
+            p.main_window_xaml.contains('\u{2192}'),
+            "title should carry a real rightwards arrow (U+2192), got:\n{}",
+            p.main_window_xaml
+        );
+        // `Ã¢` is the giveaway: a UTF-8 em dash reinterpreted as Latin-1 and
+        // re-encoded.
+        assert!(
+            !p.main_window_xaml.contains('\u{00e2}'),
+            "title contains a double-encoded character, got:\n{}",
+            p.main_window_xaml
+        );
+
         // App.xaml.cs references MainWindow.
         assert!(p.app_xaml_cs.contains("new MainWindow()"));
         // MainWindow.xaml.cs has the dispatch stub.


### PR DESCRIPTION
Part of #12017. Closes the mojibake item in #12028.

Every generated WinUI app displayed a mojibake title bar. The em dash and arrow were double-encoded **in the emitter's own source literal** — UTF-8 bytes reinterpreted as Latin-1 and re-encoded — so the corruption shipped to every consumer. The `MainWindow` status text carried the same defect in its ellipsis.

Four literals across both `RootShape` variants.

## The guard is the point

An assertion on the generated `MainWindow.xaml`: it must contain real `U+2014`/`U+2192` and **no `U+00E2`**, the tell-tale of a Latin-1 round trip.

That assertion immediately caught a **second occurrence** (the status-text ellipsis) that I'd missed when fixing only the title — which is exactly the argument for asserting on the property rather than patching the instances I happened to notice.

## Verification

On the running app, the live window title's non-ASCII code points are exactly:

```
U+2014
U+2192
```

215 tests pass across all 7 targets (`--no-fail-fast`, unfiltered).

## A warning for anyone re-checking this

It cost me two false readings. `Get-Content` and many terminals default to ANSI and will **display correct UTF-8 as mojibake**. Mid-verification the emitted file looked wrong when it was already right.

Byte-level (`od -tx1`) or code-point-level inspection is the only reliable check here. A visual one is worthless — which is also plausibly why this shipped in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
