### PR TITLE
feat(semantic-ir-to-c): implement SIR22 APL addendum (Phase A Slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,131 @@
 # Changelog
 
+## 0.41.0 — SIR22 "APL addendum" (Phase A Slice 3, second-wave backend rollout)
+
+Implements the 9-node SIR22 "APL addendum" this backend's own Slice 2 left
+cleanly rejected: `Expr::Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`. No `ACCEPTED_FEATURES` change
+was needed — all nine already shared `Feature::{NDArrays, MatrixOps,
+ArrayColumnMajor}` with the base cut. One of five parallel, independent
+backend PRs for this slice.
+
+**Nine new `_sir_array_*` runtime functions** (`runtime.rs`, appended to the
+existing "SIR22 array/matrix domain" section as a new "SIR22 addendum: APL
+primitive operators" subsection): ported 1:1 from `semantic-ir-to-javascript`'s
+own already-proven addendum functions (`reduce`/`scan`/`outer`/`shape`/
+`reshape`/`indexGenerator`/`indexOf`/`ravel`/`catenate`), which are themselves
+1:1 ports of `apl-runtime::builtins`. Two small shared helpers were added
+alongside them: `_sir_array_flatten_row_major` (re-walks a `SirNDArray`'s
+column-major storage into row-major element order — needed by both `ravel`
+and `reshape`) and `_sir_array_require_nonneg_int` (a finite-non-negative-
+integer validator shared by `reshape`'s shape-vector elements and
+`indexGenerator`'s scalar argument, itself built on the existing
+`_sir_array_assert_valid_position`'s NaN/overflow-safe cast).
+
+**One naming collision, fixed by renaming the NEW function**: `reduce` would
+have collided with a pre-existing `static SirValue _sir_array_reduce(SirSeq
+*s, ...)` — Ruby's `Array#reduce`/`#inject` Sequence method, which already
+claimed the `_sir_array_` prefix for "Ruby Array collection method" well
+before SIR22 NDArrays existed and reused the same prefix for itself. The new
+APL reduce is named `_sir_array_apl_reduce` instead; the pre-existing,
+unrelated Sequence method is untouched.
+
+**The core representational problem this port had to solve**: the JS/Ruby
+references have a genuine RANK-1 "vector" shape (`shape.length === 1`) that
+several addendum functions branch on or produce. This backend's `SirNDArray`
+has never had one — Slice 2 documented that a base-cut "vector" is always
+represented as a degenerate `1 x n` RANK-2 row, since no base-cut constructor
+here ever needs true rank-1. This slice extends that same convention to every
+addendum function: any "vector" a `Reduce`/`Scan`/`Shape`/`Reshape`/
+`IndexGenerator`/`Ravel`/`Catenate` result would be in JS is built here as a
+`1 x n` row (`_sir_array_new_matrix(1, n, …)`), and a new `_sir_array_
+logical_rank` classifier maps an INPUT `SirNDArray` onto this domain's three
+logical ranks (0 = true scalar, 1 = `rows == 1`, 2 = everything else) for
+`outer`/`shape`/`reshape`/`indexOf`/`catenate` to dispatch on. This
+classification is DELIBERATELY ASYMMETRIC between rows and cols — `rows == 1`
+alone, not `rows == 1 || cols == 1` — because a `cols == 1, rows > 1` shape
+(e.g. `ArrayLit([[5],[6]])`, or an `IndexGet` whole-row/scalar-column
+selection) is a construct the JS/Ruby references themselves treat as a
+genuine rank-2 matrix, not a vector (their own `ArrayLit` never produces a
+true rank-1 result either); an earlier, symmetric version of this rule was
+caught by this slice's OWN new test suite, which found it silently broke
+`catenate`'s matrix-matrix branch for a `2 x 1` right operand (a real matrix
+being misclassified as a vector, changing which code path — and which
+"equal row counts" validation — it went through). `reduce`/`scan` need no
+such classification at all: their "fold/scan each row across its columns"
+loop already generalizes correctly to a 1-row or 1-column input without a
+special case.
+
+**Ground-truthed the 1-based `IndexGenerator`/`IndexOf` claim against the
+actual `apl-runtime` crate, not the SIR node's own doc comment**: `semantic-
+ir`'s `nodes.rs` doc comment on `Expr::IndexGenerator` currently (incorrectly)
+describes `⍳N` as producing the 0-based vector `0, 1, ..., N-1`. The real
+`apl-runtime::builtins::index_generator` — and its own test,
+`index_generator_produces_one_based_run` — is 1-based (`[1, 2, …, n]`), and
+the JS backend's own addendum port already settled on 1-based to match it.
+This port follows the ACTUAL implementation, not the stale doc comment (which
+is out of scope to fix in this PR — flagged separately). Likewise `IndexOf`
+(dyadic `⍳`) is 1-based, and "not found" returns `haystack.length + 1` (an
+always-in-range position), never `-1`.
+
+**Reused this backend's existing overflow-safe allocation discipline
+throughout, extending it rather than reinventing it**: every new allocation
+whose size depends on more than one runtime-computed operand routes through
+the existing `_sir_array_checked_size` (the same overflow-safe-before-
+multiplying check Slice 2 built for `matmul`/`indexGet`) — `outer`'s `[m, n]`
+vector-x-vector output, `indexOf`'s `O(haystack * needle)` work-product cap
+(reusing `checked_size` purely for its product check, exactly as the JS
+reference reuses `checkedShapeSize` for the same reason), `reshape`'s target
+element count, `indexGenerator`'s `n`, and `catenate`'s combined length (a
+single up-front check regardless of which of the five rank combinations
+follows, since `a = [a, a]` can double an array's size every line with no
+other ceiling). `catenate`'s `na + nb` addition itself needs no overflow
+guard (each operand is already `<= SIR_ARRAY_MAX_ELEMENTS`, so their sum
+can't approach `int64_t`'s range) — only the cap COMPARISON does, which is
+what `checked_size` still provides via a `1 x (na + nb)` framing.
+
+**Reshape's "fill row-major, then transpose into column-major storage"
+gotcha, ported verbatim from the JS reference's own CRITICAL warning**: APL's
+reshape fills a target shape in ROW-major order, but this domain's storage is
+COLUMN-major — handing the row-major-filled sequence straight to the matrix
+constructor would silently reshape column-major instead, a wrong answer that
+still looks plausible (right multiset of values, wrong positions). The new
+`reshape_fills_row_major_then_transposes_into_column_major_storage` test
+picks a NON-SQUARE reshape specifically because a square one can hide this
+exact bug class (right multiset, wrong positions, but often the same values
+happen to line up on the diagonal).
+
+**Removed the now-obsolete addendum-rejection mechanism**: the dedicated
+`scan_expr_for_builtin` arms Slice 2 added for these nine node kinds (each
+returning a clean `Some((message, span))` "SIR22 addendum node X" rejection)
+are gone, replaced by ordinary recursive scan arms (matching the base cut's
+own `ArrayLit`/`Range`/`MatMul`/etc. treatment just above them) that only
+recurse into sub-expressions now — nine real `emit_assign` arms handle actual
+codegen instead. `lib.rs`'s `ACCEPTED_FEATURES` doc comment was updated to
+match (no feature-list change, just the comment describing what's deferred).
+
+**Extended `tests/sir22_array.rs`** with 11 new execution tests (23 total,
+up from 13 — 2 of the original 13 were the now-obsolete `Reduce`/`Catenate`
+rejection tests, replaced): `reduce` on both a row vector (full fold) and a
+2x3 matrix (proving the row-independent fold and the column-major `col *
+rows + row` indexing the doc comment calls "the single easiest place to
+introduce a wrong-answer bug"), `scan` on a row vector, `outer` product of
+two vectors (all four corners of the resulting 2x2 checked), `shape` of a
+scalar (asserted INDIRECTLY via `Shape(Shape(5))`, since an empty result
+can't be read back through `IndexGet` directly — the trickiest addendum case
+to get right) and of a matrix, `reshape` with the row-major-fill-then-
+transpose correctness check described above, `indexGenerator` (confirms
+1-based), `indexOf` both found and not-found (confirms `length + 1`, never
+`-1`), `ravel` of a matrix (confirms row-major output despite column-major
+storage), and `catenate` of two differently-sized vectors plus two matrices
+with equal row counts. Every test runs against a real `cc`/`clang`/`gcc`
+toolchain via the existing `find_cc`/`compile_and_link`/`run` helpers (no
+duplication), skipping gracefully when none is present.
+
+Verified via the full `semantic-ir-to-c` test suite (all pre-existing
+integration tests still green) and `cargo clippy --all-targets -- -D
+warnings` (clean).
+
 ## 0.40.0 — SIR22 array/matrix base cut (Phase A Slice 2, second-wave backend rollout)
 
 Opens this backend to `Feature::{NDArrays, MatrixOps, ArrayColumnMajor}` and

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -305,16 +305,15 @@ against — and every index position is bounds-checked before the
 `(double)`→`int64_t` cast that would otherwise be undefined behaviour on a
 NaN or out-of-range value. The 9-node SIR22 "APL addendum" (`Reduce`/
 `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-`Ravel`/`Catenate`) shares these same three features but stays deferred to
-a later slice — rejected cleanly by the SAME structural pre-emit scan
-`first_unsupported_builtin` already uses for every other well-formed-but-
-unimplemented construct, not a new mechanism. See
+`Ravel`/`Catenate`) shares these same three features and is implemented
+too — real `_sir_array_*` functions ported 1:1 from the JS reference's own
+addendum section, adapted to this backend's rank-0-or-2-only `SirNDArray`
+(a "vector" is always a degenerate `1 x n` row, same convention the base
+cut already established for `Range`/`IndexGet`). See
 [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, a `class << self` singleton, the SIR22 "APL addendum" nodes
-(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-`IndexOf`/`Ravel`/`Catenate`), and
+`Intrinsics`, a `class << self` singleton, and
 every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1215,6 +1215,130 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
             out.push_str(");\n");
             let _ = writeln!(out, "{pad}}}");
         }
+        // ── SIR22 addendum: APL primitive operators — real codegen ──────
+        // Each of the nine maps 1:1 onto a call into the `_sir_array_*`
+        // functions in `runtime.rs`'s "SIR22 addendum" section — the same
+        // treatment `ElementwiseOp`/`Transpose`/`MatMul` above already get
+        // for the SIR22 base cut. `Reduce`/`Scan`/`OuterProduct` carry an
+        // `ElementwiseOpKind` and so reuse `elementwise_op_c_name` exactly
+        // like `ElementwiseOp` does; the remaining six have no `op` field
+        // at all (they are "bespoke, not BinOp-shaped" per the SIR22 spec
+        // addendum and `apl-runtime::builtins`'s own doc comment) and just
+        // hoist their operand(s).
+        Expr::Reduce { op, target, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[target.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_apl_reduce({}, {});",
+                elementwise_op_c_name(*op),
+                names[0]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[target.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_scan({}, {});",
+                elementwise_op_c_name(*op),
+                names[0]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[lhs.as_ref(), rhs.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_outer({}, {}, {});",
+                elementwise_op_c_name(*op),
+                names[0],
+                names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::Shape { target, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[target.as_ref()], inner);
+            let _ = writeln!(out, "{ipad}{dst} = _sir_array_shape({});", names[0]);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // Field order here is `shape, target` (per the SIR22 spec: the
+        // shape vector is not interchangeable with the data being
+        // reshaped, so the node spells out the roles instead of reusing
+        // `lhs`/`rhs`) — `_sir_array_reshape(shapeArg, target)` takes the
+        // same order, so no argument reordering is needed at this call
+        // site (contrast `Expr::Range`'s `start, step, stop` vs.
+        // `_sir_array_range`'s `start, stop, step` above, which DOES
+        // reorder).
+        Expr::Reshape { shape, target, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[shape.as_ref(), target.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_reshape({}, {});",
+                names[0], names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::IndexGenerator { count, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[count.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_index_generator({});",
+                names[0]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[haystack.as_ref(), needle.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_index_of({}, {});",
+                names[0], names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::Ravel { target, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[target.as_ref()], inner);
+            let _ = writeln!(out, "{ipad}{dst} = _sir_array_ravel({});", names[0]);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[lhs.as_ref(), rhs.as_ref()], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}{dst} = _sir_array_catenate({}, {});",
+                names[0], names[1]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
         // A call whose arguments contain control flow: hoist every argument
         // into a temp (left-to-right), then make the call.
         _ => emit_compound_call(out, dst, e, indent),
@@ -2837,38 +2961,32 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             }
             scan_expr_for_builtin(target).or_else(|| indices.iter().find_map(scan_index_arg_for_builtin))
         }
-        // ── SIR22 "APL addendum" — deferred, rejected cleanly ────────────
+        // ── SIR22 "APL addendum": real codegen (Phase A Slice 3) ─────────
         // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
-        // `IndexOf`/`Ravel`/`Catenate` share `NDArrays`/`MatrixOps`/
-        // `ArrayColumnMajor` with the base cut above, so they pass the
-        // ordinary feature-flag capability check — this dedicated scan arm
-        // (folded into this crate's existing single shared pre-emit scan,
-        // the SAME mechanism `first_unsupported_builtin` already uses for
-        // every other "well-formed but not yet lowered" construct, not a
-        // new one) is what actually rejects them, cleanly, until their own
-        // later rollout slice. Mirrors JS/TS's own (since-removed once
-        // THEIR addendum shipped) `find_unimplemented_sir22_addendum_node`
-        // and the sibling Ruby backend's `ScanHit::Sir22AddendumNode`.
-        Expr::Reduce { span, .. } => Some(("SIR22 addendum node Reduce".to_string(), span.clone())),
-        Expr::Scan { span, .. } => Some(("SIR22 addendum node Scan".to_string(), span.clone())),
-        Expr::OuterProduct { span, .. } => Some((
-            "SIR22 addendum node OuterProduct".to_string(),
-            span.clone(),
-        )),
-        Expr::Shape { span, .. } => Some(("SIR22 addendum node Shape".to_string(), span.clone())),
-        Expr::Reshape { span, .. } => {
-            Some(("SIR22 addendum node Reshape".to_string(), span.clone()))
+        // `IndexOf`/`Ravel`/`Catenate` now have real `emit_expr` arms
+        // (below) and real `_sir_array_*` runtime backing (`runtime.rs`'s
+        // "SIR22 addendum" section) — the dedicated rejection arms that
+        // used to live here through Slice 2 are gone. Like the base cut
+        // just above, this scan arm's only remaining job is recursing into
+        // each node's own sub-expressions, to catch a DEEPER deferred
+        // builtin nested inside (e.g. inside a `Reduce`'s `target`), not to
+        // reject the node itself.
+        Expr::Reduce { target, .. } => scan_expr_for_builtin(target),
+        Expr::Scan { target, .. } => scan_expr_for_builtin(target),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
         }
-        Expr::IndexGenerator { span, .. } => Some((
-            "SIR22 addendum node IndexGenerator".to_string(),
-            span.clone(),
-        )),
-        Expr::IndexOf { span, .. } => {
-            Some(("SIR22 addendum node IndexOf".to_string(), span.clone()))
+        Expr::Shape { target, .. } => scan_expr_for_builtin(target),
+        Expr::Reshape { shape, target, .. } => {
+            scan_expr_for_builtin(shape).or_else(|| scan_expr_for_builtin(target))
         }
-        Expr::Ravel { span, .. } => Some(("SIR22 addendum node Ravel".to_string(), span.clone())),
-        Expr::Catenate { span, .. } => {
-            Some(("SIR22 addendum node Catenate".to_string(), span.clone()))
+        Expr::IndexGenerator { count, .. } => scan_expr_for_builtin(count),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => scan_expr_for_builtin(haystack).or_else(|| scan_expr_for_builtin(needle)),
+        Expr::Ravel { target, .. } => scan_expr_for_builtin(target),
+        Expr::Catenate { lhs, rhs, .. } => {
+            scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
         }
         _ => None,
     }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -211,11 +211,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // convention (this backend always inlines, unlike the TS/Python
     // imported-package model). The SIR22 "APL addendum" nodes (`Reduce`/
     // `Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
-    // `Ravel`/`Catenate`) share these same three features but stay
-    // deferred to a later slice — rejected cleanly by `emit.rs`'s
-    // `scan_expr_for_builtin` (folded into this crate's existing
-    // structural pre-emit scan, not a new mechanism), since the
-    // feature-flag gate alone can't distinguish them from the base cut.
+    // `Ravel`/`Catenate`, Phase A Slice 3) share these same three features
+    // and are now implemented too — real `emit.rs` arms calling into the
+    // `_sir_array_*` addendum functions `runtime.rs` adds alongside the
+    // base cut. (Through Slice 2 these were deferred and rejected cleanly
+    // by `emit.rs`'s `scan_expr_for_builtin`, since the feature-flag gate
+    // alone couldn't distinguish them from the base cut; that dedicated
+    // rejection arm is gone now that real codegen exists.)
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -3981,11 +3981,69 @@ SirValue _sir_unknown_builtin(const char *name) {
  * inlined-runtime convention (this backend always inlines, unlike the
  * TS/Python imported-package model). The 9-node SIR22 "APL addendum"
  * (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
- * `IndexOf`/`Ravel`/`Catenate`) is a SEPARATE, later rollout slice — see
- * `emit.rs`'s `scan_expr_for_builtin`, which rejects those nine cleanly
- * (a compile-time error, not a reachable `unreachable!` panic) even
- * though they share `NDArrays`/`MatrixOps`/`ArrayColumnMajor` with the
- * base cut this file implements.
+ * `IndexOf`/`Ravel`/`Catenate`, Phase A Slice 3) is implemented further
+ * below, in its own "SIR22 addendum: APL primitive operators" section —
+ * ported 1:1 from the SAME `semantic-ir-to-javascript` reference's own
+ * addendum section (`runtime.rs`'s `reduce`/`scan`/`outer`/`shape`/
+ * `reshape`/`indexGenerator`/`indexOf`/`ravel`/`catenate`), adapted to
+ * this file's rank-0-or-2-only value model (see "Vector representation
+ * in the addendum" below for exactly how).
+ *
+ * ## Vector representation in the addendum
+ *
+ * The JS/Ruby references have a genuine RANK-1 shape (`shape.length ===
+ * 1`) that several addendum functions produce (`shape`/`ravel`/
+ * `indexGenerator`/`catenate`'s vector cases/`reduce`'s matrix-branch
+ * output) and others dispatch on (`outer`/`indexOf`/`catenate` all branch
+ * on true rank 0 vs 1 vs 2). This file has no rank-1 at all (see "Value
+ * model" above) — by design, since the base cut's own constructors never
+ * needed one. Extending that design forward: every addendum function
+ * that would produce a JS/Ruby rank-1 "vector" here constructs a `1 x n`
+ * RANK-2 row instead (`_sir_array_new_matrix(1, n, …)`), exactly
+ * mirroring `_sir_array_range`'s and `_sir_array_index_get`'s own
+ * existing "vector = row" convention — so a caller who then does a
+ * single-scalar-argument `IndexGet` (linear indexing) on an addendum
+ * result sees the identical layout a base-cut vector would give.
+ *
+ * For the INPUT side, `_sir_array_logical_rank` below classifies a
+ * `SirNDArray` into this domain's three logical ranks: 0 (a true `rank ==
+ * 0` scalar), 1 (`rank == 2` with `rows == 1` — this file's stand-in for
+ * the references' genuine rank-1), or 2 (`rank == 2` with `rows != 1` —
+ * an unambiguous "real" matrix, INCLUDING a `cols == 1` column shape).
+ * Every addendum function that branches on rank in the references
+ * (`outer`/`shape`/`reshape`/`indexOf`/`catenate`) uses this classifier.
+ *
+ * This is DELIBERATELY ASYMMETRIC between rows and cols, not "rows == 1
+ * OR cols == 1": every vector this backend ever actually constructs —
+ * `_sir_array_range`, `_sir_array_index_get`'s non-scalar 1-argument
+ * result, and every addendum function below that produces a "vector"
+ * result — is a `1 x n` ROW, never a column (see the paragraph above).
+ * A `cols == 1, rows > 1` shape, by contrast, only ever arises from a
+ * genuine 2-D construct this backend's OWN base cut already treats as a
+ * real matrix (a literal column via `ArrayLit`, e.g. `[[5],[6]]`, or an
+ * `IndexGet` whole-row/scalar-column selection) — and the JS/Ruby
+ * references treat that SAME construct as a genuine rank-2 matrix too
+ * (their own `ArrayLit`/`fromRows` never produce a rank-1 result either;
+ * see the base cut's own module doc above), so classifying it as
+ * logical rank 2, not 1, keeps this port's dispatch faithful to the
+ * references for every shape this backend can actually produce — not
+ * merely a "most useful" judgment call, but the reading that actually
+ * matches JS/Ruby behaviour for every reachable input. (`_sir_array_
+ * logical_rank`'s own doc comment notes the earlier, symmetric version
+ * of this rule this replaced, and the `catenate` matrix-matrix case it
+ * silently broke.)
+ *
+ * `reduce`/`scan` need no such classification at all: their "fold/scan
+ * each row across its columns" loop already generalizes correctly to a
+ * 1-row or 1-column input without a special case (folding a single row
+ * of `n` columns IS folding the whole vector; folding `n` rows of a
+ * single column each is a correct no-op, matching the references' own
+ * rank-2 branch exactly).
+ *
+ * `emit.rs`'s pre-emit scan (`scan_expr_for_builtin`) no longer rejects
+ * these nine node kinds — that dedicated rejection arm, present only
+ * through Slice 2, is removed now that real `emit_expr` arms exist for
+ * all nine (mirroring the base cut's own treatment).
  *
  * ## Value model
  *
@@ -4710,5 +4768,513 @@ void _sir_array_index_set(SirValue targetv, SirValue value, int n, ...) {
             }
         }
     }
+}
+
+/* ── SIR22 addendum: APL primitive operators ─────────────────────────
+ * `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+ * `IndexOf`/`Ravel`/`Catenate` (Phase A Slice 3) — see the module doc
+ * comment above ("Vector representation in the addendum") for how this
+ * file's rank-0-or-2-only value model stands in for the JS/Ruby
+ * references' genuine rank-1 vector shape. Every function below is
+ * ported 1:1 from `semantic-ir-to-javascript`'s own already-proven
+ * addendum section (same function names, same doc-comment subtleties),
+ * adapted to that representation and to this file's OWN overflow-safe
+ * allocation discipline (`_sir_array_checked_size`, reused throughout —
+ * see the module doc's "C-specific overflow hazard" section). */
+
+/* Classify `a` into this domain's three logical ranks for addendum
+ * dispatch — see the module doc's "Vector representation in the
+ * addendum" section for the full rationale: 0 (a true `rank == 0`
+ * scalar), 1 (`rank == 2` with `rows == 1` — this file's stand-in for
+ * the JS/Ruby references' genuine rank-1 "vector" shape), or 2 (`rank ==
+ * 2` with `rows != 1` — including a `cols == 1` COLUMN shape, e.g. from
+ * `ArrayLit([[5],[6]])` or `IndexGet`'s whole-row/scalar-col selector).
+ *
+ * DELIBERATELY asymmetric between rows and cols: every vector this
+ * backend ever actually constructs (`_sir_array_range`, `_sir_array_
+ * index_get`'s non-scalar 1-argument result, and every one of THIS
+ * file's own addendum functions below) is a `1 x n` ROW — never a
+ * column — so `rows == 1` alone exactly captures "this is this
+ * backend's vector representation". A `cols == 1, rows > 1` shape, by
+ * contrast, only ever arises from a genuine 2-D construct (a literal
+ * column via `ArrayLit`, or an `IndexGet` column selection) that the
+ * JS/Ruby references ALSO treat as a true rank-2 matrix (their own
+ * `ArrayLit`/`IndexGet` never produce a genuine rank-1 result either —
+ * see the base cut's own module doc above) — so classifying it as
+ * logical rank 2 here, not 1, keeps this port's addendum dispatch
+ * faithful to the references for every shape this backend can actually
+ * produce. (An earlier version of this function treated `cols == 1` as
+ * a vector too, symmetrically with `rows == 1`; that broke `_sir_array_
+ * catenate`'s matrix-matrix branch for a `2 x 1` right operand, which
+ * this asymmetric rule fixes — a `2 x 1` `ArrayLit` is a real matrix,
+ * not a vector.) */
+int _sir_array_logical_rank(const SirNDArray *a) {
+    if (a->rank == 0) return 0;
+    if (a->rows == 1) return 1;
+    return 2;
+}
+
+/* Flatten (rank <= 2, this domain's ceiling) `a` to ROW-major order —
+ * last axis varies fastest. `a` itself stores COLUMN-major
+ * (`_sir_array_get`'s own doc comment above), so a matrix must be walked
+ * "row, then column" via `_sir_array_get` to produce true row-major
+ * order; returning the raw column-major buffer would silently ravel in
+ * the WRONG order. Writes the element count to `*out_len` and ALWAYS
+ * returns a FRESH buffer (never `a->data` itself, even in the rank-0
+ * no-op case) — mirrors `apl_runtime::builtins::flatten` returning an
+ * owned `Vec`, not a borrow, so the result never accidentally aliases
+ * `a`'s own buffer (relevant because `_sir_array_index_set` mutates an
+ * `SirNDArray`'s data IN PLACE — a shared buffer here could let a later
+ * mutation of `a` silently corrupt an already-returned ravel/reshape
+ * result). */
+double *_sir_array_flatten_row_major(const SirNDArray *a, int64_t *out_len) {
+    if (a->rank == 0) {
+        double *out = (double *)_sir_alloc(sizeof(double));
+        out[0] = a->data[0];
+        *out_len = 1;
+        return out;
+    }
+    {
+        int64_t r = a->rows, c = a->cols, row, col, k = 0;
+        int64_t n = a->data_len;
+        double *out = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (row = 0; row < r; row++) {
+            for (col = 0; col < c; col++) {
+                double v;
+                _sir_array_get(a, row, col, &v); /* always in-bounds by construction */
+                out[k++] = v;
+            }
+        }
+        *out_len = n;
+        return out;
+    }
+}
+
+/* Validate `x` is a finite non-negative integer and return it as
+ * `int64_t` — shared by `_sir_array_reshape`'s shape-vector elements and
+ * `_sir_array_index_generator`'s scalar argument (both APL/MATLAB "give
+ * me a non-negative integer count/dimension" contexts). Reuses
+ * `_sir_array_assert_valid_position`'s NaN-safe, magnitude-checked
+ * finite-integer cast (see that function's own SECURITY doc above), then
+ * additionally rejects negative — that function alone permits negative
+ * integers (valid for e.g. a `Range` step), which neither caller here
+ * accepts. */
+int64_t _sir_array_require_nonneg_int(double x, const char *ctx) {
+    int64_t n = _sir_array_assert_valid_position(_sir_float(x), ctx);
+    if (n < 0) {
+        fprintf(stderr, "sir: %s: value must be a non-negative integer, got %lld\n", ctx, (long long)n);
+        exit(1);
+    }
+    return n;
+}
+
+/* `+/A` (APL reduce, dyadic-op monadic-adverb) — fold `target` with `op`
+ * along its one axis. Ported 1:1 from `array_runtime::ops::reduce`:
+ * - a true scalar (`rank == 0`): nothing to fold, returns `target`
+ *   itself (the SAME `SirNDArray`, not a copy — matching the JS/Ruby
+ *   references' own `return a;`).
+ * - everything else (`rank == 2`, `rows` x `cols`): folds EACH ROW
+ *   independently across its `cols` columns, producing a `1 x rows` row
+ *   (one folded value per row of `target`) — no special "is this really
+ *   a vector" branch is needed here (unlike `_sir_array_outer`/`_sir_
+ *   array_shape`/etc. below): folding a single row of `cols` columns IS
+ *   folding the whole vector, and folding `rows` rows of a single column
+ *   each is a correct no-op, so this loop already generalizes correctly
+ *   to every logical rank (see the module doc's "Vector representation
+ *   in the addendum" section). An empty row (`cols == 0`) is a clean
+ *   error — unlike `sum`/`mean` (which have a built-in identity, 0),
+ *   `reduce` is generic over any `op`, and guessing an identity (`0` for
+ *   `Add`? `1` for `Mul`? `-Infinity` for `Max`?) for an arbitrary,
+ *   possibly-future op would be silently wrong for most of them.
+ *
+ * COLUMN-MAJOR storage means element `(row, col)` lives at `col * rows +
+ * row` — the row loop reads `data[row]` as the seed (column 0) then
+ * walks `data[col * rows + row]` for `col = 1..cols`; getting `row` and
+ * `col` swapped here silently TRANSPOSES the result instead of throwing,
+ * so this indexing is the single easiest place to introduce a
+ * wrong-answer bug when reading this function (mirrors the JS
+ * reference's own warning, verbatim).
+ *
+ * Named `_sir_array_apl_reduce`, not the shorter `_sir_array_reduce` every
+ * sibling addendum function's naming would suggest — that plainer name is
+ * already taken by the PRE-EXISTING `SirSeq` `Array#reduce`/`#inject`
+ * helper a few thousand lines up (`_sir_array_` was this file's generic
+ * "Ruby Array collection method" prefix well before SIR22 NDArrays
+ * existed and claimed the same prefix for itself). `_sir_array_apl_reduce`
+ * disambiguates without renaming that unrelated, already-shipped
+ * function. */
+SirValue _sir_array_apl_reduce(SirElementwiseOp op, SirValue targetv) {
+    SirNDArray *a = _sir_array_coerce(targetv, "reduce");
+    if (a->rank == 0) {
+        SirValue v; v.tag = SIR_ARRAY; v.as.arr = a; return v;
+    }
+    {
+        int64_t r = a->rows, c = a->cols, row;
+        double *out;
+        if (c == 0) {
+            fprintf(stderr, "sir: reduce: cannot fold an empty vector or row (no identity element for an arbitrary op)\n");
+            exit(1);
+        }
+        out = (r > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)r) : NULL;
+        for (row = 0; row < r; row++) {
+            double acc = a->data[row]; /* column-major: (row, 0) lives at plain `row` */
+            int64_t col;
+            for (col = 1; col < c; col++) {
+                acc = _sir_array_apply_op(op, acc, a->data[col * r + row]);
+            }
+            out[row] = acc;
+        }
+        return _sir_array_new_matrix(1, r, out, "reduce");
+    }
+}
+
+/* `+\A` (APL scan) — the same fold as `_sir_array_apl_reduce`, but keeping
+ * EVERY intermediate result instead of only the last; output has the
+ * SAME shape as `target`. Ported 1:1 from `array_runtime::ops::scan`.
+ * Unlike `_sir_array_apl_reduce`, an empty row/vector (`cols == 0`) is NOT an
+ * error here: there is simply nothing to scan, and the (empty) output
+ * shape already says so. Same column-major `col * rows + row` indexing,
+ * and same "no special vector branch needed" reasoning, as `_sir_array_
+ * reduce` above. */
+SirValue _sir_array_scan(SirElementwiseOp op, SirValue targetv) {
+    SirNDArray *a = _sir_array_coerce(targetv, "scan");
+    if (a->rank == 0) {
+        SirValue v; v.tag = SIR_ARRAY; v.as.arr = a; return v;
+    }
+    {
+        int64_t r = a->rows, c = a->cols, row;
+        int64_t n = a->data_len; /* == r * c, already validated when `a` was built */
+        double *out = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (row = 0; row < r; row++) {
+            double acc = 0.0;
+            int started = 0;
+            int64_t col;
+            for (col = 0; col < c; col++) {
+                double x = a->data[col * r + row]; /* column-major */
+                acc = started ? _sir_array_apply_op(op, acc, x) : x;
+                started = 1;
+                out[col * r + row] = acc;
+            }
+        }
+        return _sir_array_new_matrix(r, c, out, "scan");
+    }
+}
+
+/* `A∘.×B` (APL outer product) — apply `op` to every pair `(aᵢ, bⱼ)`,
+ * producing a result of combined logical rank. Ported 1:1 from
+ * `array_runtime::ops::outer`, scoped identically to `rank(a) <= 1` and
+ * `rank(b) <= 1` (`_sir_array_logical_rank` — see the module doc's
+ * "Vector representation in the addendum" section for exactly what
+ * counts as rank <= 1 here); any operand of logical rank 2 is a clean
+ * "not yet supported" error, matching the Rust/JS references' own scope
+ * limit. `_sir_array_checked_size` validates the `[m, n]` output shape
+ * BEFORE allocating in the vector x vector case — `m`/`n` are two
+ * INDEPENDENT operand lengths, each individually under `SIR_ARRAY_
+ * MAX_ELEMENTS`, but nothing bounds their PRODUCT alone (the same
+ * outer-product-shaped allocation `_sir_array_matmul`/`_sir_array_
+ * index_get` above guard). */
+SirValue _sir_array_outer(SirElementwiseOp op, SirValue lhsv, SirValue rhsv) {
+    SirNDArray *a = _sir_array_coerce(lhsv, "outer");
+    SirNDArray *b = _sir_array_coerce(rhsv, "outer");
+    int ra = _sir_array_logical_rank(a);
+    int rb = _sir_array_logical_rank(b);
+    if (ra == 0 && rb == 0) {
+        return _sir_array_scalar(_sir_array_apply_op(op, a->data[0], b->data[0]));
+    }
+    if (ra == 0 && rb == 1) {
+        double x = a->data[0];
+        int64_t n = b->data_len, i;
+        double *out = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (i = 0; i < n; i++) out[i] = _sir_array_apply_op(op, x, b->data[i]);
+        return _sir_array_new_matrix(1, n, out, "outer");
+    }
+    if (ra == 1 && rb == 0) {
+        double y = b->data[0];
+        int64_t n = a->data_len, i;
+        double *out = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+        for (i = 0; i < n; i++) out[i] = _sir_array_apply_op(op, a->data[i], y);
+        return _sir_array_new_matrix(1, n, out, "outer");
+    }
+    if (ra == 1 && rb == 1) {
+        int64_t m = a->data_len, n = b->data_len;
+        int64_t out_len = _sir_array_checked_size(m, n, "outer");
+        double *out = (out_len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)out_len) : NULL;
+        int64_t i, j;
+        for (j = 0; j < n; j++) {
+            for (i = 0; i < m; i++) {
+                out[j * m + i] = _sir_array_apply_op(op, a->data[i], b->data[j]); /* column-major */
+            }
+        }
+        return _sir_array_new_matrix(m, n, out, "outer");
+    }
+    fprintf(stderr, "sir: outer: operands of rank > 1 not yet supported\n");
+    exit(1);
+    return _sir_nil(); /* unreachable */
+}
+
+/* Monadic `⍴` (shape-of) — `target`'s dimensions as a vector. Ported 1:1
+ * from `apl_runtime::builtins::shape`: a SCALAR has zero dimensions, so
+ * its shape is the EMPTY vector (not a scalar!) — `⍴5` is a length-0
+ * vector (a `1 x 0` row here — see the module doc's "Vector
+ * representation in the addendum" section). A logical-rank-1 operand
+ * (this file's vector stand-in — always `rows == 1`, see `_sir_array_
+ * logical_rank`'s own doc comment) has shape `[n]` where `n` is its
+ * element count (a `1 x 1` row result); a logical-rank-2 operand (`rows
+ * != 1`, including a `cols == 1` column shape) has shape `[rows, cols]`
+ * (a `1 x 2` row result) built from `target`'s REAL `rows`/`cols`
+ * fields. */
+SirValue _sir_array_shape(SirValue targetv) {
+    SirNDArray *a = _sir_array_coerce(targetv, "shape");
+    int lr = _sir_array_logical_rank(a);
+    if (lr == 0) {
+        return _sir_array_new_matrix(1, 0, NULL, "shape");
+    }
+    if (lr == 1) {
+        double *out = (double *)_sir_alloc(sizeof(double));
+        out[0] = (double)a->data_len;
+        return _sir_array_new_matrix(1, 1, out, "shape");
+    }
+    {
+        double *out = (double *)_sir_alloc(sizeof(double) * 2);
+        out[0] = (double)a->rows;
+        out[1] = (double)a->cols;
+        return _sir_array_new_matrix(1, 2, out, "shape");
+    }
+}
+
+/* Dyadic `⍴` (reshape) — reinterpret `target`'s data under the new
+ * dimensions `shapev`. Ported 1:1 from `apl_runtime::builtins::reshape`.
+ * `shapev` must itself have logical rank <= 1 (a scalar or vector — see
+ * `_sir_array_logical_rank`) of non-negative integers; its ELEMENT COUNT
+ * becomes the target's dimensionality (0 elements -> a scalar result, 1
+ * element -> a `1 x n` row, 2 elements -> a genuine `r x c` matrix) and
+ * is itself capped at <= 2 (this domain's ceiling — more elements is a
+ * clean error, not a silent truncation). `target`'s elements are
+ * ravelled (`_sir_array_flatten_row_major`) then cyclically repeated or
+ * truncated to fill the target shape's element count.
+ *
+ * CRITICAL: the cyclic fill happens in ROW-major order (APL's reshape
+ * fills the LAST axis fastest, same convention as ravel), but this
+ * domain's storage is COLUMN-major — so for a 2-element target shape the
+ * row-major `filled` sequence must be TRANSPOSED into column-major
+ * storage (`data[col * r + row] = filled[row * c + col]`) before
+ * constructing the result. Handing `filled` straight to `_sir_array_
+ * new_matrix` would silently reshape column-major instead of APL's
+ * row-major convention — a wrong answer that still LOOKS plausible
+ * (right multiset of values, wrong positions). A 1-element target shape
+ * needs NO such transpose: a `1 x n` row IS its own row-major order
+ * (column-major storage of a single row is identical to linear order),
+ * so `filled` is used as-is. */
+SirValue _sir_array_reshape(SirValue shapev, SirValue targetv) {
+    SirNDArray *shape_arr = _sir_array_coerce(shapev, "reshape");
+    SirNDArray *target = _sir_array_coerce(targetv, "reshape");
+    int64_t dims[2];
+    int64_t ndims;
+    int64_t total;
+    int64_t source_len;
+    double *source;
+    double *filled;
+    int64_t k;
+
+    if (_sir_array_logical_rank(shape_arr) == 2) {
+        fprintf(stderr, "sir: reshape: shape argument must be a scalar or vector (got a matrix)\n");
+        exit(1);
+    }
+    ndims = shape_arr->data_len;
+    if (ndims > 2) {
+        fprintf(stderr, "sir: reshape: reshape to rank > 2 is not yet supported (%lld shape elements)\n",
+                (long long)ndims);
+        exit(1);
+    }
+    { int64_t i; for (i = 0; i < ndims; i++) dims[i] = _sir_array_require_nonneg_int(shape_arr->data[i], "reshape"); }
+
+    if (ndims == 0) {
+        total = 1;
+    } else if (ndims == 1) {
+        total = _sir_array_checked_size(1, dims[0], "reshape");
+    } else {
+        total = _sir_array_checked_size(dims[0], dims[1], "reshape");
+    }
+
+    source = _sir_array_flatten_row_major(target, &source_len);
+    if (total > 0 && source_len == 0) {
+        fprintf(stderr, "sir: reshape: cannot reshape an empty source into a non-empty shape\n");
+        exit(1);
+    }
+    filled = (total > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)total) : NULL;
+    for (k = 0; k < total; k++) {
+        filled[k] = source[k % source_len];
+    }
+
+    if (ndims == 0) {
+        return _sir_array_scalar(filled[0]);
+    }
+    if (ndims == 1) {
+        return _sir_array_new_matrix(1, dims[0], filled, "reshape");
+    }
+    {
+        int64_t r = dims[0], c = dims[1], row, col;
+        double *data = (total > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)total) : NULL;
+        for (row = 0; row < r; row++) {
+            for (col = 0; col < c; col++) {
+                data[col * r + row] = filled[row * c + col];
+            }
+        }
+        return _sir_array_new_matrix(r, c, data, "reshape");
+    }
+}
+
+/* Monadic `⍳` (index generator / iota) — `⍳n` is the 1-BASED vector `[1,
+ * 2, …, n]`. Ported 1:1 from `apl_runtime::builtins::index_generator` —
+ * note this is 1-based, unlike every 0-based index elsewhere in this
+ * domain (`IndexGet`/`IndexSet`), because that is genuinely what APL's
+ * `⍳` means at the SURFACE-SYNTAX level, confirmed directly against
+ * `apl-runtime`'s own `index_generator_produces_one_based_run` test (NOT
+ * the stale claim in `semantic-ir`'s own `Expr::IndexGenerator` doc
+ * comment, which currently — incorrectly — describes this as 0-based;
+ * the JS/Ruby backends' own addendum ports already settled on 1-based to
+ * match the real `apl-runtime` behaviour, and this port matches them).
+ * `_sir_array_is_scalar` (element count 1, NOT `rank == 0` — matching the
+ * JS reference's own `isScalar`, which also checks element count rather
+ * than true rank) accepts a bare number, a `rank == 0` scalar, or a
+ * degenerate `1 x 1` NDArray alike. `_sir_array_checked_size([1, n])`
+ * caps `n` at `SIR_ARRAY_MAX_ELEMENTS` before allocating — `n` is a
+ * runtime value a compiled program computes, not a fixed constant, so
+ * `⍳` of an absurd size must fail cleanly. */
+SirValue _sir_array_index_generator(SirValue countv) {
+    SirNDArray *a = _sir_array_coerce(countv, "indexGenerator");
+    int64_t x, n, i;
+    double *out;
+    if (!_sir_array_is_scalar(a)) {
+        fprintf(stderr, "sir: indexGenerator: monadic argument must be a scalar\n");
+        exit(1);
+    }
+    x = _sir_array_require_nonneg_int(a->data[0], "indexGenerator");
+    n = _sir_array_checked_size(1, x, "indexGenerator");
+    out = (n > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)n) : NULL;
+    for (i = 0; i < n; i++) out[i] = (double)(i + 1);
+    return _sir_array_new_matrix(1, n, out, "indexGenerator");
+}
+
+/* Dyadic `⍳` (index-of / search) — for every element of `needle`, the
+ * 1-based index of its first occurrence in the vector `haystack` (or
+ * `haystack`'s element count + 1 if not found — "not found" is a valid,
+ * always-in-range position, not `-1`). Ported 1:1 from `apl_runtime::
+ * builtins::index_of`: plain EXACT `==` equality (no floating-point
+ * tolerance — a NaN haystack element correctly never matches, same as
+ * the Rust/JS references' own `==`/`indexOf`). `haystack` must have
+ * logical rank <= 1 (`_sir_array_logical_rank`; a genuine matrix
+ * haystack is a clean error). The result takes `needle`'s OWN ACTUAL
+ * `rank`/`rows`/`cols` (NOT `_sir_array_logical_rank`) — mirrors the
+ * references' `ndarray(b.shape, out)`, so a genuine-matrix needle
+ * round-trips through with its shape unchanged.
+ *
+ * The work done is O(len(haystack) * len(needle)) (a full linear scan per
+ * needle element) — `_sir_array_checked_size` is reused here PURELY for
+ * its "product <= SIR_ARRAY_MAX_ELEMENTS" overflow-safe check (both
+ * lengths are already valid non-negative `int64_t`s, so its own
+ * dimension-validity half is a no-op) to cap the PRODUCT before
+ * scanning, since each operand individually staying under the cap does
+ * not bound their product (up to ~4.5 * 10^15 comparisons otherwise). */
+SirValue _sir_array_index_of(SirValue haystackv, SirValue needlev) {
+    SirNDArray *a = _sir_array_coerce(haystackv, "indexOf");
+    SirNDArray *b = _sir_array_coerce(needlev, "indexOf");
+    int64_t hn = a->data_len, nn = b->data_len, i;
+    double *out;
+    if (_sir_array_logical_rank(a) == 2) {
+        fprintf(stderr, "sir: indexOf: left argument must be a scalar or vector (got a matrix)\n");
+        exit(1);
+    }
+    (void)_sir_array_checked_size(hn, nn, "indexOf");
+    out = (nn > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)nn) : NULL;
+    for (i = 0; i < nn; i++) {
+        double needle = b->data[i];
+        int64_t pos = -1, k;
+        for (k = 0; k < hn; k++) {
+            if (a->data[k] == needle) { pos = k; break; }
+        }
+        out[i] = (pos >= 0) ? (double)(pos + 1) : (double)(hn + 1);
+    }
+    if (b->rank == 0) {
+        return _sir_array_scalar(out[0]);
+    }
+    return _sir_array_new_matrix(b->rows, b->cols, out, "indexOf");
+}
+
+/* Monadic `,` (ravel) — flatten `target` to a `1 x n` row (see
+ * `_sir_array_flatten_row_major`'s own doc comment for the
+ * column-major-storage-vs-row-major-order subtlety this must respect).
+ * Ported 1:1 from `apl_runtime::builtins::ravel`. */
+SirValue _sir_array_ravel(SirValue targetv) {
+    SirNDArray *a = _sir_array_coerce(targetv, "ravel");
+    int64_t n;
+    double *flat = _sir_array_flatten_row_major(a, &n);
+    return _sir_array_new_matrix(1, n, flat, "ravel");
+}
+
+/* Dyadic `,` (catenate) — supports scalar/vector operands in any
+ * combination (logical rank 0 or 1 on EITHER side, per `_sir_array_
+ * logical_rank` — a "vector" here is specifically `rows == 1`; see the
+ * module doc's "Vector representation in the addendum" section for why
+ * that's asymmetric with `cols == 1`, and why a vector of either length
+ * combines with a scalar or a differently-sized vector with no
+ * equal-length requirement), all producing a `1 x n` row; and
+ * matrix-matrix (BOTH operands logical rank 2 — including a `cols == 1`
+ * column shape) WITH EQUAL ROW COUNTS (column/last-axis catenate,
+ * producing `rows x (cols_a + cols_b)`). Any other combination (a vector
+ * catenated with a genuine matrix, or mismatched-row matrices) is a
+ * clean error. Ported 1:1 from `apl_runtime::builtins::catenate`.
+ *
+ * The combined-length cap check happens ONCE, up front, regardless of
+ * which combination follows (mirroring the Rust/JS references' own
+ * structure, and reusing `_sir_array_checked_size`'s overflow-safe
+ * product check via a `1 x (na + nb)` framing) — neither operand alone
+ * need be oversized for the RESULT to be, since code that repeatedly
+ * catenates a value with itself (`a = [a, a]`) doubles the size every
+ * line with no other ceiling. `na + nb` itself cannot overflow `int64_t`
+ * (each of `na`/`nb` is already <= `SIR_ARRAY_MAX_ELEMENTS`, ~6.7e7, by
+ * construction — their sum stays far below `int64_t`'s range), so only
+ * the CAP comparison, not the addition, needs guarding here; the
+ * `outer`/`indexOf` product checks above are the ones that need
+ * `_sir_array_checked_size`'s multiplication-overflow guard
+ * specifically. */
+SirValue _sir_array_catenate(SirValue lhsv, SirValue rhsv) {
+    SirNDArray *a = _sir_array_coerce(lhsv, "catenate");
+    SirNDArray *b = _sir_array_coerce(rhsv, "catenate");
+    int64_t na = a->data_len, nb = b->data_len;
+    int ra = _sir_array_logical_rank(a);
+    int rb = _sir_array_logical_rank(b);
+    (void)_sir_array_checked_size(1, na + nb, "catenate");
+
+    if (ra != 2 && rb != 2) {
+        double *out = (na + nb > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)(na + nb)) : NULL;
+        if (na > 0) memcpy(out, a->data, sizeof(double) * (size_t)na);
+        if (nb > 0) memcpy(out + na, b->data, sizeof(double) * (size_t)nb);
+        return _sir_array_new_matrix(1, na + nb, out, "catenate");
+    }
+    if (ra == 2 && rb == 2) {
+        int64_t r = a->rows, ca = a->cols, cb = b->cols, row, col;
+        int64_t out_len;
+        double *data;
+        if (r != b->rows) {
+            fprintf(stderr, "sir: catenate: matrix catenate needs equal row counts (%lld vs %lld)\n",
+                    (long long)r, (long long)b->rows);
+            exit(1);
+        }
+        out_len = _sir_array_checked_size(r, ca + cb, "catenate");
+        data = (out_len > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)out_len) : NULL;
+        for (row = 0; row < r; row++) {
+            for (col = 0; col < ca; col++) {
+                data[col * r + row] = a->data[col * r + row];
+            }
+            for (col = 0; col < cb; col++) {
+                data[(ca + col) * r + row] = b->data[col * r + row];
+            }
+        }
+        return _sir_array_new_matrix(r, ca + cb, data, "catenate");
+    }
+    fprintf(stderr, "sir: catenate: catenate of a vector with a matrix is not yet supported\n");
+    exit(1);
+    return _sir_nil(); /* unreachable */
 }
 "####;

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -5073,8 +5073,6 @@ SirValue _sir_array_reshape(SirValue shapev, SirValue targetv) {
     int64_t total;
     int64_t source_len;
     double *source;
-    double *filled;
-    int64_t k;
 
     if (_sir_array_logical_rank(shape_arr) == 2) {
         fprintf(stderr, "sir: reshape: shape argument must be a scalar or vector (got a matrix)\n");
@@ -5101,15 +5099,36 @@ SirValue _sir_array_reshape(SirValue shapev, SirValue targetv) {
         fprintf(stderr, "sir: reshape: cannot reshape an empty source into a non-empty shape\n");
         exit(1);
     }
-    filled = (total > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)total) : NULL;
-    for (k = 0; k < total; k++) {
-        filled[k] = source[k % source_len];
-    }
 
+    /* SECURITY (DoS/memory-amplification fix): the 0-/1-element target
+     * shapes below need only ONE `total`-sized buffer — the cyclically-
+     * filled row-major sequence itself IS the final result (a 1-element
+     * target is its own row-major order; see this function's own CRITICAL
+     * doc comment above `data[col * r + row] = ...`). Only the 2-element
+     * (matrix) target genuinely needs the row-major-to-column-major
+     * TRANSPOSE — so ONLY that branch allocates a second buffer, and it
+     * computes each transposed cell directly from `source[(row * c + col)
+     * % source_len]` rather than first materializing a full `total`-sized
+     * row-major `filled` buffer and then copying out of it. An earlier
+     * version of this function built `filled` unconditionally before
+     * branching, so the matrix case held THREE `<= SIR_ARRAY_MAX_ELEMENTS`
+     * buffers live at once (`source`, `filled`, `data`) — up to 3x this
+     * domain's per-call memory ceiling that every other addendum/base-cut
+     * function (`matmul`/`outer`/`indexGenerator`/`catenate`) holds to at
+     * most one or two buffers — a real memory-exhaustion amplification a
+     * compiled program could trigger by reshaping an already-large array
+     * to an equally large 2-D target, found in this slice's own security
+     * review. This version allocates at most 2 buffers (`source` + the
+     * single final result buffer) for every target rank. */
     if (ndims == 0) {
-        return _sir_array_scalar(filled[0]);
+        return _sir_array_scalar(source[0 % source_len]);
     }
     if (ndims == 1) {
+        double *filled = (total > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)total) : NULL;
+        int64_t k;
+        for (k = 0; k < total; k++) {
+            filled[k] = source[k % source_len];
+        }
         return _sir_array_new_matrix(1, dims[0], filled, "reshape");
     }
     {
@@ -5117,7 +5136,7 @@ SirValue _sir_array_reshape(SirValue shapev, SirValue targetv) {
         double *data = (total > 0) ? (double *)_sir_alloc(sizeof(double) * (size_t)total) : NULL;
         for (row = 0; row < r; row++) {
             for (col = 0; col < c; col++) {
-                data[col * r + row] = filled[row * c + col];
+                data[col * r + row] = source[(row * c + col) % source_len];
             }
         }
         return _sir_array_new_matrix(r, c, data, "reshape");

--- a/code/packages/rust/semantic-ir-to-c/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/sir22_array.rs
@@ -352,46 +352,268 @@ fn index_set_with_a_range_selector_overwrites_a_sub_range_linearly() {
     }
 }
 
-// ── SIR22 "APL addendum": deferred, rejected cleanly (compile-time) ──────
+// ── SIR22 "APL addendum": real compile-and-run proof (Phase A Slice 3) ───
+//
+// The nine addendum node kinds now have real `_sir_array_*` runtime
+// backing (see `runtime.rs`'s "SIR22 addendum" section) instead of the
+// clean-rejection stubs Slice 2 left here — every test below hand-builds
+// a module calling one of the nine directly, compiles+runs it, and reads
+// results back through `IndexGet` (matching every base-cut test above),
+// same "no frontend targets this backend for SIR22 yet" caveat.
 
 #[test]
-fn reduce_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // `Reduce` shares NDArrays/MatrixOps/ArrayColumnMajor with the base
-    // cut, so the ordinary feature-flag check alone can't reject it --
-    // proves the dedicated pre-emit scan arm in `scan_expr_for_builtin`
-    // does, with a clean `Err`, not an `emit_expr`/`emit_assign`
-    // `unreachable!` panic.
-    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3)]]);
-    let m = array_module(vec![puts(Expr::Reduce {
-        op: ElementwiseOpKind::Add,
-        target: Box::new(target),
-        span: s(),
-    })]);
-    let err = semantic_ir_to_c::compile(&m).expect_err("Reduce must be rejected, not emitted");
-    assert!(
-        err.message.contains("Reduce"),
-        "error should name the rejected node: {}",
-        err.message
-    );
+fn reduce_of_a_row_vector_folds_across_all_elements() {
+    // [1 2 3 4], Reduce(Add) -> a single folded value (10), read back
+    // through a 1-element linear IndexGet.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]);
+    let reduced = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("r", reduced),
+        puts(index_get(local("r"), vec![scalar(0)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "10.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
 }
 
 #[test]
-fn catenate_node_is_rejected_cleanly_not_a_compile_time_panic() {
-    // A second addendum node, to prove the rejection is a real per-variant
-    // scan arm (all nine), not a fluke that only happens to catch `Reduce`.
-    let a = array_lit(vec![vec![ilit(1)]]);
-    let b = array_lit(vec![vec![ilit(2)]]);
-    let m = array_module(vec![puts(Expr::Catenate {
-        lhs: Box::new(a),
-        rhs: Box::new(b),
+fn reduce_of_a_matrix_folds_each_row_independently() {
+    // [1 2 3; 4 5 6], Reduce(Add) -> [6, 15] (row 0 sums to 6, row 1 to
+    // 15) -- proves the row-independent fold AND the column-major
+    // `col * rows + row` indexing the doc comment calls out as "the
+    // single easiest place to introduce a wrong-answer bug": a
+    // row/col swap here would silently transpose the input before
+    // folding and produce a completely different pair of sums.
+    let target = array_lit(vec![
+        vec![ilit(1), ilit(2), ilit(3)],
+        vec![ilit(4), ilit(5), ilit(6)],
+    ]);
+    let reduced = Expr::Reduce { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("r", reduced),
+        puts(index_get(local("r"), vec![scalar(0)])),
+        puts(index_get(local("r"), vec![scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "6.0\n15.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn scan_of_a_row_vector_keeps_every_running_fold() {
+    // [1 2 3 4], Scan(Add) -> [1, 3, 6, 10] (running sums, same shape as
+    // input) -- unlike Reduce, every intermediate is kept.
+    let target = array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4)]]);
+    let scanned = Expr::Scan { op: ElementwiseOpKind::Add, target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("s", scanned),
+        puts(index_get(local("s"), vec![scalar(0)])),
+        puts(index_get(local("s"), vec![scalar(3)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n10.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn outer_product_of_two_vectors_computes_every_pairwise_product() {
+    // [1 2] outer* [10 20] -> [[10 20]; [20 40]] (2x2): out[i][j] =
+    // a[i] * b[j]. Read all four corners via 2-arg IndexGet.
+    let lhs = array_lit(vec![vec![ilit(1), ilit(2)]]);
+    let rhs = array_lit(vec![vec![ilit(10), ilit(20)]]);
+    let outer = Expr::OuterProduct {
+        op: ElementwiseOpKind::Mul,
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
         span: s(),
-    })]);
-    let err = semantic_ir_to_c::compile(&m).expect_err("Catenate must be rejected, not emitted");
-    assert!(
-        err.message.contains("Catenate"),
-        "error should name the rejected node: {}",
-        err.message
-    );
+    };
+    let m = array_module(vec![
+        let_binding("o", outer),
+        puts(index_get(local("o"), vec![scalar(0), scalar(0)])),
+        puts(index_get(local("o"), vec![scalar(0), scalar(1)])),
+        puts(index_get(local("o"), vec![scalar(1), scalar(0)])),
+        puts(index_get(local("o"), vec![scalar(1), scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "10.0\n20.0\n20.0\n40.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn shape_of_a_scalar_is_the_empty_vector_not_a_scalar() {
+    // `Shape(5)` must be a length-0 VECTOR ("⍴5" is "⍳0"-shaped), not a
+    // scalar itself -- the trickiest addendum case to get right. Since
+    // every test in this file reads results back via IndexGet (which
+    // errors on an out-of-bounds read, so an empty result can't be
+    // IndexGet'd directly), assert emptiness INDIRECTLY: take Shape of
+    // the Shape -- `Shape(Shape(5))` reads back the ELEMENT COUNT of
+    // `Shape(5)` itself (a length-1 vector containing that count, since
+    // a 1x0 array has logical rank 1 here), which must be 0.0. A buggy
+    // implementation that returned a genuine SCALAR for `Shape(5)`
+    // instead of an empty vector would make the outer `Shape` call see
+    // rank 0 and (per `_sir_array_shape`'s own `lr == 0` branch) return
+    // ANOTHER empty vector -- so this also exercises the "scalar in,
+    // empty vector out" path a second, independent way.
+    let inner = Expr::Shape { target: Box::new(ilit(5)), span: s() };
+    let outer = Expr::Shape { target: Box::new(inner), span: s() };
+    let m = array_module(vec![
+        let_binding("sh", outer),
+        puts(index_get(local("sh"), vec![scalar(0)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "0.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn shape_of_a_matrix_is_its_dimensions() {
+    // A 2x3 matrix's shape is the 2-element vector [2, 3].
+    let target = array_lit(vec![
+        vec![ilit(1), ilit(2), ilit(3)],
+        vec![ilit(4), ilit(5), ilit(6)],
+    ]);
+    let sh = Expr::Shape { target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("sh", sh),
+        puts(index_get(local("sh"), vec![scalar(0)])),
+        puts(index_get(local("sh"), vec![scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "2.0\n3.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn reshape_fills_row_major_then_transposes_into_column_major_storage() {
+    // Source [1 2 3 4 5 6] (row-major) reshaped to a NON-SQUARE 2x3
+    // target must read back as [[1 2 3]; [4 5 6]] (APL fills the target
+    // in ROW-major order). This domain stores COLUMN-major, so a naive
+    // port that handed the row-major fill straight to the matrix
+    // constructor without transposing would silently produce
+    // [[1 3 5]; [2 4 6]] instead -- same multiset of values, WRONG
+    // positions, which a square reshape could hide but this non-square
+    // one cannot (the two layouts disagree at (0, 1): 2 if correct, 3 if
+    // the transpose step were skipped).
+    let source = array_lit(vec![vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5), ilit(6)]]);
+    let target_shape = array_lit(vec![vec![ilit(2), ilit(3)]]);
+    let reshaped = Expr::Reshape {
+        shape: Box::new(target_shape),
+        target: Box::new(source),
+        span: s(),
+    };
+    let m = array_module(vec![
+        let_binding("m", reshaped),
+        puts(index_get(local("m"), vec![scalar(0), scalar(0)])),
+        puts(index_get(local("m"), vec![scalar(0), scalar(1)])),
+        puts(index_get(local("m"), vec![scalar(1), scalar(0)])),
+        puts(index_get(local("m"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n2.0\n4.0\n6.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn index_generator_produces_a_one_based_run() {
+    // `⍳3` is `[1, 2, 3]` -- 1-based, the one deliberate exception to
+    // this domain's otherwise-uniform 0-based indexing (ground-truthed
+    // directly against `apl-runtime::builtins::index_generator_produces_
+    // one_based_run`, not the stale 0-based claim in `semantic-ir`'s own
+    // `Expr::IndexGenerator` doc comment).
+    let gen = Expr::IndexGenerator { count: Box::new(ilit(3)), span: s() };
+    let m = array_module(vec![
+        let_binding("g", gen),
+        puts(index_get(local("g"), vec![scalar(0)])),
+        puts(index_get(local("g"), vec![scalar(2)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n3.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn index_of_reports_a_one_based_position_or_length_plus_one_when_absent() {
+    // haystack [10 20 30], needle [20 99]: 20 is at (0-based) position 1
+    // -> 1-based 2; 99 is absent -> haystack.length + 1 = 4, NEVER -1.
+    let haystack = array_lit(vec![vec![ilit(10), ilit(20), ilit(30)]]);
+    let needle = array_lit(vec![vec![ilit(20), ilit(99)]]);
+    let idx = Expr::IndexOf { haystack: Box::new(haystack), needle: Box::new(needle), span: s() };
+    let m = array_module(vec![
+        let_binding("ix", idx),
+        puts(index_get(local("ix"), vec![scalar(0)])),
+        puts(index_get(local("ix"), vec![scalar(1)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "2.0\n4.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn ravel_of_a_matrix_flattens_to_row_major_order() {
+    // [1 2; 3 4] stores column-major internally (data = [1, 3, 2, 4]);
+    // Ravel must read back ROW-major ([1, 2, 3, 4]), proving
+    // `_sir_array_flatten_row_major` re-walks "row, then column" rather
+    // than handing back the raw column-major buffer (which would give
+    // [1, 3, 2, 4] instead).
+    let target = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let raveled = Expr::Ravel { target: Box::new(target), span: s() };
+    let m = array_module(vec![
+        let_binding("r", raveled),
+        puts(index_get(local("r"), vec![scalar(0)])),
+        puts(index_get(local("r"), vec![scalar(1)])),
+        puts(index_get(local("r"), vec![scalar(2)])),
+        puts(index_get(local("r"), vec![scalar(3)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n2.0\n3.0\n4.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn catenate_of_two_vectors_concatenates_regardless_of_matching_length() {
+    // [1 2] , [3 4 5] -> [1 2 3 4 5] -- vector catenate has no
+    // equal-length requirement (unlike the matrix case below).
+    let lhs = array_lit(vec![vec![ilit(1), ilit(2)]]);
+    let rhs = array_lit(vec![vec![ilit(3), ilit(4), ilit(5)]]);
+    let cat = Expr::Catenate { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() };
+    let m = array_module(vec![
+        let_binding("c", cat),
+        puts(index_get(local("c"), vec![scalar(0)])),
+        puts(index_get(local("c"), vec![scalar(4)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n5.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn catenate_of_two_matrices_with_equal_rows_concatenates_columns() {
+    // [1 2; 3 4] , [5; 6] (2x2 , 2x1, equal row counts) -> [1 2 5; 3 4 6]
+    // (2x3): column/last-axis catenate.
+    let lhs = array_lit(vec![vec![ilit(1), ilit(2)], vec![ilit(3), ilit(4)]]);
+    let rhs = array_lit(vec![vec![ilit(5)], vec![ilit(6)]]);
+    let cat = Expr::Catenate { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() };
+    let m = array_module(vec![
+        let_binding("c", cat),
+        puts(index_get(local("c"), vec![scalar(0), scalar(0)])),
+        puts(index_get(local("c"), vec![scalar(0), scalar(2)])),
+        puts(index_get(local("c"), vec![scalar(1), scalar(2)])),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1.0\n5.0\n6.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
 }
 
 // ── malformed hand-built shapes: rejected cleanly, not a runtime panic ───


### PR DESCRIPTION
## Summary

Part of the SIR22/SIR23 backend-expansion initiative (Phase A Slice 3, one of 5 parallel backend PRs). Opens the **C backend** (`semantic-ir-to-c`) to the nine-node SIR22 array/matrix "APL addendum" that Phase A Slice 2 (merged) left behind a dedicated pre-emit rejection arm in `scan_expr_for_builtin`:

`Reduce` / `Scan` / `OuterProduct` / `Shape` / `Reshape` / `IndexGenerator` / `IndexOf` / `Ravel` / `Catenate`

- **Nine new `_sir_array_*` C runtime functions** (`runtime.rs`, embedded in the `RUNTIME` raw-string constant emitted verbatim into every generated `.c` file), ported 1:1 from `semantic-ir-to-javascript`'s own already-shipped addendum section, which are themselves 1:1 ports of `apl-runtime::builtins`. Two shared helpers: `_sir_array_flatten_row_major` (column-major -> row-major re-walk, needed by both `ravel` and `reshape`) and `_sir_array_require_nonneg_int` (built on the existing NaN/overflow-safe `_sir_array_assert_valid_position`).
- **Nine new `emit.rs` match arms** calling into the new runtime functions, and **removal** of the now-obsolete `scan_expr_for_builtin` rejection arms Slice 2 added for these nine node kinds — replaced with ordinary recursive sub-expression scanning, matching the base cut's own treatment.
- **The core representational problem**: the JS/Ruby references have a genuine rank-1 "vector" shape this backend's `SirNDArray` has never had (Slice 2 already collapsed a base-cut "vector" into a degenerate `1 x n` rank-2 row). This slice extends that same convention to the addendum, and adds a `_sir_array_logical_rank` classifier for the functions that dispatch on operand rank (`outer`/`shape`/`reshape`/`indexOf`/`catenate`) — deliberately asymmetric between rows and cols (`rows == 1` only, not `rows == 1 || cols == 1`), because a `cols == 1, rows > 1` shape is a construct the JS/Ruby references themselves treat as a genuine matrix, not a vector. An earlier symmetric version of this rule was caught by this slice's own new test suite, which found it silently broke `catenate`'s matrix-matrix branch for a `2 x 1` operand.
- **Ground-truthed the 1-based `IndexGenerator`/`IndexOf` behavior** directly against `apl-runtime`'s own tests, after finding `semantic-ir`'s `nodes.rs` doc comment on `Expr::IndexGenerator` currently (incorrectly) claims 0-based — flagged separately rather than fixed in this PR, since it's outside this crate.
- **Reused the existing overflow-safe allocation discipline throughout** (`_sir_array_checked_size`) rather than reinventing it — `outer`'s `[m, n]` output, `indexOf`'s `O(haystack * needle)` work-product cap, `reshape`'s target element count, `indexGenerator`'s `n`, and `catenate`'s combined length are all validated before allocating/looping.

## Security

A `/security-review` sub-agent reviewed the full diff and found one MEDIUM finding: `_sir_array_reshape`'s 2-D (matrix) target branch built an intermediate `total`-sized `filled` buffer unconditionally, then transposed it into a second `total`-sized `data` buffer — holding three `<= SIR_ARRAY_MAX_ELEMENTS` (~512 MiB of `double`s) buffers live at once versus every other addendum/base-cut function's one-or-two-buffer ceiling, a real memory-exhaustion amplification a compiled program could trigger by reshaping an already-large array to an equally large 2-D target. Fixed by computing each transposed cell directly from the flattened source (`source[(row * c + col) % source_len]`) instead of materializing an intermediate row-major buffer first, dropping peak usage to at most 2 buffers per call. A round-2 review of the fix confirmed it is correct and introduces no new issue, and returned **SECURITY REVIEW PASSED — no vulnerabilities found.**

## Test plan

- [x] Extended `tests/sir22_array.rs` with 11 new compile-and-run tests (23 total, replacing the 2 now-obsolete rejection tests): `reduce` on a row vector and a matrix (row-independent fold + column-major indexing correctness), `scan` on a vector, `outer` product of two vectors, `shape` of a scalar (asserted indirectly via `Shape(Shape(5))`, since an empty result can't be read back through `IndexGet` directly) and of a matrix, `reshape` with a non-square target (catches the row-major-fill-vs-column-major-storage transposition bug class a square reshape would hide), `indexGenerator` (confirms 1-based), `indexOf` found and not-found (confirms `length + 1`, never `-1`), `ravel` of a matrix, and `catenate` of two differently-sized vectors plus two matrices with equal row counts. All run against a real `cc`/`clang`/`gcc` toolchain via the crate's existing `find_cc`/`compile_and_link`/`run` helpers, skipping gracefully when none is present.
- [x] Full `semantic-ir-to-c` test suite green (all pre-existing tests unaffected).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Downstream consumers (`c-to-semantic-ir`, `sir-conformance`, `sir-bench`) build clean against the version bump.
- [x] `/security-review` passed (2 rounds — see Security section above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
