### PR TITLE
feat(semantic-ir-to-ruby): implement SIR22 APL addendum (Phase A Slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,116 @@
 # Changelog
 
+## 0.26.0 — SIR22 "APL addendum" (Phase A Slice 3)
+
+Part of the SIR22/SIR23 backend-expansion initiative (see
+`code/specs/SIR22-array-matrix-semantic-ir.md`'s "Backend impact"
+section). This backend now implements the nine-node SIR22 "APL addendum"
+that Slice 2 (0.25.0, merged) deferred: `Reduce`/`Scan`/`OuterProduct`/
+`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`. These nine
+share `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` with the base
+cut, so no new feature flags are added — only new node coverage.
+
+**New runtime functions** (`runtime.rs`'s "SIR22 addendum" section):
+`sir_array_reduce`/`sir_array_scan`/`sir_array_outer`/`sir_array_shape`/
+`sir_array_reshape`/`sir_array_index_generator`/`sir_array_index_of`/
+`sir_array_ravel`/`sir_array_catenate`, plus the internal
+`sir_array_flatten_row_major` helper `reshape`/`ravel` both need. All are
+1:1 ports of `semantic-ir-to-javascript`'s own already-proven addendum
+functions (themselves 1:1 ports of `apl_runtime::builtins`/
+`array_runtime::ops`), reusing this crate's existing `sir_array_apply_op`/
+`sir_array_checked_shape_size`/`sir_array_ndarray`/`sir_array_get`/
+`sir_array_nrows`/`sir_array_ncols`/`sir_array_to_array_value` helpers from
+Slice 2 rather than duplicating any of that logic.
+
+**New `emit.rs` arms**: the nine node kinds each lower to a call into their
+`sir_array_*` counterpart. `Reduce`/`Scan`/`OuterProduct` carry an
+`ElementwiseOpKind` and reuse `elementwise_op_ruby_name` exactly like
+`ElementwiseOp` does; the other six have no `op` field and just recurse
+into their operand(s). `Reshape`'s field order (`shape, target`) needs no
+reordering at the call site — `sir_array_reshape(shape_arg, target)` takes
+the same order.
+
+**Non-obvious ported behaviour, called out explicitly because a naive
+reading of this crate's own `Expr::IndexGenerator`/`Expr::IndexOf` doc
+comments (and the SIR22 spec prose) would get it backwards**:
+- `IndexGenerator`/`IndexOf` are **1-based** (`⍳5` = `[1, 2, 3, 4, 5]`;
+  "not found" reports `haystack.length + 1`, never `-1`/`nil`) — a
+  deliberate exception to this domain's otherwise-universal 0-based
+  indexing. `nodes.rs`'s own doc comment on `Expr::IndexGenerator` and the
+  SIR22 spec's prose both describe this as "0-based", but that is stale
+  relative to the actual, tested ground truth: `apl-runtime`'s own
+  `index_generator_produces_one_based_run`/`index_of_finds_and_reports_not_found`
+  tests, and `semantic-ir-to-javascript`'s own shipped `indexGenerator`/
+  `indexOf` (`out[i] = i + 1`, `idx === -1 ? haystack.length + 1 : idx + 1`).
+  This backend matches the shipped, tested behaviour for cross-backend
+  parity rather than the stale doc prose; the doc drift is a pre-existing
+  issue upstream of this crate, out of this slice's scope to fix.
+- `Reduce`/`Scan` on a rank-2 (matrix) `target` fold **each row
+  independently** across its columns — not the whole matrix into one
+  value. Column-major storage means `(row, col)` lives at `col * r + row`,
+  so the row loop must seed from `d[row]` (column 0) and then walk
+  `d[col * r + row]`; swapping `row`/`col` here silently transposes the
+  result instead of raising, which the port replicates the JS reference's
+  own warning about verbatim in a doc comment.
+- `Reshape` fills its target shape in **row-major** order (APL's own
+  convention: last axis varies fastest) but this domain's storage is
+  **column-major** — so the row-major-filled sequence must be
+  **transposed** into column-major storage before the result is
+  constructed. Handing the row-major sequence straight to the
+  `SirNDArray` constructor would silently reshape column-major instead,
+  producing a wrong answer that still looks plausible (right multiset of
+  values, wrong positions). `sir_array_flatten_row_major` (the shared
+  `reshape`/`ravel` helper) has the mirror-image concern: it must walk a
+  column-major matrix "row, then column" via `sir_array_get` to produce
+  true row-major order, never return the raw column-major buffer.
+- `Shape` of a scalar returns the **empty vector** (`shape=[0]`,
+  `data=[]`), never a scalar wrapping `0` — `⍴5` is a length-0 vector, not
+  a rank-0 value. The distinction only shows up structurally (a second
+  `Shape` call on the result behaves differently for the two), not in any
+  single displayed value — see the new test
+  `shape_of_a_scalar_is_the_empty_vector_not_a_scalar` for the executable
+  proof.
+
+**Security**: every function that computes an output size from operand
+data validates it via `sir_array_checked_shape_size` *before* allocating,
+matching the JS reference's DoS-safety discipline exactly — `outer`'s
+`[m, n]` output (two independent operand lengths whose PRODUCT isn't
+bounded by either alone), `index_of`'s `haystack.length * needle.length`
+scan-work product, `catenate`'s combined length (checked ONCE up front,
+regardless of which of the five rank combinations follows — a script that
+repeatedly self-catenates doubles its size every line with no other
+ceiling), `index_generator`'s `n`, and `reshape`'s target size. Reused
+`/security-review` before push; no CRITICAL/HIGH/MEDIUM findings against
+this diff.
+
+**Removed**: the Slice 2 pre-emit rejection check for these nine node
+kinds (`ScanHit::Sir22AddendumNode` in `emit.rs`, its `compile()` match arm
+in `lib.rs`) — now dead once real codegen exists, so the variant and its
+handling are deleted rather than left unreachable. `Scan::expr`'s
+addendum arms now recurse into their sub-expression(s) instead of
+rejecting, matching every other composite-expr arm (`MatMul`/
+`ElementwiseOp`, etc.) — a deferred builtin or injectable name nested
+inside one of these nine nodes is still caught by the shared pre-emit
+scan.
+
+**`tests/sir22_array.rs`**: 12 new execution tests (up from 8), each
+hand-building a `Module`, compiling it, and running the result through a
+real `ruby` interpreter (skips gracefully when absent) — `reduce` on both
+a vector and a matrix (the row-independent-fold/column-major-indexing
+case), `scan` on a vector, `outer` product of two vectors, `shape` of a
+scalar (the empty-vector proof above) and of a matrix, `reshape` (the
+row-major-fill-then-transpose-to-column-major proof above, picked at a
+non-square shape so a transposition bug would produce a wrong-but-
+plausible answer rather than crash), `index_generator` (1-based),
+`index_of` found and not-found, `ravel` of a matrix, and `catenate` of two
+vectors and of two matrices with equal row counts. Since `ArrayLit`
+always builds rank-2 (`1xn`) storage and this domain's addendum functions
+often require a genuine rank-1 vector operand, most tests route a `1xn`
+`ArrayLit` through `Ravel` (or `Shape`, for `Reshape`'s shape argument)
+first to obtain one — exactly as a compiled APL program would.
+
+`semantic-ir-to-ruby` 0.25.0 -> 0.26.0.
+
 ## 0.25.0 — SIR22 array/matrix base cut (second-wave backend rollout, Phase A Slice 2)
 
 Part of the SIR22/SIR23 backend-expansion initiative (opening

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -122,10 +122,13 @@ native Ruby Integer/Float type propagation rather than JS's uniform-double
 storage (`Div`/`Pow` force a Float result; `Add`/`Sub`/`Mul` don't), so an
 all-integer computation prints without a spurious `.0` — see
 `runtime.rs`'s own module doc and the CHANGELOG for the full reasoning.
-The nine-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/etc.)
-shares these same three features with the base cut, so a dedicated
-pre-emit scan (`ScanHit::Sir22AddendumNode`) rejects it cleanly until its
-own later slice lands.
+The nine-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) shares these same
+three features with the base cut and is now implemented too (Phase A Slice
+3), also routing into `sir_array_*`. `IndexGenerator`/`IndexOf` are
+1-based (`⍳n` = `[1, ..., n]`) — a deliberate exception to this domain's
+otherwise-universal 0-based indexing, matching `apl-runtime`'s own ground
+truth.
 Rejects `TailCalls`, `Intrinsics`, and every other not-yet-wired feature
 (array-pattern destructuring; built-in collection methods; plus a
 namespaced class/constant definition or a non-`@@x`-init class/module

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -235,15 +235,6 @@ pub enum ScanHit {
     /// A `Scope::ClassVar` name (`@@x`) that is not a valid Ruby class-variable
     /// name (`@@<identifier>`) — injection guard at the class-variable positions.
     ClassVarName(String, semantic_ir::Span),
-    /// SIR22 "APL addendum" node (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-    /// `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — shares
-    /// `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut this
-    /// slice implements, so a bare feature-flag check cannot tell a module
-    /// using one of these nine apart from a safe base-cut-only module.
-    /// Rejected cleanly here rather than reaching `emit_expr`'s
-    /// `unreachable!` — mirrors JS/TS's own (since-removed, once the
-    /// addendum shipped there) `find_unimplemented_sir22_addendum_node`.
-    Sir22AddendumNode(&'static str, semantic_ir::Span),
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
@@ -956,23 +947,25 @@ impl Scan {
                 IndexArg::Whole => None,
             })
         }),
-        // ── SIR22 "APL addendum" — deferred, rejected cleanly ────────
-        // Shares NDArrays/MatrixOps/ArrayColumnMajor with the base cut
-        // above, so it must be checked explicitly here (not just at the
-        // feature-flag gate) — see `ScanHit::Sir22AddendumNode`'s doc.
-        Expr::Reduce { span, .. } => Some(ScanHit::Sir22AddendumNode("Reduce", span.clone())),
-        Expr::Scan { span, .. } => Some(ScanHit::Sir22AddendumNode("Scan", span.clone())),
-        Expr::OuterProduct { span, .. } => {
-            Some(ScanHit::Sir22AddendumNode("OuterProduct", span.clone()))
+        // ── SIR22 "APL addendum" (Phase A Slice 3) ───────────────────
+        // Now implemented (see `emit_expr`'s own arms and `runtime.rs`'s
+        // "SIR22 addendum" section) — sub-expressions may themselves hide
+        // a deferred builtin or injectable name, so recurse into them,
+        // matching every other composite expr arm above (e.g. `MatMul`/
+        // `ElementwiseOp` just above).
+        Expr::Reduce { target, .. } => self.expr(target),
+        Expr::Scan { target, .. } => self.expr(target),
+        Expr::OuterProduct { lhs, rhs, .. } => self.expr(lhs).or_else(|| self.expr(rhs)),
+        Expr::Shape { target, .. } => self.expr(target),
+        Expr::Reshape { shape, target, .. } => {
+            self.expr(shape).or_else(|| self.expr(target))
         }
-        Expr::Shape { span, .. } => Some(ScanHit::Sir22AddendumNode("Shape", span.clone())),
-        Expr::Reshape { span, .. } => Some(ScanHit::Sir22AddendumNode("Reshape", span.clone())),
-        Expr::IndexGenerator { span, .. } => {
-            Some(ScanHit::Sir22AddendumNode("IndexGenerator", span.clone()))
-        }
-        Expr::IndexOf { span, .. } => Some(ScanHit::Sir22AddendumNode("IndexOf", span.clone())),
-        Expr::Ravel { span, .. } => Some(ScanHit::Sir22AddendumNode("Ravel", span.clone())),
-        Expr::Catenate { span, .. } => Some(ScanHit::Sir22AddendumNode("Catenate", span.clone())),
+        Expr::IndexGenerator { count, .. } => self.expr(count),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => self.expr(haystack).or_else(|| self.expr(needle)),
+        Expr::Ravel { target, .. } => self.expr(target),
+        Expr::Catenate { lhs, rhs, .. } => self.expr(lhs).or_else(|| self.expr(rhs)),
         _ => None,
     }
     }
@@ -1566,6 +1559,78 @@ fn emit_expr(e: &Expr) -> String {
                 "sir_array_index_get({}, [{}])",
                 emit_expr(target),
                 emit_index_args(indices)
+            )
+        }
+        // ── SIR22 addendum: APL primitive operators (Phase A Slice 3) ──
+        // Each of the nine maps 1:1 onto a call into `sir_array_*` (see
+        // `runtime.rs`'s "SIR22 addendum" section) — the same treatment
+        // `ElementwiseOp`/`Transpose`/`MatMul` above already get for the
+        // SIR22 base cut. `Reduce`/`Scan`/`OuterProduct` carry an
+        // `ElementwiseOpKind` and so reuse `elementwise_op_ruby_name`
+        // exactly like `ElementwiseOp` does; the remaining six have no
+        // `op` field at all (they are "bespoke, not BinOp-shaped" per the
+        // SIR22 spec addendum and `apl-runtime::builtins`'s own doc
+        // comment) and just recurse into their operand(s).
+        Expr::Reduce { op, target, .. } => {
+            format!(
+                "sir_array_reduce({}, {})",
+                elementwise_op_ruby_name(*op),
+                emit_expr(target)
+            )
+        }
+        Expr::Scan { op, target, .. } => {
+            format!(
+                "sir_array_scan({}, {})",
+                elementwise_op_ruby_name(*op),
+                emit_expr(target)
+            )
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            format!(
+                "sir_array_outer({}, {}, {})",
+                elementwise_op_ruby_name(*op),
+                emit_expr(lhs),
+                emit_expr(rhs)
+            )
+        }
+        Expr::Shape { target, .. } => {
+            format!("sir_array_shape({})", emit_expr(target))
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `sir_array_reshape(shape_arg, target)` takes the
+        // same order, so no argument reordering is needed at this call
+        // site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `sir_array_range`'s `start, stop, step` above, which DOES
+        // reorder).
+        Expr::Reshape { shape, target, .. } => {
+            format!(
+                "sir_array_reshape({}, {})",
+                emit_expr(shape),
+                emit_expr(target)
+            )
+        }
+        Expr::IndexGenerator { count, .. } => {
+            format!("sir_array_index_generator({})", emit_expr(count))
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            format!(
+                "sir_array_index_of({}, {})",
+                emit_expr(haystack),
+                emit_expr(needle)
+            )
+        }
+        Expr::Ravel { target, .. } => {
+            format!("sir_array_ravel({})", emit_expr(target))
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            format!(
+                "sir_array_catenate({}, {})",
+                emit_expr(lhs),
+                emit_expr(rhs)
             )
         }
         other => unreachable!("Ruby backend reached unsupported expr: {other:?}"),

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -232,14 +232,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
-    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // ── SIR22 array/matrix (base cut + APL addendum) ──────────────────
     // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
-    // (+ `Stmt::IndexSet`) route into `sir_array_*` helpers, an inlined
-    // port of the already-proven `semantic-ir-to-javascript` `ArrayRt`
-    // sub-runtime (see `runtime.rs`). The SIR22 "APL addendum" nodes
-    // share these same three features but stay deferred — rejected by a
-    // dedicated pre-emit scan (`ScanHit::Sir22AddendumNode`), not this
-    // capability gate, since the gate alone can't distinguish them.
+    // (+ `Stmt::IndexSet`), and the nine-node "APL addendum"
+    // (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+    // `IndexOf`/`Ravel`/`Catenate`, Phase A Slice 3), all route into
+    // `sir_array_*` helpers, an inlined port of the already-proven
+    // `semantic-ir-to-javascript` `ArrayRt` sub-runtime (see `runtime.rs`).
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -357,16 +356,6 @@ impl Backend for RubyBackend {
                     message: format!(
                         "the Ruby backend cannot emit the class variable `{name}` \
                          (not a valid `@@identifier`)"
-                    ),
-                    span,
-                });
-            }
-            Some(emit::ScanHit::Sir22AddendumNode(kind, span)) => {
-                return Err(BackendError {
-                    kind: BackendErrorKind::UnsupportedFeature,
-                    message: format!(
-                        "the Ruby backend does not yet implement the SIR22 addendum node `{kind}` \
-                         (deferred to a later slice)"
                     ),
                     span,
                 });

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -343,11 +343,11 @@ end
 # REAL Float, e.g. from `Div`).
 #
 # The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-# `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is deferred —
-# these nine share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base
-# cut above, so `lib.rs`'s `compile` adds a dedicated pre-emit scan
-# (`ScanHit::Sir22AddendumNode`) rejecting them cleanly, beyond the
-# ordinary feature-flag capability check.
+# `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`, Phase A Slice 3) —
+# these nine are implemented below, in the "SIR22 addendum" section further
+# down this file — an inlined port of `semantic-ir-to-javascript`'s own
+# already-proven addendum functions, following the exact same
+# `sir_array_*` naming/style convention as the base cut above.
 SirNDArray = Struct.new(:shape, :data)
 
 # SECURITY: every factory below validates a shape/output size *before*
@@ -717,5 +717,342 @@ def sir_array_index_set(a, indices, value)
     return
   end
   raise "sir_array_index_set: only 1 or 2 index arguments are supported (rank <= 2 scope), got #{indices.length}"
+end
+
+# ── SIR22 addendum: APL primitive operators (Phase A Slice 3) ──
+#
+# `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+# `IndexOf`/`Ravel`/`Catenate` lower to the `sir_array_*` functions below —
+# an inlined port of `semantic-ir-to-javascript`'s own already-proven
+# addendum functions (`runtime.rs`'s own "SIR22 addendum: APL primitive
+# operators" section, itself ported 1:1 from `apl-runtime::builtins` /
+# `array_runtime::ops`), following the exact same naming/style convention
+# as the base cut above. `SIR_ARRAY_MAX_ELEMENTS` (defined above) is reused
+# as-is for every new bounded-allocation check here — this file has exactly
+# one array-size cap, not one per domain.
+
+# `+/A` (APL reduce, dyadic-op monadic-adverb) — fold `target` with `op`
+# along its one axis. Ported 1:1 from `array_runtime::ops::reduce`:
+# - rank 0 (scalar): nothing to fold, returns `target` itself.
+# - rank 1 (vector `[n]`): left-fold across all `n` elements
+#   (`op(op(op(v0, v1), v2), ...)`); an EMPTY vector is a clean error --
+#   unlike `sum`/`mean` (which have a built-in identity, 0), `reduce` is
+#   generic over any `op`, and guessing an identity (is it `0` for `Add`,
+#   `1` for `Mul`, `-Infinity` for `Max`?) for an arbitrary, possibly-future
+#   op would be silently wrong for most of them.
+# - rank 2 (matrix `[r, c]`): folds EACH ROW independently across its `c`
+#   columns, producing a `[r]` vector (one folded value per row).
+#   Column-major storage means element `(row, col)` lives at
+#   `col * r + row` -- the row loop reads `d[row]` as the seed (column 0)
+#   then walks `d[col * r + row]` for `col = 1..c`; getting `row` and `col`
+#   swapped here silently transposes the result instead of raising, so this
+#   indexing is the single easiest place to introduce a wrong-answer bug
+#   when reading this function.
+def sir_array_reduce(op, a)
+  a = sir_array_to_array_value(a)
+  shape = a.shape
+  return a if shape.empty?
+  if shape.length == 1
+    n = shape[0]
+    raise "sir_array_reduce: cannot fold an empty vector (no identity element for an arbitrary op)" if n == 0
+    d = a.data
+    acc = d[0]
+    (1...n).each { |i| acc = sir_array_apply_op(op, acc, d[i]) }
+    return sir_array_ndarray([], [acc])
+  end
+  if shape.length == 2
+    r, c = shape
+    raise "sir_array_reduce: cannot fold an empty row (no identity element for an arbitrary op)" if c == 0
+    d = a.data
+    out = Array.new(r)
+    (0...r).each do |row|
+      acc = d[row] # column-major: (row, 0) lives at plain `row`
+      (1...c).each { |col| acc = sir_array_apply_op(op, acc, d[col * r + row]) }
+      out[row] = acc
+    end
+    return sir_array_ndarray([r], out)
+  end
+  raise "sir_array_reduce: rank > 2 not yet supported (shape #{shape})"
+end
+
+# `+\A` (APL scan) — the same fold as `sir_array_reduce`, but keeping EVERY
+# intermediate result instead of only the last; output has the same shape
+# as `target`. Ported 1:1 from `array_runtime::ops::scan`. An empty axis is
+# NOT an error here (unlike `reduce`): there is simply nothing to scan, and
+# the (empty) output shape already says so.
+def sir_array_scan(op, a)
+  a = sir_array_to_array_value(a)
+  shape = a.shape
+  return a if shape.empty?
+  if shape.length == 1
+    n = shape[0]
+    d = a.data
+    out = Array.new(n)
+    acc = nil
+    started = false
+    (0...n).each do |i|
+      acc = started ? sir_array_apply_op(op, acc, d[i]) : d[i]
+      started = true
+      out[i] = acc
+    end
+    return sir_array_ndarray([n], out)
+  end
+  if shape.length == 2
+    r, c = shape
+    d = a.data
+    out = Array.new(d.length)
+    (0...r).each do |row|
+      acc = nil
+      started = false
+      (0...c).each do |col|
+        x = d[col * r + row] # column-major
+        acc = started ? sir_array_apply_op(op, acc, x) : x
+        started = true
+        out[col * r + row] = acc
+      end
+    end
+    return sir_array_ndarray([r, c], out)
+  end
+  raise "sir_array_scan: rank > 2 not yet supported (shape #{shape})"
+end
+
+# `A∘.×B` (APL outer product) — apply `op` to every pair `(aᵢ, bⱼ)`,
+# producing a result of rank `rank(a) + rank(b)`. Ported 1:1 from
+# `array_runtime::ops::outer`, scoped identically to `rank(a) <= 1` and
+# `rank(b) <= 1` (the vector⊗vector case below already reaches this
+# domain's rank-2 ceiling). `sir_array_checked_shape_size` validates the
+# `[m, n]` output shape *before* allocating — `m`/`n` are two INDEPENDENT
+# operand lengths, each individually under `SIR_ARRAY_MAX_ELEMENTS`, but
+# nothing bounds their product alone (the same outer-product-shaped
+# allocation `sir_array_matmul`/`sir_array_index_get` above guard).
+def sir_array_outer(op, a, b)
+  a = sir_array_to_array_value(a)
+  b = sir_array_to_array_value(b)
+  as = a.shape
+  bs = b.shape
+  if as.empty? && bs.empty?
+    return sir_array_ndarray([], [sir_array_apply_op(op, a.data[0], b.data[0])])
+  end
+  if as.empty? && bs.length == 1
+    x = a.data[0]
+    return sir_array_ndarray([bs[0]], b.data.map { |y| sir_array_apply_op(op, x, y) })
+  end
+  if as.length == 1 && bs.empty?
+    y = b.data[0]
+    return sir_array_ndarray([as[0]], a.data.map { |x| sir_array_apply_op(op, x, y) })
+  end
+  if as.length == 1 && bs.length == 1
+    m = as[0]
+    n = bs[0]
+    out_len = sir_array_checked_shape_size([m, n])
+    ad = a.data
+    bd = b.data
+    out = Array.new(out_len)
+    (0...n).each do |j|
+      (0...m).each { |i| out[j * m + i] = sir_array_apply_op(op, ad[i], bd[j]) } # column-major
+    end
+    return sir_array_ndarray([m, n], out)
+  end
+  raise "sir_array_outer: operands of rank > 1 not yet supported (shapes #{as}, #{bs})"
+end
+
+# Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order — last
+# axis varies fastest. `a` itself stores COLUMN-major
+# (`sir_array_get`'s own doc comment), so a matrix must be walked "row,
+# then column" via `sir_array_get` to produce true row-major order;
+# returning the raw column-major buffer would silently ravel in the WRONG
+# order. Always returns a FRESH Array (`.dup`, never `a.data` itself, even
+# in the rank <= 1 no-op case) — mirrors `apl_runtime::builtins::flatten`
+# returning an owned `Vec`, not a borrow, so the result never accidentally
+# aliases `a`'s own buffer (a caller mutating the returned Array must not
+# also mutate `a`).
+def sir_array_flatten_row_major(a)
+  shape = a.shape
+  return a.data.dup if shape.length <= 1
+  if shape.length == 2
+    r, c = shape
+    out = Array.new(r * c)
+    k = 0
+    (0...r).each do |row|
+      (0...c).each do |col|
+        out[k] = sir_array_get(a, row, col)
+        k += 1
+      end
+    end
+    return out
+  end
+  # Unreachable in practice (this domain's rank <= 2 ceiling) -- total
+  # rather than raising, mirroring the JS reference's own fallback.
+  a.data.dup
+end
+
+# Monadic `⍴` (shape-of) — `target`'s dimensions as a vector. Ported 1:1
+# from `apl_runtime::builtins::shape`: a SCALAR has zero dimensions, so its
+# shape is the EMPTY vector (not a scalar!) — `⍴5` is a length-0 vector,
+# mirroring `shape.length == 0` exactly. A vector `[n]` has shape `[n]`
+# (one element); a matrix `[r, c]` has shape `[r, c]` (two elements).
+def sir_array_shape(a)
+  a = sir_array_to_array_value(a)
+  sir_array_ndarray([a.shape.length], a.shape.dup)
+end
+
+# Dyadic `⍴` (reshape) — reinterpret `target`'s data under the new
+# dimensions `shape_arg`. Ported 1:1 from `apl_runtime::builtins::reshape`.
+# `shape_arg` must itself be a scalar or vector (rank <= 1) of
+# non-negative integers, and is itself capped at rank <= 2 (this domain's
+# ceiling — a longer target shape is a clean error, not a silent
+# truncation). `target`'s elements are ravelled (`sir_array_flatten_row_major`)
+# then cyclically repeated or truncated to fill the target shape's element
+# count.
+#
+# CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+# fills the LAST axis fastest, same convention as ravel), but this
+# domain's storage is COLUMN-major — so for a rank-2 target the row-major
+# `filled` sequence must be TRANSPOSED into column-major storage
+# (`data[col * r + row] = filled[row * c + col]`) before calling
+# `sir_array_ndarray`. Handing `filled` straight to `sir_array_ndarray`
+# would silently reshape column-major instead of APL's row-major
+# convention — a wrong answer that still LOOKS plausible (right multiset
+# of values, wrong positions).
+def sir_array_reshape(shape_arg, target)
+  shape_arg = sir_array_to_array_value(shape_arg)
+  target = sir_array_to_array_value(target)
+  if shape_arg.shape.length > 1
+    raise "sir_array_reshape: shape argument must be a scalar or vector (got rank #{shape_arg.shape.length})"
+  end
+  dims = shape_arg.data.map do |x|
+    unless sir_array_integer_dim?(x) && x >= 0
+      raise "sir_array_reshape: shape elements must be non-negative integers, got #{x}"
+    end
+    x.to_i
+  end
+  if dims.length > 2
+    raise "sir_array_reshape: reshape to rank > 2 is not yet supported (target shape #{dims})"
+  end
+  total = sir_array_checked_shape_size(dims)
+  source = sir_array_flatten_row_major(target)
+  if total > 0 && source.empty?
+    raise "sir_array_reshape: cannot reshape an empty source into a non-empty shape"
+  end
+  filled = Array.new(total)
+  (0...total).each { |k| filled[k] = source[k % source.length] }
+  return sir_array_ndarray(dims, filled) if dims.length <= 1
+  r, c = dims
+  data = Array.new(total)
+  (0...r).each do |row|
+    (0...c).each do |col|
+      data[col * r + row] = filled[row * c + col]
+    end
+  end
+  sir_array_ndarray(dims, data)
+end
+
+# Monadic `⍳` (index generator / iota) — `⍳n` is the 1-BASED vector
+# `[1, 2, ..., n]`. Ported 1:1 from `apl_runtime::builtins::
+# index_generator` — note this is 1-based, unlike every 0-based index
+# elsewhere in this domain (`sir_array_index_get`/`sir_array_index_set`),
+# because that is genuinely what APL's `⍳` means at the SURFACE-SYNTAX
+# level (see `apl-runtime`'s own tests, e.g.
+# `index_generator_produces_one_based_run`). `sir_array_checked_shape_size`
+# both validates `n` is a non-negative integer AND caps it at
+# `SIR_ARRAY_MAX_ELEMENTS` before allocating — `n` is a runtime value a
+# compiled program computes, not a fixed constant, so `⍳` of an absurd size
+# must fail cleanly.
+def sir_array_index_generator(a)
+  a = sir_array_to_array_value(a)
+  raise "sir_array_index_generator: monadic argument must be a scalar" unless sir_array_is_scalar(a)
+  x = a.data[0]
+  unless sir_array_integer_dim?(x) && x >= 0
+    raise "sir_array_index_generator: monadic argument must be a non-negative integer, got #{x}"
+  end
+  n = sir_array_checked_shape_size([x.to_i])
+  sir_array_ndarray([n], Array.new(n) { |i| i + 1 })
+end
+
+# Dyadic `⍳` (index-of / search) — for every element of `needle`, the
+# 1-based index of its first occurrence in the vector `haystack` (or
+# `haystack.length + 1` if not found — "not found" is a valid,
+# always-in-range position, not `-1`/`nil`). Ported 1:1 from
+# `apl_runtime::builtins::index_of`: plain EXACT equality (`Array#index`
+# uses `==`, so `Float::NAN` correctly never matches itself, same as
+# Rust's `==`). The work done is O(len(haystack) * len(needle)) (a full
+# linear scan per needle element) — `sir_array_checked_shape_size` is
+# reused here purely for its "product <= SIR_ARRAY_MAX_ELEMENTS" check
+# (both lengths are already valid non-negative integers, so its
+# dimension-validity half is a no-op) to cap the PRODUCT before scanning,
+# since each operand individually staying under `SIR_ARRAY_MAX_ELEMENTS`
+# does not bound their product (up to ~4.5 * 10^15 comparisons otherwise).
+def sir_array_index_of(a, b)
+  a = sir_array_to_array_value(a)
+  b = sir_array_to_array_value(b)
+  if a.shape.length > 1
+    raise "sir_array_index_of: left argument must be a scalar or vector (got rank #{a.shape.length})"
+  end
+  sir_array_checked_shape_size([a.data.length, b.data.length])
+  haystack = a.data
+  out = b.data.map do |needle|
+    idx = haystack.index(needle)
+    idx.nil? ? haystack.length + 1 : idx + 1
+  end
+  sir_array_ndarray(b.shape, out)
+end
+
+# Monadic `,` (ravel) — flatten `target` to a rank-1 vector, in row-major
+# order (see `sir_array_flatten_row_major`'s own doc comment for the
+# column-major-storage-vs-row-major-order subtlety). Ported 1:1 from
+# `apl_runtime::builtins::ravel`.
+def sir_array_ravel(a)
+  a = sir_array_to_array_value(a)
+  flat = sir_array_flatten_row_major(a)
+  sir_array_ndarray([flat.length], flat)
+end
+
+# Dyadic `,` (catenate) — supports scalar-scalar, scalar-vector,
+# vector-scalar, vector-vector (all producing a vector), and
+# matrix-matrix-with-equal-row-counts (column/last-axis catenate,
+# producing `[r, ca + cb]`). Any other rank combination is a clean "not
+# yet supported" error. Ported 1:1 from `apl_runtime::builtins::catenate`.
+# The combined-length cap check happens ONCE, up front, regardless of
+# which rank combination follows (mirroring the Rust reference's own
+# structure) — neither operand alone need be oversized for the RESULT to
+# be, since a script that repeatedly catenates a value with itself
+# (`A <- A,A`) doubles the size every line with no other ceiling.
+def sir_array_catenate(a, b)
+  a = sir_array_to_array_value(a)
+  b = sir_array_to_array_value(b)
+  sir_array_checked_shape_size([a.data.length + b.data.length])
+  ra = a.shape.length
+  rb = b.shape.length
+  if ra == 0 && rb == 0
+    return sir_array_ndarray([2], [a.data[0], b.data[0]])
+  end
+  if ra == 0 && rb == 1
+    out = [a.data[0]] + b.data
+    return sir_array_ndarray([out.length], out)
+  end
+  if ra == 1 && rb == 0
+    out = a.data + [b.data[0]]
+    return sir_array_ndarray([out.length], out)
+  end
+  if ra == 1 && rb == 1
+    out = a.data + b.data
+    return sir_array_ndarray([out.length], out)
+  end
+  if ra == 2 && rb == 2
+    r = sir_array_nrows(a)
+    unless r == sir_array_nrows(b)
+      raise "sir_array_catenate: matrix catenate needs equal row counts (#{r} vs #{sir_array_nrows(b)})"
+    end
+    ca = sir_array_ncols(a)
+    cb = sir_array_ncols(b)
+    out_len = sir_array_checked_shape_size([r, ca + cb])
+    data = Array.new(out_len)
+    (0...r).each do |row|
+      (0...ca).each { |col| data[col * r + row] = sir_array_get(a, row, col) }
+      (0...cb).each { |col| data[(ca + col) * r + row] = sir_array_get(b, row, col) }
+    end
+    return sir_array_ndarray([r, ca + cb], data)
+  end
+  raise "sir_array_catenate: catenate of rank #{ra} and rank #{rb} is not yet supported"
 end
 "####;

--- a/code/packages/rust/semantic-ir-to-ruby/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/sir22_array.rs
@@ -1,5 +1,7 @@
-//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/
-//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the
+//! SIR22 execution proof, base cut + "APL addendum": `ArrayLit`/`Range`/
+//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` (Phase A
+//! Slice 2) and `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+//! `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` (Phase A Slice 3) on the
 //! Ruby backend — hand-builds a module calling each node directly
 //! (bypassing the frontend, since no frontend targets this backend for
 //! SIR22 yet), emits Ruby, runs it with a real `ruby` interpreter, and
@@ -7,11 +9,11 @@
 //! not fail) when no `ruby` is on `PATH`.
 //!
 //! Ported from `semantic-ir-to-javascript`'s own already-proven
-//! `tests/sir22_array.rs` — same worked examples, adapted to this
-//! backend's own value-type conventions (Ruby preserves native
-//! Integer/Float type propagation rather than JS's uniform-double
-//! storage; see `runtime.rs`'s own module doc for why an all-integer
-//! computation here prints without a spurious `.0`).
+//! `tests/sir22_array.rs` and `runtime.rs` addendum doc comments — same
+//! worked examples, adapted to this backend's own value-type conventions
+//! (Ruby preserves native Integer/Float type propagation rather than JS's
+//! uniform-double storage; see `runtime.rs`'s own module doc for why an
+//! all-integer computation here prints without a spurious `.0`).
 //!
 //! Every test constructs `Module`s directly via `print_stmt`'s scalar
 //! `IndexGet` reads (top-left/bottom-right element, etc.) — sidesteps
@@ -256,24 +258,278 @@ fn index_set_mutates_in_place() {
     }
 }
 
-// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+// ── SIR22 "APL addendum" (Phase A Slice 3): real execution proofs ──────
+//
+// `ArrayLit` always builds RANK-2 storage (even a single-row literal is a
+// `1xn` matrix, matching MATLAB's own row-vector convention -- see
+// `sir_array_from_rows`), and so does `Range`/`IndexGet`'s `Whole`
+// selector. But several addendum functions (`Reduce`/`OuterProduct`'s
+// operands, `Reshape`'s `shape` argument, `IndexOf`'s `haystack`) require
+// a genuine RANK-1 vector (`shape == [n]`, not `[1, n]`). `Ravel`/`Shape`
+// are themselves the addendum's own way to produce one (their outputs are
+// always rank <= 1) -- so most tests below route a `1xn` `ArrayLit`
+// through `Ravel` first to get a real vector operand, exactly as a
+// compiled APL program would.
 
 #[test]
-fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
-    // cut, so the ordinary feature-flag check alone can't reject it --
-    // proves the dedicated `ScanHit::Sir22AddendumNode` pre-emit scan
-    // does, with a clean `Err`, not an `emit_expr` `unreachable!` panic.
-    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
-    let m = array_module(vec![print_stmt(Expr::Reduce {
+fn reduce_folds_a_vector_left_to_right() {
+    // +/[1 2 3 4] = 10 (left fold: ((1+2)+3)+4). The vector operand comes
+    // from `Ravel` (a `1x4` `ArrayLit` is rank-2, not rank-1).
+    let row = array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]);
+    let vector = Expr::Ravel { target: Box::new(row), span: s() };
+    let reduced = Expr::Reduce {
         op: ElementwiseOpKind::Add,
-        target: Box::new(target),
+        target: Box::new(vector),
         span: s(),
-    })]);
-    let err = semantic_ir_to_ruby::compile(&m).expect_err("Reduce must be rejected, not emitted");
-    assert!(
-        err.message.contains("Reduce"),
-        "error should name the rejected node: {}",
-        err.message
-    );
+    };
+    let m = array_module(vec![print_stmt(index_get(reduced, vec![scalar(0)]))]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "10\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn reduce_on_a_matrix_folds_each_row_independently() {
+    // +/ on [[1 2 3];[4 5 6]] folds EACH ROW across its columns
+    // independently -- [1+2+3, 4+5+6] = [6, 15]. This is the exact
+    // column-major-indexing case `runtime.rs`'s own doc comment warns is
+    // "the single easiest place to introduce a wrong-answer bug": getting
+    // `row`/`col` swapped here would silently transpose the result
+    // instead of raising.
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let reduced = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("r", reduced),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "6\n15\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn scan_on_a_vector_keeps_every_prefix_fold() {
+    // +\[1 2 3 4] = [1, 3, 6, 10] -- every prefix sum, not just the last
+    // (unlike `Reduce`, which only keeps the final fold).
+    let row = array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]);
+    let vector = Expr::Ravel { target: Box::new(row), span: s() };
+    let scanned = Expr::Scan { op: ElementwiseOpKind::Add, target: Box::new(vector), span: s() };
+    let m = array_module(vec![
+        let_binding("sc", scanned),
+        print_stmt(index_get(local("sc"), vec![scalar(0)])),
+        print_stmt(index_get(local("sc"), vec![scalar(1)])),
+        print_stmt(index_get(local("sc"), vec![scalar(2)])),
+        print_stmt(index_get(local("sc"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n3\n6\n10\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn outer_product_applies_op_to_every_pair() {
+    // [1 2] outer+ [10 20 30] -> [[11 21 31];[12 22 32]] (shape [2,3]:
+    // out(i,j) = a[i] + b[j]).
+    let va = Expr::Ravel { target: Box::new(array_lit(vec![vec![ilit(1), ilit(2)]])), span: s() };
+    let vb = Expr::Ravel {
+        target: Box::new(array_lit(vec![vec![ilit(10), ilit(20), ilit(30)]])),
+        span: s(),
+    };
+    let outer = Expr::OuterProduct {
+        op: ElementwiseOpKind::Add,
+        lhs: Box::new(va),
+        rhs: Box::new(vb),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("o", outer),
+        print_stmt(index_get(local("o"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("o"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "11\n32\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_scalar_is_the_empty_vector_not_a_scalar() {
+    // ⍴5 must be a length-0 VECTOR (shape=[0], data=[]), never a scalar
+    // wrapping the value 0. Applying `Shape` a SECOND time distinguishes
+    // the two: the correct result's OWN shape is [1] (one dimension,
+    // whose value is 0), directly readable -- whereas a wrong "scalar
+    // containing 0" implementation (shape=[], data=[0]) would make the
+    // SECOND `Shape` call produce an EMPTY vector instead (shape=[0],
+    // data=[]), which raises on this test's own `index_get` -- so a
+    // regression here fails LOUDLY (non-zero exit), not silently.
+    let inner = Expr::Shape { target: Box::new(ilit(5)), span: s() };
+    let outer = Expr::Shape { target: Box::new(inner), span: s() };
+    let m = array_module(vec![print_stmt(index_get(outer, vec![scalar(0)]))]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "0\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_matrix_returns_its_dimensions() {
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let sh = Expr::Shape { target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("sh", sh),
+        print_stmt(index_get(local("sh"), vec![scalar(0)])),
+        print_stmt(index_get(local("sh"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n3\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn reshape_fills_row_major_then_stores_column_major() {
+    // Reshape [1 2 3 4 5 6] (a row-major source) into a 2x3 matrix. APL's
+    // reshape fills the LAST axis fastest (row-major): row 0 gets
+    // [1 2 3], row 1 gets [4 5 6]. This domain's storage is column-major,
+    // so a regression that hands the row-major `filled` sequence straight
+    // to storage would silently TRANSPOSE the result -- `get(0,1)` would
+    // read 3 instead of 2, `get(1,0)` would read 2 instead of 4 -- a wrong
+    // answer that still looks plausible (right multiset of values, wrong
+    // positions).
+    let dims_source = array_lit(vec![
+        vec![ilit(0), ilit(0), ilit(0)],
+        vec![ilit(0), ilit(0), ilit(0)],
+    ]); // a throwaway 2x3 matrix, used only for its `Shape` ([2, 3]) --
+        // `Shape`'s own output is a genuine rank-1 vector, which is what
+        // `Reshape`'s `shape` argument requires (rank <= 1).
+    let shape_arg = Expr::Shape { target: Box::new(dims_source), span: s() };
+    let data_source =
+        array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5), ilit(6)]]);
+    let reshaped = Expr::Reshape {
+        shape: Box::new(shape_arg),
+        target: Box::new(data_source),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("r", reshaped),
+        print_stmt(index_get(local("r"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("r"), vec![scalar(1), scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n4\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn index_generator_is_one_based_not_zero_based() {
+    // ⍳5 = [1 2 3 4 5] -- a deliberate exception to this domain's
+    // otherwise-universal 0-based indexing (`apl-runtime`'s own
+    // `index_generator_produces_one_based_run` test is the ground truth
+    // this ports; the SIR22 spec's/`nodes.rs`'s own prose calling this
+    // "0-based" is stale relative to the shipped `apl-runtime`/JS-backend
+    // behaviour, which this backend matches for cross-backend parity).
+    let ig = Expr::IndexGenerator { count: Box::new(ilit(5)), span: s() };
+    let m = array_module(vec![
+        let_binding("g", ig),
+        print_stmt(index_get(local("g"), vec![scalar(0)])),
+        print_stmt(index_get(local("g"), vec![scalar(4)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n5\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn index_of_finds_and_reports_not_found_as_length_plus_one() {
+    // haystack [10 20 30] ⍳ needle [20 99]: 20 is at (1-based) position 2;
+    // 99 is not found, reported as haystack.length + 1 = 4 -- NEVER -1 or
+    // nil, always a valid in-range position.
+    let haystack = Expr::Ravel {
+        target: Box::new(array_lit(vec![vec![ilit(10), ilit(20), ilit(30)]])),
+        span: s(),
+    };
+    let needle = Expr::Ravel {
+        target: Box::new(array_lit(vec![vec![ilit(20), ilit(99)]])),
+        span: s(),
+    };
+    let found =
+        Expr::IndexOf { haystack: Box::new(haystack), needle: Box::new(needle), span: s() };
+    let m = array_module(vec![
+        let_binding("f", found),
+        print_stmt(index_get(local("f"), vec![scalar(0)])),
+        print_stmt(index_get(local("f"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n4\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn ravel_flattens_a_matrix_in_row_major_order() {
+    // ,[[1 2];[3 4];[5 6]] = [1 2 3 4 5 6] -- row-major order (last axis
+    // fastest), even though the source is stored column-major.
+    let a = array_lit(vec![
+        vec![ilit(1), ilit(2)],
+        vec![ilit(3), ilit(4)],
+        vec![ilit(5), ilit(6)],
+    ]);
+    let raveled = Expr::Ravel { target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("v", raveled),
+        print_stmt(index_get(local("v"), vec![scalar(0)])),
+        print_stmt(index_get(local("v"), vec![scalar(1)])),
+        print_stmt(index_get(local("v"), vec![scalar(2)])),
+        print_stmt(index_get(local("v"), vec![scalar(3)])),
+        print_stmt(index_get(local("v"), vec![scalar(4)])),
+        print_stmt(index_get(local("v"), vec![scalar(5)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n2\n3\n4\n5\n6\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_vectors_concatenates_end_to_end() {
+    let a = Expr::Ravel { target: Box::new(array_lit(vec![vec![ilit(1), ilit(2)]])), span: s() };
+    let b = Expr::Ravel {
+        target: Box::new(array_lit(vec![vec![ilit(3), ilit(4), ilit(5)]])),
+        span: s(),
+    };
+    let cat = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("c", cat),
+        print_stmt(index_get(local("c"), vec![scalar(0)])),
+        print_stmt(index_get(local("c"), vec![scalar(4)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n5\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_matrices_with_equal_rows_appends_columns() {
+    // [[1 2];[3 4]] , [[5];[6]] -> [[1 2 5];[3 4 6]] (equal row counts;
+    // `rhs`'s columns are appended after `lhs`'s own).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5)], vec![ilit(6)]]);
+    let cat = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("c", cat),
+        print_stmt(index_get(local("c"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("c"), vec![scalar(0), scalar(2)])),
+        print_stmt(index_get(local("c"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n5\n6\n"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
 }


### PR DESCRIPTION
## Summary

- Opens the Ruby backend (`semantic-ir-to-ruby`) to the SIR22 "APL addendum" — 9 array/matrix node kinds beyond the base cut Slice 2 already shipped (merged): `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`.
- New `sir_array_*` runtime functions in `runtime.rs`, ported 1:1 from `semantic-ir-to-javascript`'s already-proven addendum implementation, reusing this crate's Slice-2 helpers (`sir_array_apply_op`/`sir_array_checked_shape_size`/`sir_array_ndarray`/`sir_array_get`/`sir_array_nrows`/`sir_array_ncols`/`sir_array_to_array_value`) rather than duplicating logic.
- New `emit.rs` match arms route each of the 9 node kinds to its runtime function.
- Removes the now-obsolete `ScanHit::Sir22AddendumNode` pre-emit rejection (Slice 2's placeholder for "not implemented yet"); `Scan::expr`'s addendum arms now recurse into their sub-expressions like every other composite-expr arm, so a deferred builtin/injectable name nested inside one of these nodes is still caught by the shared pre-emit scan.
- Bumps `semantic-ir-to-ruby` 0.25.0 → 0.26.0; CHANGELOG/README updated.

One of 5 parallel, independent backend PRs for this slice (C/Go/Rust/Python/Ruby).

### Notable ported behavior
- `IndexGenerator`/`IndexOf` are **1-based** (`⍳5 = [1,2,3,4,5]`; "not found" = `haystack.length + 1`, never `-1`). This is a deliberate APL exception to the domain's otherwise-0-based indexing, confirmed against `apl-runtime`'s own tests and the already-shipped JS backend — even though this crate's own `nodes.rs` doc comment and the SIR22 spec prose stale-ly describe it as 0-based. Matched the shipped/tested ground truth for cross-backend parity; flagged the doc drift as out of this slice's scope.
- `Reduce`/`Scan` on a matrix fold each row independently (column-major indexing `col * r + row`, not the whole matrix into one value).
- `Reshape` fills row-major then transposes into column-major storage — handing the row-major sequence straight to the constructor would silently produce a plausible-but-wrong-position result.
- `Shape` of a scalar is the empty vector (`shape=[0]`, `data=[]`), not a scalar wrapping `0`.

## Test plan

- [x] `cargo test -p semantic-ir-to-ruby` — 156 tests pass (124 lib + 19 sir22_array.rs incl. 12 new addendum execution tests, run against a real `ruby` interpreter + 6 division_ops + 7 sys_write).
- [x] `cargo clippy -p semantic-ir-to-ruby --all-targets -- -D warnings` — clean.
- [x] `/security-review` — passed, no findings (verified the DoS-safety discipline — every new function validates output size via `sir_array_checked_shape_size` before allocating — for `outer`, `index_of`'s product check, `catenate`'s combined-size check, `index_generator`, and `reshape`).
- [x] New execution tests cover: `reduce` (vector + matrix row-independent fold), `scan`, `outer` product, `shape` (scalar-is-empty-vector proof + matrix), `reshape` (row-major/column-major transposition proof), `index_generator` (1-based), `index_of` (found + not-found), `ravel`, `catenate` (vectors + matrices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)