### PR TITLE
feat(semantic-ir-to-rust): implement SIR22 APL addendum (Phase A Slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,129 @@
 # Changelog
 
+## 0.43.0 — SIR22 "APL addendum" (Phase A Slice 3, second-wave backend rollout)
+
+Implements the 9-node SIR22 "APL addendum" this backend deferred in Slice 2:
+`Expr::Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+`IndexOf`/`Ravel`/`Catenate`. Shares `Feature::{NDArrays, MatrixOps,
+ArrayColumnMajor}` with the base cut (`ArrayLit`/`Range`/`MatMul`/
+`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet`) already shipped —
+all 16 SIR22 node kinds are now real codegen for this backend, and the
+dedicated `reject_sir22_addendum` pre-emit scan Slice 2 added specifically
+to reject these nine cleanly (since the shared feature flags alone could
+not distinguish them from the safe base cut) is **removed**: real codegen
+makes it dead code. Part of the SIR22/SIR23 second-wave backend-expansion
+initiative — one of 5 parallel, independent backend PRs for this slice.
+
+**Runtime port** (`runtime.rs`, new "SIR22 addendum: APL primitive
+operators" section, inserted right after the base cut's `array_index_set`):
+a 1:1 port of `semantic-ir-to-javascript`'s already-proven `reduce`/`scan`/
+`outer`/`flattenRowMajor`/`shape`/`reshape`/`indexGenerator`/`indexOf`/
+`ravel`/`catenate`, reusing this backend's existing `array_coerce`/
+`array_apply_op`/`array_checked_shape_size`/`array_ndarray`/`array_nrows`/
+`array_ncols`/`array_is_scalar` helpers from the base cut rather than
+duplicating any of that logic. New functions: `array_reduce`/`array_scan`/
+`array_outer`/`array_flatten_row_major` (an internal helper, not itself
+one of the nine node-backing functions — `array_reshape`/`array_ravel` both
+need it)/`array_shape`/`array_reshape`/`array_index_generator`/
+`array_index_of`/`array_ravel`/`array_catenate`.
+
+**Three subtleties ported exactly, each independently capable of producing
+a silently-wrong-but-plausible answer if gotten wrong** (all three are
+covered by dedicated test cases below, not just described in prose):
+
+- `array_reduce`/`array_scan` on a rank-2 (matrix) target fold EACH ROW
+  independently, not the whole matrix and not each column. Column-major
+  storage means element `(row, col)` lives at `col * r + row` — swapping
+  `row`/`col` in that indexing silently transposes the result instead of
+  raising, which the runtime doc comment calls "the single easiest place
+  to introduce a wrong-answer bug" in the whole addendum.
+- `array_reshape` cyclically repeats/truncates `target`'s RAVELED (row-
+  major) elements to fill the new shape, but this domain's storage is
+  COLUMN-major — so a rank-2 target must TRANSPOSE the row-major-filled
+  sequence into column-major storage before construction
+  (`data[col * r + row] = filled[row * c + col]`). Handing the row-major
+  sequence straight to the constructor produces a wrong answer with the
+  right multiset of values in the wrong positions — the kind of bug a
+  membership-only test would miss entirely.
+- `array_index_generator` (APL `⍳n`) and `array_index_of` (dyadic `⍳`) are
+  both **1-based** (`[1, 2, …, n]`; "not found" is `haystack.len() + 1`,
+  never `-1`), unlike every 0-based index elsewhere in this domain
+  (`array_index_get`/`array_index_set`) — a deliberate, documented
+  exception matching APL's own surface-syntax meaning, not a bug. Note:
+  the `Expr::IndexGenerator` doc comment in `semantic-ir`'s `nodes.rs`
+  currently describes this as 0-based — that doc comment is *stale*
+  relative to `apl_runtime::builtins::index_generator`'s own ground-truth
+  behaviour and tests (`index_generator_produces_one_based_run`), which
+  every backend implementing this addendum (JS reference included)
+  actually follows. This PR does not fix that stale doc comment (out of
+  this backend-only slice's scope — it lives in the shared `semantic-ir`
+  crate other backends also depend on) but flags it explicitly in
+  `array_index_generator`'s own doc comment so the next reader isn't
+  misled by it.
+
+**Security discipline**: every function validates its output size via
+`array_checked_shape_size` (the base cut's existing `checked_mul`-based,
+overflow-safe validator) BEFORE allocating — `array_outer`'s `[m, n]`
+output, `array_index_of`'s `haystack.len() * needle.len()` product,
+`array_catenate`'s combined length, `array_index_generator`'s `n`,
+`array_reshape`'s target size — each of these could otherwise let a
+compiled program exhaust memory from two individually-small-looking
+operands (e.g. a script that repeatedly catenates a value with itself,
+`A = [A, A]`, doubles the size every line with no other ceiling). Reuses
+`ARRAY_MAX_ELEMENTS` (defined for the base cut) as the one array-size cap
+for this whole domain, rather than introducing a second, competing bound.
+
+**Emitter** (`emit.rs`): 9 new `Expr` arms, replacing the panic-on-reach
+placeholder Slice 2 left for these nodes ("SIR22 addendum ... — same
+deferral rationale"). `Reduce`/`Scan`/`OuterProduct` reuse
+`elementwise_op_rs_name` exactly like `ElementwiseOp` does (they carry an
+`op: ElementwiseOpKind` field); the remaining six have no `op` field and
+just recurse into their operand(s), matching the JS reference's own
+`emit.rs` call shapes 1:1 (including `Reshape`'s `shape, target` field/
+argument order, which — unlike `Range`'s `start, step, stop` vs.
+`array_range`'s `start, stop, step` — does NOT get reordered at the call
+site). `collect_expr_assigned` (used to pre-declare `let mut` locals) now
+recurses into these nine nodes' real sub-expressions instead of the
+previous "rejected before emit, nothing reachable" no-op — this is the
+`collect_*_assigned` helper-recursion gap Slice 2's own summary flagged as
+a recurring risk class for this crate (the same gap Slice 2 itself had to
+fix for the base cut, relative to an even earlier no-op baseline); this
+slice closes it for the addendum the same way, before it could ever miss a
+nested `Assign` inside a `Reduce`/`Reshape`/etc. operand.
+
+**Removed**: `lib.rs`'s `reject_sir22_addendum` function, its call site in
+`compile`, and the now-unused `Visitor`/`walk_expr_default` imports it was
+the only user of — confirmed unused via a full-crate grep before removal.
+
+**Tests**: `tests/sir22_array.rs` gains 12 new tests (20 total in the
+file). Neither the JS nor the Ruby backend has addendum execution tests
+yet at this repo's current HEAD (both still reject these nine nodes), so
+these are new, hand-derived from `apl_runtime::builtins`'s own ground-truth
+tests and this PR's own runtime doc comments — not ported from an existing
+suite. Covers: `reduce` on a vector AND a matrix (pins the row-independent-
+fold / column-major-indexing correctness called out above), `scan` on a
+vector, `outer` product of two vectors, `shape` of a scalar (an explicit,
+discriminating assertion that a wrong scalar-shaped implementation fails
+the test with a runtime "out of bounds" raise rather than silently passing
+— see the test's own comment for the full argument) and of a matrix,
+`reshape` with a non-square target (pins the row-major-fill-then-
+column-major-transpose correctness above; a wrong implementation produces
+a different, still-plausible-looking answer, not a crash), `indexGenerator`
+(1-based), `indexOf` found AND not-found (confirms `length + 1`, not `-1`),
+`ravel` of a matrix, and `catenate` of two vectors AND two matrices with
+equal row counts. New `vector1` test helper builds a genuine RANK-1 vector
+via `ArrayLit` + `Ravel` (`ArrayLit` alone always produces rank 2, even for
+a single row) — several addendum functions dispatch on rank, so a "vector"
+test must hand them something genuinely rank 1, not a 1-row rank-2 matrix
+that would silently exercise the wrong branch. All new tests run through
+the same real-`rustc` `run_array_program` helper the base-cut tests already
+use, skipping (not failing) when no `rustc`/usable linker is on the host.
+
+**Docs**: `README.md`'s `NDArrays`/`MatrixOps`/`ArrayColumnMajor` capability
+description updated — no longer describes the addendum as deferred/
+rejected; `lib.rs`'s `ACCEPTED_FEATURES` doc comment and `runtime.rs`'s
+"SIR22 array/matrix domain" module doc updated the same way.
+
 ## 0.42.0 — SIR22 array/matrix base cut (Phase A Slice 2, second-wave backend rollout)
 
 Opens this backend to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -298,31 +298,35 @@ backend emits — bare `"print"`/`"puts"` `BuiltinCall`s and the `print`/
 every frontend finished migrating to `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
-**`NDArrays` / `MatrixOps` / `ArrayColumnMajor`** (SIR22 array/matrix base
-cut, Phase A Slice 2): `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
-`Transpose`/`IndexGet` and `Stmt::IndexSet` route into a new `__sir::array_*`
-sub-runtime — an inlined port of `semantic-ir-to-javascript`'s own
-already-proven `ArrayRt` sub-runtime (this backend inlines its runtime
-helpers, same as `seq_*`/`map_*`, since the generated program has no
-`Cargo.toml`/dependency graph to hang a real crate dependency off). Array
-data is stored uniformly as `f64` (mirroring the JS backend's
-`Float64Array`), so `IndexGet` on a scalar position always yields a
-`Value::Float`. `Stmt::IndexSet` mutates through the new
+**`NDArrays` / `MatrixOps` / `ArrayColumnMajor`** (SIR22 array/matrix
+domain, Phase A Slices 2-3): `Expr::ArrayLit`/`Range`/`MatMul`/
+`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` (the "base cut",
+Slice 2) and `Expr::Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` (the 9-node "APL addendum",
+Slice 3) all route into a new `__sir::array_*` sub-runtime — an inlined
+port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
+sub-runtime (this backend inlines its runtime helpers, same as
+`seq_*`/`map_*`, since the generated program has no `Cargo.toml`/
+dependency graph to hang a real crate dependency off). Array data is
+stored uniformly as `f64` (mirroring the JS backend's `Float64Array`), so
+`IndexGet` on a scalar position always yields a `Value::Float`.
+`Stmt::IndexSet` mutates through the new
 `Value::NDArray(Rc<RefCell<SirNDArray>>)` handle — the same shared-mutable
 pattern `Seq`/`Map` already use, so every alias of an array binding
-observes the write. The 9-node SIR22 "APL addendum"
-(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-`IndexOf`/`Ravel`/`Catenate`) shares these same three features with the
-base cut but stays deferred to a later slice — rejected cleanly by a
-dedicated pre-emit scan (`reject_sir22_addendum` in `lib.rs`) rather than
-this capability gate, since the gate alone can't tell the two groups
-apart. See [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
+observes the write. All 16 SIR22 node kinds now share the same three
+features with no capability-check ambiguity left to resolve — Slice 2's
+dedicated pre-emit scan (`reject_sir22_addendum` in `lib.rs`), which used
+to reject the addendum nine specifically, was removed once Slice 3 gave
+them real codegen. `IndexGenerator`/`IndexOf` are 1-based (`⍳n` =
+`[1, …, n]`; "not found" = `haystack.len() + 1`), a deliberate APL
+surface-syntax exception documented on `array_index_generator`/
+`array_index_of` in `runtime.rs`. See
+[SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
 
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), `StringInterpolation`, a stateful (non-empty
 body) `Class`/`Module` or a non-name-slot `Const` reference (rejected
-cleanly by the soundness gates), and the SIR22 "APL addendum" nodes above
-(rejected cleanly by `reject_sir22_addendum`, not this capability gate).
+cleanly by the soundness gates).
 
 ## Value model
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -565,20 +565,34 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
                 collect_index_arg_assigned(arg, out);
             }
         }
-        // SIR22 addendum: APL primitive operators — rejected before emit
-        // (`reject_sir22_addendum` in `lib.rs`), so none of these carry a
-        // reachable `Assign` for THIS backend: a validated, accepted
-        // module can never contain them.
-        Expr::Reduce { .. }
-        | Expr::Scan { .. }
-        | Expr::OuterProduct { .. }
-        | Expr::Shape { .. }
-        | Expr::Reshape { .. }
-        | Expr::IndexGenerator { .. }
-        | Expr::IndexOf { .. }
-        | Expr::Ravel { .. }
-        | Expr::Catenate { .. }
-        | Expr::Convert { .. } => {}
+        // SIR22 addendum: APL primitive operators (Phase A Slice 3) —
+        // real recursion now, since this backend accepts them: each
+        // sub-expression can nest an `Assign` the same as any other
+        // operand position (mirrors the base-cut arms just above).
+        Expr::Reduce { target, .. } | Expr::Scan { target, .. } => {
+            collect_expr_assigned(target, out);
+        }
+        Expr::OuterProduct { lhs, rhs, .. } | Expr::Catenate { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::Shape { target, .. } | Expr::Ravel { target, .. } => {
+            collect_expr_assigned(target, out);
+        }
+        Expr::Reshape { shape, target, .. } => {
+            collect_expr_assigned(shape, out);
+            collect_expr_assigned(target, out);
+        }
+        Expr::IndexGenerator { count, .. } => collect_expr_assigned(count, out),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            collect_expr_assigned(haystack, out);
+            collect_expr_assigned(needle, out);
+        }
+        // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
+        // validated module.
+        Expr::Convert { .. } => {}
         // SIR23 symbolic-expression/pattern nodes: same rationale as the
         // SIR22 nodes above — rejected before emit, so none of these carry
         // a reachable `Assign` for this backend.
@@ -1254,28 +1268,98 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_index_args(out, indices, indent);
             out.push_str("])");
         }
-        // SIR22 addendum: APL primitive operators — same deferral rationale
-        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // features the base cut above now accepts; a dedicated pre-emit
-        // scan, `reject_sir22_addendum` in `lib.rs`, rejects a module
-        // using one of these nine BEFORE it ever reaches emit — see that
-        // function's doc for why the feature gate alone can't tell the
-        // two groups apart). Defensive panic below covers internal bugs
-        // only (matches the `StrConcat`/`Intrinsic` arms above).
-        Expr::Reduce { span, .. }
-        | Expr::Scan { span, .. }
-        | Expr::OuterProduct { span, .. }
-        | Expr::Shape { span, .. }
-        | Expr::Reshape { span, .. }
-        | Expr::IndexGenerator { span, .. }
-        | Expr::IndexOf { span, .. }
-        | Expr::Ravel { span, .. }
-        | Expr::Catenate { span, .. }
+        // ── SIR22 addendum: APL primitive operators (Phase A Slice 3) ──
+        // Real codegen: calls into the new `__sir::array_*` addendum
+        // functions (see `runtime.rs`'s "SIR22 addendum: APL primitive
+        // operators" section) — a Rust port of
+        // `semantic-ir-to-javascript`'s own already-proven `reduce`/
+        // `scan`/`outer`/`shape`/`reshape`/`indexGenerator`/`indexOf`/
+        // `ravel`/`catenate`. `Reduce`/`Scan`/`OuterProduct` carry an
+        // `op: ElementwiseOpKind` field, so reuse `elementwise_op_rs_name`
+        // exactly like `ElementwiseOp` does; the remaining six have no
+        // `op` field at all (they are "bespoke, not BinOp-shaped" per the
+        // SIR22 spec addendum and `apl_runtime::builtins`'s own doc
+        // comment) and just recurse into their operand(s).
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__sir::array_reduce({}, &(",
+                quote_rs_string(elementwise_op_rs_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push_str("))");
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(
+                out,
+                "__sir::array_scan({}, &(",
+                quote_rs_string(elementwise_op_rs_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push_str("))");
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "__sir::array_outer({}, &(",
+                quote_rs_string(elementwise_op_rs_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str("), &(");
+            emit_expr(out, rhs, indent);
+            out.push_str("))");
+        }
+        Expr::Shape { target, .. } => {
+            out.push_str("__sir::array_shape(&(");
+            emit_expr(out, target, indent);
+            out.push_str("))");
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `__sir::array_reshape(shapeArg, target)` takes
+        // the same order, so no argument reordering is needed at this
+        // call site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `array_range`'s `start, stop, step` above, which DOES reorder).
+        Expr::Reshape { shape, target, .. } => {
+            out.push_str("__sir::array_reshape(&(");
+            emit_expr(out, shape, indent);
+            out.push_str("), &(");
+            emit_expr(out, target, indent);
+            out.push_str("))");
+        }
+        Expr::IndexGenerator { count, .. } => {
+            out.push_str("__sir::array_index_generator(&(");
+            emit_expr(out, count, indent);
+            out.push_str("))");
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            out.push_str("__sir::array_index_of(&(");
+            emit_expr(out, haystack, indent);
+            out.push_str("), &(");
+            emit_expr(out, needle, indent);
+            out.push_str("))");
+        }
+        Expr::Ravel { target, .. } => {
+            out.push_str("__sir::array_ravel(&(");
+            emit_expr(out, target, indent);
+            out.push_str("))");
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            out.push_str("__sir::array_catenate(&(");
+            emit_expr(out, lhs, indent);
+            out.push_str("), &(");
+            emit_expr(out, rhs, indent);
+            out.push_str("))");
+        }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
-        // validated module.
-        | Expr::Convert { span, .. } => {
+        // validated module. Defensive panic covers internal bugs only
+        // (matches the `StrConcat`/`Intrinsic` arms above).
+        Expr::Convert { span, .. } => {
             panic!(
-                "rust backend reached a deferred SIR22-addendum/SIR26 expression ({}) at {} — not accepted yet",
+                "rust backend reached a deferred SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 span
             );

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -29,7 +29,7 @@ mod runtime;
 
 use semantic_ir::{
     Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr, Feature, IndexArg,
-    Module, ParamKind, Scope, Stmt, Visitor, walk_expr_default,
+    Module, ParamKind, Scope, Stmt,
 };
 
 pub use emit::sanitize_ident;
@@ -212,18 +212,21 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
-    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // ── SIR22 array/matrix domain (second-wave backend rollout) ──────
     // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
-    // (+ `Stmt::IndexSet`) route into `__sir::array_*` helpers, an
-    // inlined port of the already-proven `semantic-ir-to-javascript`
-    // `ArrayRt` sub-runtime (see `runtime.rs`'s "SIR22 array/matrix
-    // domain" section) — this backend's existing "self-contained, no
-    // external crate" convention, same as `seq_*`/`map_*`.  The SIR22
-    // "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share these
-    // same three features but stay deferred — rejected by a dedicated
-    // pre-emit scan (`reject_sir22_addendum`, below), not this capability
-    // gate, since the gate alone can't distinguish them.
+    // (+ `Stmt::IndexSet`) — the "base cut" (Phase A Slice 2) — and the
+    // 9-node "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`, Phase A
+    // Slice 3) route into `__sir::array_*` helpers, an inlined port of
+    // the already-proven `semantic-ir-to-javascript` `ArrayRt` sub-
+    // runtime (see `runtime.rs`'s "SIR22 array/matrix domain" and "SIR22
+    // addendum: APL primitive operators" sections) — this backend's
+    // existing "self-contained, no external crate" convention, same as
+    // `seq_*`/`map_*`. All 16 SIR22 node kinds now share the same three
+    // features below with no need for a dedicated pre-emit scan to tell
+    // any subset apart — Slice 2's `reject_sir22_addendum` (which used
+    // to reject the addendum nine) was removed once Slice 3 gave them
+    // real codegen.
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -282,15 +285,6 @@ impl Backend for RustBackend {
             return Err(e);
         }
         if let Some(e) = reject_const_ref(module) {
-            return Err(e);
-        }
-
-        // 2d. SIR22 "APL addendum" soundness gate — shares
-        //     `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the SIR22
-        //     base cut this backend now implements, so the feature-flag
-        //     capability check above cannot tell the two groups apart.
-        //     See `reject_sir22_addendum`'s doc.
-        if let Some(e) = reject_sir22_addendum(module) {
             return Err(e);
         }
 
@@ -758,75 +752,6 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
         // Leaf / already-supported expressions carry no nested Const.
         _ => None,
     }
-}
-
-/// Reject a module containing any of the nine SIR22 "APL addendum" nodes
-/// (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-/// `IndexOf`/`Ravel`/`Catenate`).
-///
-/// These share `Feature::NDArrays`/`Feature::MatrixOps`/
-/// `Feature::ArrayColumnMajor` with the SIR22 **base cut** this backend now
-/// implements (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
-/// `IndexGet`/`Stmt::IndexSet`) — see the SIR22 spec's "Backend impact"
-/// section. That means `check_module`'s ordinary feature-flag capability
-/// check cannot tell a module using one of these nine apart from a safe
-/// base-cut-only module: both declare the identical three features. A
-/// dedicated pre-emit scan is the only way to reject them cleanly, mirroring
-/// `semantic-ir-to-ruby`'s own `ScanHit::Sir22AddendumNode` (implemented for
-/// this exact rollout wave) and `semantic-ir-to-javascript`'s (since-removed,
-/// once that backend's own addendum codegen shipped)
-/// `find_unimplemented_sir22_addendum_node`.
-///
-/// Unlike `reject_stateful_class`/`reject_const_ref` above (hand-rolled
-/// recursive walks over a hand-picked subset of `Stmt`/`Expr` positions),
-/// this uses `semantic_ir`'s shared [`semantic_ir::Visitor`] walker: with
-/// ~40 `Expr` variants and growing, a hand-picked-subset walk is exactly the
-/// kind of check that can silently drift out of sync with the emitter as new
-/// node kinds are added — the shared walker's `walk_expr_default`/
-/// `walk_stmt_default` guarantee every position the validator itself visits
-/// is covered here too, so this check can never miss a nested occurrence
-/// (inside a closure capture, a `TryCatch` body, a parameter default, …).
-///
-/// Returns `Some(err)` for the FIRST offending node found (fail-fast, like
-/// the other capability checks), or `None` if the module is clean.
-fn reject_sir22_addendum(module: &Module) -> Option<BackendError> {
-    struct Finder(Option<(&'static str, semantic_ir::Span)>);
-
-    impl Visitor for Finder {
-        fn visit_expr(&mut self, e: &Expr, depth: usize) {
-            if self.0.is_some() {
-                return;
-            }
-            let hit = match e {
-                Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
-                Expr::Scan { span, .. } => Some(("Scan", span.clone())),
-                Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
-                Expr::Shape { span, .. } => Some(("Shape", span.clone())),
-                Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
-                Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
-                Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
-                Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
-                Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
-                _ => None,
-            };
-            if hit.is_some() {
-                self.0 = hit;
-                return;
-            }
-            walk_expr_default(self, e, depth);
-        }
-    }
-
-    let mut finder = Finder(None);
-    finder.visit_module(module);
-    finder.0.map(|(kind, span)| BackendError {
-        kind: BackendErrorKind::UnsupportedFeature,
-        message: format!(
-            "the rust backend does not yet implement the SIR22 addendum node `{kind}` \
-             (deferred to a later slice)"
-        ),
-        span,
-    })
 }
 
 fn unsupported_const(span: semantic_ir::Span) -> BackendError {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1322,11 +1322,19 @@ pub const RUNTIME: &str = r##"mod __sir {
     // other backend's port of this same runtime.
     //
     // The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is
-    // deferred — these nine share `NDArrays`/`MatrixOps`/
-    // `ArrayColumnMajor` with the base cut above, so `lib.rs`'s `compile`
-    // adds a dedicated pre-emit scan (`reject_sir22_addendum`) rejecting
-    // them cleanly, beyond the ordinary feature-flag capability check.
+    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is now
+    // implemented too (Phase A Slice 3) — see the `array_reduce`/
+    // `array_scan`/`array_outer`/`array_flatten_row_major`/`array_shape`/
+    // `array_reshape`/`array_index_generator`/`array_index_of`/
+    // `array_ravel`/`array_catenate` functions further down this section,
+    // a 1:1 port of `semantic-ir-to-javascript`'s own `reduce`/`scan`/
+    // `outer`/`flattenRowMajor`/`shape`/`reshape`/`indexGenerator`/
+    // `indexOf`/`ravel`/`catenate`. These nine share `NDArrays`/
+    // `MatrixOps`/`ArrayColumnMajor` with the base cut above, so the
+    // ordinary feature-flag capability check alone could never tell them
+    // apart from the base cut; Slice 2's dedicated pre-emit scan
+    // (`reject_sir22_addendum` in `lib.rs`) that used to reject them is
+    // now removed, since real codegen exists for all nine.
 
     /// Element cap for any array/matrix allocation in this domain —
     /// mirrors the JS/TS/Ruby backends' identical `MAX_ELEMENTS`/
@@ -1873,6 +1881,441 @@ pub const RUNTIME: &str = r##"mod __sir {
             n => array_raise(format!(
                 "array_index_set: only 1 or 2 index arguments are supported (rank <= 2 scope), got {}",
                 n
+            )),
+        }
+    }
+
+    // ── SIR22 addendum: APL primitive operators ─────────────────────
+    //
+    // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+    // `IndexOf`/`Ravel`/`Catenate` — a 1:1 port of
+    // `semantic-ir-to-javascript`'s own already-proven `reduce`/`scan`/
+    // `outer`/`flattenRowMajor`/`shape`/`reshape`/`indexGenerator`/
+    // `indexOf`/`ravel`/`catenate` (this section's own module doc there,
+    // and `apl_runtime::builtins`, are the two ground-truth references
+    // every function below matches). `ARRAY_MAX_ELEMENTS` (defined above)
+    // is reused as-is for every bounded-allocation check here — this file
+    // has exactly one array-size cap, not one per domain, so `⍳`/dyadic
+    // `⍴`/`⍳` (index-of)/`,` (catenate) share it with `array_matmul`/
+    // `array_range`/`array_index_get` rather than reintroducing
+    // `apl_runtime::builtins::MAX_ARRAY_LENGTH`'s smaller 1,000,000
+    // figure as a second, competing constant.
+
+    /// `+/A` (APL reduce, dyadic-op monadic-adverb) — fold `target` with
+    /// `op` along its one axis. Ported 1:1 from `array_runtime::ops::
+    /// reduce` (via the JS reference's `reduce`):
+    /// - rank 0 (scalar): nothing to fold, returns `target` itself.
+    /// - rank 1 (vector `[n]`): left-fold across all `n` elements
+    ///   (`op(op(op(v0, v1), v2), …)`); an EMPTY vector is a clean error —
+    ///   unlike `sum`/`mean` (which have a built-in identity, 0), `reduce`
+    ///   is generic over any `op`, and guessing an identity (is it `0` for
+    ///   `Add`, `1` for `Mul`, `-Infinity` for `Max`?) for an arbitrary,
+    ///   possibly-future op would be silently wrong for most of them.
+    /// - rank 2 (matrix `[r, c]`): folds EACH ROW independently across its
+    ///   `c` columns, producing a `[r]` vector (one folded value per row).
+    ///   Column-major storage means element `(row, col)` lives at
+    ///   `col * r + row` — the row loop reads `d[row]` as the seed (column
+    ///   0) then walks `d[col * r + row]` for `col = 1..c`; getting `row`
+    ///   and `col` swapped here silently transposes the result instead of
+    ///   raising, so this indexing is the single easiest place to
+    ///   introduce a wrong-answer bug when reading this function.
+    pub fn array_reduce(op: &str, target: &Value) -> Value {
+        let a = array_coerce(target);
+        if a.shape.is_empty() {
+            return array_ndarray(a.shape, a.data);
+        }
+        if a.shape.len() == 1 {
+            let n = a.shape[0];
+            if n == 0 {
+                array_raise(
+                    "array_reduce: cannot fold an empty vector (no identity element for an \
+                     arbitrary op)"
+                        .to_string(),
+                );
+            }
+            let mut acc = a.data[0];
+            for i in 1..n {
+                acc = array_apply_op(op, acc, a.data[i]);
+            }
+            return array_ndarray(vec![], vec![acc]);
+        }
+        if a.shape.len() == 2 {
+            let (r, c) = (a.shape[0], a.shape[1]);
+            if c == 0 {
+                array_raise(
+                    "array_reduce: cannot fold an empty row (no identity element for an \
+                     arbitrary op)"
+                        .to_string(),
+                );
+            }
+            let mut out = vec![0.0f64; r];
+            for row in 0..r {
+                let mut acc = a.data[row]; // column-major: (row, 0) lives at plain `row`
+                for col in 1..c {
+                    acc = array_apply_op(op, acc, a.data[col * r + row]);
+                }
+                out[row] = acc;
+            }
+            return array_ndarray(vec![r], out);
+        }
+        array_raise(format!(
+            "array_reduce: rank > 2 not yet supported (shape {:?})",
+            a.shape
+        ));
+    }
+
+    /// `+\A` (APL scan) — the same fold as `array_reduce`, but keeping
+    /// EVERY intermediate result instead of only the last; output has the
+    /// same shape as `target`. Ported 1:1 from `array_runtime::ops::scan`
+    /// (via the JS reference's `scan`). An empty axis is NOT an error here
+    /// (unlike `array_reduce`): there is simply nothing to scan, and the
+    /// (empty) output shape already says so.
+    pub fn array_scan(op: &str, target: &Value) -> Value {
+        let a = array_coerce(target);
+        if a.shape.is_empty() {
+            return array_ndarray(a.shape, a.data);
+        }
+        if a.shape.len() == 1 {
+            let n = a.shape[0];
+            let mut out = vec![0.0f64; n];
+            let mut acc = 0.0f64;
+            let mut started = false;
+            for i in 0..n {
+                acc = if started { array_apply_op(op, acc, a.data[i]) } else { a.data[i] };
+                started = true;
+                out[i] = acc;
+            }
+            return array_ndarray(vec![n], out);
+        }
+        if a.shape.len() == 2 {
+            let (r, c) = (a.shape[0], a.shape[1]);
+            let mut out = vec![0.0f64; a.data.len()];
+            for row in 0..r {
+                let mut acc = 0.0f64;
+                let mut started = false;
+                for col in 0..c {
+                    let x = a.data[col * r + row]; // column-major
+                    acc = if started { array_apply_op(op, acc, x) } else { x };
+                    started = true;
+                    out[col * r + row] = acc;
+                }
+            }
+            return array_ndarray(vec![r, c], out);
+        }
+        array_raise(format!(
+            "array_scan: rank > 2 not yet supported (shape {:?})",
+            a.shape
+        ));
+    }
+
+    /// `A∘.×B` (APL outer product) — apply `op` to every pair `(aᵢ, bⱼ)`,
+    /// producing a result of rank `rank(a) + rank(b)`. Ported 1:1 from
+    /// `array_runtime::ops::outer`, scoped identically to `rank(a) <= 1`
+    /// and `rank(b) <= 1` (the vector⊗vector case below already reaches
+    /// this domain's rank-2 ceiling). `array_checked_shape_size` validates
+    /// the `[m, n]` output shape *before* allocating — `m`/`n` are two
+    /// INDEPENDENT operand lengths, each individually under
+    /// `ARRAY_MAX_ELEMENTS`, but nothing bounds their product alone (the
+    /// same outer-product-shaped allocation `array_matmul`/
+    /// `array_index_get` above guard).
+    pub fn array_outer(op: &str, lhs: &Value, rhs: &Value) -> Value {
+        let a = array_coerce(lhs);
+        let b = array_coerce(rhs);
+        match (a.shape.len(), b.shape.len()) {
+            (0, 0) => array_ndarray(vec![], vec![array_apply_op(op, a.data[0], b.data[0])]),
+            (0, 1) => {
+                let x = a.data[0];
+                let data: Vec<f64> = b.data.iter().map(|&y| array_apply_op(op, x, y)).collect();
+                array_ndarray(vec![b.shape[0]], data)
+            }
+            (1, 0) => {
+                let y = b.data[0];
+                let data: Vec<f64> = a.data.iter().map(|&x| array_apply_op(op, x, y)).collect();
+                array_ndarray(vec![a.shape[0]], data)
+            }
+            (1, 1) => {
+                let m = a.shape[0];
+                let n = b.shape[0];
+                let out_len = array_checked_shape_size(&[m, n]);
+                let mut out = vec![0.0f64; out_len];
+                for j in 0..n {
+                    for i in 0..m {
+                        out[j * m + i] = array_apply_op(op, a.data[i], b.data[j]); // column-major
+                    }
+                }
+                array_ndarray(vec![m, n], out)
+            }
+            _ => array_raise(format!(
+                "array_outer: operands of rank > 1 not yet supported (shapes {:?}, {:?})",
+                a.shape, b.shape
+            )),
+        }
+    }
+
+    /// Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order —
+    /// last axis varies fastest. `a` itself stores COLUMN-major
+    /// (`array_get`'s own doc comment), so a matrix must be walked "row,
+    /// then column" to produce true row-major order; returning the raw
+    /// column-major buffer would silently ravel in the WRONG order. Always
+    /// returns a fresh `Vec` (never `a.data` itself, even in the rank <= 1
+    /// no-op case) — mirrors `apl_runtime::builtins::flatten` returning an
+    /// owned `Vec`, not a borrow, so the result never accidentally
+    /// aliases `a`'s own buffer.
+    fn array_flatten_row_major(a: &SirNDArray) -> Vec<f64> {
+        if a.shape.len() <= 1 {
+            return a.data.clone();
+        }
+        if a.shape.len() == 2 {
+            let (r, c) = (a.shape[0], a.shape[1]);
+            let mut out = vec![0.0f64; r * c];
+            let mut k = 0;
+            for row in 0..r {
+                for col in 0..c {
+                    out[k] = a.data[col * r + row]; // column-major read
+                    k += 1;
+                }
+            }
+            return out;
+        }
+        // Unreachable in practice (this domain's rank <= 2 ceiling) --
+        // total rather than raising, mirroring the JS reference's own
+        // fallback.
+        a.data.clone()
+    }
+
+    /// Monadic `⍴` (shape-of) — `target`'s dimensions as a vector. Ported
+    /// 1:1 from `apl_runtime::builtins::shape`: a SCALAR has zero
+    /// dimensions, so its shape is the EMPTY vector (not a scalar!) — `⍴5`
+    /// is a length-0 vector, mirroring `shape.len() == 0` exactly. A
+    /// vector `[n]` has shape `[n]` (one element); a matrix `[r, c]` has
+    /// shape `[r, c]` (two elements).
+    pub fn array_shape(target: &Value) -> Value {
+        let a = array_coerce(target);
+        let dims: Vec<f64> = a.shape.iter().map(|&d| d as f64).collect();
+        let n = dims.len();
+        array_ndarray(vec![n], dims)
+    }
+
+    /// Dyadic `⍴` (reshape) — reinterpret `target`'s data under the new
+    /// dimensions `shape_arg`. Ported 1:1 from `apl_runtime::builtins::
+    /// reshape`. `shape_arg` must itself be a scalar or vector (rank <= 1)
+    /// of non-negative integers, and is itself capped at rank <= 2 (this
+    /// domain's ceiling — a longer target shape is a clean error, not a
+    /// silent truncation). `target`'s elements are ravelled
+    /// (`array_flatten_row_major`) then cyclically repeated or truncated
+    /// to fill the target shape's element count.
+    ///
+    /// CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+    /// fills the LAST axis fastest, same convention as ravel), but this
+    /// domain's storage is COLUMN-major — so for a rank-2 target the
+    /// row-major `filled` sequence must be TRANSPOSED into column-major
+    /// storage (`data[col * r + row] = filled[row * c + col]`) before
+    /// calling `array_ndarray`. Handing `filled` straight to `array_ndarray`
+    /// would silently reshape column-major instead of APL's row-major
+    /// convention — a wrong answer that still LOOKS plausible (right
+    /// multiset of values, wrong positions).
+    pub fn array_reshape(shape_arg: &Value, target: &Value) -> Value {
+        let shape_arg = array_coerce(shape_arg);
+        let target = array_coerce(target);
+        if shape_arg.shape.len() > 1 {
+            array_raise(format!(
+                "array_reshape: shape argument must be a scalar or vector (got rank {})",
+                shape_arg.shape.len()
+            ));
+        }
+        let dims: Vec<usize> = shape_arg
+            .data
+            .iter()
+            .map(|&x| {
+                if !(x.is_finite() && x == x.trunc() && x >= 0.0) {
+                    array_raise(format!(
+                        "array_reshape: shape elements must be non-negative integers, got {}",
+                        x
+                    ));
+                }
+                x as usize
+            })
+            .collect();
+        if dims.len() > 2 {
+            array_raise(format!(
+                "array_reshape: reshape to rank > 2 is not yet supported (target shape {:?})",
+                dims
+            ));
+        }
+        let total = array_checked_shape_size(&dims);
+        let source = array_flatten_row_major(&target);
+        if total > 0 && source.is_empty() {
+            array_raise(
+                "array_reshape: cannot reshape an empty source into a non-empty shape".to_string(),
+            );
+        }
+        let mut filled = vec![0.0f64; total];
+        for (k, slot) in filled.iter_mut().enumerate() {
+            *slot = source[k % source.len()];
+        }
+        if dims.len() <= 1 {
+            return array_ndarray(dims, filled);
+        }
+        let (r, c) = (dims[0], dims[1]);
+        let mut data = vec![0.0f64; total];
+        for row in 0..r {
+            for col in 0..c {
+                data[col * r + row] = filled[row * c + col];
+            }
+        }
+        array_ndarray(dims, data)
+    }
+
+    /// Monadic `⍳` (index generator / iota) — `⍳n` is the 1-BASED vector
+    /// `[1, 2, …, n]`. Ported 1:1 from `apl_runtime::builtins::
+    /// index_generator` — note this is 1-based, unlike every 0-based index
+    /// elsewhere in this domain (`array_index_get`/`array_index_set`),
+    /// because that is genuinely what APL's `⍳` means at the
+    /// SURFACE-SYNTAX level. (The `Expr::IndexGenerator` doc comment in
+    /// `semantic-ir`'s `nodes.rs` describes the underlying `Array` as
+    /// 0-based; that doc comment is stale relative to
+    /// `apl_runtime::builtins::index_generator`'s own ground-truth
+    /// behaviour and tests — e.g.
+    /// `index_generator_produces_one_based_run` — which this backend
+    /// matches, exactly like the JS/Ruby references already do.)
+    /// `array_checked_shape_size([n])` both validates `n` is a
+    /// non-negative integer AND caps it at `ARRAY_MAX_ELEMENTS` before
+    /// allocating — `n` is a runtime value a compiled program computes,
+    /// not a fixed constant, so `⍳` of an absurd size must fail cleanly.
+    pub fn array_index_generator(count: &Value) -> Value {
+        let a = array_coerce(count);
+        if !array_is_scalar(&a) {
+            array_raise("array_index_generator: monadic argument must be a scalar".to_string());
+        }
+        let x = a.data[0];
+        if !(x.is_finite() && x == x.trunc() && x >= 0.0) {
+            array_raise(format!(
+                "array_index_generator: monadic argument must be a non-negative integer, got {}",
+                x
+            ));
+        }
+        let n = array_checked_shape_size(&[x as usize]);
+        let mut out = vec![0.0f64; n];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = (i + 1) as f64;
+        }
+        array_ndarray(vec![n], out)
+    }
+
+    /// Dyadic `⍳` (index-of / search) — for every element of `needle`, the
+    /// 1-based index of its first occurrence in the vector `haystack` (or
+    /// `haystack.len() + 1` if not found — "not found" is a valid,
+    /// always-in-range position, not `-1`). Ported 1:1 from
+    /// `apl_runtime::builtins::index_of`: plain EXACT equality (no
+    /// floating-point tolerance), so `NaN` correctly never matches. The
+    /// work done is O(len(haystack) * len(needle)) (a full linear scan per
+    /// needle element) — `array_checked_shape_size` is reused here purely
+    /// for its "product <= ARRAY_MAX_ELEMENTS" check (both lengths are
+    /// already valid non-negative integers, so its dimension-validity half
+    /// is a no-op) to cap the PRODUCT before scanning, since each operand
+    /// individually staying under `ARRAY_MAX_ELEMENTS` does not bound
+    /// their product.
+    pub fn array_index_of(haystack: &Value, needle: &Value) -> Value {
+        let a = array_coerce(haystack);
+        let b = array_coerce(needle);
+        if a.shape.len() > 1 {
+            array_raise(format!(
+                "array_index_of: left argument must be a scalar or vector (got rank {})",
+                a.shape.len()
+            ));
+        }
+        array_checked_shape_size(&[a.data.len(), b.data.len()]);
+        let haystack_len = a.data.len();
+        let out: Vec<f64> = b
+            .data
+            .iter()
+            .map(|&needle_val| match a.data.iter().position(|&x| x == needle_val) {
+                Some(idx) => (idx + 1) as f64,
+                None => (haystack_len + 1) as f64,
+            })
+            .collect();
+        array_ndarray(b.shape.clone(), out)
+    }
+
+    /// Monadic `,` (ravel) — flatten `target` to a rank-1 vector, in
+    /// row-major order (see `array_flatten_row_major`'s own doc comment
+    /// for the column-major-storage-vs-row-major-order subtlety). Ported
+    /// 1:1 from `apl_runtime::builtins::ravel`.
+    pub fn array_ravel(target: &Value) -> Value {
+        let a = array_coerce(target);
+        let flat = array_flatten_row_major(&a);
+        let n = flat.len();
+        array_ndarray(vec![n], flat)
+    }
+
+    /// Dyadic `,` (catenate) — supports scalar-scalar, scalar-vector,
+    /// vector-scalar, vector-vector (all producing a vector), and
+    /// matrix-matrix-with-equal-row-counts (column/last-axis catenate,
+    /// producing `[r, ca + cb]`). Any other rank combination is a clean
+    /// "not yet supported" error. Ported 1:1 from
+    /// `apl_runtime::builtins::catenate`. The combined-length cap check
+    /// happens ONCE, up front, regardless of which rank combination
+    /// follows (mirroring the JS reference's own structure) — neither
+    /// operand alone need be oversized for the RESULT to be, since a
+    /// script that repeatedly catenates a value with itself (`A = [A, A]`)
+    /// doubles the size every line with no other ceiling. (`a.data.len()`/
+    /// `b.data.len()` are each already bounded by `ARRAY_MAX_ELEMENTS` —
+    /// every `Value::NDArray` in existence was itself built through
+    /// `array_ndarray`/`array_checked_shape_size` — so their sum cannot
+    /// overflow `usize` before this check runs.)
+    pub fn array_catenate(lhs: &Value, rhs: &Value) -> Value {
+        let a = array_coerce(lhs);
+        let b = array_coerce(rhs);
+        array_checked_shape_size(&[a.data.len() + b.data.len()]);
+        let ra = a.shape.len();
+        let rb = b.shape.len();
+        match (ra, rb) {
+            (0, 0) => array_ndarray(vec![2], vec![a.data[0], b.data[0]]),
+            (0, 1) => {
+                let mut out = vec![0.0f64; 1 + b.data.len()];
+                out[0] = a.data[0];
+                out[1..].copy_from_slice(&b.data);
+                let n = out.len();
+                array_ndarray(vec![n], out)
+            }
+            (1, 0) => {
+                let mut out = a.data.clone();
+                out.push(b.data[0]);
+                let n = out.len();
+                array_ndarray(vec![n], out)
+            }
+            (1, 1) => {
+                let mut out = a.data.clone();
+                out.extend_from_slice(&b.data);
+                let n = out.len();
+                array_ndarray(vec![n], out)
+            }
+            (2, 2) => {
+                let r = array_nrows(&a);
+                if r != array_nrows(&b) {
+                    array_raise(format!(
+                        "array_catenate: matrix catenate needs equal row counts ({} vs {})",
+                        r,
+                        array_nrows(&b)
+                    ));
+                }
+                let ca = array_ncols(&a);
+                let cb = array_ncols(&b);
+                let out_len = array_checked_shape_size(&[r, ca + cb]);
+                let mut data = vec![0.0f64; out_len];
+                for row in 0..r {
+                    for col in 0..ca {
+                        data[col * r + row] = a.data[col * r + row]; // column-major
+                    }
+                    for col in 0..cb {
+                        data[(ca + col) * r + row] = b.data[col * r + row]; // column-major
+                    }
+                }
+                array_ndarray(vec![r, ca + cb], data)
+            }
+            _ => array_raise(format!(
+                "array_catenate: catenate of rank {} and rank {} is not yet supported",
+                ra, rb
             )),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/sir22_array.rs
@@ -1,25 +1,32 @@
-//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/`MatMul`/
-//! `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the Rust
-//! backend — hand-builds a module calling each node directly (bypassing
-//! the frontend, since no frontend targets this backend for SIR22 yet),
-//! emits Rust, compiles it with a real `rustc`, runs the binary, and
-//! asserts stdout. Mirrors `compile_and_run_floats.rs`'s pattern; skips
-//! (does not fail) when no `rustc` is on `PATH` or no usable linker is
-//! present, exactly like every other `compile_and_run_*` test in this
-//! crate.
+//! SIR22 execution proof: `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+//! `Transpose`/`IndexGet`/`Stmt::IndexSet` (the "base cut", Phase A
+//! Slice 2) AND `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+//! `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` (the 9-node "APL
+//! addendum", Phase A Slice 3) on the Rust backend — hand-builds a module
+//! calling each node directly (bypassing the frontend, since no frontend
+//! targets this backend for SIR22 yet), emits Rust, compiles it with a
+//! real `rustc`, runs the binary, and asserts stdout. Mirrors
+//! `compile_and_run_floats.rs`'s pattern; skips (does not fail) when no
+//! `rustc` is on `PATH` or no usable linker is present, exactly like every
+//! other `compile_and_run_*` test in this crate.
 //!
-//! Ported from `semantic-ir-to-javascript`'s own already-proven
-//! `tests/sir22_array.rs` (and cross-checked against
-//! `semantic-ir-to-ruby`'s own port of the same suite) — same worked
-//! examples, adapted to this backend's own value-type convention: this
-//! port's `array_*` runtime (`runtime.rs`) stores every element as `f64`
-//! (mirroring the JS backend's `Float64Array`, not Ruby's Int/Float-
-//! preserving choice — see `runtime.rs`'s own module doc for why), so
-//! `Expr::IndexGet` on a scalar position always yields a `Value::Float`.
-//! Every printed assertion below therefore expects the `.0`-suffixed
-//! float rendering (`format_float` in `runtime.rs`), e.g. `"19.0"` rather
-//! than `"19"` — a deliberate, documented divergence from the Ruby
-//! reference's Integer-preserving output, not a bug.
+//! The base-cut tests were ported from `semantic-ir-to-javascript`'s own
+//! already-proven `tests/sir22_array.rs` (and cross-checked against
+//! `semantic-ir-to-ruby`'s own port of the same suite). Neither the JS nor
+//! the Ruby backend has addendum execution tests yet (both still reject
+//! the nine addendum nodes at this repo's current HEAD) — the addendum
+//! tests below are new, hand-derived from `apl_runtime::builtins`'s own
+//! ground-truth tests (`code/packages/rust/apl-runtime/src/builtins.rs`)
+//! and this backend's own `runtime.rs` doc comments.
+//!
+//! This port's `array_*` runtime (`runtime.rs`) stores every element as
+//! `f64` (mirroring the JS backend's `Float64Array`, not Ruby's
+//! Int/Float-preserving choice — see `runtime.rs`'s own module doc for
+//! why), so `Expr::IndexGet` on a scalar position always yields a
+//! `Value::Float`. Every printed assertion below therefore expects the
+//! `.0`-suffixed float rendering (`format_float` in `runtime.rs`), e.g.
+//! `"19.0"` rather than `"19"` — a deliberate, documented divergence from
+//! the Ruby reference's Integer-preserving output, not a bug.
 //!
 //! Every test constructs `Module`s directly via `print_stmt`'s scalar
 //! `IndexGet` reads (top-left/bottom-right element, etc.) — sidesteps
@@ -70,6 +77,59 @@ fn scalar(i: i64) -> IndexArg {
 }
 fn index_get(target: Expr, indices: Vec<IndexArg>) -> Expr {
     Expr::IndexGet { target: Box::new(target), indices, span: s() }
+}
+
+// ── SIR22 "APL addendum" node constructors ──────────────────────────
+
+/// Build a genuine RANK-1 vector `Value` from a list of ints. `array_lit`
+/// alone always produces rank 2 (`array_from_rows` unconditionally shapes
+/// its output `[nrows, ncols]`, even for a single row) — this ravels a
+/// single-row `ArrayLit` to collapse it to rank 1. This matters: several
+/// addendum functions dispatch on rank (`array_reduce`/`array_scan`/
+/// `array_outer`/`array_index_of`/`array_catenate` each have a DIFFERENT
+/// code path for rank 1 than for rank 2), so a "vector" test must hand
+/// them a value that is genuinely rank 1, not a 1-row rank-2 matrix that
+/// would silently exercise the WRONG branch while still producing a
+/// plausible-looking answer.
+fn vector1(values: Vec<i64>) -> Expr {
+    let row = array_lit(vec![values.into_iter().map(ilit).collect()]);
+    Expr::Ravel { target: Box::new(row), span: s() }
+}
+
+fn reduce_expr(op: ElementwiseOpKind, target: Expr) -> Expr {
+    Expr::Reduce { op, target: Box::new(target), span: s() }
+}
+
+fn scan_expr(op: ElementwiseOpKind, target: Expr) -> Expr {
+    Expr::Scan { op, target: Box::new(target), span: s() }
+}
+
+fn outer_expr(op: ElementwiseOpKind, lhs: Expr, rhs: Expr) -> Expr {
+    Expr::OuterProduct { op, lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() }
+}
+
+fn shape_expr(target: Expr) -> Expr {
+    Expr::Shape { target: Box::new(target), span: s() }
+}
+
+fn reshape_expr(shape: Expr, target: Expr) -> Expr {
+    Expr::Reshape { shape: Box::new(shape), target: Box::new(target), span: s() }
+}
+
+fn index_generator_expr(count: Expr) -> Expr {
+    Expr::IndexGenerator { count: Box::new(count), span: s() }
+}
+
+fn index_of_expr(haystack: Expr, needle: Expr) -> Expr {
+    Expr::IndexOf { haystack: Box::new(haystack), needle: Box::new(needle), span: s() }
+}
+
+fn ravel_expr(target: Expr) -> Expr {
+    Expr::Ravel { target: Box::new(target), span: s() }
+}
+
+fn catenate_expr(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::Catenate { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() }
 }
 
 const ARRAY_FEATURES: &[Feature] =
@@ -304,24 +364,236 @@ fn index_set_mutates_in_place() {
     }
 }
 
-// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+// ── SIR22 "APL addendum": real execution proofs (Phase A Slice 3) ──────
 
 #[test]
-fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
-    // cut, so the ordinary feature-flag check alone can't reject it --
-    // proves the dedicated `reject_sir22_addendum` pre-emit scan does,
-    // with a clean `Err`, not an `emit_expr` internal-bug panic.
-    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
-    let m = array_module(vec![print_stmt(Expr::Reduce {
-        op: ElementwiseOpKind::Add,
-        target: Box::new(target),
-        span: s(),
-    })]);
-    let err = semantic_ir_to_rust::compile(&m).expect_err("Reduce must be rejected, not emitted");
-    assert!(
-        err.message.contains("Reduce"),
-        "error should name the rejected node: {}",
-        err.message
-    );
+fn reduce_of_a_vector_folds_across_all_elements() {
+    // +/[1 2 3 4] = 10 -- a rank-0 result, read back with a single linear
+    // index (`array_index_get` supports that regardless of rank).
+    let m = array_module(vec![
+        let_binding("r", reduce_expr(ElementwiseOpKind::Add, vector1(vec![1, 2, 3, 4]))),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "10.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn reduce_of_a_matrix_folds_each_row_independently() {
+    // [[1 2] [3 4] [5 6]] (3 rows x 2 cols) reduced with `+` folds EACH ROW
+    // independently: row sums [3, 7, 11], a rank-1 [3] result -- not the
+    // column sums [9, 12] a row/col-swapped column-major indexing bug
+    // would produce. `runtime.rs`'s own doc comment on `array_reduce`
+    // calls this "the single easiest place to introduce a wrong-answer
+    // bug" in the whole addendum -- this test pins it.
+    let matrix =
+        array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)], vec![ilit(5), ilit(6)]]);
+    let m = array_module(vec![
+        let_binding("r", reduce_expr(ElementwiseOpKind::Add, matrix)),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(1)])),
+        print_stmt(index_get(local("r"), vec![scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "3.0\n7.0\n11.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn scan_of_a_vector_keeps_every_running_fold() {
+    // +\[1 2 3 4] = [1 3 6 10] -- every prefix sum, not just the last.
+    let m = array_module(vec![
+        let_binding("s", scan_expr(ElementwiseOpKind::Add, vector1(vec![1, 2, 3, 4]))),
+        print_stmt(index_get(local("s"), vec![scalar(0)])),
+        print_stmt(index_get(local("s"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n10.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn outer_product_of_two_vectors_computes_every_pairwise_product() {
+    // [1 2] outer* [3 4 5] -- a [2, 3] result; column-major storage means
+    // out[j*m+i] = a[i]*b[j], so as a matrix: row0 = [3, 4, 5],
+    // row1 = [6, 8, 10].
+    let m = array_module(vec![
+        let_binding(
+            "o",
+            outer_expr(ElementwiseOpKind::Mul, vector1(vec![1, 2]), vector1(vec![3, 4, 5])),
+        ),
+        print_stmt(index_get(local("o"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("o"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "3.0\n10.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_scalar_is_the_empty_vector_not_a_scalar() {
+    // `shape(5)` must be the EMPTY vector (rank 1, length 0) -- NOT a
+    // scalar (the trickiest part of this domain's `shape` semantics).
+    // Proven by taking `shape` a SECOND time: `shape(shape(5))` reads the
+    // dimensions of that empty vector, which is itself the single-element
+    // vector `[0]` (one dimension, of size 0), so `index_get(0)` reads
+    // back `0.0`. Had `array_shape` wrongly returned a genuine SCALAR for
+    // `shape(5)` instead (rank 0, not rank 1 length 0), the outer `shape`
+    // call would ALSO see rank 0 and (per `array_shape`'s own "a scalar
+    // has 0 dimensions" rule) return the empty vector again -- at which
+    // point `index_get(0)` finds no element at position 0 and RAISES
+    // ("out of bounds"), which `run_array_program` surfaces as a non-zero
+    // exit and fails the test. So a clean `"0.0"` here is only reachable
+    // through the correct rank-1-length-0 representation.
+    let m = array_module(vec![
+        let_binding("sh", shape_expr(shape_expr(ilit(5)))),
+        print_stmt(index_get(local("sh"), vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "0.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_matrix_is_a_two_element_vector() {
+    // shape([[1 2 3][4 5 6]]) (2 rows x 3 cols) = [2, 3].
+    let matrix = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let m = array_module(vec![
+        let_binding("sh", shape_expr(matrix)),
+        print_stmt(index_get(local("sh"), vec![scalar(0)])),
+        print_stmt(index_get(local("sh"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2.0\n3.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn reshape_fills_row_major_then_transposes_into_column_major_storage() {
+    // Source [[1 2 3][4 5 6]] (2x3) ravels (row-major) to [1 2 3 4 5 6].
+    // Reshaping that sequence into a [3, 2] target must fill ROW-major
+    // (APL's convention: last axis fastest) THEN transpose into this
+    // domain's column-major storage -- so as a matrix, the [3, 2] result
+    // reads back as rows [1,2], [3,4], [5,6] (the row-major
+    // reinterpretation of the flat sequence). A reshape that (wrongly)
+    // handed the row-major `filled` sequence straight to the column-major
+    // constructor would instead read back as [1,4], [2,5], [3,6] -- a
+    // DIFFERENT, still-plausible-looking (same multiset of values) wrong
+    // answer. This test checks POSITIONS, not just membership, which is
+    // exactly what `array_reshape`'s own "CRITICAL" doc comment warns is
+    // needed.
+    let source = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let target_shape = vector1(vec![3, 2]);
+    let m = array_module(vec![
+        let_binding("re", reshape_expr(target_shape, source)),
+        print_stmt(index_get(local("re"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("re"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("re"), vec![scalar(1), scalar(0)])),
+        print_stmt(index_get(local("re"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n2.0\n3.0\n6.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn index_generator_is_one_based_not_zero_based() {
+    // Iota 4 = [1 2 3 4] -- 1-based, unlike every 0-based index elsewhere
+    // in this domain (a deliberate, documented APL surface-syntax
+    // exception, not a bug -- see `array_index_generator`'s doc comment).
+    let m = array_module(vec![
+        let_binding("ix", index_generator_expr(ilit(4))),
+        print_stmt(index_get(local("ix"), vec![scalar(0)])),
+        print_stmt(index_get(local("ix"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n4.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn index_of_reports_a_one_based_position_when_found() {
+    // [10 20 30] index-of [20] -- 20 is the SECOND element, so index-of
+    // reports the 1-based position 2 (not the 0-based 1).
+    let m = array_module(vec![
+        let_binding("found", index_of_expr(vector1(vec![10, 20, 30]), vector1(vec![20]))),
+        print_stmt(index_get(local("found"), vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn index_of_reports_haystack_length_plus_one_when_not_found() {
+    // [10 20 30] index-of [99] -- 99 is absent, so index-of reports
+    // `haystack.len() + 1 == 4`, never `-1`/a sentinel outside the valid
+    // range ("not found" is a valid, always-in-range position).
+    let m = array_module(vec![
+        let_binding("missing", index_of_expr(vector1(vec![10, 20, 30]), vector1(vec![99]))),
+        print_stmt(index_get(local("missing"), vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "4.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn ravel_flattens_a_matrix_in_row_major_order() {
+    // ravel([[1 2 3][4 5 6]]) = [1 2 3 4 5 6] -- row-major order (last
+    // axis fastest), even though the matrix itself is stored column-major.
+    let matrix = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let m = array_module(vec![
+        let_binding("flat", ravel_expr(matrix)),
+        print_stmt(index_get(local("flat"), vec![scalar(0)])),
+        print_stmt(index_get(local("flat"), vec![scalar(1)])),
+        print_stmt(index_get(local("flat"), vec![scalar(5)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n2.0\n6.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_vectors_concatenates_end_to_end() {
+    // [1 2] catenate [3 4 5] = [1 2 3 4 5]
+    let m = array_module(vec![
+        let_binding("cat", catenate_expr(vector1(vec![1, 2]), vector1(vec![3, 4, 5]))),
+        print_stmt(index_get(local("cat"), vec![scalar(0)])),
+        print_stmt(index_get(local("cat"), vec![scalar(4)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n5.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_matrices_with_equal_row_counts_joins_columns() {
+    // [[1 2][3 4]] catenate [[5][6]] -- both have 2 rows, so catenate
+    // joins along columns: [[1 2 5][3 4 6]].
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5)], vec![ilit(6)]]);
+    let m = array_module(vec![
+        let_binding("cat", catenate_expr(a, b)),
+        print_stmt(index_get(local("cat"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("cat"), vec![scalar(0), scalar(2)])),
+        print_stmt(index_get(local("cat"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1.0\n5.0\n6.0\n"),
+        None => eprintln!("skip: no usable rustc/linker on PATH"),
+    }
 }


### PR DESCRIPTION
## Summary

- Opens the Rust backend (`semantic-ir-to-rust`) to the SIR22 array/matrix "APL addendum" — the 9 `Expr` node kinds (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) that Slice 2 (already merged) deferred, on top of the base cut it already shipped.
- Ports `semantic-ir-to-javascript`'s already-proven `reduce`/`scan`/`outer`/`flattenRowMajor`/`shape`/`reshape`/`indexGenerator`/`indexOf`/`ravel`/`catenate` 1:1 into new `array_*` functions inlined in this backend's generated-Rust-text runtime (`runtime.rs`), reusing the existing `array_coerce`/`array_apply_op`/`array_checked_shape_size` helpers from the base cut.
- Removes the now-obsolete `reject_sir22_addendum` pre-emit scan in `lib.rs` (confirmed unused after removal) and its `Visitor`/`walk_expr_default` imports, now that real codegen exists for all nine nodes.
- Fixes the `collect_expr_assigned` helper-recursion gap for these nine node kinds — they previously had a documented "rejected before emit, nothing reachable" no-op arm; now they recurse into their real sub-expressions so a nested `Assign` inside e.g. a `Reduce`/`Reshape` operand is never missed when pre-declaring `let mut` locals.
- Adds 9 new `emit.rs` match arms calling into the new runtime functions, matching the JS reference's call shapes 1:1 (including `Reshape`'s non-reordered `shape, target` argument order).
- Ports three particularly easy-to-get-wrong subtleties exactly, each pinned by a dedicated test: row-independent fold + column-major indexing in `reduce`/`scan` on a matrix; the row-major-fill-then-column-major-transpose step in `reshape`; and the 1-based `indexGenerator`/`indexOf` convention (flagging that `semantic-ir`'s own `Expr::IndexGenerator` doc comment is stale/wrong — it currently claims 0-based, but the `apl-runtime` ground-truth tests and every backend that implements this addendum are 1-based).
- Every new runtime function validates its output size via the existing `array_checked_shape_size` (overflow-checked, capped at `ARRAY_MAX_ELEMENTS`) before allocating.
- Bumps `Cargo.toml` 0.42.0 → 0.43.0, adds a detailed `CHANGELOG.md` entry, updates `README.md` (no longer describes the addendum as deferred/rejected).

## Test plan

- [x] `cargo build` / `cargo build --tests` — clean
- [x] `cargo test` (full crate) — all suites green, including 20/20 in `tests/sir22_array.rs` (8 existing base-cut tests + 12 new addendum tests covering `reduce` on a vector and a matrix, `scan`, `outer` product, `shape` of a scalar (explicit empty-vector assertion) and a matrix, `reshape` with a non-square target, `indexGenerator` (1-based), `indexOf` found/not-found, `ravel`, and `catenate` of vectors and matrices) — every test compiles emitted Rust with a real `rustc` and runs it
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `/security-review` — sub-agent reported "SECURITY REVIEW PASSED — no vulnerabilities found", focused specifically on DoS-via-unvalidated-allocation-size in the generated runtime text and any unsafe blocks (none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)