### PR TITLE
fix(hl-c257): the two ReDoS bounds were measuring the scheduler, not the scanner

### DIFF
--- a/code/packages/typescript/human-language-data/tests/glyph-coverage.test.ts
+++ b/code/packages/typescript/human-language-data/tests/glyph-coverage.test.ts
@@ -268,9 +268,21 @@ describe("hostile preamble input", () => {
   it("matches a font family declaration in linear time", () => {
     // Two nullable `\s*` around an optional group split whitespace ambiguously:
     // 2,530ms at 64k spaces.
+    //
+    // THE BOUND IS 2s, NOT 500ms, AND THE GAP IS THE POINT. Measured on this
+    // input, the fixed scanner takes 1ms median and 3ms worst of seven runs --
+    // so 500ms was never measuring the scanner, it was measuring whether the
+    // process got descheduled. It duly failed at 530ms locally and 578ms on a
+    // macOS runner, on changes that touched only lesson markdown.
+    //
+    // 2s still separates the two cases decisively: healthy is ~1ms, the
+    // ambiguous-regex regression is ~2,530ms, and a machine loaded enough to
+    // stretch 1ms past 2s would have stretched 2,530ms far past it too. Do not
+    // tighten this back toward the healthy time -- the headroom is protecting
+    // against scheduler noise, not slack in the scanner.
     const started = Date.now();
     scriptWrappers("\\newfontfamily\\af" + " ".repeat(64_000) + "{A.ttf}");
-    expect(Date.now() - started).toBeLessThan(500);
+    expect(Date.now() - started).toBeLessThan(2_000);
   });
 
   it("is linear on many UNTERMINATED declaration heads", () => {
@@ -278,10 +290,17 @@ describe("hostile preamble input", () => {
     // `[^\]]*` inside `\[...\]` rescanned to end-of-input from every
     // unterminated `[`, so N heads cost O(N^2). Fixing the whitespace split left
     // this standing. Both shapes CodeQL reported are covered.
+    //
+    // 2s for the same reason as the test above, but this one was the tighter of
+    // the two and nobody had noticed: measured, the fixed scanner takes 196ms
+    // and 207ms on these two inputs, so a 500ms bound left barely 2.4x of head-
+    // room. The sibling test flaked first only because process starvation hits
+    // a 1ms call more visibly than a 200ms one; this bound was closer to the
+    // edge all along.
     for (const unit of ["\\newfontfamily\\a[", "\\newfontfamily\\a{{"]) {
       const started = Date.now();
       scriptWrappers(unit.repeat(32_000));
-      expect(Date.now() - started).toBeLessThan(500);
+      expect(Date.now() - started).toBeLessThan(2_000);
     }
   });
 


### PR DESCRIPTION
Two wallclock assertions in `glyph-coverage.test.ts` had 500ms bounds. Both have now cost unrelated work a CI cycle, so I measured them rather than nudging.

| Test | Healthy | Regression it catches | Old bound |
|---|---|---|---|
| `matches a font family declaration in linear time` | **1ms** median, 3ms worst of 7 | 2,530ms | 500ms |
| `is linear on many UNTERMINATED declaration heads` | **196ms** and **207ms** | O(N²) | 500ms |

## What the failures actually were

The first bound sat **500× above** the healthy time, which is why its failures were confusing: at 530ms locally and 578ms on a macOS runner, the scanner wasn't slow — **the process was descheduled for half a second**. The assertion can't tell those apart, and the change it failed on touched only lesson markdown.

The second is the more fragile of the two and nobody had noticed, because it never flaked first: 500ms over a 200ms healthy time is **2.4× of headroom**. Starvation shows up more visibly on a 1ms call than on a 200ms one, so the loud test wasn't the tight one.

## Why 2s

It's what **this same file already uses for its other three timing bounds** — the two 500ms values were the outliers, not the new number. 2s still separates the cases decisively: healthy is 1ms and 200ms, the regressions are ~2,530ms and quadratic, and a machine loaded enough to stretch those healthy times past 2s would have stretched the regressions far past it too.

The comments record the measurements and say not to tighten the bounds back toward the healthy time, since the headroom protects against scheduler noise rather than covering slack in the scanner.

## Not fixed here

The same class of assertion in `code/scripts/tests/test_adj_stdlib_provenance.py:3615` — a 0.5s bound that failed at 0.5596s on Windows. That file's other two wallclock bounds are 8s and 4s, so it has the same outlier shape. Filed as #12083.

## Verification

human-language-data 45/45 files and 805 tests; `check:books`, `check:progress`, `validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)