### PR TITLE
fix(mosaic-emit-xaml): emit Content for Checkbox/Radio/Link expression labels

### DIFF
--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog — mosaic-emit-xaml
 
+## [Unreleased] — emit Content for Checkbox, Radio and Link expression labels
+
+#12045 fixed a missing `LayoutPropValue::Expr` arm in `emit_host_button`'s
+`label` match, where the trailing `_ => {}` silently swallowed an expression
+label and the button emitted no `Content` attribute at all. It noted, without
+fixing, that the sibling match in the `HostCheckbox` / `HostRadio` lowering had
+the same shape.
+
+It does, and it reproduces. A `HostCheckbox` and a `HostRadio` inside a `For`,
+labelled `label: ( row[1] )`, emitted:
+
+    <CheckBox x:Name="HostCheckbox_2"/>
+    <RadioButton x:Name="HostRadio_3"/>
+
+— no `Content`, so both render blank, while the already-fixed `Button` beside
+them emitted its binding correctly. Both now route through
+`lower_expr_for_xbind`, exactly as `emit_host_button` does.
+
+Auditing the rest of the file for the same shape turned up a third instance:
+`emit_host_link`'s `label`. Its symptom differed only because its catch-all is
+not empty — it falls back to `href`, so an expression label rendered the raw
+URL with a string `href` and rendered blank with a slot or expression `href`.
+An explicit label now wins. Fixed here because it is the same attribute, the
+same binding mode and the same helper; no judgement call was involved.
+
+`host_button_with_row_expression_label_emits_content` is generalised (and
+renamed `labelled_hosts_with_row_expression_label_emit_content`) rather than
+duplicated. Its useful half — that no emitted content control lacks `Content` —
+now covers `CheckBox`, `RadioButton` and `HyperlinkButton` alongside `Button`,
+so the next element to grow a label match without an `Expr` arm trips it.
+
+No golden churn: no current layout binds these labels to an expression, so
+emitted output for every existing fixture is byte-identical. This is a latent
+bug closed before it shipped, not a live one repaired.
+
+Left open deliberately (recorded on #12047): seven further `find_prop_value`
+matches in this file end in a bare `_ => {}` that swallows `Expr` the same way
+— `HostTooltip.text`, `HostInput.value` and `.placeholder`,
+`HostNumberInput.value`, `HostDialog.title`, `a11y-label` on `Text` and
+`HostSlider`, and `Image.src`. All were confirmed to drop the expression, but
+unlike the label sites they are not mechanically identical: they need per-site
+decisions about the target attribute, the binding mode (`value` wants TwoWay,
+not OneWay) and type conversion (`Image.src` needs a `string`→`ImageSource`
+step). They are not guessed at here.
+
+The structural cause is worth naming: the `Text` `content` match handles the
+same ten variants but ends `Some(LayoutPropValue::EmitRef(_)) | None => …`,
+which is exhaustive. Adding a variant to `LayoutPropValue` would be a compile
+error there and silence at every `_ => {}` site. That is why this class of bug
+keeps recurring in exactly these matches and never in that one.
+
 ## [Unreleased] — fix double-encoded characters in the generated host
 
 Every generated WinUI app displayed a mojibake title bar:

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -7645,6 +7645,23 @@ fn emit_host_checkbox(
         Some(LayoutPropValue::Keyword(k)) => {
             attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
         }
+        // An expression label — `label: ( row[1] )` is the common shape.
+        //
+        // Same missing arm, same silent catch-all, and the same blank-control
+        // symptom that #12045 fixed on HostButton: with no arm here the
+        // checkbox emitted no Content attribute at all. See emit_host_button
+        // for the full story.
+        Some(LayoutPropValue::Expr(src)) => match lower_expr_for_xbind(src, ctx) {
+            ExprLowering::Bindable(path) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {path}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Helper(call) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {call}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Unsupported(reason) => {
+                return Err(PipelineEmitError::UnsupportedExpression(reason));
+            }
+        },
         _ => {}
     }
 
@@ -7790,6 +7807,20 @@ fn emit_host_radio(
         Some(LayoutPropValue::Keyword(k)) => {
             attrs.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
         }
+        // An expression label — see emit_host_button and emit_host_checkbox.
+        // A radio button with no Content renders as a bare dot with no text
+        // beside it, which is worse than useless in a mutex group.
+        Some(LayoutPropValue::Expr(src)) => match lower_expr_for_xbind(src, ctx) {
+            ExprLowering::Bindable(path) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {path}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Helper(call) => {
+                attrs.push_str(&format!(" Content=\"{{x:Bind {call}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Unsupported(reason) => {
+                return Err(PipelineEmitError::UnsupportedExpression(reason));
+            }
+        },
         _ => {}
     }
 
@@ -8122,6 +8153,23 @@ fn emit_host_link(
                 content_attr.push_str(&format!(" Content=\"{}\"", escape_xaml_attr(k)));
             }
         }
+        // An expression label — the third instance of the same gap (see
+        // emit_host_button, emit_host_checkbox, emit_host_radio). Here the
+        // catch-all below is not empty, it falls back to `href`, so the
+        // symptom varied: with a string href the link rendered the raw URL
+        // instead of its label, and with a slot/expression href it rendered
+        // blank. Both are wrong; an explicit label must win.
+        Some(LayoutPropValue::Expr(src)) => match lower_expr_for_xbind(src, ctx) {
+            ExprLowering::Bindable(path) => {
+                content_attr.push_str(&format!(" Content=\"{{x:Bind {path}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Helper(call) => {
+                content_attr.push_str(&format!(" Content=\"{{x:Bind {call}, Mode=OneWay}}\""));
+            }
+            ExprLowering::Unsupported(reason) => {
+                return Err(PipelineEmitError::UnsupportedExpression(reason));
+            }
+        },
         _ => {
             // No label â€” fall back to href as the visible text.
             if let Some(LayoutPropValue::String(s)) = find_prop_value(node, "href") {
@@ -12839,16 +12887,46 @@ mod tests {
         );
     }
 
-    /// A `HostButton` whose label is a row expression must emit `Content`.
+    /// A labelled control whose label is a row expression must emit `Content`.
     ///
     /// `label: ( row[1] )` lands on `LayoutPropValue::Expr`, and that arm was
     /// missing from the label match — the catch-all swallowed it, so the
-    /// button emitted no `Content` attribute at all and rendered blank. It
-    /// looked like a styling gap for weeks because an empty button is
+    /// control emitted no `Content` attribute at all and rendered blank. It
+    /// looked like a styling gap for weeks because an empty control is
     /// invisible rather than obviously broken; it affected every task row,
     /// project-rail row and notes row.
+    ///
+    /// The gap was first found and fixed on `HostButton`. The sibling label
+    /// matches in the `HostCheckbox`, `HostRadio` and `HostLink` lowerings
+    /// had the exact same shape and the exact same missing arm, so this
+    /// guard covers all four content controls rather than just the one that
+    /// was noticed first. The general assertion — that no emitted content
+    /// control lacks `Content` — is the half that matters: it is what
+    /// catches the next element to grow a label match without an `Expr` arm.
+    ///
+    /// `HostLink` differed only in its symptom: its catch-all is not empty,
+    /// it falls back to `href`, so an expression label rendered the raw URL
+    /// (string href) or nothing at all (slot/expression href) rather than
+    /// the label the author asked for.
     #[test]
-    fn host_button_with_row_expression_label_emits_content() {
+    fn labelled_hosts_with_row_expression_label_emit_content() {
+        /// The XAML tags whose visible text comes from `Content`. A control
+        /// of one of these types with no `Content` attribute renders blank.
+        const CONTENT_CONTROLS: [&str; 4] =
+            ["Button", "CheckBox", "RadioButton", "HyperlinkButton"];
+
+        fn labelled(tag: &str) -> LayoutNode {
+            LayoutNode {
+                tag: tag.to_string(),
+                part_name: None,
+                props: vec![LayoutProp {
+                    name: "label".to_string(),
+                    value: LayoutPropValue::Expr("row[1]".to_string()),
+                }],
+                children: Vec::new(),
+            }
+        }
+
         let c = component(
             "Foo",
             vec![slot(
@@ -12872,35 +12950,39 @@ mod tests {
                     LayoutPropValue::SlotRef("rows".to_string()),
                     "row",
                     None,
-                    vec![LayoutNode {
-                        tag: "HostButton".to_string(),
-                        part_name: None,
-                        props: vec![LayoutProp {
-                            name: "label".to_string(),
-                            value: LayoutPropValue::Expr("row[1]".to_string()),
-                        }],
-                        children: Vec::new(),
-                    }],
+                    vec![
+                        labelled("HostButton"),
+                        labelled("HostCheckbox"),
+                        labelled("HostRadio"),
+                        labelled("HostLink"),
+                    ],
                 )],
             },
         );
         let r = compile(&c, &l, &empty_style("Foo"));
 
-        // Every emitted Button must carry a Content attribute — a button that
-        // renders empty is the failure mode this guards against.
+        // Every emitted content control must carry a Content attribute — a
+        // control that renders empty is the failure mode this guards against.
         for line in r.xaml.lines() {
             let t = line.trim();
-            if t.starts_with("<Button ") {
-                assert!(
-                    t.contains("Content="),
-                    "emitted a Button with no Content, which renders blank:\n{t}\n\nfull XAML:\n{}",
-                    r.xaml
-                );
+            for tag in CONTENT_CONTROLS {
+                if t.starts_with(&format!("<{tag} ")) {
+                    assert!(
+                        t.contains("Content="),
+                        "emitted a <{tag}> with no Content, which renders blank:\n{t}\n\nfull XAML:\n{}",
+                        r.xaml
+                    );
+                }
             }
         }
-        assert!(
-            r.xaml.contains("Content=\"{x:Bind"),
-            "row-expression label should lower to a binding, got:\n{}",
+
+        // ...and each of the three must specifically have lowered the row
+        // expression to a binding, not to some empty placeholder.
+        let bindings = r.xaml.matches("Content=\"{x:Bind").count();
+        assert_eq!(
+            bindings,
+            CONTENT_CONTROLS.len(),
+            "expected every row-expression label to lower to a binding, got {bindings}:\n{}",
             r.xaml
         );
     }


### PR DESCRIPTION
## What

#12045 fixed a missing `LayoutPropValue::Expr` arm in `emit_host_button`'s `label` match, where the trailing `_ => {}` swallowed an expression label and the button emitted **no `Content` attribute at all**. It noted, without fixing, that the sibling match in the `HostCheckbox` / `HostRadio` lowering had the same shape.

It does, and it reproduces.

## Reproduced first

Before touching any lowering code, a `HostCheckbox` and a `HostRadio` inside a `For` labelled `label: ( row[1] )` emitted:

```xml
<Button x:Name="HostButton_1" Content="{x:Bind Expr_da1b4b7a, Mode=OneWay}"/>
<CheckBox x:Name="HostCheckbox_2"/>
<RadioButton x:Name="HostRadio_3"/>
```

No `Content` on either, so both render blank — while the already-fixed `Button` beside them in the same `DataTemplate` emitted its binding correctly. Both now route through `lower_expr_for_xbind`, exactly as `emit_host_button` does.

## A third instance found by the audit

Auditing every `find_prop_value(node, "…")` match in the file turned up `emit_host_link`'s `label`. Its symptom differed only because its catch-all is not empty — it falls back to `href`, so an expression label rendered the raw URL with a string `href`, and rendered blank with a slot or expression `href`. An explicit label now wins.

Fixed here because it is the same attribute, the same binding mode and the same helper — no judgement call was involved.

## Guard extended, not duplicated

`host_button_with_row_expression_label_emits_content` is generalised and renamed `labelled_hosts_with_row_expression_label_emit_content`. Its useful half — that no emitted content control lacks `Content` — now covers `CheckBox`, `RadioButton` and `HyperlinkButton` alongside `Button`, so the next element to grow a label match without an `Expr` arm trips it. Confirmed failing on `CheckBox` before the fix, passing after.

## No golden churn

No current layout binds these labels to an expression (`Checkbox.mll` and `Radio.mll` both use `slot:`), so emitted output for every existing fixture is byte-identical. This closes a latent bug before it ships rather than repairing a live one.

## Audit results — left open deliberately

Seven further `find_prop_value` matches in this file end in a bare `_ => {}` that swallows `Expr` the same way. All were **confirmed by probe** to drop the expression silently:

| Site | Prop | Emitted with an `Expr` value |
|---|---|---|
| `emit_host_tooltip` | `text` | `<Border/>` — no tooltip |
| `emit_host_input` | `value` | `<TextBox/>` — no text |
| `emit_host_input` | `placeholder` | `<TextBox/>` — no placeholder |
| `emit_host_number_input` | `value` | `<NumberBox/>` — no value |
| `emit_host_dialog` | `title` | `<ContentDialog>` — no title |
| `emit_text` / `emit_host_slider` | `a11y-label` | no `AutomationProperties.Name` |
| `emit_image` | `src` | `<Image/>` — no `Source` |

Unlike the label sites these are **not** mechanically identical: they need per-site decisions about the target attribute, the binding mode (`value` wants TwoWay, not OneWay) and type conversion (`Image.src` needs `string` → `ImageSource`). Not guessed at here.

## Structural cause worth naming

The `Text` `content` match handles the same ten variants but ends `Some(LayoutPropValue::EmitRef(_)) | None => …`, which is **exhaustive**. Adding a variant to `LayoutPropValue` would be a compile error there and silence at every `_ => {}` site. That is why this class of bug recurs in exactly these matches and never in that one.

## Verification

- 227 tests pass across all 7 targets (`--no-fail-fast`, unfiltered; 7 `test result:` lines counted against 7 test binaries, per lessons.md)
- `cargo clippy --all-targets -- -D warnings` clean
- Consumers `mosaic-compile` and `mosaic-package-artifact-builder` both green
- `/security-review` passed first round — the reviewer verified the `escape_xaml_attr` asymmetry is safe, since `tokenise_expr` is a whitelist lexer whose output charset is closed under XAML-attribute safety (a `"` cannot reach the attribute; `{`/`}` return `Unsupported`)

Closes #12047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)