### PR TITLE
feat(semantic-ir-to-go): implement SIR22 APL addendum (Phase A Slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,119 @@
 # Changelog
 
+## 0.41.0 — SIR22 "APL addendum" (second-wave backend rollout, Phase A Slice 3)
+
+Implements the 9-node SIR22 "APL addendum" this backend's own Slice 2
+entry (below) explicitly deferred: `Expr::Reduce`/`Scan`/`OuterProduct`/
+`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`. No new
+`Feature` flags — the addendum shares `NDArrays`/`MatrixOps`/
+`ArrayColumnMajor` with the base cut, per
+`code/specs/SIR22-array-matrix-semantic-ir.md`.
+
+**New `_sir_ndarray_*` runtime functions (`runtime.rs`)**: `reduce`/
+`scan`/`outer` (which reuse `_sir_ndarray_apply_op`, the same 13-op
+dispatch table `_sir_ndarray_elementwise` uses), `flatten_row_major`
+(an internal helper both `reshape` and `ravel` need — not itself one of
+the nine node-backing functions), `shape`, `reshape`,
+`index_generator`, `index_of`, `ravel`, `catenate`. Ported 1:1 from
+`semantic-ir-to-javascript`'s own already-proven addendum functions
+(`runtime.rs`'s FIRST "SIR22 addendum: APL primitive operators" section
+— that file has a second, unrelated occurrence of the same section
+header inside its `#[cfg(test)]` module), which are themselves 1:1
+ports of `array_runtime::ops::{reduce,scan,outer}` and
+`apl_runtime::builtins::{shape,reshape,index_generator,index_of,ravel,
+catenate}`.
+
+Three subtleties carried over faithfully from the reference:
+
+- **`reduce`/`scan` on a rank-2 matrix fold EACH ROW independently**,
+  not the whole matrix into one value — column-major storage means
+  `(row, col)` lives at `col*r+row`, so the row loop reads `d[row]` as
+  the seed (column 0) then walks `d[col*r+row]` for the rest; swapping
+  `row`/`col` here would silently TRANSPOSE the result instead of
+  crashing. `tests/sir22_array.rs`'s
+  `reduce_folds_each_row_of_a_matrix_independently` pins the correct
+  per-row result against a naive whole-matrix-fold regression.
+- **`reshape` fills row-major, but must TRANSPOSE into column-major
+  storage.** APL's reshape fills the last axis fastest (row-major,
+  same convention as ravel); this domain stores column-major. Handing
+  the row-major-filled sequence straight to the constructor would
+  silently reshape column-major instead — a wrong answer that still
+  LOOKS plausible (right multiset of values, wrong positions).
+  `tests/sir22_array.rs`'s
+  `reshape_fills_row_major_then_transposes_into_column_major_storage`
+  reshapes a non-square `2x3` to `3x2` and asserts on element positions
+  that differ between the correct and the un-transposed-bug answer.
+- **`IndexGenerator`/`IndexOf` are 1-based**, unlike every other index
+  in this domain (`IndexGet`/`IndexSet` are 0-based) — this is
+  deliberate: it is genuinely what APL's monadic/dyadic `⍳` mean at the
+  surface-syntax level, confirmed against `apl_runtime::builtins::
+  index_generator`'s own tests (`index_generator_produces_one_based_run`)
+  and `index_of`'s doc comment. `IndexOf`'s "not found" case returns
+  `len(haystack) + 1` — always a valid, in-range position, never `-1`.
+  **Note**: `semantic-ir`'s own `Expr::IndexGenerator` doc comment
+  (`nodes.rs`) currently claims 0-based, which is stale/incorrect —
+  `apl_runtime::builtins::index_generator`'s source and tests are the
+  ground truth this port follows; fixing that doc comment is flagged as
+  a small follow-up, out of scope for this PR.
+
+**DoS discipline preserved exactly**: every function validates its
+output size via `_sir_ndarray_checked_shape_size` (the Slice-2
+overflow-safe validator) BEFORE allocating — `outer`'s `[m, n]` output
+(two independent operand lengths, neither bounds their product alone),
+`index_of`'s `haystack.length * needle.length` product (an
+`O(len(haystack)*len(needle))` scan, capped before scanning, not after),
+`catenate`'s combined length (checked ONCE up front regardless of which
+of its five rank combinations follows — a script that repeatedly
+catenates a value with itself doubles the size every line with no other
+ceiling), `index_generator`'s `n`, `reshape`'s target size. `reshape`'s
+and `index_generator`'s scalar-argument validation additionally guards
+`+Inf`/`NaN` explicitly (`math.IsNaN`/`math.IsInf`), not just `x !=
+math.Trunc(x)` — `math.Trunc(+Inf) == +Inf` would otherwise slip an
+infinite dimension past a naive integer check.
+
+**`emit.rs`**: the nine addendum nodes previously shared ONE combined
+`panic!` match arm with SIR26's `Expr::Convert` (a landmine Slice 2's
+own entry flagged: "these 7 [base-cut] nodes previously shared ONE
+combined panic arm with the 9 SIR22-addendum nodes AND `Expr::Convert`").
+This PR splits that arm: the nine addendum nodes get real
+`_sir_ndarray_*` call-emission (mirroring `ElementwiseOp`/`Transpose`'s
+existing style — `Reduce`/`Scan`/`OuterProduct` reuse
+`elementwise_op_go_name` exactly like `ElementwiseOp` does), and
+`Expr::Convert` moves into its own untouched arm with its original panic
+message (now naming only SIR26, not "SIR22-addendum/SIR26"). `cargo
+test -p semantic-ir-to-go` stayed 100% green throughout, confirming no
+`Expr::Convert` regression.
+
+**`lib.rs`**: `check_exception_soundness`'s nine `unsupported_sir22_
+addendum(...)` rejection arms (and that now-dead helper function) are
+removed; `check_soundness_expr` instead recurses into each addendum
+node's sub-expression(s), the same treatment every other real/supported
+composite node already gets (mirrors the base-cut `ArrayLit`/`Range`/
+`MatMul`/etc. arms Slice 2 added). `ACCEPTED_FEATURES`'s doc comment and
+this function's own doc comment are updated to say the addendum is no
+longer deferred.
+
+**`tests/sir22_array.rs`** (12 new tests, all real `go run` execution):
+`reduce` on a vector AND a matrix (the row-independent-fold proof
+above), `scan` on a vector, `outer` product of two vectors, `shape` of a
+scalar (proven via a `shape(shape(5))` double-application trick — reading
+index 0 of the double-shape yields `0.0` only if the inner `shape(5)` is
+correctly a length-0 vector, not a scalar) and of a matrix, `reshape`
+(the transposition-correctness proof above), `index_generator` (1-based),
+`index_of` found AND not-found, `ravel` of a matrix, `catenate` of two
+vectors and of two equal-row-count matrices, and a DoS-guard test
+(`outer_product_output_shape_exceeding_the_element_cap_panics_cleanly`)
+mirroring Slice 2's own `matmul_output_shape_exceeding_the_element_cap_
+panics_cleanly` pattern. None of the addendum nodes have direct literal
+syntax available in a hand-built `Module`, so genuine rank-1 "vector"
+test fixtures (as opposed to a `[1, n]` row-vector-shaped MATRIX, which
+is what `array_lit` with one row and `Range` both produce) are built via
+nested scalar `Catenate` — itself one of the nodes under test. Verified
+with a real `go vet` + `go run` pass on a hand-assembled module
+exercising all nine nodes together (via a throwaway example, not
+committed) as an additional sanity check beyond the crate's own test
+harness.
+
 ## 0.40.0 — SIR22 array/matrix base cut (second-wave backend rollout, Phase A Slice 2)
 
 Opens this backend to `Feature::NDArrays`/`Feature::MatrixOps`/

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -290,14 +290,17 @@ that used to implement them were removed once every frontend finished
 migrating to `__sys_write__` (SIR28 §7) — see
 [SIR28](../../../specs/SIR28-syscall-primitives.md).
 
-### SIR22 — array/matrix base cut (`NDArrays`, `MatrixOps`, `ArrayColumnMajor`)
+### SIR22 — array/matrix: base cut + APL addendum (`NDArrays`, `MatrixOps`, `ArrayColumnMajor`)
 
 `Expr::ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` and
-`Stmt::IndexSet` (MATLAB/Octave-style dense numeric arrays and matrix ops)
-lower to calls into an inlined `_sir_ndarray_*` sub-runtime — a plain-Go
-port of `semantic-ir-to-javascript`'s own already-proven `ArrayRt`
-sub-runtime, following this backend's existing "paste the runtime helpers
-inline, no `go.mod` dependency" convention. See
+`Stmt::IndexSet` (MATLAB/Octave-style dense numeric arrays and matrix ops,
+the "base cut", Phase A Slice 2), plus the 9-node "APL addendum"
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+`IndexOf`/`Ravel`/`Catenate`, Phase A Slice 3), all lower to calls into an
+inlined `_sir_ndarray_*` sub-runtime — a plain-Go port of
+`semantic-ir-to-javascript`'s own already-proven `ArrayRt` sub-runtime,
+following this backend's existing "paste the runtime helpers inline, no
+`go.mod` dependency" convention. See
 [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md) for the full
 node-by-node spec. Every array element is a `float64` (MATLAB's own
 "everything is a double" numeric model — see `runtime.rs`'s module doc for
@@ -306,14 +309,23 @@ way the sibling Ruby backend's SIR22 port does). Shape/output sizes are
 validated (with explicit multiplication-overflow guards, since Go's `int`
 can wrap where JS's `Number` cannot) BEFORE any `[]float64` allocation, an
 `_sirNdarrayMaxElements = 1 << 26` cap mirroring the JS reference's
-`MAX_ELEMENTS` exactly.
+`MAX_ELEMENTS` exactly — every addendum function reuses this same cap
+(`outer`'s `[m, n]` output, `index_of`'s `haystack * needle` scan bound,
+`catenate`'s combined length, `index_generator`'s `n`, `reshape`'s target
+size).
 
-The 9-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) is **not yet
-supported** — it shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
-base cut above, so a plain feature-flag check can't reject it; `lib.rs`'s
-`check_exception_soundness` (extended for this PR) rejects it cleanly with
-a `BackendError` naming the offending node, before `emit` is ever reached.
+Two addendum-specific subtleties worth flagging for a future reader:
+`reduce`/`scan` on a rank-2 matrix fold **each row independently** (not
+the whole matrix into one value) — column-major indexing inside that row
+loop is, per the runtime's own doc comment, "the single easiest place to
+introduce a wrong-answer bug"; and `reshape` fills in APL's row-major
+order but must **transpose** the filled sequence into this domain's
+column-major storage before returning it — handing the row-major
+sequence straight to the constructor produces a wrong answer that still
+looks plausible (right values, wrong positions). `IndexGenerator`/
+`IndexOf` are deliberately **1-based** (unlike every 0-based index
+elsewhere in this domain), matching APL's own `⍳` surface semantics.
+`tests/sir22_array.rs` has an execution-proof test for each of these.
 
 ## Value model
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -986,35 +986,110 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_index_args(out, indices, indent);
             out.push_str("})");
         }
-        // ── SIR22 addendum: APL primitive operators (still deferred) ──
-        // These nine share `Feature::NDArrays`/`MatrixOps`/
-        // `ArrayColumnMajor` with the base cut just above, so the SIR10
-        // capability gate alone can no longer reject them now that this
-        // backend accepts those three features — `lib.rs`'s
-        // `check_exception_soundness` (a dedicated structural soundness
-        // gate; see its doc comment) is what actually rejects a module
-        // using one of these, with a clean `Err`, BEFORE `compile` ever
-        // calls `emit_module`. Reaching this arm at runtime would mean
-        // that gate has a bug, not a user error.
-        Expr::Reduce { .. }
-        | Expr::Scan { .. }
-        | Expr::OuterProduct { .. }
-        | Expr::Shape { .. }
-        | Expr::Reshape { .. }
-        | Expr::IndexGenerator { .. }
-        | Expr::IndexOf { .. }
-        | Expr::Ravel { .. }
-        | Expr::Catenate { .. }
+        // ── SIR22 addendum: APL primitive operators — real codegen ────
+        // Each of the nine maps 1:1 onto a call into the ported
+        // `_sir_ndarray_*` sub-runtime (see `runtime.rs`'s "SIR22
+        // addendum" section) — the same treatment `ElementwiseOp`/
+        // `Transpose`/`MatMul` above already get for the SIR22 base cut.
+        // `Reduce`/`Scan`/`OuterProduct` carry an `ElementwiseOpKind` and
+        // so reuse `elementwise_op_go_name` exactly like `ElementwiseOp`
+        // does; the remaining six have no `op` field at all (they are
+        // "bespoke, not BinOp-shaped" per the SIR22 spec addendum and
+        // `apl_runtime::builtins`'s own doc comment) and just recurse
+        // into their operand(s). These nine were previously rejected by
+        // `lib.rs`'s `check_exception_soundness` structural soundness
+        // gate (shared `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
+        // base cut meant the plain capability gate couldn't tell them
+        // apart) — that gate no longer rejects them either, now that
+        // real codegen exists here.
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(
+                out,
+                "_sir_ndarray_reduce({}, ",
+                quote_go_string(elementwise_op_go_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(
+                out,
+                "_sir_ndarray_scan({}, ",
+                quote_go_string(elementwise_op_go_name(*op))
+            );
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "_sir_ndarray_outer({}, ",
+                quote_go_string(elementwise_op_go_name(*op))
+            );
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::Shape { target, .. } => {
+            out.push_str("_sir_ndarray_shape(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `_sir_ndarray_reshape(shapeArgV, targetV)` takes
+        // the same order, so no argument reordering is needed at this
+        // call site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `_sir_ndarray_range`'s `start, stop, step` above, which DOES
+        // reorder).
+        Expr::Reshape { shape, target, .. } => {
+            out.push_str("_sir_ndarray_reshape(");
+            emit_expr(out, shape, indent);
+            out.push_str(", ");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::IndexGenerator { count, .. } => {
+            out.push_str("_sir_ndarray_index_generator(");
+            emit_expr(out, count, indent);
+            out.push(')');
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            out.push_str("_sir_ndarray_index_of(");
+            emit_expr(out, haystack, indent);
+            out.push_str(", ");
+            emit_expr(out, needle, indent);
+            out.push(')');
+        }
+        Expr::Ravel { target, .. } => {
+            out.push_str("_sir_ndarray_ravel(");
+            emit_expr(out, target, indent);
+            out.push(')');
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            out.push_str("_sir_ndarray_catenate(");
+            emit_expr(out, lhs, indent);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent);
+            out.push(')');
+        }
         // SIR26 `Convert` — unrelated to SIR22; this backend still does
         // not accept `Feature::Conversions`, so the ordinary SIR10
         // capability gate (not the SIR22-specific soundness gate above)
-        // rejects any module using it before emit is ever reached —
-        // unaffected by this PR.
-        | Expr::Convert { .. } => {
+        // rejects any module using it before emit is ever reached — its
+        // own dedicated arm, kept separate from the nine addendum arms
+        // above (they previously shared ONE combined `panic!` arm with
+        // this node; splitting them out to real codegen must not change
+        // `Convert`'s own untouched behavior here).
+        Expr::Convert { span, .. } => {
             panic!(
-                "go backend reached a deferred SIR22-addendum/SIR26 expression ({}) at {} — not accepted yet",
+                "go backend reached a deferred SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
-                e.span()
+                span
             );
         }
         // ── SIR23 (symbolic expression + pattern/rewrite IR) ──────────

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -178,20 +178,23 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // nothing emits it yet, so this declares acceptance ahead of any
     // frontend using it.
     Feature::ConsoleIO,
-    // ── SIR22 array/matrix base cut (second-wave backend rollout) ────
+    // ── SIR22 array/matrix, base cut + APL addendum (second-wave backend
+    // rollout, Phase A Slices 2-3) ────────────────────────────────────
     // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
-    // (+ `Stmt::IndexSet`) route into `_sir_ndarray_*` helpers, an
-    // inlined port of the already-proven `semantic-ir-to-javascript`
-    // `ArrayRt` sub-runtime (see `runtime.rs`'s "SIR22 array/matrix
-    // domain" section). The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/
+    // (+ `Stmt::IndexSet`, the base cut, Slice 2) and `Reduce`/`Scan`/
     // `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-    // `Ravel`/`Catenate`) share these same three features but stay
-    // deferred to a later slice — rejected by `check_exception_soundness`
-    // below (extended for this PR to also cover SIR22, despite its
-    // E3-era name — see that function's doc comment), NOT this
-    // capability gate, since the gate alone can no longer distinguish
-    // the base cut from the addendum once these three flags are
-    // accepted.
+    // `Ravel`/`Catenate` (the "APL addendum", Slice 3) all route into
+    // `_sir_ndarray_*` helpers, an inlined port of the already-proven
+    // `semantic-ir-to-javascript` `ArrayRt` sub-runtime (see
+    // `runtime.rs`'s "SIR22 array/matrix domain" + "SIR22 addendum"
+    // sections). All sixteen nodes observe just these three features —
+    // the addendum spec gives them no feature flag of their own — so
+    // this capability gate alone cannot tell a base-cut-only module from
+    // one also using the addendum; that distinction no longer matters
+    // now that both are real, accepted codegen (Slice 2 needed
+    // `check_exception_soundness` below to reject addendum usage
+    // cleanly while it was still unimplemented — that rejection is gone
+    // as of Slice 3).
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -351,25 +354,21 @@ fn check_no_keyword_rest_mix(module: &Module, errs: &mut Vec<BackendError>) {
 /// **Second job, added for the SIR22 second-wave backend rollout (still
 /// under this E3-era name — renaming was judged unnecessary churn for a
 /// crate-private function, but is flagged here for a future reader):**
-/// this same walk ALSO rejects the SIR22 "APL addendum" nodes (`Reduce`/
-/// `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-/// `Ravel`/`Catenate`).  Those nine share `Feature::NDArrays`/
-/// `Feature::MatrixOps`/`Feature::ArrayColumnMajor` with the SIR22 BASE
-/// cut this backend now implements (`ArrayLit`/`Range`/`MatMul`/
-/// `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet`) — the SIR22
-/// addendum spec gives them no feature flag of their own — so the
-/// ordinary `accepts_features()` capability check can no longer tell a
-/// module using only the base cut (real codegen, safe) from one that
-/// also uses these nine (still deferred in `emit`, would panic) now that
-/// `ACCEPTED_FEATURES` declares those three flags.  Reusing THIS
-/// existing recursive walk (rather than adding a second, separate
-/// tree-walk mechanism the way `semantic-ir-to-javascript`'s now-removed
-/// `find_unimplemented_sir22_addendum_node` or
-/// `semantic-ir-to-ruby`'s `ScanHit::Sir22AddendumNode` each did) follows
-/// this backend's OWN pre-existing idiom: one shared structural
-/// soundness gate, called once from `compile()` right beside the
-/// manifest gate, before any emission — see the doc comment above for
-/// the original (E3) rationale, which applies identically here.
+/// during Phase A Slice 2, this same walk ALSO rejected the SIR22 "APL
+/// addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+/// `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — those nine share
+/// `Feature::NDArrays`/`Feature::MatrixOps`/`Feature::ArrayColumnMajor`
+/// with the SIR22 base cut, giving the ordinary `accepts_features()`
+/// capability check no way to tell a module using only the base cut
+/// (real codegen, safe) from one that also used the addendum (still
+/// deferred in `emit`, would panic) once `ACCEPTED_FEATURES` declared
+/// those three flags. As of Phase A Slice 3, `emit.rs` has real
+/// `_sir_ndarray_*` codegen for all nine addendum nodes too, so this
+/// walk no longer rejects them — `check_soundness_expr`'s addendum arms
+/// now just recurse into sub-expressions, same as every other
+/// real/supported composite node. This function's ORIGINAL (E3) job —
+/// rejecting a `Const` used as a value / a `Const` assignment outside
+/// exception-class references, described above — is unaffected.
 fn check_exception_soundness(module: &Module, errs: &mut Vec<BackendError>) {
     for f in &module.functions {
         for s in &f.body.stmts {
@@ -638,48 +637,38 @@ fn check_soundness_expr(e: &semantic_ir::Expr, errs: &mut Vec<BackendError>) {
                 check_soundness_index_arg(idx, errs);
             }
         }
-        // ── SIR22 "APL addendum": still deferred — see
-        // `check_exception_soundness`'s doc comment (this function's
-        // caller) for the full "why here, why this mechanism" rationale.
-        // These nine share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with
-        // the base cut above, so only a dedicated structural check (not
-        // the plain capability gate) can tell them apart.
-        Expr::Reduce { span, .. } => errs.push(unsupported_sir22_addendum("Reduce", span.clone())),
-        Expr::Scan { span, .. } => errs.push(unsupported_sir22_addendum("Scan", span.clone())),
-        Expr::OuterProduct { span, .. } => {
-            errs.push(unsupported_sir22_addendum("OuterProduct", span.clone()))
+        // ── SIR22 "APL addendum": now REAL, supported nodes (Phase A
+        // Slice 3) — recurse into their sub-expressions for the same
+        // residual checks (nested `Const` usage, ...) every other
+        // composite expression gets above, mirroring the base-cut arms
+        // just above. `emit.rs` now has real `_sir_ndarray_*` codegen
+        // for all nine, so they are no longer rejected here.
+        Expr::Reduce { target, .. } => check_soundness_expr(target, errs),
+        Expr::Scan { target, .. } => check_soundness_expr(target, errs),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            check_soundness_expr(lhs, errs);
+            check_soundness_expr(rhs, errs);
         }
-        Expr::Shape { span, .. } => errs.push(unsupported_sir22_addendum("Shape", span.clone())),
-        Expr::Reshape { span, .. } => {
-            errs.push(unsupported_sir22_addendum("Reshape", span.clone()))
+        Expr::Shape { target, .. } => check_soundness_expr(target, errs),
+        Expr::Reshape { shape, target, .. } => {
+            check_soundness_expr(shape, errs);
+            check_soundness_expr(target, errs);
         }
-        Expr::IndexGenerator { span, .. } => {
-            errs.push(unsupported_sir22_addendum("IndexGenerator", span.clone()))
+        Expr::IndexGenerator { count, .. } => check_soundness_expr(count, errs),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            check_soundness_expr(haystack, errs);
+            check_soundness_expr(needle, errs);
         }
-        Expr::IndexOf { span, .. } => {
-            errs.push(unsupported_sir22_addendum("IndexOf", span.clone()))
-        }
-        Expr::Ravel { span, .. } => errs.push(unsupported_sir22_addendum("Ravel", span.clone())),
-        Expr::Catenate { span, .. } => {
-            errs.push(unsupported_sir22_addendum("Catenate", span.clone()))
+        Expr::Ravel { target, .. } => check_soundness_expr(target, errs),
+        Expr::Catenate { lhs, rhs, .. } => {
+            check_soundness_expr(lhs, errs);
+            check_soundness_expr(rhs, errs);
         }
         // Leaves / nodes with no sub-exprs of interest.
         _ => {}
     }
-}
-
-/// One `BackendError` for a SIR22 "APL addendum" node — see
-/// `check_exception_soundness`'s doc comment for the full rationale.
-fn unsupported_sir22_addendum(kind: &str, span: semantic_ir::Span) -> BackendError {
-    unsupported(
-        &format!(
-            "go backend does not yet implement the SIR22 addendum node `{kind}` (deferred to \
-             a later slice; it shares Feature::NDArrays/MatrixOps/ArrayColumnMajor with the \
-             SIR22 base cut this backend now accepts, so the feature-flag capability gate \
-             alone cannot reject it — this dedicated structural check does instead)"
-        ),
-        span,
-    )
 }
 
 fn check_soundness_block(b: &semantic_ir::Block, errs: &mut Vec<BackendError>) {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -5360,6 +5360,437 @@ func _sir_ndarray_index_set(av Value, indices []_sirIndexArg, value Value) {
 	}
 }
 
+// ── SIR22 addendum: APL primitive operators ────────────────────────
+// Ported 1:1 from `semantic-ir-to-javascript`'s own already-proven
+// `ArrayRt` addendum functions (`runtime.rs`, the FIRST "SIR22 addendum:
+// APL primitive operators" section -- NOT the second occurrence inside
+// that file's `#[cfg(test)]` module), which are themselves 1:1 ports of
+// `array_runtime::ops::{reduce,scan,outer}` (the three that take an
+// `ElementwiseOpKind`) and `apl_runtime::builtins`'s bespoke,
+// non-`BinOp`-shaped `shape`/`reshape`/`index_generator`/`index_of`/
+// `ravel`/`catenate`. `Reduce`/`Scan`/`OuterProduct` reuse
+// `_sir_ndarray_apply_op` above -- the same dispatch table
+// `_sir_ndarray_elementwise` uses -- so an `op` string here is the exact
+// same `elementwise_op_go_name` spelling (`"Add"`, not `"add"`).
+// `_sirNdarrayMaxElements`/`_sir_ndarray_checked_shape_size` (defined
+// above) are reused as-is for every new bounded-allocation check below --
+// this runtime has exactly one array-size cap, not one per domain.
+
+// `+/A` (APL reduce, dyadic-op monadic-adverb) -- fold `target` with `op`
+// along its one axis. Ported 1:1 from `array_runtime::ops::reduce`:
+//   - rank 0 (scalar): nothing to fold, returns `target` itself.
+//   - rank 1 (vector `[n]`): left-fold across all `n` elements
+//     (`op(op(op(v0, v1), v2), ...)`); an EMPTY vector is a clean error --
+//     unlike `sum`/`mean` (which have a built-in identity, 0), `reduce`
+//     is generic over any `op`, and guessing an identity (`0` for `Add`,
+//     `1` for `Mul`, `-Inf` for `Max`, ...) for an arbitrary, possibly
+//     future op would be silently wrong for most of them.
+//   - rank 2 (matrix `[r, c]`): folds EACH ROW independently across its
+//     `c` columns, producing a `[r]` vector (one folded value per row).
+//     Column-major storage means element `(row, col)` lives at
+//     `col*r+row` -- the row loop reads `d[row]` as the seed (column 0)
+//     then walks `d[col*r+row]` for `col = 1..c`; getting `row`/`col`
+//     swapped here silently transposes the result instead of panicking,
+//     so this indexing is the single easiest place to introduce a
+//     wrong-answer bug when reading this function.
+func _sir_ndarray_reduce(op string, av Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	shape := a.Shape
+	if len(shape) == 0 {
+		return a
+	}
+	if len(shape) == 1 {
+		n := shape[0]
+		if n == 0 {
+			panic("reduce: cannot fold an empty vector (no identity element for an arbitrary op)")
+		}
+		d := a.Data
+		acc := d[0]
+		for i := 1; i < n; i++ {
+			acc = _sir_ndarray_apply_op(op, acc, d[i])
+		}
+		return _sir_ndarray_new([]int{}, []float64{acc})
+	}
+	if len(shape) == 2 {
+		r, c := shape[0], shape[1]
+		if c == 0 {
+			panic("reduce: cannot fold an empty row (no identity element for an arbitrary op)")
+		}
+		d := a.Data
+		out := make([]float64, r)
+		for row := 0; row < r; row++ {
+			acc := d[row] // column-major: (row, 0) lives at plain `row`
+			for col := 1; col < c; col++ {
+				acc = _sir_ndarray_apply_op(op, acc, d[col*r+row])
+			}
+			out[row] = acc
+		}
+		return _sir_ndarray_new([]int{r}, out)
+	}
+	panic(fmt.Sprintf("reduce: rank > 2 not yet supported (shape %v)", shape))
+}
+
+// `+\A` (APL scan) -- the same fold as `reduce`, but keeping EVERY
+// intermediate result instead of only the last; output has the same
+// shape as `target`. Ported 1:1 from `array_runtime::ops::scan`. An
+// empty axis is NOT an error here (unlike `reduce`): there is simply
+// nothing to scan, and the (empty) output shape already says so.
+func _sir_ndarray_scan(op string, av Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	shape := a.Shape
+	if len(shape) == 0 {
+		return a
+	}
+	if len(shape) == 1 {
+		n := shape[0]
+		d := a.Data
+		out := make([]float64, n)
+		var acc float64
+		started := false
+		for i := 0; i < n; i++ {
+			if started {
+				acc = _sir_ndarray_apply_op(op, acc, d[i])
+			} else {
+				acc = d[i]
+			}
+			started = true
+			out[i] = acc
+		}
+		return _sir_ndarray_new([]int{n}, out)
+	}
+	if len(shape) == 2 {
+		r, c := shape[0], shape[1]
+		d := a.Data
+		out := make([]float64, len(d))
+		for row := 0; row < r; row++ {
+			var acc float64
+			started := false
+			for col := 0; col < c; col++ {
+				x := d[col*r+row] // column-major
+				if started {
+					acc = _sir_ndarray_apply_op(op, acc, x)
+				} else {
+					acc = x
+				}
+				started = true
+				out[col*r+row] = acc
+			}
+		}
+		return _sir_ndarray_new([]int{r, c}, out)
+	}
+	panic(fmt.Sprintf("scan: rank > 2 not yet supported (shape %v)", shape))
+}
+
+// `A o.x B` (APL outer product) -- apply `op` to every pair `(ai, bj)`,
+// producing a result of rank `rank(a) + rank(b)`. Ported 1:1 from
+// `array_runtime::ops::outer`, scoped identically to `rank(a) <= 1` and
+// `rank(b) <= 1` (the vector<x>vector case below already reaches this
+// domain's rank-2 ceiling). `_sir_ndarray_checked_shape_size` validates
+// the `[m, n]` output shape BEFORE allocating -- `m`/`n` are two
+// INDEPENDENT operand lengths, each individually under
+// `_sirNdarrayMaxElements`, but nothing bounds their product alone (the
+// same outer-product-shaped allocation `_sir_ndarray_matmul`/
+// `_sir_ndarray_index_get` above guard).
+func _sir_ndarray_outer(op string, av Value, bv Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	b := _sir_ndarray_to_array_value(bv)
+	as := a.Shape
+	bs := b.Shape
+	switch {
+	case len(as) == 0 && len(bs) == 0:
+		return _sir_ndarray_new([]int{}, []float64{_sir_ndarray_apply_op(op, a.Data[0], b.Data[0])})
+	case len(as) == 0 && len(bs) == 1:
+		x := a.Data[0]
+		out := make([]float64, len(b.Data))
+		for i, y := range b.Data {
+			out[i] = _sir_ndarray_apply_op(op, x, y)
+		}
+		return _sir_ndarray_new([]int{bs[0]}, out)
+	case len(as) == 1 && len(bs) == 0:
+		y := b.Data[0]
+		out := make([]float64, len(a.Data))
+		for i, x := range a.Data {
+			out[i] = _sir_ndarray_apply_op(op, x, y)
+		}
+		return _sir_ndarray_new([]int{as[0]}, out)
+	case len(as) == 1 && len(bs) == 1:
+		m := as[0]
+		n := bs[0]
+		outLen := _sir_ndarray_checked_shape_size([]int{m, n})
+		ad := a.Data
+		bd := b.Data
+		out := make([]float64, outLen)
+		for j := 0; j < n; j++ {
+			for i := 0; i < m; i++ {
+				out[j*m+i] = _sir_ndarray_apply_op(op, ad[i], bd[j]) // column-major
+			}
+		}
+		return _sir_ndarray_new([]int{m, n}, out)
+	default:
+		panic(fmt.Sprintf("outer: operands of rank > 1 not yet supported (shapes %v, %v)", as, bs))
+	}
+}
+
+// Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order --
+// last axis varies fastest. `a` itself stores COLUMN-major
+// (`_sir_ndarray_get`'s own doc comment), so a matrix must be walked
+// "row, then column" via `_sir_ndarray_get` to produce true row-major
+// order; returning the raw column-major buffer would silently ravel in
+// the WRONG order. Always returns a FRESH slice (never `a.Data` itself,
+// even in the rank <= 1 no-op case) -- mirrors `apl_runtime::builtins::
+// flatten` returning an owned `Vec`, not a borrow, so the result never
+// accidentally aliases `a`'s own buffer (a later in-place `IndexSet` on
+// `a` must not silently mutate an already-returned ravel/reshape
+// result).
+func _sir_ndarray_flatten_row_major(a *NDArray) []float64 {
+	shape := a.Shape
+	if len(shape) <= 1 {
+		out := make([]float64, len(a.Data))
+		copy(out, a.Data)
+		return out
+	}
+	if len(shape) == 2 {
+		r, c := shape[0], shape[1]
+		out := make([]float64, r*c)
+		k := 0
+		for row := 0; row < r; row++ {
+			for col := 0; col < c; col++ {
+				v, _ := _sir_ndarray_get(a, row, col) // always in-bounds by construction
+				out[k] = v
+				k++
+			}
+		}
+		return out
+	}
+	// Unreachable in practice (this domain's rank <= 2 ceiling) -- total
+	// rather than panicking, mirroring the JS/Rust reference's own
+	// fallback.
+	out := make([]float64, len(a.Data))
+	copy(out, a.Data)
+	return out
+}
+
+// Monadic shape-of (rho) -- `target`'s dimensions as a vector. Ported 1:1
+// from `apl_runtime::builtins::shape`: a SCALAR has zero dimensions, so
+// its shape is the EMPTY vector (not a scalar!) -- shape-of a scalar is a
+// length-0 vector, mirroring `len(a.Shape) == 0` exactly. A vector `[n]`
+// has shape `[n]` (one element); a matrix `[r, c]` has shape `[r, c]`
+// (two elements).
+func _sir_ndarray_shape(av Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	dims := make([]float64, len(a.Shape))
+	for i, d := range a.Shape {
+		dims[i] = float64(d)
+	}
+	return _sir_ndarray_new([]int{len(dims)}, dims)
+}
+
+// Dyadic reshape (rho) -- reinterpret `target`'s data under the new
+// dimensions `shapeArg`. Ported 1:1 from `apl_runtime::builtins::
+// reshape`. `shapeArg` must itself be a scalar or vector (rank <= 1) of
+// non-negative integers, and the TARGET reshape rank is itself capped at
+// <= 2 (this domain's ceiling -- a longer target shape is a clean error,
+// not a silent truncation). `target`'s elements are ravelled
+// (`_sir_ndarray_flatten_row_major`) then cyclically repeated or
+// truncated to fill the target shape's element count.
+//
+// CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+// fills the LAST axis fastest, same convention as ravel), but this
+// domain's storage is COLUMN-major -- so for a rank-2 target the
+// row-major `filled` sequence must be TRANSPOSED into column-major
+// storage (`data[col*r+row] = filled[row*c+col]`) before constructing
+// the result. Handing `filled` straight to `_sir_ndarray_new` would
+// silently reshape column-major instead of APL's row-major convention --
+// a wrong answer that still LOOKS plausible (right multiset of values,
+// wrong positions).
+//
+// SECURITY: `shapeArg`'s elements are validated with the same
+// NaN/Inf-safe form `_sir_ndarray_assert_valid_position` uses
+// (`math.IsNaN`/`math.IsInf` checked explicitly, not just `x !=
+// math.Trunc(x)`) -- `+Inf` passes a bare `x == math.Trunc(x)` check
+// (`math.Trunc(+Inf) == +Inf`) and is `>= 0`, so without the explicit
+// `IsInf` guard a reshape with an infinite dimension would slip through
+// this validation and reach `_sir_ndarray_checked_shape_size` with a
+// non-finite dimension.
+func _sir_ndarray_reshape(shapeArgV Value, targetV Value) *NDArray {
+	shapeArg := _sir_ndarray_to_array_value(shapeArgV)
+	target := _sir_ndarray_to_array_value(targetV)
+	if len(shapeArg.Shape) > 1 {
+		panic(fmt.Sprintf("reshape: shape argument must be a scalar or vector (got rank %d)", len(shapeArg.Shape)))
+	}
+	dims := make([]int, len(shapeArg.Data))
+	for i, x := range shapeArg.Data {
+		if math.IsNaN(x) || math.IsInf(x, 0) || x != math.Trunc(x) || x < 0 {
+			panic(fmt.Sprintf("reshape: shape elements must be non-negative integers, got %v", x))
+		}
+		dims[i] = int(x)
+	}
+	if len(dims) > 2 {
+		panic(fmt.Sprintf("reshape: reshape to rank > 2 is not yet supported (target shape %v)", dims))
+	}
+	total := _sir_ndarray_checked_shape_size(dims)
+	source := _sir_ndarray_flatten_row_major(target)
+	if total > 0 && len(source) == 0 {
+		panic("reshape: cannot reshape an empty source into a non-empty shape")
+	}
+	filled := make([]float64, total)
+	for k := 0; k < total; k++ {
+		filled[k] = source[k%len(source)]
+	}
+	if len(dims) <= 1 {
+		return _sir_ndarray_new(dims, filled)
+	}
+	r, c := dims[0], dims[1]
+	data := make([]float64, total)
+	for row := 0; row < r; row++ {
+		for col := 0; col < c; col++ {
+			data[col*r+row] = filled[row*c+col]
+		}
+	}
+	return _sir_ndarray_new(dims, data)
+}
+
+// Monadic index generator / iota -- of `n` is the 1-BASED vector `[1, 2,
+// ..., n]`. Ported 1:1 from `apl_runtime::builtins::index_generator` (see
+// that function's own tests, e.g.
+// `index_generator_produces_one_based_run`) -- note this is 1-based,
+// unlike every 0-based index elsewhere in this domain
+// (`_sir_ndarray_index_get`/`_sir_ndarray_index_set`), because that is
+// genuinely what APL's iota means at the SURFACE-SYNTAX level. (A stale
+// doc comment on `semantic-ir`'s own `Expr::IndexGenerator` node claims
+// 0-based -- `apl_runtime::builtins::index_generator`'s own source and
+// tests are the ground truth this port follows; that doc comment is
+// wrong and worth fixing separately.) `_sir_ndarray_checked_shape_size`
+// both validates `n` is representable AND caps it at
+// `_sirNdarrayMaxElements` before allocating -- `n` is a runtime value a
+// compiled program computes, not a fixed constant, so this must fail
+// cleanly on an absurd size.
+func _sir_ndarray_index_generator(av Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	if !_sir_ndarray_is_scalar(a) {
+		panic("indexGenerator: monadic argument must be a scalar")
+	}
+	x := a.Data[0]
+	if math.IsNaN(x) || math.IsInf(x, 0) || x != math.Trunc(x) || x < 0 {
+		panic(fmt.Sprintf("indexGenerator: monadic argument must be a non-negative integer, got %v", x))
+	}
+	n := _sir_ndarray_checked_shape_size([]int{int(x)})
+	out := make([]float64, n)
+	for i := 0; i < n; i++ {
+		out[i] = float64(i + 1) // 1-based, per apl_runtime::builtins::index_generator
+	}
+	return _sir_ndarray_new([]int{n}, out)
+}
+
+// Dyadic index-of / search -- for every element of `needle`, the 1-based
+// index of its first occurrence in the vector `haystack` (or
+// `len(haystack) + 1` if not found -- "not found" is a valid,
+// always-in-range position, not `-1`). Ported 1:1 from
+// `apl_runtime::builtins::index_of`: plain EXACT equality (no
+// floating-point tolerance -- `NaN` correctly never matches itself, same
+// as Rust's `==`). The work done is O(len(haystack) * len(needle)) (a
+// full linear scan per needle element) -- `_sir_ndarray_checked_shape_size`
+// is reused here purely for its "product <= _sirNdarrayMaxElements"
+// check (both lengths are already valid non-negative integers, so its
+// dimension-validity half is a no-op) to cap the PRODUCT before
+// scanning, since each operand individually staying under
+// `_sirNdarrayMaxElements` does not bound their product (up to
+// ~4.5 * 10^15 comparisons otherwise).
+func _sir_ndarray_index_of(av Value, bv Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	b := _sir_ndarray_to_array_value(bv)
+	if len(a.Shape) > 1 {
+		panic(fmt.Sprintf("indexOf: left argument must be a scalar or vector (got rank %d)", len(a.Shape)))
+	}
+	_sir_ndarray_checked_shape_size([]int{len(a.Data), len(b.Data)})
+	haystack := a.Data
+	out := make([]float64, len(b.Data))
+	for i, needle := range b.Data {
+		found := -1
+		for j, x := range haystack {
+			if x == needle {
+				found = j
+				break
+			}
+		}
+		if found == -1 {
+			out[i] = float64(len(haystack) + 1)
+		} else {
+			out[i] = float64(found + 1)
+		}
+	}
+	return _sir_ndarray_new(b.Shape, out)
+}
+
+// Monadic ravel -- flatten `target` to a rank-1 vector, in row-major
+// order (see `_sir_ndarray_flatten_row_major`'s own doc comment for the
+// column-major-storage-vs-row-major-order subtlety). Ported 1:1 from
+// `apl_runtime::builtins::ravel`.
+func _sir_ndarray_ravel(av Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	flat := _sir_ndarray_flatten_row_major(a)
+	return _sir_ndarray_new([]int{len(flat)}, flat)
+}
+
+// Dyadic catenate -- supports scalar-scalar, scalar-vector, vector-scalar,
+// vector-vector (all producing a vector), and
+// matrix-matrix-with-equal-row-counts (column/last-axis catenate,
+// producing `[r, ca+cb]`). Any other rank combination is a clean "not
+// yet supported" error. Ported 1:1 from `apl_runtime::builtins::
+// catenate`. The combined-length cap check happens ONCE, up front,
+// regardless of which rank combination follows (mirroring the Rust
+// reference's own structure) -- neither operand alone need be oversized
+// for the RESULT to be, since a script that repeatedly catenates a value
+// with itself doubles the size every line with no other ceiling.
+func _sir_ndarray_catenate(av Value, bv Value) *NDArray {
+	a := _sir_ndarray_to_array_value(av)
+	b := _sir_ndarray_to_array_value(bv)
+	_sir_ndarray_checked_shape_size([]int{len(a.Data) + len(b.Data)})
+	ra := len(a.Shape)
+	rb := len(b.Shape)
+	switch {
+	case ra == 0 && rb == 0:
+		return _sir_ndarray_new([]int{2}, []float64{a.Data[0], b.Data[0]})
+	case ra == 0 && rb == 1:
+		out := make([]float64, 1+len(b.Data))
+		out[0] = a.Data[0]
+		copy(out[1:], b.Data)
+		return _sir_ndarray_new([]int{len(out)}, out)
+	case ra == 1 && rb == 0:
+		out := make([]float64, len(a.Data)+1)
+		copy(out, a.Data)
+		out[len(a.Data)] = b.Data[0]
+		return _sir_ndarray_new([]int{len(out)}, out)
+	case ra == 1 && rb == 1:
+		out := make([]float64, len(a.Data)+len(b.Data))
+		copy(out, a.Data)
+		copy(out[len(a.Data):], b.Data)
+		return _sir_ndarray_new([]int{len(out)}, out)
+	case ra == 2 && rb == 2:
+		r := _sir_ndarray_nrows(a)
+		if r != _sir_ndarray_nrows(b) {
+			panic(fmt.Sprintf("catenate: matrix catenate needs equal row counts (%d vs %d)", r, _sir_ndarray_nrows(b)))
+		}
+		ca := _sir_ndarray_ncols(a)
+		cb := _sir_ndarray_ncols(b)
+		outLen := _sir_ndarray_checked_shape_size([]int{r, ca + cb})
+		data := make([]float64, outLen)
+		for row := 0; row < r; row++ {
+			for col := 0; col < ca; col++ {
+				v, _ := _sir_ndarray_get(a, row, col)
+				data[col*r+row] = v
+			}
+			for col := 0; col < cb; col++ {
+				v, _ := _sir_ndarray_get(b, row, col)
+				data[(ca+col)*r+row] = v
+			}
+		}
+		return _sir_ndarray_new([]int{r, ca + cb}, data)
+	default:
+		panic(fmt.Sprintf("catenate: catenate of rank %d and rank %d is not yet supported", ra, rb))
+	}
+}
+
 "##;
 
 #[cfg(test)]

--- a/code/packages/rust/semantic-ir-to-go/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/sir22_array.rs
@@ -1,10 +1,12 @@
-//! SIR22 base-cut execution proof: `ArrayLit`/`Range`/`MatMul`/
-//! `ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet` on the Go
-//! backend — hand-builds `Module`s directly (bypassing any frontend,
-//! since none targets this backend for SIR22 yet), emits Go, runs it
-//! with a real `go run`, and asserts stdout. Mirrors
-//! `compile_and_run_division_ops.rs`'s pattern; skips (does not fail)
-//! when no `go` is on `PATH`.
+//! SIR22 execution proof, base cut + APL addendum: `ArrayLit`/`Range`/
+//! `MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/`Stmt::IndexSet`
+//! (Phase A Slice 2) and `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+//! `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` (Phase A
+//! Slice 3) on the Go backend — hand-builds `Module`s directly
+//! (bypassing any frontend, since none targets this backend for SIR22
+//! yet), emits Go, runs it with a real `go run`, and asserts stdout.
+//! Mirrors `compile_and_run_division_ops.rs`'s pattern; skips (does not
+//! fail) when no `go` is on `PATH`.
 //!
 //! Ported from `semantic-ir-to-javascript`'s own already-proven
 //! `tests/sir22_array.rs` (and cross-checked against the sibling Ruby
@@ -322,25 +324,282 @@ fn matmul_output_shape_exceeding_the_element_cap_panics_cleanly() {
     }
 }
 
-// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+// ── SIR22 "APL addendum": real codegen (Phase A Slice 3) ───────────────
+//
+// None of the addendum node kinds have direct literal syntax in this
+// crate's hand-built `Module`s, so a genuine rank-1 "vector" (as opposed
+// to a `[1, n]` row-vector-shaped MATRIX, which is what `array_lit` with
+// one row and `Range` both produce) is built via nested `Catenate` of
+// bare scalars -- `Catenate(scalar, scalar)` is itself one of the nodes
+// under test, and is the only base-available way to reach a true rank-1
+// shape here, mirroring how the JS/Ruby sibling ports' own SIR22
+// addendum tests do the same thing.
+
+fn cat(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::Catenate { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() }
+}
+
+/// `[a, b, c]` as a genuine rank-1 vector via nested scalar `Catenate`.
+fn vec3(a: i64, b: i64, c: i64) -> Expr {
+    cat(cat(ilit(a), ilit(b)), ilit(c))
+}
 
 #[test]
-fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
-    // cut, so the ordinary feature-flag check alone can't reject it --
-    // proves the dedicated structural soundness check (`lib.rs`'s
-    // `check_exception_soundness`, extended for SIR22) does, with a
-    // clean `Err`, not an `emit_expr` `panic!`.
-    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
-    let m = array_module(vec![print_stmt(Expr::Reduce {
-        op: ElementwiseOpKind::Add,
-        target: Box::new(target),
+fn reduce_folds_a_vector_left_to_right() {
+    // reduce(+, [1, 2, 3]) = ((1+2)+3) = 6, a rank-0 (scalar-shaped)
+    // result -- read back via a two-scalar-index IndexGet, since
+    // `_sir_ndarray_nrows`/`ncols` treat a rank-0 array as 1x1.
+    let target = vec3(1, 2, 3);
+    let reduced = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("r", reduced),
+        print_stmt(index_get(local("r"), vec![scalar(0), scalar(0)])),
+    ]);
+    match run(&m, "reduce_vector") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["6.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn reduce_folds_each_row_of_a_matrix_independently() {
+    // reduce(+, [1 2 3; 4 5 6]) = [6, 15] -- one folded value PER ROW,
+    // not one grand total. This is the exact case the runtime's own doc
+    // comment calls out as "the single easiest place to introduce a
+    // wrong-answer bug" (column-major indexing inside the row loop) --
+    // a row/col swap there would silently TRANSPOSE the fold instead of
+    // panicking, so this test pins the correct row-independent result.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let reduced = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("r", reduced),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(1)])),
+    ]);
+    match run(&m, "reduce_matrix") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["6.0", "15.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn scan_keeps_every_intermediate_fold_result() {
+    // scan(+, [1, 2, 3]) = [1, 3, 6] -- every prefix fold, not just the
+    // last (that's `reduce`'s job).
+    let target = vec3(1, 2, 3);
+    let scanned = Expr::Scan { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("s", scanned),
+        print_stmt(index_get(local("s"), vec![scalar(0)])),
+        print_stmt(index_get(local("s"), vec![scalar(1)])),
+        print_stmt(index_get(local("s"), vec![scalar(2)])),
+    ]);
+    match run(&m, "scan_vector") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "3.0", "6.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn outer_product_of_two_vectors_computes_every_pairwise_product() {
+    // outer(*, [1, 2], [3, 4, 5]) -- a 2x3 matrix, out[i][j] = a[i]*b[j].
+    let a = cat(ilit(1), ilit(2));
+    let b = vec3(3, 4, 5);
+    let outer =
+        Expr::OuterProduct { op: ElementwiseOpKind::Mul, lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("o", outer),
+        print_stmt(index_get(local("o"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("o"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run(&m, "outer_product") {
+        // (row 0, col 0) = 1*3 = 3; (row 1, col 2) = 2*5 = 10.
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["3.0", "10.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_scalar_is_the_empty_vector_not_a_scalar() {
+    // `shape(5)` must be a length-0 VECTOR (rank 1, zero elements), never
+    // a scalar -- the trickiest of the nine to get right, per the
+    // runtime's own doc comment. Proven by taking `shape` TWICE:
+    // `shape(shape(5))` reads the INNER shape's own dimensions. If
+    // `shape(5)` is correctly a rank-1, length-0 array (`Shape: [0]`),
+    // then `shape` of THAT is a length-1 vector containing `0` (one
+    // dimension, of size 0) -- so index 0 of the double-shape reads
+    // `0.0`. If `shape(5)` were wrongly a bare scalar (rank 0) instead,
+    // `shape` of THAT would be a length-0 vector, and reading index 0 of
+    // it would panic (out of bounds) -- a different, test-failing
+    // outcome, not a silently-wrong number.
+    let double_shape = Expr::Shape {
+        target: Box::new(Expr::Shape { target: Box::new(ilit(5)), span: s() }),
         span: s(),
-    })]);
-    let err = compile(&m).expect_err("Reduce must be rejected, not emitted");
-    assert!(
-        err.message.contains("Reduce"),
-        "error should name the rejected node: {}",
-        err.message
-    );
+    };
+    let m = array_module(vec![print_stmt(index_get(double_shape, vec![scalar(0)]))]);
+    match run(&m, "shape_scalar") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["0.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_matrix_reports_both_dimensions() {
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let sh = Expr::Shape { target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("sh", sh),
+        print_stmt(index_get(local("sh"), vec![scalar(0)])),
+        print_stmt(index_get(local("sh"), vec![scalar(1)])),
+    ]);
+    match run(&m, "shape_matrix") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["2.0", "3.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn reshape_fills_row_major_then_transposes_into_column_major_storage() {
+    // reshape([1 2 3; 4 5 6], [3, 2]) must equal [1 2; 3 4; 5 6] -- APL's
+    // reshape fills the TARGET in row-major order from the source's own
+    // row-major ravel (here that ravel is already [1,2,3,4,5,6], since
+    // total element count matches exactly, no cyclic repeat needed), but
+    // this domain stores COLUMN-major. A backend that forgot to
+    // transpose the row-major-filled sequence before storing it would
+    // instead produce [1 4; 2 5; 3 6] -- same six values, WRONG
+    // positions, which is exactly why this needs a real numeric
+    // assertion rather than just "did it crash".
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let new_shape = cat(ilit(3), ilit(2));
+    let reshaped =
+        Expr::Reshape { shape: Box::new(new_shape), target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("re", reshaped),
+        print_stmt(index_get(local("re"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("re"), vec![scalar(1), scalar(0)])),
+        print_stmt(index_get(local("re"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run(&m, "reshape") {
+        // (0,0)=1, (1,0)=3 (NOT 2 -- that's the transposition bug), (2,1)=6.
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "3.0", "6.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn index_generator_is_one_based_not_zero_based() {
+    // `IndexGenerator(5)` (APL monadic `iota`) is `[1, 2, 3, 4, 5]` --
+    // deliberately 1-based, unlike every 0-based index elsewhere in this
+    // domain (`IndexGet`/`IndexSet`). Reading linear position 0 must
+    // therefore be `1.0`, not `0.0`.
+    let gen = Expr::IndexGenerator { count: Box::new(ilit(5)), span: s() };
+    let m = array_module(vec![
+        let_binding("g", gen),
+        print_stmt(index_get(local("g"), vec![scalar(0)])),
+        print_stmt(index_get(local("g"), vec![scalar(4)])),
+    ]);
+    match run(&m, "index_generator") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "5.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn index_of_reports_one_based_position_or_length_plus_one_when_absent() {
+    // haystack = [10, 20, 30]; needle = [20, 99]. 20 is found at 0-based
+    // position 1, reported 1-based as `2`; 99 is absent, reported as
+    // `haystack.length + 1 = 4` -- a valid, always-in-range sentinel,
+    // never `-1`.
+    let haystack = cat(cat(ilit(10), ilit(20)), ilit(30));
+    let needle = cat(ilit(20), ilit(99));
+    let idx = Expr::IndexOf { haystack: Box::new(haystack), needle: Box::new(needle), span: s() };
+    let m = array_module(vec![
+        let_binding("i", idx),
+        print_stmt(index_get(local("i"), vec![scalar(0)])),
+        print_stmt(index_get(local("i"), vec![scalar(1)])),
+    ]);
+    match run(&m, "index_of") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["2.0", "4.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn ravel_flattens_a_matrix_in_row_major_order() {
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let raveled = Expr::Ravel { target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("rv", raveled),
+        print_stmt(index_get(local("rv"), vec![scalar(0)])),
+        print_stmt(index_get(local("rv"), vec![scalar(5)])),
+    ]);
+    match run(&m, "ravel") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "6.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn catenate_joins_two_vectors_end_to_end() {
+    let a = cat(ilit(1), ilit(2));
+    let b = cat(ilit(3), ilit(4));
+    let joined = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("j", joined),
+        print_stmt(index_get(local("j"), vec![scalar(0)])),
+        print_stmt(index_get(local("j"), vec![scalar(3)])),
+    ]);
+    match run(&m, "catenate_vectors") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["1.0", "4.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+#[test]
+fn catenate_joins_two_matrices_with_equal_row_counts_along_columns() {
+    // [1 2; 3 4] , [5 6; 7 8] -> [1 2 5 6; 3 4 7 8] (column/last-axis
+    // catenate; both operands have 2 rows).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5), ilit(6)], vec![ilit(7), ilit(8)]]);
+    let joined = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("j", joined),
+        print_stmt(index_get(local("j"), vec![scalar(0), scalar(2)])),
+        print_stmt(index_get(local("j"), vec![scalar(1), scalar(3)])),
+    ]);
+    match run(&m, "catenate_matrices") {
+        Some(out) => assert_eq!(out.lines().collect::<Vec<_>>(), vec!["5.0", "8.0"]),
+        None => eprintln!("skip: no go on PATH"),
+    }
+}
+
+// ── DoS guard: addendum shape-size cap enforced BEFORE allocation ──────
+
+#[test]
+fn outer_product_output_shape_exceeding_the_element_cap_panics_cleanly() {
+    // Two INDEPENDENT 9000-element vectors (each individually far under
+    // the 2^26-element cap) whose OUTER PRODUCT output shape
+    // (9000x9000 = 81,000,000 elements) exceeds it -- same
+    // "product of two independently-bounded dimensions isn't itself
+    // bounded" gap `matmul_output_shape_exceeding_the_element_cap_panics_
+    // cleanly` proves above, now for `_sir_ndarray_outer`.
+    let a = Expr::IndexGenerator { count: Box::new(ilit(9000)), span: s() };
+    let b = Expr::IndexGenerator { count: Box::new(ilit(9000)), span: s() };
+    let outer =
+        Expr::OuterProduct { op: ElementwiseOpKind::Add, lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![Stmt::ExprStmt { expr: outer, span: s() }]);
+    match run_raw(&m, "outer_overflow") {
+        Some(out) => {
+            assert!(
+                !out.status.success(),
+                "expected a clean panic (nonzero exit) for an over-cap shape, got success"
+            );
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            assert!(
+                stderr.contains("exceeds the 67108864-element cap"),
+                "expected the checkedShapeSize cap message on stderr, got:\n{stderr}"
+            );
+        }
+        None => eprintln!("skip: no go on PATH"),
+    }
 }


### PR DESCRIPTION
## Summary

- Implements the 9-node SIR22 "APL addendum" for the Go backend (`Expr::Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`), which Phase A Slice 2 (already merged) explicitly deferred. No new `Feature` flags — the addendum shares `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the already-shipped base cut.
- `src/runtime.rs`: nine new `_sir_ndarray_*` Go functions ported 1:1 from `semantic-ir-to-javascript`'s proven addendum runtime (itself a port of `array_runtime::ops`/`apl_runtime::builtins`), preserving the row-independent matrix fold in `reduce`/`scan`, the row-major-fill-then-transpose-to-column-major `reshape` correctness, the 1-based `IndexGenerator`/`IndexOf` indexing (confirmed against `apl_runtime::builtins::index_generator`'s own tests — `semantic-ir`'s own doc comment on `Expr::IndexGenerator` is stale and claims 0-based, a small pre-existing doc bug flagged but not fixed here), and the pre-allocation DoS-size validation discipline throughout (every function routes through the existing overflow-safe `_sir_ndarray_checked_shape_size` before allocating).
- `src/emit.rs`: splits the addendum nodes out of the single combined `panic!` arm they previously shared with SIR26's `Expr::Convert`, giving them real codegen while leaving `Convert`'s own arm/behavior untouched (verified: same `span` value, same trigger condition, only cosmetic message-text difference).
- `src/lib.rs`: removes the now-obsolete `check_soundness_expr` rejection arms for the nine nodes (and the now-dead `unsupported_sir22_addendum` helper), replacing them with ordinary sub-expression recursion, matching every other real/supported composite node.
- `tests/sir22_array.rs`: 12 new tests, all real `go run` execution proofs — `reduce` on a vector AND a matrix (row-independent-fold correctness), `scan`, `outer` product, `shape` of a scalar (proven via a `shape(shape(5))` double-application trick) and of a matrix, `reshape` (transposition correctness on a non-square reshape), `index_generator` (1-based), `index_of` found/not-found, `ravel`, `catenate` of vectors and of matrices, and a DoS-guard test for `outer`'s `[m,n]` product.
- Version bump 0.40.0 → 0.41.0, CHANGELOG entry, README updated (the addendum section no longer says "not yet supported").

## Test plan

- [x] `cargo test -p semantic-ir-to-go` — 100% green (all suites, including the new 21-test `sir22_array.rs`, real `go run` execution since `go` is on `PATH`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `go vet` — clean, run against a hand-assembled artifact exercising all 9 new nodes together (plus `go run` producing the expected output for each)
- [x] `/security-review` — passed, no findings (DoS-guard routing, float→int conversion safety, and the `Expr::Convert` split were specifically verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)