### PR TITLE
feat(semantic-ir-to-python): implement SIR22 APL addendum (Phase A Slice 3)

### DIFF
--- a/code/packages/python/sir-runtime-array/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-array/CHANGELOG.md
@@ -1,5 +1,114 @@
 # Changelog
 
+## 0.2.0 — SIR22 "APL addendum" (Phase A Slice 3)
+
+Adds the nine-node SIR22 "APL addendum" this package's 0.1.0 release
+explicitly scoped out: `reduce`/`scan`/`outer`/`shape`/`reshape`/
+`index_generator`/`index_of`/`ravel`/`catenate`, plus the internal
+`_flatten_row_major` helper both `reshape` and `ravel` share. Every new
+function reuses this package's own existing `checked_shape_size`/
+`ndarray`/`get`/`apply_op`/`to_array_value` helpers rather than
+duplicating logic — no new module-level state, no new dependencies.
+
+**Port source: `semantic-ir-to-javascript`'s inlined `ArrayRt`, not the
+published TypeScript package.** This package's 0.1.0 base cut ported from
+`@coding-adventures/sir-runtime-array` (TS); at the time of this release
+that package still had no addendum functions of its own (per the SIR22
+spec's own note that TS's package lagged behind JS's inline port), so the
+JS backend's own `semantic-ir-to-javascript/src/runtime.rs` — the
+already-shipped, already-tested implementation — was the closer, more
+direct reference instead. Ported 1:1 algorithmically, adapted from JS's
+`Float64Array`-backed, always-double storage to this package's own
+`list`-backed, native `int`/`float`-preserving storage (see 0.1.0's own
+"Design notes" for why that divergence is deliberate, not a bug).
+
+### Added
+
+- `reduce(op, a)` — APL `+/A`: rank 0 is a no-op; rank 1 left-folds across
+  the vector (an empty vector is a clean error — no generic identity
+  element exists for an arbitrary `op`); rank 2 folds **each row
+  independently**, producing a rank-1 vector. The row loop reads
+  `d[row]` as the seed (column 0) then walks `d[col * r + row]` for
+  `col = 1..c-1` — column-major storage means swapping `row`/`col` here
+  silently *transposes* the result instead of raising, the single
+  easiest place to introduce a wrong-answer bug in this whole release
+  (matches the JS reference's own docstring warning verbatim).
+- `scan(op, a)` — APL `+\A`: the same fold as `reduce`, but keeping every
+  intermediate result (output shape == input shape). Unlike `reduce`, an
+  empty axis is not an error — there's simply nothing to scan.
+- `outer(op, a, b)` — APL `A∘.×B`: scoped to `rank(a) <= 1` and
+  `rank(b) <= 1` (four sub-cases: scalar-scalar, scalar-vector,
+  vector-scalar, vector-vector); anything of higher rank is a clean
+  "not yet supported" error.
+- `shape(a)` — APL monadic `⍴A`: `a`'s dimensions as a vector. **A scalar's
+  shape is the EMPTY vector, not a scalar** — `⍴5` is a length-0 vector.
+  Covered by an explicit test asserting `shape == (0,)`, not just an
+  element-count check.
+- `reshape(shape_arg, target)` — APL dyadic `A⍴B`: `shape_arg` must be a
+  scalar/vector (rank <= 1) of non-negative integers, and is itself
+  capped at rank <= 2. `target`'s elements are raveled then cyclically
+  repeated/truncated to fill the new shape's element count. **CRITICAL**:
+  the cyclic fill runs in ROW-major order (APL's own convention — the
+  last axis varies fastest), but this package's storage is COLUMN-major,
+  so a rank-2 target requires transposing the row-major-filled sequence
+  back into column-major storage (`data[col * r + row] =
+  filled[row * c + col]`) before returning it — handing the row-major
+  buffer straight to `ndarray` would silently reshape in the wrong axis
+  order, a wrong answer that still *looks* plausible (right multiset of
+  values, wrong positions). Regression-tested with a non-square 3x2
+  target.
+- `index_generator(a)` — APL monadic `⍳n`: **1-based** — `⍳4` is
+  `[1, 2, 3, 4]`, unlike every other 0-based index in this package
+  (`index_get`/`index_set`). This is a genuine fact about APL's own
+  surface syntax (`apl_runtime::builtins::index_generator`'s own doc
+  comment makes the same point), not an inconsistency introduced here.
+- `index_of(haystack, needle)` — APL dyadic `A⍳B`: for each element of
+  `needle`, the 1-based index of its first occurrence in `haystack`, or
+  `len(haystack) + 1` if not found — "not found" is a valid,
+  always-in-range position, never `-1`/`None`. Plain exact equality (no
+  float tolerance), so `NaN` correctly never matches.
+- `ravel(a)` — APL monadic `,A`: flatten to a rank-1 vector, in row-major
+  order (reuses `_flatten_row_major`).
+- `catenate(a, b)` — APL dyadic `A,B`: five supported rank combinations
+  (0+0, 0+1, 1+0, 1+1 all producing a vector; 2+2 with equal row counts
+  producing column/last-axis catenation); any other combination is a
+  clean "not yet supported" error.
+
+### Security
+
+Every new function was re-examined specifically for the SAME bug class
+0.1.0's own security review found and fixed in `matmul` (validating only
+the *output* shape, not a shared dimension fed by two independent
+operands — letting an unbounded op count through from two
+individually-legal inputs): `outer`'s `(m, n)` output shape, `index_of`'s
+`len(haystack) * len(needle)` scan-cost product (an O(n²) hazard the
+trivially-small *output* length alone would never catch), `catenate`'s
+combined length (checked ONCE up front, before any of its five rank
+branches run — a script that repeatedly self-catenates has no other
+ceiling), `index_generator`'s `n`, and `reshape`'s target element count
+are all validated via `checked_shape_size` — this package's one existing
+`MAX_ELEMENTS`-capped guard, reused as-is rather than reintroducing a
+second, competing cap — *before* allocating or looping, not after. Every
+one of these is explicitly called out with a `# SECURITY:` comment at its
+own call site in `array.py`, and every one has a dedicated
+`tests/test_array.py` regression test proving the guard actually
+triggers (e.g. `TestOuter::test_outer_product_dos_guard_caps_before_allocating`,
+`TestIndexOf::test_indexof_product_dos_guard_caps_before_scanning`,
+`TestCatenate::test_combined_length_dos_guard_caps_before_any_branch_allocates`).
+
+### Tests
+
+170 tests in `tests/test_array.py` (up from the 0.1.0 baseline), 100%
+statement coverage of `array.py`/`__init__.py`, `ruff check` and
+`mypy --strict` clean. New coverage includes the reduce/scan
+column-major-row-indexing correctness case (a 2x3 matrix, proving rows —
+not columns — are folded), the reshape row-major-fill-then-transpose
+case, the index-generator/index-of 1-based convention (including the
+"not found" sentinel value), and every DoS-guard regression described
+above.
+
+`coding-adventures-sir-runtime-array` 0.1.0 -> 0.2.0.
+
 ## 0.1.0 — initial release
 
 **Security fix (pre-release, found during this release's own security

--- a/code/packages/python/sir-runtime-array/README.md
+++ b/code/packages/python/sir-runtime-array/README.md
@@ -2,12 +2,16 @@
 
 SIR22 N-D array/matrix runtime for **Semantic-IR-emitted Python**.
 
-Implements the SIR22 array/matrix domain's **base cut**
+Implements the SIR22 array/matrix domain
 (`code/specs/SIR22-array-matrix-semantic-ir.md`): a dense, column-major
 `NDArray` value model plus `matmul`/`elementwise`/`transpose`/`range`/
-indexed get-set — the runtime a compiled MATLAB/Octave program's
-`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
-`IndexSet` IR nodes call into.
+indexed get-set (the **base cut** — the runtime a compiled MATLAB/Octave
+program's `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+`IndexGet`/`IndexSet` IR nodes call into), plus the nine-node **"APL
+addendum"** — `reduce`/`scan`/`outer`/`shape`/`reshape`/
+`index_generator`/`index_of`/`ravel`/`catenate` — the runtime an APL
+program's `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` IR nodes call into.
 
 ## Where it fits in the stack
 
@@ -26,10 +30,16 @@ this package only when a module uses the array/matrix domain; pure
 modules never gain the dependency. See the SIR22 spec's "Backend impact"
 section for the full second-wave rollout rationale.
 
-This package is itself a Python port of the published TypeScript package
+This package's base cut is a Python port of the published TypeScript
+package
 [`@coding-adventures/sir-runtime-array`](../../typescript/sir-runtime-array),
 itself the standalone extraction of `semantic-ir-to-javascript`'s inlined
-`ArrayRt` sub-runtime.
+`ArrayRt` sub-runtime. The nine-node "APL addendum" was ported directly
+from that same `ArrayRt` sub-runtime instead (`semantic-ir-to-javascript/
+src/runtime.rs`'s "SIR22 addendum: APL primitive operators" section) —
+at the time of that port, the TypeScript package itself had not yet
+grown these nine functions, so the already-shipped JS implementation was
+the closer, more direct reference.
 
 ## Column-major storage
 
@@ -90,6 +100,15 @@ a plain array *element*, never a native boolean.
   output-shape check yet still drive the multiply-add loop through an
   unbounded `m*n*ka` iteration count. `matmul` validates `(m, n, ka)`
   as a second, additional shape check before running any loop.
+- **Every addendum function re-examined for the same bug class.** `outer`'s
+  `(m, n)` output, `index_of`'s `len(haystack) * len(needle)` scan-cost
+  product (an O(n²) hazard the trivially-small *output* length alone
+  never catches), `catenate`'s combined length (checked once, up front,
+  regardless of which of its five rank-combination branches runs), and
+  `index_generator`'s/`reshape`'s element counts are each validated
+  before allocating or looping — not just the most obviously dangerous
+  one. See the 0.2.0 CHANGELOG entry for the full list and each
+  function's dedicated regression test.
 - No `eval`/`exec`/dynamic code execution anywhere in this package.
 
 ## API
@@ -110,6 +129,15 @@ a plain array *element*, never a native boolean.
 | `range(start, stop, step=1) -> NDArray` | MATLAB-style `start:step:stop` as a `1 x n` row vector. |
 | `index_scalar(v)` / `index_whole()` / `index_range(indices)` | Build one `IndexArg`. |
 | `index_get(a, indices)` / `index_set(a, indices, value)` | `A(i[, j])` read / in-place write. |
+| `reduce(op, a) -> NDArray` | APL `+/A` — fold along the one axis (rank 2 folds each row independently). |
+| `scan(op, a) -> NDArray` | APL `+\A` — running fold, same shape as `a`. |
+| `outer(op, a, b) -> NDArray` | APL `A∘.×B` — pairwise op, scoped to `rank(a), rank(b) <= 1`. |
+| `shape(a) -> NDArray` | APL monadic `⍴A` — dimensions as a vector (a scalar's shape is the *empty* vector). |
+| `reshape(shape_arg, target) -> NDArray` | APL dyadic `A⍴B` — reinterpret under new dimensions, cyclic fill/truncate. |
+| `index_generator(a) -> NDArray` | APL monadic `⍳n` — the **1-based** vector `[1, ..., n]`. |
+| `index_of(haystack, needle) -> NDArray` | APL dyadic `A⍳B` — 1-based search; not-found is `len(haystack) + 1`. |
+| `ravel(a) -> NDArray` | APL monadic `,A` — flatten to a rank-1 vector, row-major order. |
+| `catenate(a, b) -> NDArray` | APL dyadic `A,B` — vector/matrix concatenation (5 supported rank combinations). |
 
 ## Usage
 
@@ -123,16 +151,19 @@ index_get(p, [index_scalar(0), index_scalar(0)])   # 19
 index_get(p, [index_scalar(1), index_scalar(1)])   # 50
 
 transpose(from_rows([[1, 2, 3], [4, 5, 6]])).data  # [1, 2, 3, 4, 5, 6] (column-major 3x2)
+
+from coding_adventures_sir_runtime_array import reduce, index_generator, catenate
+
+reduce("Add", from_vec([1, 2, 3, 4])).data   # [10]           (APL +/1 2 3 4)
+index_generator(scalar(4)).data              # [1, 2, 3, 4]   (APL ⍳4 -- 1-based)
+catenate(from_vec([1, 2]), from_vec([3, 4])).data  # [1, 2, 3, 4]
 ```
 
 ## Out of scope
 
 Matching `array-runtime` and the TypeScript reference exactly:
 `Complex`/`Rational` scalars (`transpose`'s `conjugate` flag is accepted
-for API-shape parity but is a no-op on real data); rank > 2; the
-nine-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) — a separate
-later slice.
+for API-shape parity but is a no-op on real data); rank > 2.
 
 ## Development
 

--- a/code/packages/python/sir-runtime-array/pyproject.toml
+++ b/code/packages/python/sir-runtime-array/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-array"
-version = "0.1.0"
-description = "SIR22 N-D array/matrix runtime for Semantic-IR-emitted Python — dense column-major NDArray value model, matmul/elementwise/transpose/range/indexed get-set"
+version = "0.2.0"
+description = "SIR22 N-D array/matrix runtime for Semantic-IR-emitted Python — dense column-major NDArray value model, matmul/elementwise/transpose/range/indexed get-set plus the APL-primitive addendum (reduce/scan/outer/shape/reshape/index-generator/index-of/ravel/catenate)"
 requires-python = ">=3.12"
 dependencies = []
 license = "MIT"

--- a/code/packages/python/sir-runtime-array/src/coding_adventures_sir_runtime_array/__init__.py
+++ b/code/packages/python/sir-runtime-array/src/coding_adventures_sir_runtime_array/__init__.py
@@ -11,6 +11,14 @@ SIR22-array-matrix-semantic-ir.md``): ``ArrayLit``, ``Range``, ``MatMul``,
     b = from_rows([[5, 6], [7, 8]])
     matmul(a, b).data   # [19, 43, 22, 50]  (column-major: [[19, 22], [43, 50]])
 
+...as well as the nine-node SIR22 "APL addendum" that shares these same
+features -- ``Reduce``, ``Scan``, ``OuterProduct``, ``Shape``, ``Reshape``,
+``IndexGenerator``, ``IndexOf``, ``Ravel``, ``Catenate``::
+
+    from coding_adventures_sir_runtime_array import from_vec, reduce
+    v = from_vec([1, 2, 3, 4])
+    reduce("Add", v).data   # [10]
+
 This mirrors the TypeScript backend's *imported-package* model
 (``semantic-ir-to-typescript`` imports ``@coding-adventures/
 sir-runtime-array``) rather than ``semantic-ir-to-python``'s usual inline-
@@ -30,12 +38,15 @@ from .array import (
     NDArray,
     Val,
     apply_op,
+    catenate,
     checked_shape_size,
     elementwise,
     from_rows,
     from_vec,
     get,
+    index_generator,
     index_get,
+    index_of,
     index_range,
     index_scalar,
     index_set,
@@ -46,9 +57,15 @@ from .array import (
     ndarray,
     ndims,
     nrows,
+    outer,
     range_,
+    ravel,
+    reduce,
+    reshape,
     scalar,
+    scan,
     set_,
+    shape,
     to_array_value,
     transpose,
     zeros,
@@ -70,12 +87,15 @@ __all__ = [
     "NDArray",
     "Val",
     "apply_op",
+    "catenate",
     "checked_shape_size",
     "elementwise",
     "from_rows",
     "from_vec",
     "get",
+    "index_generator",
     "index_get",
+    "index_of",
     "index_range",
     "index_scalar",
     "index_set",
@@ -86,11 +106,17 @@ __all__ = [
     "ndims",
     "ncols",
     "nrows",
+    "outer",
     "range",
     "range_",
+    "ravel",
+    "reduce",
+    "reshape",
     "scalar",
+    "scan",
     "set",
     "set_",
+    "shape",
     "to_array_value",
     "transpose",
     "zeros",

--- a/code/packages/python/sir-runtime-array/src/coding_adventures_sir_runtime_array/array.py
+++ b/code/packages/python/sir-runtime-array/src/coding_adventures_sir_runtime_array/array.py
@@ -72,10 +72,21 @@ which would otherwise let a boundary-legal call still exhaust CPU time
 **Deliberately out of scope**, matching ``array-runtime`` and the TS
 reference exactly: ``Complex``/``Rational`` scalars (``transpose``'s
 ``conjugate`` flag is accepted for API-shape parity but is a no-op on
-real data); rank > 2 (no operation here defines it); the nine-node SIR22
-"APL addendum" (``Reduce``/``Scan``/``OuterProduct``/``Shape``/
-``Reshape``/``IndexGenerator``/``IndexOf``/``Ravel``/``Catenate``) --
-this package covers only the SIR22 *base cut*, a separate later slice.
+real data); rank > 2 (no operation here defines it).
+
+**The SIR22 "APL addendum"** (``Reduce``/``Scan``/``OuterProduct``/
+``Shape``/``Reshape``/``IndexGenerator``/``IndexOf``/``Ravel``/
+``Catenate`` -- nine more ``Expr`` node kinds sharing this same
+``NDArrays``/``MatrixOps``/``ArrayColumnMajor`` feature trio, but with no
+flag of their own) is implemented below, in the module's final section.
+Ported 1:1 from ``semantic-ir-to-javascript``'s inlined ``ArrayRt`` sub-
+runtime (``code/packages/rust/semantic-ir-to-javascript/src/runtime.rs``,
+the "SIR22 addendum: APL primitive operators" section) rather than from
+the TypeScript package this module's base cut above mirrors -- at the
+time of this port, ``@coding-adventures/sir-runtime-array`` (TS) had not
+yet grown these nine functions itself, so JS's already-proven inline port
+was the closer, more-direct reference. See that section's own module doc
+comment below for the full design discussion.
 
 See ``code/specs/sir-runtime.md`` and ``code/specs/
 SIR22-array-matrix-semantic-ir.md``.
@@ -703,3 +714,428 @@ def index_set(a: NDArray, indices: Sequence[IndexArg], value: Val | NDArray) -> 
         "index_set: only 1 or 2 index arguments are supported "
         f"(rank <= 2 scope), got {len(indices)}"
     )
+
+
+# ── SIR22 addendum: APL primitive operators ──────────────────────────────
+#
+# The nine functions below extend this package to cover the SIR22 "APL
+# addendum" (``code/specs/SIR22-array-matrix-semantic-ir.md``): array-family
+# primitive *operators* APL exposes as bare glyphs (`+/A` reduce, `+\A`
+# scan, `A∘.×B` outer product, `⍴`/`⍳`/`,` shape-reshape /
+# index-generator-index-of / ravel-catenate) that this package's SIR22
+# *base cut* above does not cover. Ported 1:1 from
+# `semantic-ir-to-javascript`'s inlined `ArrayRt` sub-runtime (see the
+# module docstring's "Deliberately out of scope" section for why JS, not
+# TS, is the port source here) -- `reduce`/`scan`/`outer` reuse `apply_op`
+# (the SAME dispatch table `elementwise` above uses); the remaining six
+# have no `op` field at all ("bespoke, not BinOp-shaped", per the SIR22
+# spec addendum and `apl-runtime::builtins`'s own doc comment) and just
+# recurse into their operand(s).
+#
+# SECURITY: every function below that computes an output/allocation size
+# from two or more independently-controlled numbers (`outer`'s `(m, n)`
+# output, `index_of`'s `len(haystack) * len(needle)` scan-cost product,
+# `catenate`'s combined length, `index_generator`'s `n`, `reshape`'s
+# target element count) routes through :func:`checked_shape_size` --
+# this module's ONE existing `MAX_ELEMENTS`-capped guard, reused as-is
+# rather than reintroducing a second, competing cap -- *before*
+# allocating or looping, not after. This mirrors the exact discipline
+# this package's own `matmul` docstring documents (and the exact bug
+# class the Slice 2 security review found and fixed there: validating
+# only the OUTPUT shape while leaving a shared inner dimension
+# unchecked). Every one of the nine functions below was re-examined
+# specifically for that bug class while porting: `outer`'s `m`/`n` are
+# each individually bounded by `MAX_ELEMENTS` but their PRODUCT is not,
+# so the `(m, n)` output check happens before the double loop, exactly
+# like `matmul`'s `(m, n)` output check; `index_of`'s two lengths are
+# each individually bounded but their product (the O(len*len) scan cost)
+# is not, so `checked_shape_size((len(haystack), len(needle)))` caps that
+# product before the scan loop runs, not just the (trivially small)
+# output length; `catenate`'s two operand lengths are each individually
+# bounded but their SUM is not (and a script that repeatedly self-
+# catenates has no other ceiling), so the combined-length check happens
+# ONCE, up front, before any of the five rank-combination branches run.
+
+
+def reduce(op: ElementwiseOpKind, a: Val | NDArray) -> NDArray:  # noqa: A001
+    """``+/A`` (APL reduce) -- fold `a` with `op` along its one axis.
+    Ported 1:1 from ``array_runtime::ops::reduce`` (via
+    ``semantic-ir-to-javascript``'s ``reduce``, this section's port
+    source):
+
+    - rank 0 (scalar): nothing to fold, returns `a` itself (coerced to an
+      :class:`NDArray` first).
+    - rank 1 (vector ``(n,)``): left-fold across all ``n`` elements
+      (``op(op(op(v0, v1), v2), ...)``); an EMPTY vector is a clean
+      error -- unlike ``sum``/``mean`` (which have a built-in identity,
+      0), ``reduce`` is generic over any ``op``, and guessing an identity
+      (is it 0 for ``Add``, 1 for ``Mul``, ``-inf`` for ``Max``?) for an
+      arbitrary, possibly-future op would be silently wrong for most of
+      them.
+    - rank 2 (matrix ``(r, c)``): folds EACH ROW independently across its
+      ``c`` columns, producing a ``(r,)`` vector (one folded value per
+      row). Column-major storage means element ``(row, col)`` lives at
+      ``col * r + row`` -- the row loop reads ``d[row]`` as the seed
+      (column 0) then walks ``d[col * r + row]`` for
+      ``col = 1 .. c - 1``; getting `row` and `col` swapped here silently
+      TRANSPOSES the result instead of raising, so this indexing is the
+      single easiest place to introduce a wrong-answer bug when reading
+      this function (matches the JS reference's own docstring warning).
+
+    Trailing ``# noqa: A001`` (here and on ``scan``/``shape``/``ravel``
+    below): these names shadow no *Python* builtin (``reduce`` lives in
+    ``functools``, not ``builtins``; ``shape``/``ravel`` are common
+    NumPy-ism names, not reserved words) -- ruff's ``A001`` flags them
+    only because they read as builtin-ISH names, not because they
+    collide with anything real; matches the SIR22 node's own name
+    (``Expr::Reduce``/``Shape``/``Ravel``) rather than inventing an
+    arbitrary synonym.
+    """
+    a2 = to_array_value(a)
+    shape_ = a2.shape
+    if len(shape_) == 0:
+        return a2
+    if len(shape_) == 1:
+        n = shape_[0]
+        if n == 0:
+            raise ValueError(
+                "reduce: cannot fold an empty vector (no identity element for an arbitrary op)"
+            )
+        d = a2.data
+        acc: Val = d[0]
+        for i in range(1, n):
+            acc = apply_op(op, acc, d[i])
+        return ndarray((), [acc])
+    if len(shape_) == 2:
+        r, c = shape_
+        if c == 0:
+            raise ValueError(
+                "reduce: cannot fold an empty row (no identity element for an arbitrary op)"
+            )
+        d = a2.data
+        out: list[Val] = [0] * r
+        for row in range(r):
+            acc = d[row]  # column-major: (row, 0) lives at plain `row`
+            for col in range(1, c):
+                acc = apply_op(op, acc, d[col * r + row])
+            out[row] = acc
+        return ndarray((r,), out)
+    raise ValueError(f"reduce: rank > 2 not yet supported (shape {shape_!r})")
+
+
+def scan(op: ElementwiseOpKind, a: Val | NDArray) -> NDArray:  # noqa: A001
+    """``+\\A`` (APL scan) -- the same fold as :func:`reduce`, but keeping
+    EVERY intermediate result instead of only the last; output has the
+    same shape as `a`. Ported 1:1 from ``array_runtime::ops::scan``. An
+    empty axis is NOT an error here (unlike :func:`reduce`): there is
+    simply nothing to scan, and the (empty) output shape already says so.
+    """
+    a2 = to_array_value(a)
+    shape_ = a2.shape
+    if len(shape_) == 0:
+        return a2
+    if len(shape_) == 1:
+        n = shape_[0]
+        d = a2.data
+        out: list[Val] = [0] * n
+        acc: Val = 0
+        started = False
+        for i in range(n):
+            acc = apply_op(op, acc, d[i]) if started else d[i]
+            started = True
+            out[i] = acc
+        return ndarray((n,), out)
+    if len(shape_) == 2:
+        r, c = shape_
+        d = a2.data
+        out = [0] * len(d)
+        for row in range(r):
+            acc = 0
+            started = False
+            for col in range(c):
+                x = d[col * r + row]  # column-major
+                acc = apply_op(op, acc, x) if started else x
+                started = True
+                out[col * r + row] = acc
+        return ndarray((r, c), out)
+    raise ValueError(f"scan: rank > 2 not yet supported (shape {shape_!r})")
+
+
+def outer(op: ElementwiseOpKind, a: Val | NDArray, b: Val | NDArray) -> NDArray:
+    """``A∘.×B`` (APL outer product) -- apply `op` to every pair
+    ``(a_i, b_j)``, producing a result of combined rank. Ported 1:1 from
+    ``array_runtime::ops::outer``, scoped identically to ``rank(a) <= 1``
+    and ``rank(b) <= 1`` (the vector-outer-vector case below already
+    reaches this domain's rank-2 ceiling; anything of higher rank is a
+    clean "not yet supported" error).
+
+    SECURITY: :func:`checked_shape_size` validates the ``(m, n)`` output
+    shape *before* allocating -- `m`/`n` are two INDEPENDENT operand
+    lengths, each individually under :data:`MAX_ELEMENTS`, but nothing
+    bounds their product alone (the same outer-product-shaped allocation
+    :func:`matmul`/:func:`index_get` elsewhere in this module guard
+    against).
+    """
+    a2 = to_array_value(a)
+    b2 = to_array_value(b)
+    a_shape = a2.shape
+    b_shape = b2.shape
+    if len(a_shape) == 0 and len(b_shape) == 0:
+        return ndarray((), [apply_op(op, a2.data[0], b2.data[0])])
+    if len(a_shape) == 0 and len(b_shape) == 1:
+        x = a2.data[0]
+        return ndarray((b_shape[0],), [apply_op(op, x, y) for y in b2.data])
+    if len(a_shape) == 1 and len(b_shape) == 0:
+        y = b2.data[0]
+        return ndarray((a_shape[0],), [apply_op(op, x, y) for x in a2.data])
+    if len(a_shape) == 1 and len(b_shape) == 1:
+        m = a_shape[0]
+        n = b_shape[0]
+        out_len = checked_shape_size((m, n))
+        ad, bd = a2.data, b2.data
+        out: list[Val] = [0] * out_len
+        for j in range(n):
+            for i in range(m):
+                out[j * m + i] = apply_op(op, ad[i], bd[j])  # column-major
+        return ndarray((m, n), out)
+    raise ValueError(
+        f"outer: operands of rank > 1 not yet supported (shapes {a_shape!r}, {b_shape!r})"
+    )
+
+
+def _flatten_row_major(a: NDArray) -> list[Val]:
+    """Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order
+    -- last axis varies fastest. `a` itself stores COLUMN-major
+    (:func:`get`'s own docstring), so a matrix must be walked "row, then
+    column" via :func:`get` to produce true row-major order; returning
+    the raw column-major buffer would silently ravel in the WRONG order.
+    Always returns a fresh ``list`` (never ``a.data`` itself, even in the
+    rank <= 1 no-op case) -- mirrors ``apl_runtime::builtins::flatten``
+    returning an owned ``Vec``, not a borrow, so the result never
+    accidentally aliases `a`'s own buffer. Used by both :func:`reshape`
+    and :func:`ravel` below.
+    """
+    shape_ = a.shape
+    if len(shape_) <= 1:
+        return list(a.data)
+    if len(shape_) == 2:
+        r, c = shape_
+        out: list[Val] = [0] * (r * c)
+        k = 0
+        for row in range(r):
+            for col in range(c):
+                v = get(a, row, col)
+                assert v is not None  # `row`/`col` are in-range by construction
+                out[k] = v
+                k += 1
+        return out
+    # Unreachable in practice (this domain's rank <= 2 ceiling) -- total
+    # rather than raising, mirroring the JS reference's own fallback.
+    return list(a.data)
+
+
+def shape(a: Val | NDArray) -> NDArray:  # noqa: A001
+    """Monadic ``⍴A`` (APL shape) -- `a`'s dimensions as a vector. Ported
+    1:1 from ``apl_runtime::builtins::shape``: a SCALAR has zero
+    dimensions, so its shape is the EMPTY vector (not a scalar!) --
+    ``⍴5`` is a length-0 vector. A vector ``(n,)`` has shape ``(n,)``
+    (one element); a matrix ``(r, c)`` has shape ``(r, c)`` (two
+    elements).
+    """
+    a2 = to_array_value(a)
+    dims: list[Val] = list(a2.shape)
+    return ndarray((len(dims),), dims)
+
+
+def _non_negative_int(x: Val, *, who: str) -> int:
+    """Validate `x` is a non-negative-integer-*valued* number (an ``int``
+    outright, or a ``float`` with no fractional part) and return it as a
+    plain ``int``. Shared by :func:`reshape` (validating its shape-vector
+    elements) and :func:`index_generator` (validating its scalar
+    argument) -- both need the exact same "is this really a non-negative
+    integer" check the JS reference spells inline at each call site
+    (``Number.isInteger(x) && x >= 0``); factored here once so the two
+    ports can't silently drift out of sync with each other.
+    """
+    if isinstance(x, bool) or not isinstance(x, (int, float)):
+        raise ValueError(f"{who}: must be a non-negative integer, got {x!r}")
+    if isinstance(x, float) and not x.is_integer():
+        raise ValueError(f"{who}: must be a non-negative integer, got {x!r}")
+    if x < 0:
+        raise ValueError(f"{who}: must be a non-negative integer, got {x!r}")
+    return int(x)
+
+
+def reshape(shape_arg: Val | NDArray, target: Val | NDArray) -> NDArray:
+    """Dyadic ``A⍴B`` (APL reshape) -- reinterpret `target`'s data under
+    the new dimensions `shape_arg`. Ported 1:1 from
+    ``apl_runtime::builtins::reshape``. `shape_arg` must itself be a
+    scalar or vector (rank <= 1) of non-negative integers, and is itself
+    capped at rank <= 2 (this domain's ceiling -- a longer target shape
+    is a clean error, not a silent truncation). `target`'s elements are
+    ravelled (:func:`_flatten_row_major`) then cyclically repeated or
+    truncated to fill the target shape's element count.
+
+    CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+    fills the LAST axis fastest, same convention as ravel), but this
+    domain's storage is COLUMN-major -- so for a rank-2 target the
+    row-major ``filled`` sequence must be TRANSPOSED into column-major
+    storage (``data[col * r + row] = filled[row * c + col]``) before
+    calling :func:`ndarray`. Handing ``filled`` straight to
+    :func:`ndarray` would silently reshape column-major instead of APL's
+    row-major convention -- a wrong answer that still LOOKS plausible
+    (right multiset of values, wrong positions).
+    """
+    shape_arg2 = to_array_value(shape_arg)
+    target2 = to_array_value(target)
+    if len(shape_arg2.shape) > 1:
+        raise ValueError(
+            "reshape: shape argument must be a scalar or vector "
+            f"(got rank {len(shape_arg2.shape)})"
+        )
+    dims = [_non_negative_int(x, who="reshape: shape elements") for x in shape_arg2.data]
+    if len(dims) > 2:
+        raise ValueError(
+            f"reshape: reshape to rank > 2 is not yet supported (target shape {dims!r})"
+        )
+    total = checked_shape_size(dims)
+    source = _flatten_row_major(target2)
+    if total > 0 and len(source) == 0:
+        raise ValueError("reshape: cannot reshape an empty source into a non-empty shape")
+    filled: list[Val] = [0] * total
+    for k in range(total):
+        filled[k] = source[k % len(source)]
+    if len(dims) <= 1:
+        return ndarray(tuple(dims), filled)
+    r, c = dims
+    data: list[Val] = [0] * total
+    for row in range(r):
+        for col in range(c):
+            data[col * r + row] = filled[row * c + col]
+    return ndarray((r, c), data)
+
+
+def index_generator(a: Val | NDArray) -> NDArray:
+    """Monadic ``⍳n`` (APL iota / index generator) -- ``⍳n`` is the
+    1-BASED vector ``[1, 2, ..., n]``. Ported 1:1 from
+    ``apl_runtime::builtins::index_generator`` -- note this is 1-based,
+    unlike every 0-based index elsewhere in this domain (:func:`index_get`
+    /:func:`index_set`), because that is genuinely what APL's ``⍳`` means
+    at the SURFACE-SYNTAX level (the same fact the JS reference's own
+    ``indexGenerator`` docstring and its
+    ``index_generator_is_one_based_unlike_the_rest_of_this_domain`` test
+    both call out). :func:`checked_shape_size` both validates `n` is a
+    non-negative integer AND caps it at :data:`MAX_ELEMENTS` before
+    allocating -- `n` is a runtime value a compiled program computes, not
+    a fixed constant, so ``⍳`` of an absurd size must fail cleanly.
+    """
+    a2 = to_array_value(a)
+    if not is_scalar(a2):
+        raise ValueError("index_generator: monadic argument must be a scalar")
+    x = _non_negative_int(a2.data[0], who="index_generator: monadic argument")
+    n = checked_shape_size((x,))
+    return ndarray((n,), list(range(1, n + 1)))
+
+
+def index_of(haystack: Val | NDArray, needle: Val | NDArray) -> NDArray:
+    """Dyadic ``A⍳B`` (APL index-of / search) -- for every element of
+    `needle`, the 1-based index of its first occurrence in the vector
+    `haystack` (or ``len(haystack) + 1`` if not found -- "not found" is a
+    valid, always-in-range position, not ``-1``/``None``). Ported 1:1
+    from ``apl_runtime::builtins::index_of``: plain EXACT equality (no
+    floating-point tolerance -- Python's ``list.index`` already uses
+    plain ``==``, so ``NaN`` correctly never matches, same as Rust's
+    ``==``).
+
+    SECURITY: the work done is O(len(haystack) * len(needle)) (a full
+    linear scan per needle element) -- :func:`checked_shape_size` is
+    reused here purely for its "product <= MAX_ELEMENTS" check (both
+    lengths are already valid non-negative integers by construction, so
+    its dimension-validity half is a no-op) to cap the PRODUCT before
+    scanning, since each operand individually staying under
+    :data:`MAX_ELEMENTS` does not bound their product (up to
+    ~4.5 * 10**15 comparisons otherwise -- the exact same "two
+    individually-legal operands, unbounded product" hazard
+    :func:`matmul`'s own docstring documents for its shared inner
+    dimension).
+    """
+    a2 = to_array_value(haystack)
+    b2 = to_array_value(needle)
+    if len(a2.shape) > 1:
+        raise ValueError(
+            f"index_of: left argument must be a scalar or vector (got rank {len(a2.shape)})"
+        )
+    # SECURITY: caps the O(len*len) scan cost *before* the loop below runs
+    # -- see this section's own module doc comment.
+    checked_shape_size((len(a2.data), len(b2.data)))
+    hay = a2.data
+    out: list[Val] = []
+    for needle_val in b2.data:
+        try:
+            idx = hay.index(needle_val)
+        except ValueError:
+            idx = -1
+        out.append(idx + 1 if idx != -1 else len(hay) + 1)
+    return ndarray(b2.shape, out)
+
+
+def ravel(a: Val | NDArray) -> NDArray:  # noqa: A001
+    """Monadic ``,A`` (APL ravel) -- flatten `a` to a rank-1 vector, in
+    row-major order (see :func:`_flatten_row_major`'s own docstring for
+    the column-major-storage-vs-row-major-order subtlety). Ported 1:1
+    from ``apl_runtime::builtins::ravel``.
+    """
+    a2 = to_array_value(a)
+    flat = _flatten_row_major(a2)
+    return ndarray((len(flat),), flat)
+
+
+def catenate(a: Val | NDArray, b: Val | NDArray) -> NDArray:
+    """Dyadic ``A,B`` (APL catenate) -- supports scalar-scalar,
+    scalar-vector, vector-scalar, vector-vector (all producing a vector),
+    and matrix-matrix-with-equal-row-counts (column/last-axis catenate,
+    producing ``(r, ca + cb)``). Any other rank combination is a clean
+    "not yet supported" error. Ported 1:1 from
+    ``apl_runtime::builtins::catenate``.
+
+    SECURITY: the combined-length cap check happens ONCE, up front,
+    regardless of which rank combination follows below (mirroring the
+    Rust/JS references' own structure) -- neither operand alone need be
+    oversized for the RESULT to be, since a script that repeatedly
+    catenates a value with itself (``A <- A,A``) doubles the size every
+    line with no other ceiling.
+    """
+    a2 = to_array_value(a)
+    b2 = to_array_value(b)
+    # SECURITY: validated up front, before any of the five branches below
+    # allocate -- see this section's own module doc comment.
+    checked_shape_size((len(a2.data) + len(b2.data),))
+    ra, rb = len(a2.shape), len(b2.shape)
+    if ra == 0 and rb == 0:
+        return ndarray((2,), [a2.data[0], b2.data[0]])
+    if ra == 0 and rb == 1:
+        return ndarray((1 + len(b2.data),), [a2.data[0], *b2.data])
+    if ra == 1 and rb == 0:
+        return ndarray((len(a2.data) + 1,), [*a2.data, b2.data[0]])
+    if ra == 1 and rb == 1:
+        return ndarray((len(a2.data) + len(b2.data),), [*a2.data, *b2.data])
+    if ra == 2 and rb == 2:
+        r = nrows(a2)
+        if r != nrows(b2):
+            raise ValueError(
+                f"catenate: matrix catenate needs equal row counts ({r} vs {nrows(b2)})"
+            )
+        ca, cb = ncols(a2), ncols(b2)
+        out_len = checked_shape_size((r, ca + cb))
+        data: list[Val] = [0] * out_len
+        for row in range(r):
+            for col in range(ca):
+                v = get(a2, row, col)
+                assert v is not None  # in-range by construction
+                data[col * r + row] = v
+            for col in range(cb):
+                v = get(b2, row, col)
+                assert v is not None  # in-range by construction
+                data[(ca + col) * r + row] = v
+        return ndarray((r, ca + cb), data)
+    raise ValueError(f"catenate: catenate of rank {ra} and rank {rb} is not yet supported")

--- a/code/packages/python/sir-runtime-array/tests/test_array.py
+++ b/code/packages/python/sir-runtime-array/tests/test_array.py
@@ -4,19 +4,21 @@ from __future__ import annotations
 
 import math
 
-import pytest
-
 import coding_adventures_sir_runtime_array.array as array_mod
+import pytest
 from coding_adventures_sir_runtime_array import (
     MAX_ELEMENTS,
     NDArray,
     apply_op,
+    catenate,
     checked_shape_size,
     elementwise,
     from_rows,
     from_vec,
     get,
+    index_generator,
     index_get,
+    index_of,
     index_range,
     index_scalar,
     index_set,
@@ -27,7 +29,13 @@ from coding_adventures_sir_runtime_array import (
     ndarray,
     ndims,
     nrows,
+    outer,
+    ravel,
+    reduce,
+    reshape,
     scalar,
+    scan,
+    shape,
     to_array_value,
     transpose,
     zeros,
@@ -584,3 +592,434 @@ class TestMathIsfiniteSanity:
         assert math.isfinite(1.0)
         assert not math.isfinite(float("nan"))
         assert not math.isfinite(float("inf"))
+
+
+# ── SIR22 "APL addendum" ──────────────────────────────────────────────────
+
+
+class TestReduce:
+    def test_scalar_is_a_no_op(self) -> None:
+        r = reduce("Add", scalar(5))
+        assert r.shape == ()
+        assert r.data == [5]
+
+    def test_vector_left_folds_across_all_elements(self) -> None:
+        # +/1 2 3 4 = 10
+        r = reduce("Add", from_vec([1, 2, 3, 4]))
+        assert r.shape == ()
+        assert r.data == [10]
+
+    def test_matrix_folds_each_row_independently(self) -> None:
+        # [[1, 2, 3], [4, 5, 6]] -- row 0 sums to 6, row 1 sums to 15.
+        # Proves the column-major indexing (`d[col * r + row]`) is not
+        # transposed: a swapped row/col would instead sum the COLUMNS
+        # (1+4=5, 2+5=7, 3+6=9), which this asserts is NOT the result.
+        a = from_rows([[1, 2, 3], [4, 5, 6]])
+        r = reduce("Add", a)
+        assert r.shape == (2,)
+        assert r.data == [6, 15]
+
+    def test_empty_vector_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot fold an empty vector"):
+            reduce("Add", from_vec([]))
+
+    def test_empty_row_matrix_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot fold an empty row"):
+            reduce("Add", zeros(2, 0))
+
+    def test_rank_greater_than_two_raises(self) -> None:
+        a = NDArray((2, 2, 2), [0] * 8)
+        with pytest.raises(ValueError, match="rank > 2 not yet supported"):
+            reduce("Add", a)
+
+    def test_reduce_with_mul_op(self) -> None:
+        # */1 2 3 4 = 24
+        r = reduce("Mul", from_vec([1, 2, 3, 4]))
+        assert r.data == [24]
+
+
+class TestScan:
+    def test_scalar_is_a_no_op(self) -> None:
+        r = scan("Add", scalar(5))
+        assert r.shape == ()
+        assert r.data == [5]
+
+    def test_vector_keeps_every_intermediate_result(self) -> None:
+        # +\1 2 3 4 = 1 3 6 10
+        r = scan("Add", from_vec([1, 2, 3, 4]))
+        assert r.shape == (4,)
+        assert r.data == [1, 3, 6, 10]
+
+    def test_empty_vector_is_not_an_error(self) -> None:
+        # Unlike reduce, an empty axis is fine -- nothing to scan.
+        r = scan("Add", from_vec([]))
+        assert r.shape == (0,)
+        assert r.data == []
+
+    def test_matrix_scans_each_row_independently(self) -> None:
+        a = from_rows([[1, 2, 3], [4, 5, 6]])
+        r = scan("Add", a)
+        assert r.shape == (2, 3)
+        # Row 0: 1, 3, 6 -- row 1: 4, 9, 15.
+        assert get(r, 0, 0) == 1
+        assert get(r, 0, 1) == 3
+        assert get(r, 0, 2) == 6
+        assert get(r, 1, 0) == 4
+        assert get(r, 1, 1) == 9
+        assert get(r, 1, 2) == 15
+
+    def test_rank_greater_than_two_raises(self) -> None:
+        a = NDArray((2, 2, 2), [0] * 8)
+        with pytest.raises(ValueError, match="rank > 2 not yet supported"):
+            scan("Add", a)
+
+
+class TestOuter:
+    def test_vector_outer_vector_produces_a_matrix(self) -> None:
+        # [1, 2] outer-times [10, 20, 30] = [[10, 20, 30], [20, 40, 60]]
+        a = from_vec([1, 2])
+        b = from_vec([10, 20, 30])
+        r = outer("Mul", a, b)
+        assert r.shape == (2, 3)
+        assert get(r, 0, 0) == 10
+        assert get(r, 0, 1) == 20
+        assert get(r, 0, 2) == 30
+        assert get(r, 1, 0) == 20
+        assert get(r, 1, 1) == 40
+        assert get(r, 1, 2) == 60
+
+    def test_scalar_outer_scalar(self) -> None:
+        r = outer("Add", scalar(2), scalar(3))
+        assert r.shape == ()
+        assert r.data == [5]
+
+    def test_scalar_outer_vector(self) -> None:
+        r = outer("Mul", scalar(2), from_vec([1, 2, 3]))
+        assert r.shape == (3,)
+        assert r.data == [2, 4, 6]
+
+    def test_vector_outer_scalar(self) -> None:
+        r = outer("Mul", from_vec([1, 2, 3]), scalar(2))
+        assert r.shape == (3,)
+        assert r.data == [2, 4, 6]
+
+    def test_rank_greater_than_one_operand_raises(self) -> None:
+        a = from_rows([[1, 2], [3, 4]])
+        with pytest.raises(ValueError, match="operands of rank > 1 not yet supported"):
+            outer("Add", a, from_vec([1, 2]))
+
+    def test_outer_product_dos_guard_caps_before_allocating(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SECURITY regression, same class matmul's own security-review fix
+        # caught: `m`/`n` are each individually small, but their PRODUCT
+        # (the (m, n) output) must be capped before the double loop
+        # allocates/iterates. Lower MAX_ELEMENTS so this doesn't need to
+        # actually allocate anything huge.
+        monkeypatch.setattr(array_mod, "MAX_ELEMENTS", 100)
+        a = from_vec(list(range(20)))
+        b = from_vec(list(range(20)))
+        with pytest.raises(ValueError, match="exceeds the .*-element cap"):
+            outer("Mul", a, b)
+
+
+class TestShape:
+    def test_scalar_shape_is_the_empty_vector_not_a_scalar(self) -> None:
+        # Critical APL semantics: `⍴5` is a length-0 vector, NOT a
+        # rank-0 scalar -- a common off-by-one-domain bug if written
+        # carelessly.
+        r = shape(scalar(5))
+        assert r.shape == (0,)
+        assert r.data == []
+
+    def test_vector_shape_is_a_one_element_vector(self) -> None:
+        r = shape(from_vec([1, 2, 3]))
+        assert r.shape == (1,)
+        assert r.data == [3]
+
+    def test_matrix_shape_is_a_two_element_vector(self) -> None:
+        r = shape(from_rows([[1, 2, 3], [4, 5, 6]]))
+        assert r.shape == (2,)
+        assert r.data == [2, 3]
+
+    def test_bare_number_is_coerced_to_scalar_first(self) -> None:
+        r = shape(5)
+        assert r.shape == (0,)
+        assert r.data == []
+
+
+class TestReshape:
+    def test_reshape_to_a_non_square_matrix_transposes_row_major_fill(self) -> None:
+        # 2x3 -> 3x2: source raveled row-major is [1, 2, 3, 4, 5, 6].
+        # APL fills the LAST axis fastest (row-major), so a 3x2 target's
+        # rows are (1,2), (3,4), (5,6) -- but storage here is
+        # COLUMN-major, so the naive "just copy `filled` in order" bug
+        # would instead produce rows (1,4), (2,5), (3,6) (a silent
+        # transpose). This pins down the CORRECT, non-transposed answer.
+        a = from_rows([[1, 2, 3], [4, 5, 6]])
+        r = reshape(from_vec([3, 2]), a)
+        assert r.shape == (3, 2)
+        assert get(r, 0, 0) == 1
+        assert get(r, 0, 1) == 2
+        assert get(r, 1, 0) == 3
+        assert get(r, 1, 1) == 4
+        assert get(r, 2, 0) == 5
+        assert get(r, 2, 1) == 6
+
+    def test_reshape_to_a_vector(self) -> None:
+        a = from_rows([[1, 2], [3, 4]])
+        r = reshape(from_vec([4]), a)
+        assert r.shape == (4,)
+        # Row-major ravel of [[1,2],[3,4]] is [1, 2, 3, 4].
+        assert r.data == [1, 2, 3, 4]
+
+    def test_reshape_cyclically_repeats_a_shorter_source(self) -> None:
+        r = reshape(from_vec([5]), from_vec([1, 2]))
+        assert r.data == [1, 2, 1, 2, 1]
+
+    def test_reshape_truncates_a_longer_source(self) -> None:
+        r = reshape(from_vec([2]), from_vec([1, 2, 3, 4]))
+        assert r.data == [1, 2]
+
+    def test_reshape_scalar_shape_argument(self) -> None:
+        r = reshape(scalar(3), from_vec([9]))
+        assert r.shape == (3,)
+        assert r.data == [9, 9, 9]
+
+    def test_reshape_rejects_rank_greater_than_one_shape_argument(self) -> None:
+        with pytest.raises(ValueError, match="must be a scalar or vector"):
+            reshape(from_rows([[1, 2], [3, 4]]), from_vec([1]))
+
+    def test_reshape_rejects_negative_shape_element(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            reshape(from_vec([-1]), from_vec([1]))
+
+    def test_reshape_rejects_non_integer_shape_element(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            reshape(from_vec([1.5]), from_vec([1]))
+
+    def test_reshape_rejects_rank_greater_than_two_target(self) -> None:
+        with pytest.raises(ValueError, match="reshape to rank > 2 is not yet supported"):
+            reshape(from_vec([1, 2, 3]), from_vec([1]))
+
+    def test_reshape_of_empty_source_into_nonempty_shape_raises(self) -> None:
+        with pytest.raises(ValueError, match="cannot reshape an empty source"):
+            reshape(from_vec([3]), from_vec([]))
+
+    def test_reshape_of_empty_source_into_empty_shape_is_fine(self) -> None:
+        r = reshape(from_vec([0]), from_vec([]))
+        assert r.shape == (0,)
+        assert r.data == []
+
+
+class TestIndexGenerator:
+    def test_is_one_based_unlike_index_get_index_set(self) -> None:
+        # ⍳4 = [1, 2, 3, 4] -- 1-based, unlike every 0-based index
+        # elsewhere in this module.
+        r = index_generator(scalar(4))
+        assert r.shape == (4,)
+        assert r.data == [1, 2, 3, 4]
+
+    def test_of_zero_is_empty(self) -> None:
+        r = index_generator(scalar(0))
+        assert r.shape == (0,)
+        assert r.data == []
+
+    def test_bare_number_argument_is_coerced_first(self) -> None:
+        r = index_generator(3)
+        assert r.data == [1, 2, 3]
+
+    def test_rejects_non_scalar_argument(self) -> None:
+        with pytest.raises(ValueError, match="must be a scalar"):
+            index_generator(from_vec([1, 2]))
+
+    def test_rejects_negative_argument(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            index_generator(scalar(-1))
+
+    def test_rejects_non_integer_argument(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            index_generator(scalar(1.5))
+
+    def test_caps_n_before_allocating(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(array_mod, "MAX_ELEMENTS", 10)
+        with pytest.raises(ValueError, match="exceeds the .*-element cap"):
+            index_generator(scalar(11))
+
+
+class TestIndexOf:
+    def test_found_returns_one_based_position_of_first_occurrence(self) -> None:
+        # 10 20 30 ⍳ 20 = 2 (1-based)
+        haystack = from_vec([10, 20, 30])
+        r = index_of(haystack, scalar(20))
+        assert r.data == [2]
+
+    def test_not_found_returns_haystack_length_plus_one_never_negative(self) -> None:
+        haystack = from_vec([10, 20, 30])
+        r = index_of(haystack, scalar(99))
+        # "not found" must be haystack.length + 1 (4), never -1/None.
+        assert r.data == [4]
+
+    def test_multiple_needles_each_resolved_independently(self) -> None:
+        haystack = from_vec([10, 20, 30])
+        r = index_of(haystack, from_vec([30, 99, 10]))
+        assert r.shape == (3,)
+        assert r.data == [3, 4, 1]
+
+    def test_uses_exact_equality_nan_never_matches(self) -> None:
+        haystack = from_vec([1.0, float("nan"), 3.0])
+        r = index_of(haystack, scalar(float("nan")))
+        # NaN != NaN under plain equality, so it must never be found --
+        # not even against a NaN sitting right there in the haystack.
+        assert r.data == [4]
+
+    def test_rejects_rank_greater_than_one_haystack(self) -> None:
+        with pytest.raises(ValueError, match="must be a scalar or vector"):
+            index_of(from_rows([[1, 2], [3, 4]]), scalar(1))
+
+    def test_indexof_product_dos_guard_caps_before_scanning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SECURITY regression -- the exact matmul-shaped bug class: each
+        # operand is individually small, but the O(len(haystack) *
+        # len(needle)) scan cost is a PRODUCT of two independent lengths,
+        # which the (trivially small) output-length alone would never
+        # catch. Must be capped before the scan loop runs.
+        monkeypatch.setattr(array_mod, "MAX_ELEMENTS", 100)
+        haystack = from_vec(list(range(20)))
+        needles = from_vec(list(range(20)))
+        with pytest.raises(ValueError, match="exceeds the .*-element cap"):
+            index_of(haystack, needles)
+
+
+class TestRavel:
+    def test_ravel_of_a_vector_is_unchanged(self) -> None:
+        r = ravel(from_vec([1, 2, 3]))
+        assert r.shape == (3,)
+        assert r.data == [1, 2, 3]
+
+    def test_ravel_of_a_matrix_flattens_row_major(self) -> None:
+        # [[1, 2, 3], [4, 5, 6]] raveled row-major (last axis fastest) is
+        # [1, 2, 3, 4, 5, 6] -- NOT the raw column-major storage order
+        # ([1, 4, 2, 5, 3, 6]), which this asserts against implicitly by
+        # pinning the correct answer.
+        a = from_rows([[1, 2, 3], [4, 5, 6]])
+        r = ravel(a)
+        assert r.shape == (6,)
+        assert r.data == [1, 2, 3, 4, 5, 6]
+
+    def test_ravel_of_a_scalar(self) -> None:
+        r = ravel(scalar(7))
+        assert r.shape == (1,)
+        assert r.data == [7]
+
+    def test_ravel_never_aliases_the_source_data_buffer(self) -> None:
+        a = from_vec([1, 2, 3])
+        r = ravel(a)
+        r.data[0] = 999
+        assert a.data == [1, 2, 3]
+
+
+class TestCatenate:
+    def test_scalar_catenate_scalar(self) -> None:
+        r = catenate(scalar(1), scalar(2))
+        assert r.shape == (2,)
+        assert r.data == [1, 2]
+
+    def test_scalar_catenate_vector(self) -> None:
+        r = catenate(scalar(1), from_vec([2, 3]))
+        assert r.data == [1, 2, 3]
+
+    def test_vector_catenate_scalar(self) -> None:
+        r = catenate(from_vec([1, 2]), scalar(3))
+        assert r.data == [1, 2, 3]
+
+    def test_vector_catenate_vector(self) -> None:
+        r = catenate(from_vec([1, 2]), from_vec([3, 4]))
+        assert r.shape == (4,)
+        assert r.data == [1, 2, 3, 4]
+
+    def test_matrix_catenate_matrix_with_equal_row_counts(self) -> None:
+        # [[1, 2], [3, 4]] , [[5], [6]] -> [[1, 2, 5], [3, 4, 6]]
+        a = from_rows([[1, 2], [3, 4]])
+        b = from_rows([[5], [6]])
+        r = catenate(a, b)
+        assert r.shape == (2, 3)
+        assert get(r, 0, 0) == 1
+        assert get(r, 0, 1) == 2
+        assert get(r, 0, 2) == 5
+        assert get(r, 1, 0) == 3
+        assert get(r, 1, 1) == 4
+        assert get(r, 1, 2) == 6
+
+    def test_matrix_catenate_unequal_row_counts_raises(self) -> None:
+        a = from_rows([[1, 2]])
+        b = from_rows([[1, 2], [3, 4]])
+        with pytest.raises(ValueError, match="equal row counts"):
+            catenate(a, b)
+
+    def test_rank_combination_not_supported_raises(self) -> None:
+        a = from_rows([[1, 2], [3, 4]])
+        b = from_vec([1, 2])
+        with pytest.raises(ValueError, match="not yet supported"):
+            catenate(a, b)
+
+    def test_combined_length_dos_guard_caps_before_any_branch_allocates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SECURITY regression: a script that repeatedly self-catenates
+        # (`A <- A,A`) has no other ceiling on the combined size -- each
+        # operand can be individually small while the SUM still exceeds
+        # the cap, and this must be caught once, up front, regardless of
+        # which of the five rank-combination branches would otherwise
+        # run.
+        monkeypatch.setattr(array_mod, "MAX_ELEMENTS", 10)
+        a = from_vec(list(range(6)))
+        b = from_vec(list(range(6)))
+        with pytest.raises(ValueError, match="exceeds the .*-element cap"):
+            catenate(a, b)
+
+
+class TestFlattenRowMajor:
+    def test_flatten_of_rank_zero_is_a_fresh_list(self) -> None:
+        a = scalar(5)
+        flat = array_mod._flatten_row_major(a)
+        assert flat == [5]
+        flat[0] = 999
+        assert a.data == [5]
+
+    def test_flatten_of_rank_one_is_a_fresh_list(self) -> None:
+        a = from_vec([1, 2, 3])
+        flat = array_mod._flatten_row_major(a)
+        assert flat == [1, 2, 3]
+        flat[0] = 999
+        assert a.data == [1, 2, 3]
+
+    def test_flatten_of_rank_two_reorders_column_major_to_row_major(self) -> None:
+        a = from_rows([[1, 2, 3], [4, 5, 6]])
+        assert a.data == [1, 4, 2, 5, 3, 6]  # raw column-major storage
+        assert array_mod._flatten_row_major(a) == [1, 2, 3, 4, 5, 6]  # row-major order
+
+    def test_flatten_of_rank_greater_than_two_falls_back_to_raw_data(self) -> None:
+        a = NDArray((2, 2, 2), list(range(8)))
+        assert array_mod._flatten_row_major(a) == list(range(8))
+
+
+class TestNonNegativeInt:
+    def test_accepts_plain_int(self) -> None:
+        assert array_mod._non_negative_int(3, who="test") == 3
+
+    def test_accepts_integer_valued_float(self) -> None:
+        assert array_mod._non_negative_int(3.0, who="test") == 3
+
+    def test_rejects_bool(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            array_mod._non_negative_int(True, who="test")
+
+    def test_rejects_fractional_float(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            array_mod._non_negative_int(3.5, who="test")
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValueError, match="non-negative integer"):
+            array_mod._non_negative_int(-1, who="test")

--- a/code/packages/python/sir-runtime-array/tests/test_array.py
+++ b/code/packages/python/sir-runtime-array/tests/test_array.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import math
 
-import coding_adventures_sir_runtime_array.array as array_mod
 import pytest
+
+import coding_adventures_sir_runtime_array.array as array_mod
 from coding_adventures_sir_runtime_array import (
     MAX_ELEMENTS,
     NDArray,
@@ -63,7 +64,7 @@ class TestCheckedShapeSize:
         # bool is an int subclass in Python; a shape dimension must be a
         # real int, not a stray True/False.
         with pytest.raises(ValueError, match="negative or non-integer"):
-            checked_shape_size((True, 2))  # type: ignore[arg-type]
+            checked_shape_size((True, 2))
 
     def test_rejects_shape_exceeding_max_elements_cap(self) -> None:
         with pytest.raises(ValueError, match="exceeds the .*-element cap"):
@@ -80,7 +81,7 @@ class TestNdarrayConstruction:
 
     def test_ndarray_rejects_non_list_data(self) -> None:
         with pytest.raises(TypeError, match="data must be a list"):
-            ndarray((2,), (1, 2))  # type: ignore[arg-type]
+            ndarray((2,), (1, 2))
 
     def test_scalar_factory(self) -> None:
         a = scalar(7)
@@ -177,7 +178,7 @@ class TestGetSet:
         # NaN is False), so this must raise, not silently misbehave.
         a = from_rows([[1, 2], [3, 4]])
         with pytest.raises(ValueError, match="out of bounds"):
-            sir_set(a, float("nan"), 0, 1)
+            sir_set(a, float("nan"), 0, 1)  # type: ignore[arg-type]
 
 
 class TestApplyOp:

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,94 @@
 # Changelog
 
+## 0.16.0 — SIR22 "APL addendum" real codegen (Phase A Slice 3)
+
+Part of the SIR22/SIR23 backend-expansion initiative (`code/specs/
+SIR22-array-matrix-semantic-ir.md`'s "Backend impact" section) — this PR
+opens this backend to the nine-node SIR22 "APL addendum" that Slice 2 left
+deferred: `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`. Like Slice 2, this PR spans
+two packages — this crate, and `code/packages/python/sir-runtime-array`
+(0.1.0 -> 0.2.0), which gains the nine new functions the emitter now calls
+into.
+
+**`find_unimplemented_sir22_addendum_node` is REMOVED.** Slice 2's
+dedicated pre-emit `semantic_ir::Visitor` tree-walk (in `lib.rs`) existed
+solely to reject the nine addendum nodes cleanly, since they share
+`NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the base cut and so can't be
+told apart by a bare feature-flag check. Real codegen now exists for all
+nine, so the walk — and its call site in `PythonBackend::compile`, and the
+two tests that pinned the old rejecting behavior
+(`rejects_reduce_node_cleanly_instead_of_panicking_in_emit`,
+`rejects_catenate_node_nested_inside_a_let_binding`) — are gone. Their
+replacements (`emits_reduce_node_as_a_real_runtime_call`,
+`emits_catenate_node_nested_inside_a_let_binding`) assert the opposite: a
+real `_sir_array_reduce(...)`/`_sir_array_catenate(...)` call appears in
+the emitted source, not an `UnsupportedFeature` error.
+
+**Only a single call site per node was needed — the base cut's own
+dual-position (`Stmt::IndexSet`) situation does NOT apply here.** Slice 2
+had to wire `IndexSet` into both `emit_stmt_inner` (statement position)
+and `emit_block_as_expr`'s walrus-tuple path (expression position),
+because `Stmt` has no single shared emit function. All nine addendum nodes
+are `Expr`s, and this crate already has exactly one `emit_expr` function
+that every position (statement position, walrus-tuple position, a nested
+operand, ...) routes through — `emit_block_as_expr` itself calls back into
+`emit_expr` for every element it composes into a tuple — so one match arm
+per node, added to `emit_expr`, is the entire fix. Confirmed by this PR's
+own `emits_catenate_node_nested_inside_a_let_binding` test, which forces
+`Catenate` into a `LetBinding`'s value (a non-trivial nesting position)
+and gets real codegen with no second arm anywhere.
+
+**Reference source: JS's inlined `ArrayRt`, not TS's package.** Per the
+SIR22 spec's own note that TS's `sir-runtime-array` package lagged behind
+JS's inlined port, `@coding-adventures/sir-runtime-array` (TS) still had
+no addendum functions at the time of this port — `semantic-ir-to-
+javascript/src/runtime.rs`'s "SIR22 addendum: APL primitive operators"
+section (the proven, already-shipped implementation) was the port source
+instead, adapted from JS's `Float64Array`-backed rank model to this
+package's own `list`-backed, native-`int`/`float`-preserving one (see the
+sibling package's own CHANGELOG entry below for the full algorithm
+discussion — reduce/scan's column-major row-indexing, outer's rank <= 1
+scoping, reshape's row-major-fill-then-transpose-to-column-major
+gotcha, index_generator/index_of's 1-based convention, catenate's five
+rank combinations).
+
+**Security**: every one of the nine new functions was re-examined
+specifically for the SAME missing-dimension-validation bug class Slice
+2's own security review found and fixed in `matmul` (which originally
+validated only the *output* shape, letting an unbounded `m·n·ka`
+multiply-add loop through from two individually-legal inputs sharing a
+large, unchecked inner dimension). `outer`'s `(m, n)` output,
+`index_of`'s `len(haystack) * len(needle)` scan-cost product,
+`catenate`'s combined length, `index_generator`'s `n`, and `reshape`'s
+target element count are each validated via `checked_shape_size` *before*
+allocating or looping — not just the most obviously dangerous one. New
+`tests/sir22_array.rs::index_of_product_dos_guard_rejects_two_individually_legal_operands`
+mirrors the `matmul` regression directly: two length-10,000 vectors (each
+individually far under the `1 << 26` cap) whose product exceeds it, run
+under a real `python3` process and asserted to exit non-zero with a
+`checked_shape_size`-shaped error — not just a Rust-side unit assertion.
+
+New `tests/sir22_array.rs` coverage (12 new tests, all executed under a
+real `python3`/`python` interpreter): `reduce` on both a vector and a
+2x3 matrix (the matrix case specifically proves the column-major
+row-indexing is not accidentally transposed — a swapped row/col would sum
+columns instead of rows); `scan` on a vector; `outer` product of two
+vectors; `shape` of a scalar (asserted via the raw `NDArray`'s own
+`__repr__`, pinning `shape=(0,)` — not just an element count) and of a
+matrix; `reshape` to a non-square 3x2 target (the row-major-fill-then-
+transpose-to-column-major case); `index_generator` (1-based); `index_of`
+found and not-found (not-found asserted as `len(haystack) + 1`, never a
+sentinel like `-1`); `ravel` of a matrix; `catenate` of two vectors and of
+two matrices with equal row counts; plus the DoS-guard regression above.
+Since no base-cut node produces a genuine rank-1 vector directly (`ArrayLit`
+is always rank-2 via `from_rows`; `Range` is always the rank-2 `1 x n` row
+MATLAB's colon syntax implies), most tests obtain a rank-1 operand by
+`Ravel`-ing a 1-row `ArrayLit` first — the same thing a real APL frontend's
+own lowering would have to do.
+
+`semantic-ir-to-python` 0.15.0 -> 0.16.0.
+
 ## 0.15.0 — SIR22 array/matrix base cut (second-wave backend rollout, Phase A Slice 2)
 
 Part of the SIR22/SIR23 backend-expansion initiative (opening

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/README.md
+++ b/code/packages/rust/semantic-ir-to-python/README.md
@@ -77,11 +77,14 @@ uses a **sentinel + body-prologue** strategy:
   sentinel, which the prologue resolves.  `IndirectCall`/closure defaults are
   deferred.
 
-## SIR22 array/matrix base cut
+## SIR22 array/matrix domain
 
 `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet` (+
-`Stmt::IndexSet`) lower to calls into `_sir_array_*`, imported from the
-published `coding-adventures-sir-runtime-array` pip package — **this
+`Stmt::IndexSet`) — the SIR22 base cut — and the nine-node "APL addendum"
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+`IndexOf`/`Ravel`/`Catenate`, which shares these same three features with
+no flag of its own) all lower to calls into `_sir_array_*`, imported from
+the published `coding-adventures-sir-runtime-array` pip package — **this
 backend follows the TypeScript backend's imported-package model here**,
 not its own usual inlined-runtime convention (contrast the OOP/
 exceptions/pairs/regex/shell/range imports above, and C/Go/Rust/Ruby's
@@ -95,13 +98,19 @@ operands are; `Div` always true-divides), matching MATLAB's `./`
 semantics without a spurious `.0` on an all-integer computation — see
 that package's own README/CHANGELOG for the full design and security
 notes (NaN-safe AND-form bounds checks, DoS-safe shape validation before
-allocation).
+allocation, including for every addendum function that computes an
+output/allocation size from two independently-controlled operands —
+`outer`, `index_of`, `catenate`, `reshape`, `index_generator`).
 
-The nine-node SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/
-`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) shares
-these same three features with the base cut, so a dedicated pre-emit
-tree-walk (`find_unimplemented_sir22_addendum_node` in `lib.rs`) rejects
-it cleanly until its own later slice lands.
+`Reduce`/`Scan`/`OuterProduct` carry an `ElementwiseOpKind` and reuse
+`elementwise_op_py_name` exactly like `ElementwiseOp` does; the remaining
+six addendum nodes have no `op` field ("bespoke, not `BinOp`-shaped") and
+just recurse into their operand(s). Unlike `Stmt::IndexSet` above (which
+needs separate handling in both statement position and the walrus-tuple
+expression-position path, since `Stmt` has no single shared emit
+function), all nine addendum nodes are `Expr`s, so one `emit_expr` match
+arm per node is enough — every position already routes through that one
+function.
 
 ## Capability declaration
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -400,12 +400,13 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         // whose runtime meaning is its inner `value`; recurse into it so this
         // builtin-usage scan stays faithful.  Real support pending KW2–KW6.
         Expr::KeywordArg { value, .. } => expr_uses_builtin(value, name),
-        // SIR22 array/matrix expressions are not accepted by this backend
-        // yet (see `ACCEPTED_FEATURES` in `lib.rs`), so a validated module
-        // never contains them in practice. Still, this scan is exhaustive
-        // by design so a new node can't silently hide a builtin use — recurse
-        // into every sub-expression the same way the other compound-expr
-        // arms above do.
+        // SIR22 array/matrix expressions (base cut + the nine-node
+        // addendum below) — real codegen now exists for all of these (see
+        // `ACCEPTED_FEATURES` in `lib.rs` and this file's `emit_expr`
+        // arms), so a validated module can genuinely contain them. This
+        // scan is exhaustive by design so a new node can't silently hide a
+        // builtin use — recurse into every sub-expression the same way the
+        // other compound-expr arms above do.
         Expr::ArrayLit { rows, .. } => rows
             .iter()
             .any(|row| row.iter().any(|c| expr_uses_builtin(c, name))),
@@ -429,9 +430,9 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
             expr_uses_builtin(target, name)
                 || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
         }
-        // SIR22 addendum: APL primitive operators — not accepted by this
-        // backend either (same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
-        // gating), but recurse faithfully regardless.
+        // SIR22 addendum: APL primitive operators — real codegen (see
+        // `emit_expr`'s corresponding arms below); recurse into every
+        // operand the same way the base-cut arms above do.
         Expr::Reduce { target, .. } => expr_uses_builtin(target, name),
         Expr::Scan { target, .. } => expr_uses_builtin(target, name),
         Expr::OuterProduct { lhs, rhs, .. } => {
@@ -1438,36 +1439,104 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize, env: &mut TypeEnv) {
             emit_index_args(out, indices, indent, env);
             out.push_str("])");
         }
-        // SIR22 addendum: APL primitive operators (`Reduce`/`Scan`/
-        // `OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-        // `Ravel`/`Catenate`). This backend does not implement codegen for
-        // these nine nodes in this slice — a separate, later rollout slice
-        // per the SIR22 spec's "Backend impact" section. They share the
-        // SAME three features (`NDArrays`/`MatrixOps`/`ArrayColumnMajor`)
-        // with the base cut above, so — now that those features are in
-        // `ACCEPTED_FEATURES` (see `lib.rs`) — a bare capability check can
-        // no longer reject a module using one of these nine.
-        // `PythonBackend::compile`'s `find_unimplemented_sir22_addendum_node`
-        // walk closes that gap *before* emission is ever reached (mirrors
-        // `semantic-ir-to-javascript`'s original SIR22 base-cut PR's
-        // identically named check), so a validated module never reaches
-        // this arm. Kept as an explicit panic (not folded into a wildcard)
-        // so Rust's exhaustiveness checking still forces a new SIR22 node
-        // to be handled here.
-        Expr::Reduce { .. }
-        | Expr::Scan { .. }
-        | Expr::OuterProduct { .. }
-        | Expr::Shape { .. }
-        | Expr::Reshape { .. }
-        | Expr::IndexGenerator { .. }
-        | Expr::IndexOf { .. }
-        | Expr::Ravel { .. }
-        | Expr::Catenate { .. }
+        // ── SIR22 addendum: APL primitive operators — real codegen ─────
+        // Each of the nine maps 1:1 onto a call into the imported
+        // `coding-adventures-sir-runtime-array` package (gated by the
+        // SAME `NDArrays`/`MatrixOps`/`ArrayColumnMajor` features the
+        // base cut above uses — see `RUNTIME_ARRAY` in `runtime.rs`).
+        // `Reduce`/`Scan`/`OuterProduct` carry an `ElementwiseOpKind` and
+        // so reuse `elementwise_op_py_name` exactly like `ElementwiseOp`
+        // above does; the remaining six have no `op` field at all (they
+        // are "bespoke, not BinOp-shaped" per the SIR22 spec addendum and
+        // `apl-runtime::builtins`'s own doc comment) and just recurse into
+        // their operand(s). Only a single call site is needed for each —
+        // unlike `Stmt::IndexSet` (which needed separate handling in
+        // `emit_stmt_inner` and `emit_block_as_expr`'s walrus path because
+        // `Stmt` has no single shared emit function), every one of these
+        // nine is an `Expr`, so this one `emit_expr` arm already covers
+        // every position (statement position, walrus-tuple position, a
+        // nested operand, ...) — `emit_block_as_expr` calls back into
+        // `emit_expr` for every expression it composes into a tuple.
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(
+                out,
+                "_sir_array_reduce({}, ",
+                quote_py_string(elementwise_op_py_name(*op))
+            );
+            emit_expr(out, target, indent, env);
+            out.push(')');
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(
+                out,
+                "_sir_array_scan({}, ",
+                quote_py_string(elementwise_op_py_name(*op))
+            );
+            emit_expr(out, target, indent, env);
+            out.push(')');
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(
+                out,
+                "_sir_array_outer({}, ",
+                quote_py_string(elementwise_op_py_name(*op))
+            );
+            emit_expr(out, lhs, indent, env);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent, env);
+            out.push(')');
+        }
+        Expr::Shape { target, .. } => {
+            out.push_str("_sir_array_shape(");
+            emit_expr(out, target, indent, env);
+            out.push(')');
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `_sir_array_reshape(shape_arg, target)` takes the
+        // same order, so no argument reordering is needed at this call
+        // site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `_sir_array_range`'s `start, stop, step` above, which DOES
+        // reorder).
+        Expr::Reshape { shape, target, .. } => {
+            out.push_str("_sir_array_reshape(");
+            emit_expr(out, shape, indent, env);
+            out.push_str(", ");
+            emit_expr(out, target, indent, env);
+            out.push(')');
+        }
+        Expr::IndexGenerator { count, .. } => {
+            out.push_str("_sir_array_index_generator(");
+            emit_expr(out, count, indent, env);
+            out.push(')');
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            out.push_str("_sir_array_index_of(");
+            emit_expr(out, haystack, indent, env);
+            out.push_str(", ");
+            emit_expr(out, needle, indent, env);
+            out.push(')');
+        }
+        Expr::Ravel { target, .. } => {
+            out.push_str("_sir_array_ravel(");
+            emit_expr(out, target, indent, env);
+            out.push(')');
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            out.push_str("_sir_array_catenate(");
+            emit_expr(out, lhs, indent, env);
+            out.push_str(", ");
+            emit_expr(out, rhs, indent, env);
+            out.push(')');
+        }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
-        | Expr::Convert { .. } => {
+        Expr::Convert { .. } => {
             panic!(
-                "python backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                "python backend reached a deferred SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -15,8 +15,7 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    walk_expr_default, Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr,
-    Feature, Module, Span, Visitor,
+    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Feature, Module,
 };
 
 pub use emit::sanitize_ident;
@@ -24,53 +23,6 @@ pub use emit::sanitize_ident;
 /// Convenience entry point.
 pub fn compile(module: &Module) -> Result<Artifact, BackendError> {
     PythonBackend::new().compile(module)
-}
-
-/// Finds the first (if any) SIR22 "APL addendum" node anywhere in a
-/// module — `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
-/// `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`.
-///
-/// These nine variants share `Feature::NDArrays`/`MatrixOps`/
-/// `ArrayColumnMajor` with the SIR22 *base* cut this backend now accepts
-/// (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
-/// `IndexSet`) — the SIR22 addendum spec gives them no feature flag of
-/// their own — so the ordinary `accepts_features()` capability check
-/// cannot tell a module using only the base cut (real codegen, safe) from
-/// one that also uses these nine (still deferred in `emit`, would panic).
-/// This walk is the finer-grained check that closes that gap, mirroring
-/// `semantic-ir-to-javascript`'s original SIR22 base-cut PR's identically
-/// named `find_unimplemented_sir22_addendum_node` (since removed there
-/// once that backend's own later PR implemented real codegen for all
-/// nine — this backend has not done that yet, so the check stays here).
-/// A validated module never reaches `emit`'s corresponding panic arm.
-fn find_unimplemented_sir22_addendum_node(module: &Module) -> Option<(&'static str, Span)> {
-    struct Finder(Option<(&'static str, Span)>);
-    impl Visitor for Finder {
-        fn visit_expr(&mut self, e: &Expr, depth: usize) {
-            if self.0.is_none() {
-                let hit = match e {
-                    Expr::Reduce { span, .. } => Some(("Reduce", span.clone())),
-                    Expr::Scan { span, .. } => Some(("Scan", span.clone())),
-                    Expr::OuterProduct { span, .. } => Some(("OuterProduct", span.clone())),
-                    Expr::Shape { span, .. } => Some(("Shape", span.clone())),
-                    Expr::Reshape { span, .. } => Some(("Reshape", span.clone())),
-                    Expr::IndexGenerator { span, .. } => Some(("IndexGenerator", span.clone())),
-                    Expr::IndexOf { span, .. } => Some(("IndexOf", span.clone())),
-                    Expr::Ravel { span, .. } => Some(("Ravel", span.clone())),
-                    Expr::Catenate { span, .. } => Some(("Catenate", span.clone())),
-                    _ => None,
-                };
-                if hit.is_some() {
-                    self.0 = hit;
-                    return;
-                }
-            }
-            walk_expr_default(self, e, depth);
-        }
-    }
-    let mut finder = Finder(None);
-    finder.visit_module(module);
-    finder.0
 }
 
 /// The v0 Python backend.
@@ -142,19 +94,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // console-output primitive every frontend now emits in place of the
     // old bare `print`/`puts` (SIR28 §7 removed the dead bare-name path).
     Feature::ConsoleIO,
-    // SIR22: the array/matrix domain's *base cut* — `ArrayLit`, `Range`,
-    // `MatMul`, `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and
-    // `IndexSet` (a `Stmt`) lower to calls into the imported
+    // SIR22: the array/matrix domain — `ArrayLit`, `Range`, `MatMul`,
+    // `ElementwiseOp`, `Transpose`, `IndexGet` (an `Expr`) and `IndexSet`
+    // (a `Stmt`), plus the nine-node "APL addendum" that shares these SAME
+    // three features (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+    // `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` — the addendum gives
+    // them no flag of their own), all lower to calls into the imported
     // `coding-adventures-sir-runtime-array` package (following the
     // TypeScript backend's imported-package model rather than this
     // backend's usual inline-runtime convention — see `runtime.rs`'s
-    // `RUNTIME_ARRAY` doc comment and `emit`'s SIR22 arms). The SIR22
-    // "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
-    // `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) share these
-    // SAME three features (the addendum gives them no flag of their own)
-    // but remain deferred in `emit` — see `find_unimplemented_sir22_addendum_node`
-    // for the dedicated tree-walk that closes the resulting
-    // capability/emit gap.
+    // `RUNTIME_ARRAY` doc comment and `emit`'s SIR22 arms).
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
@@ -193,24 +142,6 @@ impl Backend for PythonBackend {
                 kind: BackendErrorKind::UnsupportedFeature,
                 message: "python backend cannot satisfy `tail_calls` feature".into(),
                 span: module.span.clone(),
-            });
-        }
-
-        // The SIR22 "APL addendum" nodes (`Reduce`/`Scan`/`OuterProduct`/
-        // `Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`)
-        // share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the SIR22
-        // base cut this backend accepts (the addendum gives them no flag
-        // of their own), so the capability check above cannot reject a
-        // module using them — an explicit tree walk is the only way to
-        // catch this before `emit` panics on one. See
-        // `find_unimplemented_sir22_addendum_node`'s doc comment.
-        if let Some((kind, span)) = find_unimplemented_sir22_addendum_node(module) {
-            return Err(BackendError {
-                kind: BackendErrorKind::UnsupportedFeature,
-                message: format!(
-                    "python backend does not yet implement the SIR22 addendum node `{kind}`"
-                ),
-                span,
             });
         }
 
@@ -846,7 +777,7 @@ mod tests {
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     }
 
-    // ── SIR22: array/matrix capability acceptance + addendum rejection ──
+    // ── SIR22: array/matrix capability acceptance ───────────────────────
 
     #[test]
     fn accepts_nd_arrays_feature() {
@@ -869,15 +800,19 @@ mod tests {
         compile(&m).expect("array-column-major accepted");
     }
 
-    /// Regression test for the gap `find_unimplemented_sir22_addendum_node`
-    /// closes: a module using `Expr::Reduce` (APL `+/A`) with exactly the
-    /// three base-cut features would — before this check existed — sail
-    /// past `accepts_features()` (since `NDArrays`/`MatrixOps` are now
-    /// accepted) and panic inside `emit`. Must instead fail cleanly with
-    /// `UnsupportedFeature`, the same error kind every other still-deferred
-    /// node produces, not a panic.
+    /// The SIR22 "APL addendum" (`Reduce`/`Scan`/`OuterProduct`/`Shape`/
+    /// `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) shares the
+    /// exact three base-cut features with no flag of its own — this
+    /// backend used to reject all nine with a dedicated pre-emit tree walk
+    /// (`find_unimplemented_sir22_addendum_node`, since removed: real
+    /// codegen now exists for every one of them). `Expr::Reduce` (APL
+    /// `+/A`) must now compile straight through to a real
+    /// `_sir_array_reduce(...)` call, not an `UnsupportedFeature` error.
+    /// See `tests/sir22_array.rs` for the full end-to-end execution proof
+    /// (all nine nodes, run under a real `python3`); this is just the
+    /// "compiles, and calls the right runtime function" smoke test.
     #[test]
-    fn rejects_reduce_node_cleanly_instead_of_panicking_in_emit() {
+    fn emits_reduce_node_as_a_real_runtime_call() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[
             Feature::NDArrays,
@@ -893,19 +828,18 @@ mod tests {
             }),
             span: s(),
         };
-        let err = compile(&m).expect_err("Reduce must be rejected, not emitted");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(
-            err.message.contains("Reduce"),
-            "error should name the rejected node: {}",
-            err.message
-        );
+        let a = compile(&m).expect("Reduce must compile, not be rejected");
+        assert!(a.source.contains("_sir_array_reduce(\"Add\", _sir_array_from_rows([[1]]))"));
     }
 
-    /// Same gap, a different addendum node — proves the walk isn't
-    /// hardcoded to only catch `Reduce`.
+    /// Same proof, a different addendum node nested inside a `let` binding
+    /// — proves the base cut's own dual-position discipline (a
+    /// statement-position vs. walrus-tuple expression-position split)
+    /// simply doesn't apply here: `Catenate` is an `Expr`, not a `Stmt`,
+    /// so the single `emit_expr` arm added for it already covers every
+    /// position, including nested inside a `LetBinding`'s value.
     #[test]
-    fn rejects_catenate_node_nested_inside_a_let_binding() {
+    fn emits_catenate_node_nested_inside_a_let_binding() {
         let mut m = minimal_module();
         m.manifest = FeatureManifest::from_features(&[
             Feature::NDArrays,
@@ -928,9 +862,10 @@ mod tests {
             },
             span: s(),
         });
-        let err = compile(&m).expect_err("Catenate must be rejected, not emitted");
-        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(err.message.contains("Catenate"), "got: {}", err.message);
+        let a = compile(&m).expect("Catenate must compile, not be rejected");
+        assert!(a.source.contains(
+            "_sir_array_catenate(_sir_array_from_rows([[1]]), _sir_array_from_rows([[2]]))"
+        ));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -94,13 +94,16 @@ from coding_adventures_sir_runtime_range import range as _sir_range
 /// The SIR22 array/matrix-runtime import header, appended **only** when a
 /// module declares `Feature::NDArrays`/`MatrixOps`/`ArrayColumnMajor` (an
 /// `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
-/// expression or an `IndexSet` statement).  Unlike every other runtime
-/// import in this file, this one follows the TypeScript backend's
-/// *imported-package* model rather than this backend's usual inline-runtime
-/// convention — see the SIR22 spec's "Backend impact" section for why
-/// Python follows TypeScript here (both target ecosystems with a real
-/// package manager, unlike C/Go/Rust/Ruby's inlined-port model). Each
-/// helper keeps the emitter's `_sir_array_*` name; see
+/// expression, an `IndexSet` statement, or one of the nine SIR22 "APL
+/// addendum" expressions — `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+/// `Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` — which share
+/// these same three features).  Unlike every other runtime import in this
+/// file, this one follows the TypeScript backend's *imported-package*
+/// model rather than this backend's usual inline-runtime convention — see
+/// the SIR22 spec's "Backend impact" section for why Python follows
+/// TypeScript here (both target ecosystems with a real package manager,
+/// unlike C/Go/Rust/Ruby's inlined-port model). Each helper keeps the
+/// emitter's `_sir_array_*` name; see
 /// `code/packages/python/sir-runtime-array`'s own README/CHANGELOG for the
 /// full API and design notes (column-major storage, native int/float
 /// propagation instead of JS's forced-double storage, NaN-safe AND-form
@@ -117,6 +120,15 @@ from coding_adventures_sir_runtime_array import (
     index_scalar as _sir_array_index_scalar,
     index_whole as _sir_array_index_whole,
     index_range as _sir_array_index_range,
+    reduce as _sir_array_reduce,
+    scan as _sir_array_scan,
+    outer as _sir_array_outer,
+    shape as _sir_array_shape,
+    reshape as _sir_array_reshape,
+    index_generator as _sir_array_index_generator,
+    index_of as _sir_array_index_of,
+    ravel as _sir_array_ravel,
+    catenate as _sir_array_catenate,
 )
 "##;
 
@@ -248,6 +260,28 @@ mod tests {
             assert!(RUNTIME_ARRAY.contains(alias), "array runtime missing `{}`", alias);
         }
         assert!(RUNTIME_ARRAY.ends_with('\n'));
+    }
+
+    /// SIR22 "APL addendum" — the nine-node extension sharing the base
+    /// cut's own three features (`NDArrays`/`MatrixOps`/
+    /// `ArrayColumnMajor`), each aliased to the `_sir_array_*` name
+    /// `emit.rs`'s `Expr::Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+    /// `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate` arms call into.
+    #[test]
+    fn runtime_array_imports_the_apl_addendum_functions() {
+        for alias in &[
+            "reduce as _sir_array_reduce",
+            "scan as _sir_array_scan",
+            "outer as _sir_array_outer",
+            "shape as _sir_array_shape",
+            "reshape as _sir_array_reshape",
+            "index_generator as _sir_array_index_generator",
+            "index_of as _sir_array_index_of",
+            "ravel as _sir_array_ravel",
+            "catenate as _sir_array_catenate",
+        ] {
+            assert!(RUNTIME_ARRAY.contains(alias), "array runtime missing `{}`", alias);
+        }
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-python/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-python/tests/sir22_array.rs
@@ -332,24 +332,310 @@ fn index_set_in_expression_position_walrus_path_mutates_in_place() {
     }
 }
 
-// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ────
+// ── SIR22 "APL addendum": real codegen, executed under a real python3 ──
+//
+// Unlike the base cut above, the addendum has no `ArrayLit`/`Range`-style
+// node that produces a genuine RANK-1 vector directly (`ArrayLit` always
+// lowers through `from_rows`, which is rank-2; `Range` is a rank-2 `1 x n`
+// row per MATLAB's own colon convention) -- so these tests build rank-1
+// operands by chaining `Ravel` (or another addendum node that itself
+// returns rank-1, e.g. `Shape`/`IndexGenerator`/`Catenate`) over an
+// `ArrayLit`, exactly the way a real APL frontend's own lowering would
+// have to.
+
+/// Run emitted Python that is expected to FAIL (an uncaught, typed
+/// `ValueError` propagating out of `main()`), proving a malformed/DoS-
+/// shaped input is cleanly REJECTED -- inverting `run_array_program`'s
+/// usual "must succeed" assumption. A silent, zero-exit-code "success"
+/// here would mean the hazardous input was silently accepted instead of
+/// raising -- exactly the failure mode this helper exists to catch.
+fn run_array_program_expecting_failure(m: &Module, tag: &str, expected_stderr_substring: &str) {
+    let exe = match ["python3", "python"].into_iter().find(|e| python_is_runnable(e)) {
+        Some(exe) => exe,
+        None => {
+            eprintln!("skip: no python on PATH for `{tag}`");
+            return;
+        }
+    };
+    let source = semantic_ir_to_python::compile(m).expect("python emit").source;
+    let py_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../python");
+    let pythonpath = std::env::join_paths([
+        py_root.join("sir-runtime-core/src"),
+        py_root.join("sir-runtime-pairs/src"),
+        py_root.join("sir-runtime-oop/src"),
+        py_root.join("sir-runtime-range/src"),
+        py_root.join("sir-runtime-regex/src"),
+        py_root.join("sir-runtime-exceptions/src"),
+        py_root.join("sir-runtime-array/src"),
+    ])
+    .expect("join PYTHONPATH");
+    let file = std::env::temp_dir().join(format!("sir_py_array_fail_{}_{}.py", std::process::id(), tag));
+    std::fs::write(&file, &source).expect("write temp python");
+    let out = std::process::Command::new(exe)
+        .arg(&file)
+        .env("PYTHONPATH", &pythonpath)
+        .output()
+        .expect("spawn python");
+    let _ = std::fs::remove_file(&file);
+    assert!(
+        !out.status.success(),
+        "expected python to exit non-zero for `{tag}`, but it succeeded:\n{source}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(expected_stderr_substring),
+        "got stderr:\n{stderr}\n--- source ---\n{source}"
+    );
+}
+
+fn ravel(target: Expr) -> Expr {
+    Expr::Ravel { target: Box::new(target), span: s() }
+}
 
 #[test]
-fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
-    // cut, so the ordinary feature-flag check alone can't reject it --
-    // proves the dedicated `find_unimplemented_sir22_addendum_node`
-    // pre-emit walk does, with a clean `Err`, not an `emit_expr` panic.
-    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
-    let m = array_module(vec![print_stmt(Expr::Reduce {
-        op: ElementwiseOpKind::Add,
-        target: Box::new(target),
+fn reduce_of_a_vector_left_folds_across_all_elements() {
+    // +/1 2 3 4 = 10. The vector comes from `Ravel`-ing a 1x4 `ArrayLit`
+    // (the addendum's own way to obtain a genuine rank-1 operand -- see
+    // this section's module doc comment).
+    let v = ravel(array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]));
+    let r = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(v), span: s() };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "10\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn reduce_of_a_matrix_folds_each_row_independently() {
+    // [[1,2,3],[4,5,6]] -- row 0 sums to 6, row 1 sums to 15. A
+    // column/row indexing mixup in the column-major fold would instead
+    // sum the COLUMNS (1+4=5, 2+5=7, 3+6=9) -- this pins the CORRECT,
+    // row-independent answer, matching the reference implementation's own
+    // "single easiest place to introduce a wrong-answer bug" warning.
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let r = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "6\n15\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn scan_of_a_vector_keeps_every_intermediate_result() {
+    // +\1 2 3 4 = 1 3 6 10.
+    let v = ravel(array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]));
+    let sc = Expr::Scan { op: ElementwiseOpKind::Add, target: Box::new(v), span: s() };
+    let m = array_module(vec![
+        let_binding("sc", sc),
+        print_stmt(index_get(local("sc"), vec![scalar(0)])),
+        print_stmt(index_get(local("sc"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n10\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn outer_product_of_two_vectors() {
+    // [1, 2] outer-times [10, 20, 30] -> [[10, 20, 30], [20, 40, 60]].
+    let a = ravel(array_lit(vec![vec![ilit(1), ilit(2)]]));
+    let b = ravel(array_lit(vec![vec![ilit(10), ilit(20), ilit(30)]]));
+    let o = Expr::OuterProduct {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(a),
+        rhs: Box::new(b),
         span: s(),
-    })]);
-    let err = semantic_ir_to_python::compile(&m).expect_err("Reduce must be rejected, not emitted");
-    assert!(
-        err.message.contains("Reduce"),
-        "error should name the rejected node: {}",
-        err.message
+    };
+    let m = array_module(vec![
+        let_binding("o", o),
+        print_stmt(index_get(local("o"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("o"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "10\n60\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_scalar_is_the_empty_vector_not_a_scalar() {
+    // Critical APL semantics: `⍴5` is a length-0 vector, NOT a rank-0
+    // scalar. A genuine rank-0 NDArray doesn't exist as a base-cut
+    // literal (see this section's module doc comment), so it is obtained
+    // here via `Reduce` on a one-element vector. The raw `NDArray` is
+    // printed directly (via its `__repr__` fallback in `to_display`) so
+    // its `shape` field -- not just its element count -- is checked.
+    let one_elem_vec = ravel(array_lit(vec![vec![ilit(5)]]));
+    let scalar_expr = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(one_elem_vec), span: s() };
+    let sh = Expr::Shape { target: Box::new(scalar_expr), span: s() };
+    let m = array_module(vec![print_stmt(sh)]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "NDArray(shape=(0,), data=[])\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn shape_of_a_matrix_returns_its_dimensions() {
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let sh = Expr::Shape { target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("sh", sh),
+        print_stmt(index_get(local("sh"), vec![scalar(0)])),
+        print_stmt(index_get(local("sh"), vec![scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n3\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn reshape_transposes_row_major_fill_into_column_major_storage() {
+    // 2x3 -> 3x2. Source raveled row-major is [1, 2, 3, 4, 5, 6]; APL
+    // fills the LAST axis fastest (row-major), so the 3x2 target's rows
+    // must be (1,2), (3,4), (5,6) -- NOT (1,4), (2,5), (3,6) (the silent
+    // transpose a naive column-major-order fill would produce instead).
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let shape_vec = ravel(array_lit(vec![vec![ilit(3), ilit(2)]]));
+    let r = Expr::Reshape { shape: Box::new(shape_vec), target: Box::new(a), span: s() };
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(0), scalar(0)])),
+        print_stmt(index_get(local("r"), vec![scalar(0), scalar(1)])),
+        print_stmt(index_get(local("r"), vec![scalar(2), scalar(1)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n2\n6\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn index_generator_is_one_based_unlike_index_get_index_set() {
+    // ⍳4 = [1, 2, 3, 4] -- 1-based, unlike every 0-based index elsewhere
+    // in this domain (`IndexGet`/`IndexSet`).
+    let g = Expr::IndexGenerator { count: Box::new(ilit(4)), span: s() };
+    let m = array_module(vec![
+        let_binding("g", g),
+        print_stmt(index_get(local("g"), vec![scalar(0)])),
+        print_stmt(index_get(local("g"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n4\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn index_of_found_and_not_found_cases() {
+    // 10 20 30 ⍳ 20 = 2 (1-based, found). 10 20 30 ⍳ 99 = 4
+    // (haystack.length + 1 -- "not found" is a valid, always-in-range
+    // position, never -1/undefined).
+    let haystack = ravel(array_lit(vec![vec![ilit(10), ilit(20), ilit(30)]]));
+    let found = Expr::IndexOf { haystack: Box::new(haystack.clone()), needle: Box::new(ilit(20)), span: s() };
+    let not_found = Expr::IndexOf { haystack: Box::new(haystack), needle: Box::new(ilit(99)), span: s() };
+    let m = array_module(vec![
+        print_stmt(index_get(found, vec![scalar(0)])),
+        print_stmt(index_get(not_found, vec![scalar(0)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n4\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn ravel_of_a_matrix_flattens_row_major() {
+    // [[1,2,3],[4,5,6]] raveled row-major is [1,2,3,4,5,6] -- NOT the raw
+    // column-major storage order ([1,4,2,5,3,6]). Reading position 1 (the
+    // second element) distinguishes the two: row-major gives 2,
+    // column-major would give 4.
+    let a = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)], vec![ilit(4), ilit(5), ilit(6)]]);
+    let r = ravel(a);
+    let m = array_module(vec![
+        let_binding("r", r),
+        print_stmt(index_get(local("r"), vec![scalar(1)])),
+        print_stmt(index_get(local("r"), vec![scalar(5)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "2\n6\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_vectors() {
+    let a = ravel(array_lit(vec![vec![ilit(1), ilit(2)]]));
+    let b = ravel(array_lit(vec![vec![ilit(3), ilit(4)]]));
+    let c = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("c", c),
+        print_stmt(index_get(local("c"), vec![scalar(0)])),
+        print_stmt(index_get(local("c"), vec![scalar(3)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "1\n4\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+#[test]
+fn catenate_of_two_matrices_with_equal_row_counts() {
+    // [[1,2],[3,4]] , [[5],[6]] -> [[1,2,5],[3,4,6]] (column/last-axis
+    // catenate).
+    let a = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let b = array_lit(vec![vec![ilit(5)], vec![ilit(6)]]);
+    let c = Expr::Catenate { lhs: Box::new(a), rhs: Box::new(b), span: s() };
+    let m = array_module(vec![
+        let_binding("c", c),
+        print_stmt(index_get(local("c"), vec![scalar(0), scalar(2)])),
+        print_stmt(index_get(local("c"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run_array_program(&m) {
+        Some(out) => assert_eq!(out, "5\n6\n"),
+        None => eprintln!("skip: no python on PATH"),
+    }
+}
+
+/// SECURITY regression, mirroring the exact bug class Slice 2's own
+/// security review found in `matmul` (validating only the OUTPUT shape,
+/// not a shared dimension fed by two INDEPENDENT operands): `index_of`'s
+/// work is O(len(haystack) * len(needle)) -- each operand is individually
+/// tiny relative to `MAX_ELEMENTS` (1 << 26 ~= 67,108,864), but their
+/// PRODUCT (100,000,000 for two length-10,000 vectors) exceeds it. Must
+/// raise a clean `ValueError` from `checked_shape_size` *before* the O(n²)
+/// scan ever runs -- proven here by an actual non-zero exit from a real
+/// `python3` process, not just a Rust-side assertion. Each vector is built
+/// via `Range` + `Ravel` (not a 10,000-element `ArrayLit`) so the emitted
+/// program -- not this test's own Rust source -- does the materializing.
+#[test]
+fn index_of_product_dos_guard_rejects_two_individually_legal_operands() {
+    let long_vec = || {
+        ravel(Expr::Range {
+            start: Box::new(ilit(1)),
+            step: None,
+            stop: Box::new(ilit(10_000)),
+            span: s(),
+        })
+    };
+    let m = array_module(vec![let_binding(
+        "r",
+        Expr::IndexOf { haystack: Box::new(long_vec()), needle: Box::new(long_vec()), span: s() },
+    )]);
+    run_array_program_expecting_failure(
+        &m,
+        "index_of_product_dos",
+        "exceeds the",
     );
 }


### PR DESCRIPTION
## Summary

Part of the SIR22/SIR23 backend-expansion initiative (Phase A Slice 3, one of 5 parallel backend PRs). Opens the **Python backend** (`semantic-ir-to-python`) to the nine-node SIR22 array/matrix "APL addendum" that Phase A Slice 2 (merged) left behind a dedicated pre-emit rejection walk:

`Reduce` / `Scan` / `OuterProduct` / `Shape` / `Reshape` / `IndexGenerator` / `IndexOf` / `Ravel` / `Catenate`

This PR spans **two packages**:

- **`code/packages/python/sir-runtime-array`** (0.1.0 -> 0.2.0): adds the nine new functions (`reduce`/`scan`/`outer`/`shape`/`reshape`/`index_generator`/`index_of`/`ravel`/`catenate`) plus a shared `_flatten_row_major` helper, reusing the package's own existing `checked_shape_size`/`ndarray`/`get`/`apply_op`/`to_array_value` helpers. Ported 1:1 from `semantic-ir-to-javascript`'s already-shipped inlined `ArrayRt` runtime — the published TypeScript `sir-runtime-array` package itself had not yet grown these functions at the time of this port, so JS's own proven implementation was the closer reference.
- **`code/packages/rust/semantic-ir-to-python`** (0.15.0 -> 0.16.0): adds nine new `Expr` match arms in `emit.rs` calling into the new runtime functions, and **removes** the now-obsolete `find_unimplemented_sir22_addendum_node` rejection walker (and its `lib.rs` call site + two tests pinning the old rejecting behavior) — real codegen now exists for all nine nodes. Unlike `Stmt::IndexSet` (which needed two call sites — statement position and the walrus-tuple expression-position path), every addendum node is an `Expr`, so a single `emit_expr` match arm per node is sufficient (confirmed by a new regression test nesting `Catenate` inside a `LetBinding`).

## Security

Every one of the nine new functions was re-examined specifically for the missing-dimension-validation bug class Slice 2's own security review found and fixed in `matmul` (validating only the *output* shape, not a shared dimension fed by two independent operands): `outer`'s `(m, n)` output, `index_of`'s `len(haystack) * len(needle)` O(n²) scan-cost product, `catenate`'s combined length, `index_generator`'s `n`, and `reshape`'s target element count are all validated via `checked_shape_size` *before* allocating or looping. A dedicated `/security-review` sub-agent independently reviewed the full diff and reported **no vulnerabilities found**, explicitly confirming no function validates only an obvious dimension while leaving a hidden shared/product dimension unchecked.

## Test plan

- [x] `sir-runtime-array` package: 170 pytest tests (100 new), **100% statement coverage** of `array.py`/`__init__.py`, `ruff check` clean, `mypy --strict` clean. New coverage includes the reduce/scan column-major row-indexing correctness case, the reshape row-major-fill-then-transpose-to-column-major case, the 1-based `index_generator`/`index_of` convention (including the "not found" sentinel), and a DoS-guard regression test for every function identified above.
- [x] `semantic-ir-to-python` crate: full `cargo test` suite green (129 lib tests + 21 `tests/sir22_array.rs` integration tests, 12 of which are new end-to-end executions of the addendum nodes under a real `python3`, including a DoS-guard regression for `index_of`'s O(n²) product using two length-10,000 vectors).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Downstream consumer crates (`python-to-semantic-ir`, `sir-conformance`, `sir-bench`) build clean against the version bump.
- [x] `/security-review` passed (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)