### PR TITLE
feat(adj-facts-stdlib): add heredity-term.adj (heredity, new source)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_heredityterm_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_heredityterm_e2e.rs
@@ -1,0 +1,135 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/heredity-term.adj`) driven through the built
+//! CLI: a native `table` naming the core NGSS MS-LS3 heredity vocabulary --
+//! gene, allele, dominant, recessive, genotype, phenotype, trait -- each with
+//! its own defining sentence from NHGRI's Talking Glossary of Genomic and
+//! Genetic Terms. 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_hereditytterm_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("biology/heredity-term.adj");
+    std::fs::copy(&src, dir.join("heredity-term.adj")).expect("copy shipped heredity-term.adj");
+}
+
+#[test]
+fn heredity_term_recall_binds_the_definition_directly() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"heredity-term.adj\"\n\
+         ? heredity_term(gene, $D)\n\
+         ? heredity_term(allele, $D)\n\
+         ? heredity_term(dominant, $D)\n\
+         ? heredity_term(recessive, $D)\n\
+         ? heredity_term(genotype, $D)\n\
+         ? heredity_term(phenotype, $D)\n\
+         ? heredity_term(trait, $D)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"D\":\"basic_unit_of_inheritance\""),
+        "gene means the basic unit of inheritance: {out}"
+    );
+    assert!(
+        out.contains(
+            "\"D\":\"one_of_two_or_more_versions_of_dna_sequence_at_a_given_genomic_location\""
+        ),
+        "allele means one of two or more versions of DNA sequence: {out}"
+    );
+    assert!(
+        out.contains(
+            "\"D\":\"one_allele_is_expressed_and_the_effect_of_the_other_allele_is_masked\""
+        ),
+        "dominant means one allele is expressed and the other is masked: {out}"
+    );
+    assert!(
+        out.contains("\"D\":\"both_alleles_must_be_present_to_express_the_trait\""),
+        "recessive means both alleles must be present to express the trait: {out}"
+    );
+    assert!(
+        out.contains(
+            "\"D\":\"a_scoring_of_the_type_of_variant_present_at_a_given_location_in_the_genome\""
+        ),
+        "genotype means a scoring of the type of variant present at a location: {out}"
+    );
+    assert!(
+        out.contains("\"D\":\"an_individuals_observable_traits\""),
+        "phenotype means an individual's observable traits: {out}"
+    );
+    assert!(
+        out.contains("\"D\":\"a_specific_characteristic_of_an_individual\""),
+        "trait means a specific characteristic of an individual: {out}"
+    );
+    assert!(
+        out.contains("genome.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NHGRI/genome.gov citation at authoritative trust: {out}"
+    );
+}
+
+#[test]
+fn heredity_term_reverse_binds_the_term_for_that_definition() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"heredity-term.adj\"\n\
+         ? heredity_term($T, a_specific_characteristic_of_an_individual)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"T\":\"trait\""),
+        "the shipped 'specific characteristic of an individual' definition is the trait term: {out}"
+    );
+}
+
+#[test]
+fn heredity_term_abstains_honestly_on_a_term_outside_the_curated_core() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"heredity-term.adj\"\n\
+         ? heredity_term(chromosome, $D)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "chromosome is a real NHGRI glossary term but outside this table's curated seven-term \
+         core -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/biology/heredity-term.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/heredity-term.adj
@@ -1,0 +1,124 @@
+% ============================================================================
+% heredity-term — the core NGSS MS-LS3 heredity vocabulary (gene, allele,
+% dominant, recessive, genotype, phenotype, trait) and the defining sentence
+% each gets from NHGRI's Talking Glossary of Genomic and Genetic Terms
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% This grounds "heredity" — ADJ-STDLIB-COVERAGE.md §5.1/§5.2's Major Gap that,
+% unlike "experiments" (`science/scientific-method-step.adj`), "models"
+% (`science/scientific-model-type.adj`), and "engineering design"
+% (`engineering/engineering-design-step.adj`), had ONLY ever been checked by
+% the causal-explanation RULE-COMPOSITION technique — asking "does an
+% already-shipped heredity table join another already-shipped table on a
+% literal key?" — never by searching for a genuinely NEW primary source.
+% This item's own notes record that check running dry twice (`biology/
+% dna-base-pairs.adj` and `biology/cell-division-genetic-outcome.adj` each
+% have no honest composable second table anywhere in the stdlib). This cycle
+% tried the OTHER technique instead: a fresh WebFetch for heredity itself.
+%
+% CANDIDATE SOURCES TRIED, in order:
+%   1. The classic K-8 "dominant/recessive HUMAN TRAIT" worksheets (widow's
+%      peak, attached/free earlobes, tongue rolling, dimples, hitchhiker's
+%      thumb) that fill nearly every search result for "dominant recessive
+%      traits middle school". REJECTED even though table-shaped and
+%      widely taught: University of Utah's Genetic Science Learning Center
+%      and a University of Delaware genetics-myths page each independently
+%      confirm no published study supports single-gene dominant/recessive
+%      inheritance for ANY of these classroom staples (tongue rolling can be
+%      learned with age; identical twins do not always share it) — shipping
+%      that table would encode a well-documented genetics-education MYTH as
+%      a fact an ADJ reasoner treats as ground truth, which this stdlib's
+%      honesty discipline forbids regardless of how commonly it is taught.
+%   2. NHGRI's (National Human Genome Research Institute, genome.gov) own
+%      "Talking Glossary of Genomic and Genetic Terms" — WebFetched directly
+%      (curl, `<p class="dm en">` definition block, byte-for-byte, no
+%      paraphrase) for seven individual glossary pages: Gene, Allele,
+%      Dominant, Recessive-Traits-Alleles, genotype, Phenotype, Trait. Every
+%      one resolved (HTTP 200) to a real, citable, primary-government
+%      definition sentence that never asserts a specific human trait's
+%      inheritance pattern at all — these are the ABSTRACT vocabulary a
+%      correct heredity claim is built FROM, not a disputed specific claim.
+%      This is what the table below grounds.
+%
+% A full-tree grep for `\bgene\b`, `\ballele\b`, `\bgenotype\b`,
+% `\bphenotype\b`, `\bdominant\b`, `\brecessive\b` across the whole shipped
+% stdlib (confirming no duplication before scoping, per this item's own
+% playbook) found zero table `row` hits on any of these atoms — only two
+% incidental prose mentions (`biology/genetic-code.adj`'s own header prose
+% "where genotype becomes phenotype", and `biology/blood-groups.query.adj`'s
+% comment about "ABO phenotypes") — neither is a table row, so this is the
+% FIRST genuine heredity-vocabulary content anywhere in this stdlib.
+%
+% Recall is a binding query:
+%
+%     ? heredity_term(gene, $D)
+%       % basic_unit_of_inheritance
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `heredity_term(term, definition)` carrying the citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the
+% definition WITH its source, on the CPU, with zero model calls, and abstains
+% on any term this curated slice does not include (see below). The query
+% also runs BACKWARD — bind a definition and recall which term it defines:
+%
+%     ? heredity_term($T, a_specific_characteristic_of_an_individual)
+%       % trait
+%
+% The seven terms, each with the exact NHGRI sentence(s) the atom below is
+% drawn from (wording never reordered or invented, only trimmed of
+% surrounding sentences that are true but not part of the core definition):
+%
+%     term        definition (atom)                                                    quote (verbatim, NHGRI Talking Glossary of Genomic and Genetic Terms)
+%     ----------  -----------------------------------------------------------------    -----------------------------------------------------------------------------------------------------------------------------------------------------------
+%     gene        basic_unit_of_inheritance                                            "The gene is considered the basic unit of inheritance."
+%     allele      one_of_two_or_more_versions_of_dna_sequence_at_a_given_genomic_location  "An allele is one of two or more versions of DNA sequence (a single base or a segment of bases) at a given genomic location."
+%     dominant    one_allele_is_expressed_and_the_effect_of_the_other_allele_is_masked  "If the alleles of a gene are different, one allele will be expressed; it is the dominant gene. The effect of the other allele, called recessive, is masked."
+%     recessive   both_alleles_must_be_present_to_express_the_trait                     "In the case of a recessive trait, ... both (recessive) alleles must be present to express the trait."
+%     genotype    a_scoring_of_the_type_of_variant_present_at_a_given_location_in_the_genome  "A genotype is a scoring of the type of variant present at a given location (i.e., a locus) in the genome."
+%     phenotype   an_individuals_observable_traits                                      "Phenotype refers to an individual's observable traits, such as height, eye color and blood type."
+%     trait       a_specific_characteristic_of_an_individual                            "A trait, as related to genetics, is a specific characteristic of an individual."
+%
+% This is a curated CORE slice of seven terms directly on the gene -> allele
+% -> dominant/recessive -> genotype -> phenotype/trait chain of ideas, not
+% the entirety of NHGRI's ~256-term glossary. Querying any other glossary
+% term this slice does not include (`chromosome`, `mutation`, `dna`, ...)
+% ABSTAINS honestly rather than inventing a definition — the table never
+% claims to be exhaustive of the glossary, only of this curated core (see
+% the query file).
+%
+% Provenance: quoted verbatim (via direct HTTP fetch, `<p class="dm en">`
+% definition block) from NHGRI's (National Human Genome Research Institute)
+% "Talking Glossary of Genomic and Genetic Terms" at genome.gov — the SAME
+% primary U.S. government genetics reference `biology/dna-base-pairs.adj`
+% and `biology/cell-division-genetic-outcome.adj` already cite, hence
+% `trust authoritative` (matching their tier, not `consensus`). An ADJ
+% `table` carries ONE provenance envelope, so `source`/`locator`/`trust`
+% below hold the strongest single span (the `gene` row's text, which fixes
+% the first row); every OTHER row's own verbatim text is quoted above and
+% additionally carried as its own `cites` entry below, so each term remains
+% independently checkable. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table heredity_term {
+    columns term, definition
+
+    row (gene, basic_unit_of_inheritance)
+    row (allele, one_of_two_or_more_versions_of_dna_sequence_at_a_given_genomic_location)
+    row (dominant, one_allele_is_expressed_and_the_effect_of_the_other_allele_is_masked)
+    row (recessive, both_alleles_must_be_present_to_express_the_trait)
+    row (genotype, a_scoring_of_the_type_of_variant_present_at_a_given_location_in_the_genome)
+    row (phenotype, an_individuals_observable_traits)
+    row (trait, a_specific_characteristic_of_an_individual)
+
+    source "The gene is considered the basic unit of inheritance."
+    locator "https://www.genome.gov/genetics-glossary/Gene"
+    trust authoritative
+
+    cites "An allele is one of two or more versions of DNA sequence (a single base or a segment of bases) at a given genomic location." locator "https://www.genome.gov/genetics-glossary/Allele"
+    cites "If the alleles of a gene are different, one allele will be expressed; it is the dominant gene. The effect of the other allele, called recessive, is masked." locator "https://www.genome.gov/genetics-glossary/Dominant"
+    cites "In the case of a recessive trait, the alleles of the trait-causing gene are the same, and both (recessive) alleles must be present to express the trait." locator "https://www.genome.gov/genetics-glossary/Recessive-Traits-Alleles"
+    cites "A genotype is a scoring of the type of variant present at a given location (i.e., a locus) in the genome." locator "https://www.genome.gov/genetics-glossary/genotype"
+    cites "Phenotype refers to an individual's observable traits, such as height, eye color and blood type." locator "https://www.genome.gov/genetics-glossary/Phenotype"
+    cites "A trait, as related to genetics, is a specific characteristic of an individual." locator "https://www.genome.gov/genetics-glossary/Trait"
+}

--- a/code/specs/data/adj-facts-stdlib/biology/heredity-term.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/heredity-term.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% heredity-term.query.adj — worked recall over the heredity-term library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is a gene?" (direct
+% binding of `gene`'s definition) or "which heredity term means 'a specific
+% characteristic of an individual'?" (reverse binding) — it states no fact of
+% its own, it only `import`s the grounded table and asks binding queries. The
+% final query demonstrates honest abstention: `chromosome` is a real NHGRI
+% glossary term but is NOT part of this table's curated seven-term core
+% (gene/allele/dominant/recessive/genotype/phenotype/trait), so recalling it
+% abstains rather than inventing a definition this slice never fetched.
+% ============================================================================
+
+import "heredity-term.adj"
+
+? heredity_term(gene, $D)         % expect basic_unit_of_inheritance (direct)
+? heredity_term(dominant, $D)     % expect one_allele_is_expressed_and_the_effect_of_the_other_allele_is_masked (direct)
+? heredity_term($T, a_specific_characteristic_of_an_individual)   % expect trait (reverse)
+? heredity_term(chromosome, $D)   % expect abstain -- a real glossary term, but outside this table's curated seven-term core

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 322 | 325 | 321 (99.7%) | 322 (100.0%) | 322 (100.0%) | 0 (0.0%) |
+| facts | 323 | 326 | 322 (99.7%) | 323 (100.0%) | 323 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -27,7 +27,7 @@ provenance bundle whose CAS graph proves all cited source bytes.
 | `facts/anatomy` | 32 | 32 | 32 | 32 | 32 | 0 |
 | `facts/art` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/astronomy` | 18 | 18 | 18 | 18 | 18 | 0 |
-| `facts/biology` | 59 | 59 | 58 | 59 | 59 | 0 |
+| `facts/biology` | 60 | 60 | 59 | 60 | 60 | 0 |
 | `facts/calendar` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `facts/chemistry` | 19 | 19 | 19 | 19 | 19 | 0 |
 | `facts/earth-science` | 11 | 11 | 11 | 11 | 11 | 0 |
@@ -73,7 +73,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (548)
+### Missing pinned source bytes (549)
 
 See the JSON form of this report for the complete machine-readable list.
 

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -2807,6 +2807,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.6to8.heredity_term",
+      "title": "Recall the defining sentence for a core NGSS MS-LS3 heredity term (gene, allele, dominant, recessive, genotype, phenotype, trait)",
+      "band": "6-8",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/biology/heredity-term.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

Grounds the "heredity" K-8-science Major Gap (`code/specs/ADJ-STDLIB-COVERAGE.md` §5.1/§5.2) with a genuinely NEW fresh-WebFetch source, per the `wave2-k8-science-foundations` loop item's path (b): this gap had only ever been checked twice before via causal-composition (asking "does an already-shipped heredity table join another one?"), never by searching for a brand-new primary source.

- New table `code/specs/data/adj-facts-stdlib/biology/heredity-term.adj`: the core NGSS MS-LS3 heredity vocabulary — `gene`, `allele`, `dominant`, `recessive`, `genotype`, `phenotype`, `trait` — each with its own defining sentence quoted verbatim from NHGRI's (National Human Genome Research Institute) Talking Glossary of Genomic and Genetic Terms at genome.gov. Same primary-government source and `trust authoritative` tier already used by `biology/dna-base-pairs.adj` and `biology/cell-division-genetic-outcome.adj`.
- The classic K-8 "dominant/recessive HUMAN TRAIT" worksheets (widow's peak, attached earlobes, tongue rolling, dimples) were tried first and explicitly rejected — University of Utah's Genetic Science Learning Center and a University of Delaware genetics-myths page each independently confirm no published study supports single-gene inheritance for any of these classroom staples, so shipping that table would have encoded a documented genetics-education myth as ground truth. The abstract NHGRI vocabulary avoids that: it defines the terms a correct heredity claim is built from, without asserting any specific trait's inheritance pattern.
- New manifest objective `adj.science.6to8.heredity_term` (recall, NGSS, band 6-8).
- New e2e test `facts_heredityterm_e2e.rs` (3 tests: direct recall across all seven terms, reverse binding, honest abstention on `chromosome` — a real glossary term outside this table's curated seven-term core).
- `COVERAGE.md` regenerated.

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI check against `heredity-term.query.adj` — all 4 queries resolve as expected, including the abstain
- [x] `cargo test -p adj-lang-cli --test facts_heredityterm_e2e` — 3/3 pass
- [x] Full `adj-lang-cli` test suite green
- [x] `python3 code/scripts/adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, `COVERAGE.md` regenerated and committed
- [x] `python3 code/scripts/adj_stdlib_manifest.py --validate-json-schema` — 21 pre-existing formula-provenance/CAS-containment errors, identical to the origin/main baseline; this objective introduces zero new errors
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] Security review (sub-agent) — PASSED, no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)