### PR TITLE
feat(semantic-ir-to-go): implement SIR23 Tier A pattern matcher (Phase A Slice 4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Changelog
 
+## 0.42.0 — SIR23 Tier A pattern matcher (second-wave backend rollout, Phase A Slice 4)
+
+Implements the 7-node SIR23 Tier A slice — the symbolic-expression
+pattern matcher and rewrite engine — as one of five parallel per-backend
+PRs for this rollout (Ruby merged first as precedent; C/Rust/Python are
+sibling PRs): `Expr::SymSymbol`/`SymRational`/`SymApply`/
+`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`. New
+`Feature` flags accepted: `SymbolicExpr`, `PatternMatching`, `Rationals`
+(the last shared with the SIR22 array/matrix domain rather than a flag
+of its own, per the SIR23 spec). Tier B (`evalTerm` — arithmetic/
+calculus/user-function folding: `Add`/`Sin`/`D`/...) is explicitly OUT
+OF SCOPE for this slice; a `SymApply` builds an inert term tree, nothing
+more.
+
+**New `_sir_cas_*` runtime functions + `*SirCasTerm` type (`runtime.rs`)**:
+an inlined port of `semantic-ir-to-javascript`'s already-proven
+`Symbolic` sub-runtime's Tier A slice — term construction (`symbol`/
+`int`/`rational`/`float`/`string`/`apply`), `matchPattern`/
+`substituteTerm`/`applyRuleTerm` (the five-case structural matcher:
+`Blank()`, `Blank(T)`, `Pattern(name, inner)`, compound-vs-compound,
+plain structural equality), and `replaceAll`/`replaceRepeated` (`/.` /
+`//.`) with their DoS guards. Cross-checked against the sibling Ruby
+backend's own port (`sir23-ruby-matcher`, merged as PR #12128).
+
+**Naming**: `_sir_cas_*` / `SirCasTerm`, NOT `_sir_sym_*` — this backend
+already owns that prefix for Ruby `Symbol#to_proc`/`Symbol` method
+dispatch (`_sir_sym_to_proc`, `_sir_symbol_*`), an unrelated domain. The
+same class of landmine Slice 2 hit with `_sir_array_*` (forced the
+rename to `_sir_ndarray_*`); this slice checked first and picked a
+distinct prefix (`_sir_cas_*`, for "Computer Algebra System", matching
+the SIR23 spec's own `cas-pattern-matching` crate name) up front.
+
+**Value model**: `*SirCasTerm`, one kind-discriminated Go struct
+(`sirCasSymbol`/`sirCasInteger`/`sirCasRational`/`sirCasFloat`/
+`sirCasString`/`sirCasApply`) — the same established pattern this
+backend already uses for SIR22's `*NDArray`, rather than one Go type per
+kind. `Head`/`Args` are typed `Value`/`[]Value` (not `*SirCasTerm`/
+`[]*SirCasTerm`) so every `_sir_cas_*` function accepts the same boxed
+interface every other runtime value flows through, asserting the
+concrete type once internally (`_sir_cas_as_term`, mirroring
+`_sir_ndarray_as_ndarray`'s identical discipline).
+
+**Bindings**: `map[string]Value`, copy-on-write via a manual
+full-copy-plus-insert in `_sir_cas_bindings_bind` (no persistent-map
+library exists anywhere in this repo's Go-facing dependency graph, and
+Go has neither Ruby's cheap `Hash#merge` nor a built-in structural-
+sharing map) — a failed match attempt never mutates a binding set an
+earlier attempt still holds a reference to.
+
+**DoS guards (CWE-674)**: `sirCasMaxTermDepth = 512` caps every tree
+WALK (`_sir_cas_walk_once`/`_sir_cas_replace_repeated`'s recursive
+descent into `head`/`args`, term equality, and display) — NOT the
+matcher functions (`_sir_cas_match_pattern`/`_sir_cas_substitute`/
+`_sir_cas_apply_rule`), which recurse only as deep as one rule's own
+author-written shape and need no cap. `_sir_cas_replace_repeated` also
+enforces `sirCasMaxIterationsDefault = 100`, a GLOBAL fixed-point
+iteration cap shared across the whole walk (a `for` loop at each call
+frame, never a recursive call per firing, so a rule firing repeatedly at
+one tree position costs O(1) native stack frames). Both caps `panic`
+directly with a `fmt.Sprintf`-formatted message the moment they are
+exceeded — a DELIBERATE departure from the Ruby/JS references (which
+thread a sentinel value back up through every recursive return,
+unwrapping/raising only once the walk fully returns): this backend's own
+`_sir_ndarray_checked_shape_size` already established "panic immediately
+with a controlled message" as the house convention for this exact class
+of guard, and Go's `panic`/`recover` gives a clean, catchable unwind
+through however many frames are on the stack — the compiled `TryCatch`
+rescue path recovers ANY panic value, not just `*SirError` — so there is
+no need for hand-rolled sentinel propagation here.
+
+**Display**: `_sir_cas_to_s` renders a term in generic `head(args, ...)`
+form (no Wolfram infix/precedence pretty-printing — separate follow-up
+work), wired into `_sir_format_d` (the existing `print`/`puts` dispatch)
+via a `*SirCasTerm` case. SIR22's own `*NDArray` deliberately has no
+display path, but this slice's own reference tests (ported from the JS
+backend's suite) print terms directly and assert on stdout, so a
+display path is load-bearing here.
+
+**Emit (`emit.rs`)**: replaces the combined SIR23 deferred-node `panic!`
+arm with seven real per-variant codegen arms, plus an `emit_sym_operand`
+helper (ported from the Ruby/JS backends' identically-named helper) that
+wraps a bare `IntLit`/`FloatLit`/`StrLit` operand through the matching
+`_sir_cas_*` leaf constructor before it sits inside a term tree. The
+SIR23 arm was already cleanly split from the unrelated SIR26 `Convert`
+deferred-node arm (a prior slice's own split) — no further separation
+needed this time.
+
+**Tests (`tests/sir23_symbolic.rs`)**: ported from `semantic-ir-to-
+javascript`'s own proven suite, Tier A cases only —
+`replace_repeated_reduces_nested_add_zero_to_bare_symbol`,
+`replace_all_single_pass_does_not_retry_at_same_position`,
+`typed_blank_matches_only_constrained_head`, `a_rational_term_prints_
+reduced`, plus `depth_limit_guard_panics_instead_of_crashing_the_go_
+stack` — a REAL compiled `Stmt::ForRange` loop builds 600 levels of
+`Wrap(...)` nesting at runtime (not a hand-built static AST), then
+`replaceAll` over it must panic cleanly instead of overflowing the Go
+stack. All five hand-build a `Module` directly (no frontend targets this
+backend for SIR23 yet), emit Go, and run it with a real `go run`,
+skipping (not failing) when no `go` is on `PATH` — mirrors
+`sir22_array.rs`'s established pattern.
+
 ## 0.41.0 — SIR22 "APL addendum" (second-wave backend rollout, Phase A Slice 3)
 
 Implements the 9-node SIR22 "APL addendum" this backend's own Slice 2

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1092,26 +1092,125 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 span
             );
         }
-        // ── SIR23 (symbolic expression + pattern/rewrite IR) ──────────
+        // ── SIR23 (symbolic expression + pattern/rewrite IR, Tier A only)
+        // ────────────────────────────────────────────────────────────
         // `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
-        // `SymPatternNamed`/`SymRule`/`SymReplaceAll` observe
-        // `Feature::SymbolicExpr` and/or `Feature::PatternMatching`, neither
-        // of which `ACCEPTED_FEATURES` declares, so the SIR10 capability
-        // gate rejects any module using one of these nodes before it ever
-        // reaches emit — mirrors the SIR22/SIR26 deferred-node panic above.
-        Expr::SymSymbol { .. }
-        | Expr::SymRational { .. }
-        | Expr::SymApply { .. }
-        | Expr::SymPatternBlank { .. }
-        | Expr::SymPatternNamed { .. }
-        | Expr::SymRule { .. }
-        | Expr::SymReplaceAll { .. } => {
-            panic!(
-                "go backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
-                e.kind_name(),
-                e.span()
-            );
+        // `SymPatternNamed`/`SymRule`/`SymReplaceAll` now observe
+        // `Feature::SymbolicExpr`/`Feature::Rationals`/`Feature::
+        // PatternMatching`, all three accepted in `lib.rs`'s
+        // `ACCEPTED_FEATURES` (Phase A Slice 4). Mirrors the Ruby/
+        // JavaScript backends' SIR23 arms, but calls into the INLINED
+        // `_sir_cas_*` runtime (runtime.rs — see its own "SIR23 symbolic
+        // expressions" doc comment for the naming rationale and Tier A/B
+        // split) rather than an imported package. Tier A (the pattern
+        // matcher) only — no `evalTerm`-equivalent arithmetic/calculus
+        // folding exists here; `SymApply` builds an inert term tree,
+        // nothing more.
+        Expr::SymSymbol { name, .. } => {
+            let _ = write!(out, "_sir_cas_symbol({})", quote_go_string(name));
         }
+        Expr::SymRational { numer, denom, .. } => {
+            let _ = write!(out, "_sir_cas_rational({numer}, {denom})");
+        }
+        Expr::SymApply { head, args, .. } => {
+            out.push_str("_sir_cas_apply(");
+            emit_sym_operand(out, head, indent);
+            out.push_str(", []Value{");
+            for (i, a) in args.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, a, indent);
+            }
+            out.push_str("})");
+        }
+        Expr::SymPatternBlank { head: None, .. } => {
+            out.push_str("_sir_cas_blank()");
+        }
+        Expr::SymPatternBlank {
+            head: Some(head), ..
+        } => match head.as_ref() {
+            Expr::SymSymbol { name, .. } => {
+                let _ = write!(out, "_sir_cas_blank_typed({})", quote_go_string(name));
+            }
+            _ => panic!(
+                "go backend: SymPatternBlank's head-constraint must be a SymSymbol, got {} at {}",
+                head.kind_name(),
+                head.span()
+            ),
+        },
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            let _ = write!(out, "_sir_cas_named({}, ", quote_go_string(name));
+            emit_sym_operand(out, pattern, indent);
+            out.push(')');
+        }
+        Expr::SymRule {
+            lhs, rhs, delayed, ..
+        } => {
+            out.push_str(if *delayed {
+                "_sir_cas_rule_delayed("
+            } else {
+                "_sir_cas_rule("
+            });
+            emit_sym_operand(out, lhs, indent);
+            out.push_str(", ");
+            emit_sym_operand(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::SymReplaceAll {
+            expr,
+            rules,
+            repeated,
+            ..
+        } => {
+            out.push_str(if *repeated {
+                "_sir_cas_replace_repeated("
+            } else {
+                "_sir_cas_replace_all("
+            });
+            emit_sym_operand(out, expr, indent);
+            out.push_str(", []Value{");
+            for (i, r) in rules.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, r, indent);
+            }
+            out.push('}');
+            if *repeated {
+                out.push_str(", sirCasMaxIterationsDefault");
+            }
+            out.push(')');
+        }
+    }
+}
+
+/// Wrap a `SymApply`/`SymPatternNamed`/`SymRule`/`SymReplaceAll` operand
+/// that is a bare literal (`IntLit`/`FloatLit`/`StrLit`) through the
+/// matching `_sir_cas_*` leaf-term constructor — a raw Go `int64`/
+/// `float64`/`string` is never a valid Symbolic term, so it must become
+/// one before it can sit inside a term tree. Any other operand (already a
+/// Symbolic-producing expression, e.g. a nested `SymApply` or a `VarRef`)
+/// emits unchanged. Mirrors the Ruby/JavaScript/TypeScript backends'
+/// identically-named helper.
+fn emit_sym_operand(out: &mut String, e: &Expr, indent: usize) {
+    match e {
+        Expr::IntLit { .. } => {
+            out.push_str("_sir_cas_int(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::FloatLit { .. } => {
+            out.push_str("_sir_cas_float(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::StrLit { .. } => {
+            out.push_str("_sir_cas_string(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        _ => emit_expr(out, e, indent),
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -198,6 +198,26 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
+    // ── SIR23 symbolic expression + pattern/rewrite, Tier A only (second-
+    // wave backend rollout, Phase A Slice 4) ───────────────────────────
+    // `SymSymbol`/`SymApply` observe `Feature::SymbolicExpr`;
+    // `SymRational` observes `Feature::Rationals` (shared with the SIR22
+    // array/matrix domain rather than a flag of its own — see the SIR23
+    // spec's own "New `Feature` flags" note, and `validator.rs`'s
+    // `Expr::SymRational` arm); `SymPatternBlank`/`SymPatternNamed`/
+    // `SymRule`/`SymReplaceAll` observe `Feature::PatternMatching`. All
+    // three route into `_sir_cas_*` helpers, an inlined port of the
+    // already-proven `semantic-ir-to-javascript` `Symbolic` sub-runtime's
+    // Tier A (matcher) slice — term construction, `matchPattern`/
+    // `substituteTerm`/`applyRuleTerm`, `replaceAll`/`replaceRepeated`
+    // with their depth + iteration DoS guards (see runtime.rs's "SIR23
+    // symbolic expressions" section). Tier B (`evalTerm`, the arithmetic/
+    // calculus/user-function evaluator) is OUT OF SCOPE for this slice —
+    // no `Add`/`Sin`/`D`/... folding is accepted or implemented; a
+    // `SymApply` builds an inert term tree, nothing more.
+    Feature::SymbolicExpr,
+    Feature::PatternMatching,
+    Feature::Rationals,
 ];
 
 impl Backend for GoBackend {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1103,6 +1103,13 @@ func _sir_format_d(v Value, visited map[Value]bool) string {
 	if _, ok := v.(*Closure); ok {
 		return "<closure>"
 	}
+	// SIR23 Tier A: a symbolic term prints in generic `head(args, ...)`
+	// form. See `_sir_cas_to_s`'s own doc comment for why this backend
+	// gives terms a display path when SIR22's `*NDArray` deliberately has
+	// none.
+	if t, ok := v.(*SirCasTerm); ok {
+		return _sir_cas_to_s(t, 0)
+	}
 	// A SIR exception prints as its message (Ruby's `exception.message`):
 	// the raised message when present, else the class name.  This lets a
 	// `rescue => e` do `print(e)` and see something meaningful rather than
@@ -5788,6 +5795,716 @@ func _sir_ndarray_catenate(av Value, bv Value) *NDArray {
 		return _sir_ndarray_new([]int{r, ca + cb}, data)
 	default:
 		panic(fmt.Sprintf("catenate: catenate of rank %d and rank %d is not yet supported", ra, rb))
+	}
+}
+
+// ── SIR23 symbolic expressions + pattern/rewrite (Tier A, Phase A Slice 4)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/`SymPatternNamed`/
+// `SymRule`/`SymReplaceAll` lower to calls into `_sir_cas_*` below — an
+// inlined port of `semantic-ir-to-javascript`'s own already-proven
+// `Symbolic` sub-runtime's Tier A (matcher) slice: term construction,
+// `matchPattern`/`substituteTerm`/`applyRuleTerm`, and `replaceAll`/
+// `replaceRepeated` with their `MAX_TERM_DEPTH` guard. Tier B (`evalTerm`,
+// the arithmetic/calculus/user-function evaluator) is explicitly OUT OF
+// SCOPE for this slice — matching the SIR23 spec's own Tier A/Tier B
+// split — so no `Add`/`Sin`/`D`/... folding exists here; a `SymApply`
+// builds an inert term tree, nothing more.
+//
+// ## Naming: `_sir_cas_*`, not `_sir_sym_*`
+//
+// The obvious prefix for "symbolic expression" is `_sir_sym_*` — the
+// sibling Ruby backend's own port (`sir23-ruby-matcher`) uses exactly
+// that. THIS backend already owns that prefix for something entirely
+// unrelated: `_sir_sym_to_proc` (Ruby `Symbol#to_proc`, the `&:name`
+// block-pass sugar — see above) and the `_sir_symbol_*` family
+// (`_sir_symbol_method`/`_sir_symbol_responds`, Ruby's `Symbol` class
+// method dispatch). Reusing `_sir_sym_*` here would collide textually
+// with that pre-existing, unrelated domain — the SAME class of landmine
+// Slice 2 hit with `_sir_array_*` (already owned by the Ruby
+// `Array`-method dispatch catalog, which forced the rename to
+// `_sir_ndarray_*`). This slice avoids it up front: `_sir_cas_*`
+// ("Computer Algebra System" — matches the `cas-pattern-matching` crate
+// this domain's own matcher algorithm is named after in the SIR23 spec)
+// keeps the two `sym`-flavoured domains textually distinct. (Checked:
+// `_sir_case_eq` — Ruby `===` case-equality, SIR16 — happens to share
+// an eight-character PREFIX with `_sir_cas_`, but the two are otherwise
+// unrelated names with no shared suffix; not a real collision, just a
+// coincidence worth a comment so a future reader doesn't grep-confuse
+// the two domains.)
+//
+// ## Value model
+//
+// `*SirCasTerm`, a single Go struct discriminated by `.Kind`
+// (`sirCasSymbol`/`sirCasInteger`/`sirCasRational`/`sirCasFloat`/
+// `sirCasString`/`sirCasApply`) — the SAME established pattern this
+// backend already uses for SIR22's `*NDArray` (one struct type, a
+// shared, pointer-handle value that is never mutated in place once
+// built, fields populated per kind) rather than Go's more common "one
+// concrete type per interface implementer" idiom. Go has no `.freeze`
+// the way the Ruby port's `SirSymTerm` uses to enforce immutability at
+// runtime; here it is a DISCIPLINE the constructors below uphold (every
+// one fully populates its result and hands back a pointer nothing else
+// holds yet) rather than a runtime guarantee.
+//
+// `Head`/`Args` are typed `Value` (`interface{}`) / `[]Value`, NOT
+// `*SirCasTerm` / `[]*SirCasTerm` — matching how `*NDArray`'s own
+// sibling helpers (`_sir_ndarray_elementwise(op string, av Value, bv
+// Value)`, etc.) universally accept/return the boxed `Value` interface
+// rather than a concrete pointer type. A `SymApply`'s head/args operands
+// reach codegen as arbitrary `Expr`s (a `VarRef` to some earlier
+// `LetBinding`, a nested `SymApply`, ...), so the emitted Go expression
+// for one is statically typed `Value` at many call sites (e.g. a local
+// bound via `:=` to a param of declared type `Value`); keeping the CAS
+// API surface itself `Value`-typed throughout means every operand slots
+// in directly with no per-call-site type assertion in the EMITTED code
+// — the assertion instead lives once, inside each `_sir_cas_*` function,
+// via the shared `_sir_cas_as_term` helper below. Mirrors
+// `_sir_ndarray_as_ndarray`'s identical "assert once, inside the runtime
+// function, with a controlled panic message" discipline.
+//
+// ## Bindings: copy-on-write via manual copy
+//
+// A pattern match's bindings (`map[string]Value`, name -> bound term)
+// must be persistent: a failed match attempt must never mutate a
+// binding set an earlier, still-live match attempt holds a reference to
+// (mirrors the Ruby port's `Hash#merge` and the JS reference's own
+// `Bindings` class). Go has neither Ruby's cheap `Hash#merge` nor a
+// persistent-map library anywhere in this repo's dependency graph
+// (checked: no `im`-style crate/package, and no existing
+// copy-on-write-map helper elsewhere in this backend's own runtime —
+// the closest precedent, `*Map` for SIR16's `Feature::Maps`, is
+// DELIBERATELY the opposite: a shared, pointer-backed, MUTATE-in-place
+// value, since `Stmt::IndexSet` on a user `Map` must mutate the very
+// map a caller's binding already holds). So `_sir_cas_bindings_bind`
+// below does a manual full-copy-plus-insert (`make` a fresh map,
+// range-copy every existing entry, add the new one) rather than
+// mutating `bindings` in place. This is O(n) per bind (n = bindings so
+// far) rather than a persistent map's typical O(log n), but n is
+// bounded by the number of DISTINCT pattern-variable names in one
+// rule's own author-written `lhs` — always small, never
+// runtime-controlled — so the asymptotic cost is immaterial here.
+//
+// ## DoS guard (CWE-674): `panic` directly, not a sentinel value
+//
+// `_sir_cas_match_pattern`/`_sir_cas_substitute`/`_sir_cas_apply_rule`
+// recurse, but only as deep as a single RULE's own author-written
+// pattern/RHS shape — always shallow regardless of how deep the TARGET
+// expression is — so they carry NO depth cap of their own (this exact
+// reasoning is in the JS reference's own doc comments). `_sir_cas_walk_
+// once`/`_sir_cas_replace_repeated`, by contrast, walk the ENTIRE target
+// expression tree, which ordinary compiled-program data (e.g. a runtime
+// loop nesting `Wrap(Wrap(...))` `sirCasMaxTermDepth` levels deep) CAN
+// build to unbounded depth — so THOSE two need an explicit cap, mirroring
+// the JS reference's `MAX_TERM_DEPTH = 512` exactly.
+//
+// Unlike the Ruby/JS references (which return a sentinel "depth-limit"/
+// "rewrite-cycle" value threaded back up through every recursive return,
+// only raising once the walk fully unwinds to its outermost caller),
+// this Go port just `panic`s DIRECTLY at the point a cap is exceeded —
+// matching this runtime's OWN already-shipped convention for the
+// identical class of guard (`_sir_ndarray_checked_shape_size`, which
+// panics immediately with `fmt.Sprintf(...)` rather than returning a
+// sentinel the caller must check). Go's `panic`/`recover` already gives
+// a clean, catchable unwind through however many frames are on the
+// stack at that point — the compiled `TryCatch` rescue path recovers ANY
+// panic value via `recover()`, not just `*SirError` (see
+// `_sir_class_of_thrown`, which classifies an arbitrary recovered value)
+// — so there is no need to hand-roll the sentinel-propagation dance the
+// Ruby/JS ports use only because raising an exception THROUGH hundreds
+// of recursive stack frames is awkward or semantically fuzzy in their
+// own host languages. `replaceRepeated`'s iteration cap (default 100,
+// `sirCasMaxIterationsDefault`) is a SEPARATE, independent counter from
+// the depth cap: it bounds how many times a rule may fire cumulatively
+// across the ENTIRE walk (CPU time), while the depth cap bounds how far
+// a genuine descent into `head`/`args` may go (stack safety) — a rule
+// firing repeatedly at ONE tree position loops in a plain Go `for` LOOP
+// at that call frame (see `_sir_cas_replace_repeated` below), never a
+// recursive call per firing, so it costs O(1) native stack frames
+// regardless of how many times it fires before hitting the cap.
+
+// sirCasMaxTermDepth caps every SIR23 tree WALK (replaceAll's single
+// pass, replaceRepeated's fixed-point loop, term-equality, and display) —
+// NOT the matcher functions (`_sir_cas_match_pattern`/`_sir_cas_
+// substitute`/`_sir_cas_apply_rule`), which recurse only as deep as one
+// rule's own shape and need no cap. Matches the JS/Ruby references'
+// `MAX_TERM_DEPTH = 512` exactly.
+const sirCasMaxTermDepth = 512
+
+// sirCasMaxIterationsDefault is `_sir_cas_replace_repeated`'s default
+// fixed-point iteration cap (SIR23 spec "Matcher semantics" point 6) —
+// referenced directly by name from emitted `SymReplaceAll{repeated:
+// true}` call sites (see emit.rs), not just used internally here.
+const sirCasMaxIterationsDefault = 100
+
+type sirCasKind uint8
+
+const (
+	sirCasSymbol sirCasKind = iota
+	sirCasInteger
+	sirCasRational
+	sirCasFloat
+	sirCasString
+	sirCasApply
+)
+
+// SirCasTerm is one SIR23 Tier A symbolic-expression / pattern node.
+// Only the fields `.Kind` actually uses are populated; the rest stay at
+// their Go zero value. See the module-level doc above for why this is
+// one kind-discriminated struct (mirroring `*NDArray`) rather than one
+// Go type per kind.
+type SirCasTerm struct {
+	Kind   sirCasKind
+	Name   string  // sirCasSymbol
+	IntVal int64   // sirCasInteger
+	Numer  int64   // sirCasRational -- already reduced (see _sir_cas_rational)
+	Denom  int64   // sirCasRational -- already reduced, > 0
+	Float  float64 // sirCasFloat -- always finite (see _sir_cas_float)
+	Str    string  // sirCasString
+	Head   Value   // sirCasApply -- a *SirCasTerm, boxed
+	Args   []Value // sirCasApply -- each element a *SirCasTerm, boxed
+}
+
+// _sir_cas_as_term asserts `v` is already a `*SirCasTerm`, panicking
+// with a clean, controlled message otherwise. Matches `_sir_ndarray_as_
+// ndarray`'s "assert once, inside the runtime function" discipline
+// exactly, so every `_sir_cas_*` function below can accept the uniform
+// `Value` interface at its boundary and still work with a concrete
+// `*SirCasTerm` internally.
+func _sir_cas_as_term(v Value) *SirCasTerm {
+	t, ok := v.(*SirCasTerm)
+	if !ok {
+		panic(fmt.Sprintf("sir-runtime-symbolic: expected a symbolic term, got %T", v))
+	}
+	return t
+}
+
+// ── term construction ───────────────────────────────────────────────────
+
+func _sir_cas_symbol(name string) *SirCasTerm {
+	return &SirCasTerm{Kind: sirCasSymbol, Name: name}
+}
+
+// _sir_cas_int wraps an emitted `IntLit` operand (always a boxed
+// `Value(int64(...))`, see `emit_expr`'s `Expr::IntLit` arm) into a
+// symbolic Integer term. Unlike the JS reference (which restricts
+// `Symbolic.int` to `Number.isSafeInteger` because JS's own `Expr::
+// IntLit` codegen already has that ceiling) or the Ruby port (arbitrary-
+// precision native Integers), this backend's own `Expr::IntLit` arm
+// already emits a fixed-width Go `int64` — the SAME numeric tower every
+// other integer value in this runtime uses — so no extra range check is
+// needed here beyond the ordinary Go `int64` bounds already implied by
+// the type assertion.
+func _sir_cas_int(v Value) *SirCasTerm {
+	n, ok := v.(int64)
+	if !ok {
+		panic(fmt.Sprintf("sir-runtime-symbolic: _sir_cas_int expected an int64, got %T", v))
+	}
+	return &SirCasTerm{Kind: sirCasInteger, IntVal: n}
+}
+
+func _sir_cas_gcd_abs(a int64, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a == 0 {
+		return 1
+	}
+	return a
+}
+
+// _sir_cas_rational reduces numer/denom by their GCD and normalizes the
+// sign onto the numerator (denominator always positive) at CONSTRUCTION
+// time, mirroring the Ruby/JS references exactly — a term's `Numer`/
+// `Denom` fields are always already in lowest terms; nothing downstream
+// (matching, equality, display) re-reduces.
+func _sir_cas_rational(numer int64, denom int64) *SirCasTerm {
+	if denom == 0 {
+		panic("sir-runtime-symbolic: rational denominator cannot be zero")
+	}
+	if denom < 0 {
+		numer = -numer
+		denom = -denom
+	}
+	g := _sir_cas_gcd_abs(numer, denom)
+	return &SirCasTerm{Kind: sirCasRational, Numer: numer / g, Denom: denom / g}
+}
+
+// _sir_cas_float wraps an emitted `FloatLit` operand into a symbolic
+// Float term, requiring finiteness (mirroring the Ruby port's `unless
+// value.is_a?(Float) && value.finite?` guard) — a NaN/Inf `FloatLit`
+// value is a malformed literal for this domain, not a valid symbolic
+// scalar, so it fails loudly here rather than silently producing a term
+// whose `Float` field can never compare or match itself.
+func _sir_cas_float(v Value) *SirCasTerm {
+	f, ok := v.(float64)
+	if !ok {
+		panic(fmt.Sprintf("sir-runtime-symbolic: _sir_cas_float expected a float64, got %T", v))
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		panic("sir-runtime-symbolic: a symbolic Float term must be finite")
+	}
+	return &SirCasTerm{Kind: sirCasFloat, Float: f}
+}
+
+func _sir_cas_string(v Value) *SirCasTerm {
+	s, ok := v.(string)
+	if !ok {
+		panic(fmt.Sprintf("sir-runtime-symbolic: _sir_cas_string expected a string, got %T", v))
+	}
+	return &SirCasTerm{Kind: sirCasString, Str: s}
+}
+
+// _sir_cas_apply builds `head(args...)` as data. `args` is defensively
+// copied (not aliased) so a caller's own backing array can't be mutated
+// out from under an already-built term — matches `_sir_ndarray_new`'s
+// "the returned handle owns its storage" discipline.
+func _sir_cas_apply(head Value, args []Value) *SirCasTerm {
+	argsCopy := make([]Value, len(args))
+	copy(argsCopy, args)
+	return &SirCasTerm{Kind: sirCasApply, Head: head, Args: argsCopy}
+}
+
+// ── structural equality ─────────────────────────────────────────────────
+
+// _sir_cas_term_equals is used by the matcher (a repeated pattern
+// variable must bind to the SAME term every occurrence), by
+// `_sir_cas_bindings_bind`'s "already bound to this exact term" fast
+// path, and by `_sir_cas_replace_repeated`'s "did this firing actually
+// change anything" fixed-point check.
+//
+// SECURITY (CWE-674): depth-capped with the same `sirCasMaxTermDepth`
+// guard the tree-walking functions use below — a term built via
+// `_sir_cas_apply` is not depth-capped at CONSTRUCTION time (only the
+// tree WALKS enforce the cap), so an attacker-influenced runtime value
+// (e.g. a compiled loop lowered to repeated `SymApply` nesting) could
+// build one arbitrarily deep directly. Past the cap, `false` ("not
+// structurally equal") is the safe, contained answer, mirroring `_sir_
+// cas_match_pattern`'s own "give up cleanly" contract for a failed
+// match.
+func _sir_cas_term_equals(av Value, bv Value, depth int) bool {
+	if depth > sirCasMaxTermDepth {
+		return false
+	}
+	a := _sir_cas_as_term(av)
+	b := _sir_cas_as_term(bv)
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case sirCasSymbol:
+		return a.Name == b.Name
+	case sirCasInteger:
+		return a.IntVal == b.IntVal
+	case sirCasRational:
+		return a.Numer == b.Numer && a.Denom == b.Denom
+	case sirCasFloat:
+		return a.Float == b.Float
+	case sirCasString:
+		return a.Str == b.Str
+	case sirCasApply:
+		if !_sir_cas_term_equals(a.Head, b.Head, depth+1) {
+			return false
+		}
+		if len(a.Args) != len(b.Args) {
+			return false
+		}
+		for i := range a.Args {
+			if !_sir_cas_term_equals(a.Args[i], b.Args[i], depth+1) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func _sir_cas_head_name(node *SirCasTerm) string {
+	if node.Kind == sirCasSymbol {
+		return node.Name
+	}
+	return ""
+}
+
+// ── pattern/rule vocabulary (cas-pattern-matching) ──────────────────────
+
+const (
+	sirCasBlankHead   = "Blank"
+	sirCasPatternHead = "Pattern"
+	sirCasRuleHead    = "Rule"
+	sirCasRuleDelayed = "RuleDelayed"
+)
+
+func _sir_cas_is_head(node *SirCasTerm, name string) bool {
+	if node.Kind != sirCasApply {
+		return false
+	}
+	h := _sir_cas_as_term(node.Head)
+	return h.Kind == sirCasSymbol && h.Name == name
+}
+
+func _sir_cas_is_blank(node *SirCasTerm) bool   { return _sir_cas_is_head(node, sirCasBlankHead) }
+func _sir_cas_is_pattern(node *SirCasTerm) bool { return _sir_cas_is_head(node, sirCasPatternHead) }
+
+func _sir_cas_is_rule(node *SirCasTerm) bool {
+	if node.Kind != sirCasApply {
+		return false
+	}
+	h := _sir_cas_as_term(node.Head)
+	if h.Kind != sirCasSymbol {
+		return false
+	}
+	return (h.Name == sirCasRuleHead || h.Name == sirCasRuleDelayed) && len(node.Args) == 2
+}
+
+func _sir_cas_blank() *SirCasTerm {
+	return _sir_cas_apply(_sir_cas_symbol(sirCasBlankHead), nil)
+}
+func _sir_cas_blank_typed(head string) *SirCasTerm {
+	return _sir_cas_apply(_sir_cas_symbol(sirCasBlankHead), []Value{_sir_cas_symbol(head)})
+}
+func _sir_cas_named(name string, inner Value) *SirCasTerm {
+	return _sir_cas_apply(_sir_cas_symbol(sirCasPatternHead), []Value{_sir_cas_symbol(name), inner})
+}
+func _sir_cas_rule(lhs Value, rhs Value) *SirCasTerm {
+	return _sir_cas_apply(_sir_cas_symbol(sirCasRuleHead), []Value{lhs, rhs})
+}
+func _sir_cas_rule_delayed(lhs Value, rhs Value) *SirCasTerm {
+	return _sir_cas_apply(_sir_cas_symbol(sirCasRuleDelayed), []Value{lhs, rhs})
+}
+
+// ── bindings: a name -> term map, copy-on-write ─────────────────────────
+
+// _sir_cas_bindings_bind never mutates `bindings` in place — see the
+// module-level "Bindings: copy-on-write via manual copy" doc above for
+// why a manual full-copy is this port's chosen strategy. The "already
+// bound to this exact term" fast path avoids the copy entirely when
+// `name` already maps to a term structurally equal to `value` (the
+// common case when the SAME pattern variable is matched again during
+// one match attempt).
+func _sir_cas_bindings_bind(bindings map[string]Value, name string, value Value) map[string]Value {
+	if existing, ok := bindings[name]; ok && _sir_cas_term_equals(existing, value, 0) {
+		return bindings
+	}
+	next := make(map[string]Value, len(bindings)+1)
+	for k, v := range bindings {
+		next[k] = v
+	}
+	next[name] = value
+	return next
+}
+
+// ── blank/pattern field accessors ───────────────────────────────────────
+
+// _sir_cas_blank_head_constraint returns `Blank(h)`'s head-constraint
+// symbol name, or `("", false)` for a bare `Blank()`.
+func _sir_cas_blank_head_constraint(node *SirCasTerm) (string, bool) {
+	if len(node.Args) == 0 {
+		return "", false
+	}
+	first := _sir_cas_as_term(node.Args[0])
+	if first.Kind == sirCasSymbol {
+		return first.Name, true
+	}
+	return "", false
+}
+
+func _sir_cas_pattern_name(node *SirCasTerm) string {
+	if len(node.Args) == 0 {
+		panic("sir-runtime-symbolic: Pattern name must be a Symbol")
+	}
+	first := _sir_cas_as_term(node.Args[0])
+	if first.Kind != sirCasSymbol {
+		panic("sir-runtime-symbolic: Pattern name must be a Symbol")
+	}
+	return first.Name
+}
+
+func _sir_cas_pattern_inner(node *SirCasTerm) Value {
+	if len(node.Args) < 2 {
+		panic("sir-runtime-symbolic: Pattern requires an inner expression")
+	}
+	return node.Args[1]
+}
+
+// _sir_cas_effective_head_name mirrors Wolfram's `Head[]`: an `Apply`
+// node's head name (or the literal string `"Apply"` for a non-Symbol,
+// e.g. computed, head), else a fixed per-kind name for a leaf term. Used
+// only by `_sir_cas_blank_head_constraint` matching (`x_Integer` etc.).
+func _sir_cas_effective_head_name(node *SirCasTerm) string {
+	if node.Kind == sirCasApply {
+		hn := _sir_cas_head_name(_sir_cas_as_term(node.Head))
+		if hn == "" {
+			return "Apply"
+		}
+		return hn
+	}
+	switch node.Kind {
+	case sirCasInteger:
+		return "Integer"
+	case sirCasRational:
+		return "Rational"
+	case sirCasFloat:
+		return "Float"
+	case sirCasString:
+		return "String"
+	default:
+		return "Symbol"
+	}
+}
+
+// ── matcher: five-case structural matcher ───────────────────────────────
+//
+// `Blank()`, `Blank(T)`, `Pattern(name, inner)`, compound-vs-compound
+// (recurse head + every arg, same arity required), and plain structural
+// equality — a direct port of `cas-pattern-matching::matchPattern`. NOT
+// depth-capped (see the module-level "DoS guard" doc above): recursion
+// here tracks the SHAPE of one rule's own author-written `lhs`, never the
+// target expression's own depth.
+func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]Value) (map[string]Value, bool) {
+	pattern := _sir_cas_as_term(patternV)
+	if _sir_cas_is_blank(pattern) {
+		constraint, has := _sir_cas_blank_head_constraint(pattern)
+		if !has {
+			return bindings, true
+		}
+		if _sir_cas_effective_head_name(_sir_cas_as_term(targetV)) == constraint {
+			return bindings, true
+		}
+		return nil, false
+	}
+	if _sir_cas_is_pattern(pattern) {
+		name := _sir_cas_pattern_name(pattern)
+		inner := _sir_cas_pattern_inner(pattern)
+		matched, ok := _sir_cas_match_pattern(inner, targetV, bindings)
+		if !ok {
+			return nil, false
+		}
+		if existing, has := matched[name]; has {
+			if _sir_cas_term_equals(existing, targetV, 0) {
+				return matched, true
+			}
+			return nil, false
+		}
+		return _sir_cas_bindings_bind(matched, name, targetV), true
+	}
+	if pattern.Kind == sirCasApply {
+		target := _sir_cas_as_term(targetV)
+		if target.Kind != sirCasApply {
+			return nil, false
+		}
+		current, ok := _sir_cas_match_pattern(pattern.Head, target.Head, bindings)
+		if !ok {
+			return nil, false
+		}
+		if len(pattern.Args) != len(target.Args) {
+			return nil, false
+		}
+		for i, p := range pattern.Args {
+			current, ok = _sir_cas_match_pattern(p, target.Args[i], current)
+			if !ok {
+				return nil, false
+			}
+		}
+		return current, true
+	}
+	if _sir_cas_term_equals(patternV, targetV, 0) {
+		return bindings, true
+	}
+	return nil, false
+}
+
+// _sir_cas_substitute replaces every `Pattern(name, ...)` in `template`
+// bound in `bindings` with its captured term, leaving an UNBOUND pattern
+// variable as-is (mirrors the Ruby/JS references — a `RuleDelayed` RHS
+// that mentions a name the LHS never bound is a rule-authoring bug, not
+// a runtime error here). NOT depth-capped, for the same reason `_sir_
+// cas_match_pattern` is not: recursion tracks one rule's own RHS shape.
+func _sir_cas_substitute(templateV Value, bindings map[string]Value) Value {
+	template := _sir_cas_as_term(templateV)
+	if _sir_cas_is_pattern(template) {
+		if captured, ok := bindings[_sir_cas_pattern_name(template)]; ok {
+			return captured
+		}
+		return template
+	}
+	if template.Kind == sirCasApply {
+		newArgs := make([]Value, len(template.Args))
+		for i, a := range template.Args {
+			newArgs[i] = _sir_cas_substitute(a, bindings)
+		}
+		return _sir_cas_apply(_sir_cas_substitute(template.Head, bindings), newArgs)
+	}
+	return template
+}
+
+// _sir_cas_apply_rule matches `rule`'s `lhs` against `expr`; on success,
+// substitutes the captured bindings into `rhs` and returns `(result,
+// true)`. Returns `(nil, false)` — never a panic — on a non-matching
+// `expr`, since "this rule doesn't apply here" is the ordinary, expected
+// outcome every `_sir_cas_walk_once`/`_sir_cas_replace_repeated` call
+// site handles by trying the next rule.
+func _sir_cas_apply_rule(ruleV Value, exprV Value) (Value, bool) {
+	rule := _sir_cas_as_term(ruleV)
+	if !_sir_cas_is_rule(rule) {
+		panic("sir-runtime-symbolic: applyRule expected a Rule/RuleDelayed term")
+	}
+	lhs := rule.Args[0]
+	rhs := rule.Args[1]
+	bindings, ok := _sir_cas_match_pattern(lhs, exprV, map[string]Value{})
+	if !ok {
+		return nil, false
+	}
+	return _sir_cas_substitute(rhs, bindings), true
+}
+
+// ── replaceAll / replaceRepeated (`/.` / `//.`) + depth guard ───────────
+
+// _sir_cas_walk_once implements `expr /. rules` — ONE pass, bottom-up: a
+// node's head/args are walked (and possibly replaced) before the node
+// itself is tried against `rules`; the first matching rule wins and the
+// freshly substituted replacement is NOT re-walked or retried at that
+// same position (Wolfram's single-pass `/.` contract, distinct from
+// `_sir_cas_replace_repeated`'s fixed point below). See the module-level
+// "DoS guard" doc above for why this panics directly on the depth cap
+// rather than returning a sentinel the way the Ruby/JS references do.
+func _sir_cas_walk_once(nodeV Value, rules []Value, depth int) Value {
+	if depth > sirCasMaxTermDepth {
+		panic(fmt.Sprintf("sir-runtime-symbolic: depth-limit (%d) exceeded during replaceAll", sirCasMaxTermDepth))
+	}
+	node := _sir_cas_as_term(nodeV)
+	current := Value(node)
+	if node.Kind == sirCasApply {
+		newHead := _sir_cas_walk_once(node.Head, rules, depth+1)
+		newArgs := make([]Value, len(node.Args))
+		for i, a := range node.Args {
+			newArgs[i] = _sir_cas_walk_once(a, rules, depth+1)
+		}
+		current = _sir_cas_apply(newHead, newArgs)
+	}
+	for _, r := range rules {
+		if replacement, ok := _sir_cas_apply_rule(r, current); ok {
+			return replacement
+		}
+	}
+	return current
+}
+
+func _sir_cas_replace_all(exprV Value, rules []Value) Value {
+	return _sir_cas_walk_once(exprV, rules, 0)
+}
+
+// _sir_cas_replace_repeated implements `expr //. rules` — a fixed
+// point: at each subtree, keep retrying `rules` until none fire
+// (re-walking any fresh replacement so its own sub-parts also converge)
+// before moving up to the parent. `maxIterations` is a GLOBAL cap shared
+// across the WHOLE walk (every firing anywhere in the tree increments
+// the SAME `counter`), guarding against a non-terminating rule set
+// (SIR23 spec "Matcher semantics" point 6).
+//
+// A rule firing loops in a plain Go `for` LOOP at the CURRENT call frame
+// (the `for { ... }` below), never a recursive call per firing — however
+// many times a rule fires at one tree position costs O(1) native stack
+// frames, not O(firings). `depth` only increases on a genuine descent
+// into `head`/`args` (the `walk(node.Head, depth+1)` / `walk(a,
+// depth+1)` calls), so `maxIterations` bounds iteration COUNT (CPU time)
+// only, never native recursion depth — the two caps are independent.
+//
+// `walk` is declared via the `var walk func(...)` forward-declaration
+// pattern (Go's idiom for a self-referential closure) specifically so it
+// can close over the shared `counter` — a top-level function would need
+// `counter` threaded through every call as an extra parameter (and
+// returned back out again), which is exactly the awkwardness a closure
+// avoids here.
+func _sir_cas_replace_repeated(exprV Value, rules []Value, maxIterations int) Value {
+	counter := 0
+	var walk func(nodeV Value, depth int) Value
+	walk = func(nodeV Value, depth int) Value {
+		if depth > sirCasMaxTermDepth {
+			panic(fmt.Sprintf("sir-runtime-symbolic: depth-limit (%d) exceeded during replaceRepeated", sirCasMaxTermDepth))
+		}
+		current := nodeV
+		for {
+			node := _sir_cas_as_term(current)
+			if node.Kind == sirCasApply {
+				newHead := walk(node.Head, depth+1)
+				newArgs := make([]Value, len(node.Args))
+				for i, a := range node.Args {
+					newArgs[i] = walk(a, depth+1)
+				}
+				current = _sir_cas_apply(newHead, newArgs)
+			}
+			fired := false
+			for _, r := range rules {
+				replacement, ok := _sir_cas_apply_rule(r, current)
+				if !ok || _sir_cas_term_equals(replacement, current, 0) {
+					continue
+				}
+				counter++
+				if counter > maxIterations {
+					panic(fmt.Sprintf("sir-runtime-symbolic: rewrite-cycle -- exceeded %d iterations", maxIterations))
+				}
+				current = replacement
+				fired = true
+				break
+			}
+			if !fired {
+				return current
+			}
+		}
+	}
+	return walk(exprV, 0)
+}
+
+// ── display ──────────────────────────────────────────────────────────
+
+// _sir_cas_to_s renders a term in generic `head(args, ...)` form — no
+// Wolfram infix/precedence pretty-printing (that is separate follow-up
+// work, out of this Tier A matcher port's scope, matching the Ruby
+// port's identical note). Depth-capped with the SAME `sirCasMaxTermDepth`
+// guard the tree-walking functions above use, for the identical reason:
+// a term built via `_sir_cas_apply` is not depth-capped at construction
+// time, so a runtime-built term can be arbitrarily deep — printing one
+// must degrade to `"..."` past the cap rather than overflow the Go
+// stack. Wired into `_sir_format_d` below so `print`/`puts`-equivalent
+// output can display a term directly — SIR22's own `*NDArray` has NO
+// display path (deliberately out of that slice's scope, per its own
+// tests reading scalar elements out via `IndexGet` instead), but this
+// slice's own reference tests (ported from the JS backend's already-
+// proven suite) print terms directly and assert on stdout, so a display
+// path is load-bearing here, not optional polish.
+func _sir_cas_to_s(v Value, depth int) string {
+	if depth > sirCasMaxTermDepth {
+		return "..."
+	}
+	node := _sir_cas_as_term(v)
+	switch node.Kind {
+	case sirCasSymbol:
+		return node.Name
+	case sirCasInteger:
+		return strconv.FormatInt(node.IntVal, 10)
+	case sirCasRational:
+		return strconv.FormatInt(node.Numer, 10) + "/" + strconv.FormatInt(node.Denom, 10)
+	case sirCasFloat:
+		return _sir_format_float(node.Float)
+	case sirCasString:
+		return strconv.Quote(node.Str)
+	case sirCasApply:
+		parts := make([]string, len(node.Args))
+		for i, a := range node.Args {
+			parts[i] = _sir_cas_to_s(a, depth+1)
+		}
+		return _sir_cas_to_s(node.Head, depth+1) + "(" + strings.Join(parts, ", ") + ")"
+	default:
+		return fmt.Sprintf("%v", node)
 	}
 }
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -5888,16 +5888,26 @@ func _sir_ndarray_catenate(av Value, bv Value) *NDArray {
 //
 // ## DoS guard (CWE-674): `panic` directly, not a sentinel value
 //
-// `_sir_cas_match_pattern`/`_sir_cas_substitute`/`_sir_cas_apply_rule`
-// recurse, but only as deep as a single RULE's own author-written
-// pattern/RHS shape — always shallow regardless of how deep the TARGET
-// expression is — so they carry NO depth cap of their own (this exact
-// reasoning is in the JS reference's own doc comments). `_sir_cas_walk_
-// once`/`_sir_cas_replace_repeated`, by contrast, walk the ENTIRE target
-// expression tree, which ordinary compiled-program data (e.g. a runtime
-// loop nesting `Wrap(Wrap(...))` `sirCasMaxTermDepth` levels deep) CAN
-// build to unbounded depth — so THOSE two need an explicit cap, mirroring
-// the JS reference's `MAX_TERM_DEPTH = 512` exactly.
+// The JS/Ruby references leave `matchPattern`/`substituteTerm`/
+// `applyRuleTerm` UNCAPPED, reasoning that they recurse only as deep as
+// a single RULE's own author-written pattern/RHS shape — always shallow
+// regardless of how deep the TARGET expression is. That reasoning
+// describes the recursion MECHANICS correctly, but this port does NOT
+// rely on it: nothing in this IR actually restricts a `SymRule`'s
+// `lhs`/`rhs` to a small, source-authored shape — `emit_sym_operand`
+// passes any `Expr` through unchanged (including a `VarRef` to a local
+// holding a runtime-constructed term), so a compiled program CAN bind
+// an arbitrarily deep term as a rule's `lhs`/`rhs`. A caught security
+// review (see this crate's PR history) confirmed that gap, so `_sir_
+// cas_match_pattern`/`_sir_cas_substitute` below DO thread and cap
+// `depth` — the SAME `sirCasMaxTermDepth` guard the tree-walk functions
+// use — even though a well-behaved rule never approaches it.
+// `_sir_cas_walk_once`/`_sir_cas_replace_repeated` separately walk the
+// ENTIRE target expression tree, which ordinary compiled-program data
+// (e.g. a runtime loop nesting `Wrap(Wrap(...))` `sirCasMaxTermDepth`
+// levels deep) CAN build to unbounded depth — so they need the identical
+// cap for their own, independent reason, mirroring the JS reference's
+// `MAX_TERM_DEPTH = 512` exactly.
 //
 // Unlike the Ruby/JS references (which return a sentinel "depth-limit"/
 // "rewrite-cycle" value threaded back up through every recursive return,
@@ -5924,12 +5934,14 @@ func _sir_ndarray_catenate(av Value, bv Value) *NDArray {
 // recursive call per firing, so it costs O(1) native stack frames
 // regardless of how many times it fires before hitting the cap.
 
-// sirCasMaxTermDepth caps every SIR23 tree WALK (replaceAll's single
-// pass, replaceRepeated's fixed-point loop, term-equality, and display) —
-// NOT the matcher functions (`_sir_cas_match_pattern`/`_sir_cas_
-// substitute`/`_sir_cas_apply_rule`), which recurse only as deep as one
-// rule's own shape and need no cap. Matches the JS/Ruby references'
-// `MAX_TERM_DEPTH = 512` exactly.
+// sirCasMaxTermDepth caps every SIR23 recursive tree traversal: the two
+// tree WALKS (replaceAll's single pass, replaceRepeated's fixed-point
+// loop), term-equality, display, AND (unlike the JS/Ruby references —
+// see the "DoS guard" doc above for why this port diverges) the matcher
+// functions `_sir_cas_match_pattern`/`_sir_cas_substitute` too, since
+// this IR does not itself bound a rule's `lhs`/`rhs` shape. Matches the
+// JS/Ruby references' `MAX_TERM_DEPTH = 512` VALUE exactly, even though
+// this port applies it more broadly than they do.
 const sirCasMaxTermDepth = 512
 
 // sirCasMaxIterationsDefault is `_sir_cas_replace_repeated`'s default
@@ -6025,9 +6037,25 @@ func _sir_cas_gcd_abs(a int64, b int64) int64 {
 // time, mirroring the Ruby/JS references exactly — a term's `Numer`/
 // `Denom` fields are always already in lowest terms; nothing downstream
 // (matching, equality, display) re-reduces.
+//
+// SECURITY (CWE-190): `math.MinInt64` is rejected up front, BEFORE any
+// sign-normalizing negation or `_sir_cas_gcd_abs` call. Two's-complement
+// negation of the minimum `int64` wraps back to itself (`-MinInt64 ==
+// MinInt64`, still negative) — undetected, this would silently corrupt
+// a rational's sign (`_sir_cas_gcd_abs`'s own `a = -a`/`b = -b` have the
+// identical wraparound), producing a term whose `Denom` field can end up
+// negative, violating this struct's own documented "always positive"
+// invariant with no panic or visible error — exactly the kind of silent
+// corruption this domain's "types carry, don't verify" discipline
+// otherwise avoids. Reachable directly from a source-level `SymRational
+// { numer: i64::MIN, .. }` (or `denom: i64::MIN`) literal, which
+// `emit.rs` emits verbatim as a Go literal argument here.
 func _sir_cas_rational(numer int64, denom int64) *SirCasTerm {
 	if denom == 0 {
 		panic("sir-runtime-symbolic: rational denominator cannot be zero")
+	}
+	if numer == math.MinInt64 || denom == math.MinInt64 {
+		panic("sir-runtime-symbolic: rational numerator/denominator cannot be math.MinInt64 (negation would overflow)")
 	}
 	if denom < 0 {
 		numer = -numer
@@ -6265,11 +6293,32 @@ func _sir_cas_effective_head_name(node *SirCasTerm) string {
 //
 // `Blank()`, `Blank(T)`, `Pattern(name, inner)`, compound-vs-compound
 // (recurse head + every arg, same arity required), and plain structural
-// equality — a direct port of `cas-pattern-matching::matchPattern`. NOT
-// depth-capped (see the module-level "DoS guard" doc above): recursion
-// here tracks the SHAPE of one rule's own author-written `lhs`, never the
-// target expression's own depth.
-func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]Value) (map[string]Value, bool) {
+// equality — a direct port of `cas-pattern-matching::matchPattern`.
+//
+// SECURITY (CWE-674): the JS/Ruby references leave this recursion
+// UNCAPPED, reasoning that it tracks the SHAPE of one rule's own
+// author-written `lhs`, never the target expression's own depth — true
+// of recursion MECHANICS, but this IR does not actually enforce that a
+// `SymRule`'s `lhs` is small or author-written: `emit_sym_operand`
+// passes any `Expr` through unchanged (including a `VarRef` to a local
+// holding a runtime-constructed term — exactly what this port's own
+// `depth_limit_guard_panics_instead_of_crashing_the_go_stack` test
+// builds via a compiled loop), and `validator.rs`'s `Expr::SymRule` arm
+// applies no shape/depth restriction of its own. So a compiled program
+// CAN bind an arbitrarily deep runtime-built term as a rule's `lhs` (or
+// `rhs`, for `_sir_cas_substitute` below) and this matcher would recurse
+// to match it — a plain Go stack overflow past ~1M frames is a FATAL,
+// unrecoverable error (unlike this runtime's deliberate `panic()`
+// calls, `recover()` cannot catch it), which would defeat every other
+// guard in this file. This port therefore diverges from the JS/Ruby
+// references here: `_sir_cas_match_pattern` (and `_sir_cas_substitute`
+// below) DO thread and cap `depth` against `sirCasMaxTermDepth`, exactly
+// like the tree-walk functions, even though a well-behaved rule never
+// approaches the cap.
+func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]Value, depth int) (map[string]Value, bool) {
+	if depth > sirCasMaxTermDepth {
+		panic(fmt.Sprintf("sir-runtime-symbolic: depth-limit (%d) exceeded during pattern matching", sirCasMaxTermDepth))
+	}
 	pattern := _sir_cas_as_term(patternV)
 	if _sir_cas_is_blank(pattern) {
 		constraint, has := _sir_cas_blank_head_constraint(pattern)
@@ -6284,7 +6333,7 @@ func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]V
 	if _sir_cas_is_pattern(pattern) {
 		name := _sir_cas_pattern_name(pattern)
 		inner := _sir_cas_pattern_inner(pattern)
-		matched, ok := _sir_cas_match_pattern(inner, targetV, bindings)
+		matched, ok := _sir_cas_match_pattern(inner, targetV, bindings, depth+1)
 		if !ok {
 			return nil, false
 		}
@@ -6301,7 +6350,7 @@ func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]V
 		if target.Kind != sirCasApply {
 			return nil, false
 		}
-		current, ok := _sir_cas_match_pattern(pattern.Head, target.Head, bindings)
+		current, ok := _sir_cas_match_pattern(pattern.Head, target.Head, bindings, depth+1)
 		if !ok {
 			return nil, false
 		}
@@ -6309,7 +6358,7 @@ func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]V
 			return nil, false
 		}
 		for i, p := range pattern.Args {
-			current, ok = _sir_cas_match_pattern(p, target.Args[i], current)
+			current, ok = _sir_cas_match_pattern(p, target.Args[i], current, depth+1)
 			if !ok {
 				return nil, false
 			}
@@ -6326,9 +6375,15 @@ func _sir_cas_match_pattern(patternV Value, targetV Value, bindings map[string]V
 // bound in `bindings` with its captured term, leaving an UNBOUND pattern
 // variable as-is (mirrors the Ruby/JS references — a `RuleDelayed` RHS
 // that mentions a name the LHS never bound is a rule-authoring bug, not
-// a runtime error here). NOT depth-capped, for the same reason `_sir_
-// cas_match_pattern` is not: recursion tracks one rule's own RHS shape.
-func _sir_cas_substitute(templateV Value, bindings map[string]Value) Value {
+// a runtime error here). Depth-capped for the SAME reason `_sir_cas_
+// match_pattern` above now is: a `SymRule`'s `rhs` is equally unrestricted
+// by this IR, so a runtime-built deep term substituted in via a bound
+// pattern variable — or used directly as `rhs` — must not recurse
+// unboundedly either.
+func _sir_cas_substitute(templateV Value, bindings map[string]Value, depth int) Value {
+	if depth > sirCasMaxTermDepth {
+		panic(fmt.Sprintf("sir-runtime-symbolic: depth-limit (%d) exceeded during substitution", sirCasMaxTermDepth))
+	}
 	template := _sir_cas_as_term(templateV)
 	if _sir_cas_is_pattern(template) {
 		if captured, ok := bindings[_sir_cas_pattern_name(template)]; ok {
@@ -6339,9 +6394,9 @@ func _sir_cas_substitute(templateV Value, bindings map[string]Value) Value {
 	if template.Kind == sirCasApply {
 		newArgs := make([]Value, len(template.Args))
 		for i, a := range template.Args {
-			newArgs[i] = _sir_cas_substitute(a, bindings)
+			newArgs[i] = _sir_cas_substitute(a, bindings, depth+1)
 		}
-		return _sir_cas_apply(_sir_cas_substitute(template.Head, bindings), newArgs)
+		return _sir_cas_apply(_sir_cas_substitute(template.Head, bindings, depth+1), newArgs)
 	}
 	return template
 }
@@ -6351,7 +6406,11 @@ func _sir_cas_substitute(templateV Value, bindings map[string]Value) Value {
 // true)`. Returns `(nil, false)` — never a panic — on a non-matching
 // `expr`, since "this rule doesn't apply here" is the ordinary, expected
 // outcome every `_sir_cas_walk_once`/`_sir_cas_replace_repeated` call
-// site handles by trying the next rule.
+// site handles by trying the next rule. Seeds both `_sir_cas_match_
+// pattern`/`_sir_cas_substitute` with `depth: 0` — each is a FRESH
+// bounded walk of that rule's own `lhs`/`rhs`, independent of how deep
+// the surrounding `_sir_cas_walk_once`/`_sir_cas_replace_repeated` tree
+// walk that invoked this rule already is.
 func _sir_cas_apply_rule(ruleV Value, exprV Value) (Value, bool) {
 	rule := _sir_cas_as_term(ruleV)
 	if !_sir_cas_is_rule(rule) {
@@ -6359,11 +6418,11 @@ func _sir_cas_apply_rule(ruleV Value, exprV Value) (Value, bool) {
 	}
 	lhs := rule.Args[0]
 	rhs := rule.Args[1]
-	bindings, ok := _sir_cas_match_pattern(lhs, exprV, map[string]Value{})
+	bindings, ok := _sir_cas_match_pattern(lhs, exprV, map[string]Value{}, 0)
 	if !ok {
 		return nil, false
 	}
-	return _sir_cas_substitute(rhs, bindings), true
+	return _sir_cas_substitute(rhs, bindings, 0), true
 }
 
 // ── replaceAll / replaceRepeated (`/.` / `//.`) + depth guard ───────────

--- a/code/packages/rust/semantic-ir-to-go/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/sir23_symbolic.rs
@@ -1,0 +1,278 @@
+//! SIR23 execution proof, Tier A pattern matcher (Phase A Slice 4):
+//! `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+//! `SymPatternNamed`/`SymRule`/`SymReplaceAll` on the Go backend —
+//! hand-builds a module calling each node directly (bypassing the
+//! frontend, since no frontend targets this backend for SIR23 yet), emits
+//! Go, runs it with a real `go run`, and asserts stdout. Mirrors
+//! `sir22_array.rs`'s pattern; skips (does not fail) when no `go` is on
+//! `PATH`.
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir23_symbolic.rs` (cross-checked against the sibling Ruby
+//! backend's own port on `sir23-ruby-matcher`) — Tier A cases only
+//! (`replace_repeated`, `replace_all`, typed-blank matching, the
+//! depth-limit and rewrite-cycle DoS guards). The JS reference's
+//! remaining tests (`assign`/`define`/`if`/elementary-function/
+//! differentiation cases) all exercise `evalTerm` — Tier B, explicitly
+//! out of scope for this slice — so they have no analogue here.
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol { name: name.into(), span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn sym_apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply { head: Box::new(head), args, span: s() }
+}
+fn blank() -> Expr {
+    Expr::SymPatternBlank { head: None, span: s() }
+}
+fn blank_typed(head: &str) -> Expr {
+    Expr::SymPatternBlank { head: Some(Box::new(sym(head))), span: s() }
+}
+fn named(name: &str, pattern: Expr) -> Expr {
+    Expr::SymPatternNamed { name: name.into(), pattern: Box::new(pattern), span: s() }
+}
+fn rule(lhs: Expr, rhs: Expr, delayed: bool) -> Expr {
+    Expr::SymRule { lhs: Box::new(lhs), rhs: Box::new(rhs), delayed, span: s() }
+}
+fn replace_all(expr: Expr, rules: Vec<Expr>, repeated: bool) -> Expr {
+    Expr::SymReplaceAll { expr: Box::new(expr), rules, repeated, span: s() }
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+
+const SYMBOLIC_FEATURES: &[Feature] =
+    &[Feature::SymbolicExpr, Feature::PatternMatching, Feature::Rationals];
+
+fn symbolic_module(stmts: Vec<Stmt>) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings];
+    features.extend_from_slice(SYMBOLIC_FEATURES);
+    Module {
+        name: "sir23symbolic".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    std::process::Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile, write to a unique temp file, `go run` it, return stdout, or
+/// `None` to skip when no `go` is on `PATH`. Unique temp-file names per
+/// call (PID + a monotonic counter) — see `sir22_array.rs::run`'s
+/// identical rationale (avoids a same-path race between concurrently
+/// running `cargo test` threads).
+fn run_symbolic_program(m: &Module) -> Option<String> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    if !go_available() {
+        return None;
+    }
+    let source = compile(m).expect("go emit").source;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!(
+        "sir_go_symbolic_{}_{}.go",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&path, &source).expect("write temp source");
+    let out = std::process::Command::new("go")
+        .arg("run")
+        .arg(&path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        out.status.success(),
+        "emitted go exited non-zero:\n{}\n--- source ---\n{source}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    Some(String::from_utf8_lossy(&out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn replace_repeated_reduces_nested_add_zero_to_bare_symbol() {
+    // Rule: x_ + 0 -> x_ (Wolfram `x_ + 0 :> x_`, held as `RuleDelayed`
+    // here so the RHS is exactly the same pattern-bound `x_` node).
+    let x_pat = named("x", blank());
+    let r = rule(sym_apply(sym("Add"), vec![x_pat.clone(), ilit(0)]), x_pat, true);
+
+    // expr: Add(Add(z, 0), 0) — both `+ 0`s should fire, to a fixed point.
+    let inner = sym_apply(sym("Add"), vec![sym("z"), ilit(0)]);
+    let expr = sym_apply(sym("Add"), vec![inner, ilit(0)]);
+
+    let m = symbolic_module(vec![print_stmt(replace_all(expr, vec![r], true))]);
+    if let Some(stdout) = run_symbolic_program(&m) {
+        assert_eq!(stdout.trim_end(), "z");
+    } else {
+        eprintln!("skip: no go on PATH");
+    }
+}
+
+#[test]
+fn replace_all_single_pass_does_not_retry_at_same_position() {
+    // `/.` (single pass): a -> b applied to Pair(a, a) fires once at EACH
+    // occurrence of `a` (bottom-up, one visit per node), not repeatedly.
+    let r = rule(sym("a"), sym("b"), false);
+    let expr = sym_apply(sym("Pair"), vec![sym("a"), sym("a")]);
+    let m = symbolic_module(vec![print_stmt(replace_all(expr, vec![r], false))]);
+    if let Some(stdout) = run_symbolic_program(&m) {
+        assert_eq!(stdout.trim_end(), "Pair(b, b)");
+    } else {
+        eprintln!("skip: no go on PATH");
+    }
+}
+
+#[test]
+fn typed_blank_matches_only_constrained_head() {
+    // f(x_Integer) -> x_ matched against f(5) and f(z): only the
+    // Integer-headed argument matches; the Symbol one is left unchanged
+    // by replaceAll's "no match, no rewrite" fallthrough.
+    let x_pat = named("x", blank_typed("Integer"));
+    let r = rule(sym_apply(sym("f"), vec![x_pat.clone()]), x_pat, false);
+    let e_int_term = sym_apply(sym("f"), vec![ilit(5)]);
+    let e_sym_term = sym_apply(sym("f"), vec![sym("z")]);
+    let m = symbolic_module(vec![
+        print_stmt(replace_all(e_int_term, vec![r.clone()], false)),
+        print_stmt(replace_all(e_sym_term, vec![r], false)),
+    ]);
+    if let Some(stdout) = run_symbolic_program(&m) {
+        let lines: Vec<&str> = stdout.trim_end().lines().collect();
+        assert_eq!(lines, vec!["5", "f(z)"]);
+    } else {
+        eprintln!("skip: no go on PATH");
+    }
+}
+
+#[test]
+fn a_rational_term_prints_reduced() {
+    // _sir_cas_rational reduces numer/denom by their gcd at construction
+    // time, mirroring the JS/Ruby references — 6/8 must print as "3/4".
+    let r = Expr::SymRational { numer: 6, denom: 8, span: s() };
+    let m = symbolic_module(vec![print_stmt(r)]);
+    if let Some(stdout) = run_symbolic_program(&m) {
+        assert_eq!(stdout.trim_end(), "3/4");
+    } else {
+        eprintln!("skip: no go on PATH");
+    }
+}
+
+#[test]
+fn depth_limit_guard_panics_instead_of_crashing_the_go_stack() {
+    // A runtime-built term nested past sirCasMaxTermDepth (512) must
+    // cause a clean, catchable `panic` from `_sir_cas_walk_once`, not
+    // overflow the native Go stack. Built via a REAL compiled `for`-loop
+    // in the emitted program (600 runtime firings of `Wrap(acc)`, not a
+    // hand-built 600-node static AST — mirrors the JS reference's own
+    // deep-term test and the Ruby port's identical construction), then
+    // run through `replaceAll` with an empty rule set (no rule ever
+    // fires, so every level of the walk is exercised).
+    let stmts = vec![
+        let_binding("acc", sym("leaf")),
+        Stmt::ForRange {
+            var: "i".into(),
+            start: ilit(0),
+            stop: ilit(600),
+            step: ilit(1),
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "acc".into(),
+                    scope: Scope::Local,
+                    value: sym_apply(sym("Wrap"), vec![local("acc")]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        },
+        print_stmt(replace_all(local("acc"), vec![], false)),
+    ];
+    let mut m = symbolic_module(stmts);
+    let mut features: Vec<Feature> = SYMBOLIC_FEATURES.to_vec();
+    features.extend_from_slice(&[
+        Feature::ConsoleIO,
+        Feature::Strings,
+        Feature::Loops,
+        Feature::MutableBindings,
+    ]);
+    m.manifest = FeatureManifest::from_features(&features);
+
+    if !go_available() {
+        eprintln!("skip: no go on PATH");
+        return;
+    }
+    let source = compile(&m).expect("go emit").source;
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("sir_go_symbolic_depth_{}.go", std::process::id()));
+    std::fs::write(&path, &source).expect("write temp source");
+    let out = std::process::Command::new("go")
+        .arg("run")
+        .arg(&path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !out.status.success(),
+        "expected a non-zero exit from the depth-limit panic, got success:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("sir-runtime-symbolic: depth-limit"),
+        "expected a depth-limit panic message, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Part of the SIR22/SIR23 backend-expansion initiative (task #33, Phase A Slice 4). Implements SIR23's **Tier A pattern matcher** on the Go backend: `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`. One of five parallel per-backend PRs for this rollout (Ruby merged first as the working precedent, PR #12128; C/Rust/Python are sibling PRs).

- New `_sir_cas_*` runtime functions + `*SirCasTerm` type in `runtime.rs`, ported from `semantic-ir-to-javascript`'s already-proven `Symbolic` sub-runtime's Tier A slice — term construction, `matchPattern`/`substituteTerm`/`applyRuleTerm`, and `replaceAll`/`replaceRepeated` with their depth/iteration guards.
- **Tier B (`evalTerm` — arithmetic/calculus/user-function evaluation) is explicitly out of scope**, matching the SIR23 spec's own Tier A/Tier B split — a `SymApply` here builds an inert term tree only.
- **Naming**: `_sir_cas_*` / `SirCasTerm`, not `_sir_sym_*` — checked first and found this backend already owns `_sir_sym_*` for Ruby `Symbol#to_proc`/`Symbol`-method dispatch (`_sir_sym_to_proc`, `_sir_symbol_*`), the same class of landmine Slice 2 hit with `_sir_array_*` (forced the rename to `_sir_ndarray_*`).
- **Value model**: `*SirCasTerm`, one kind-discriminated Go struct, mirroring this backend's own established SIR22 `*NDArray` pattern rather than one Go type per kind.
- **Bindings**: copy-on-write via manual full-copy-plus-insert (no persistent-map library exists in this repo's Go-facing dependency graph).
- New `Feature::SymbolicExpr`/`Feature::PatternMatching`/`Feature::Rationals` acceptance in `lib.rs`.
- New `emit.rs` arms for the 7 node kinds, replacing the combined deferred-node `panic!` arm, plus an `emit_sym_operand` helper (mirrors Ruby/JS/TS) wrapping bare literal operands through the matching leaf-term constructor.
- A minimal `_sir_cas_to_s` display helper wired into `_sir_format_d` so `print`/`puts`-equivalent output can render a term via the generic `head(args, ...)` form (SIR22's own `*NDArray` deliberately has no display path, but this slice's own reference tests print terms directly and assert on stdout).

**DoS guards (CWE-674)**: `sirCasMaxTermDepth = 512` caps every recursive tree traversal — the two tree walks (`replaceAll`/`replaceRepeated`), term equality, display, **and** (a deliberate divergence from the JS/Ruby references, caught by security review — see below) the matcher functions `_sir_cas_match_pattern`/`_sir_cas_substitute`, since this IR does not itself bound a rule's `lhs`/`rhs` shape. `replaceRepeated` also enforces a separate, global `sirCasMaxIterationsDefault = 100` fixed-point iteration cap via a plain `for` loop (not recursion) at each call frame, so a rule firing repeatedly at one tree position costs O(1) native stack frames. Both caps `panic` directly with a formatted message the instant they're exceeded, matching this backend's own established `_sir_ndarray_checked_shape_size` convention (Go's `panic`/`recover` already gives a clean, catchable unwind — the compiled `TryCatch` rescue recovers any panic value, not just `*SirError`).

## Security review

Two rounds. Round 1 found and both were fixed:
- **HIGH**: `_sir_cas_match_pattern`/`_sir_cas_substitute` had no depth cap, on the (unenforced-by-this-IR) assumption that a rule's `lhs`/`rhs` is always small and author-written — a runtime-built deep term bound to a local and used as a rule's `lhs`/`rhs` could drive an unrecoverable Go stack overflow. Fixed by threading a `depth` parameter through both, capped at `sirCasMaxTermDepth`.
- **MEDIUM**: `_sir_cas_gcd_abs`/`_sir_cas_rational`'s sign-normalizing negation silently overflowed on `math.MinInt64`, which could corrupt a rational term's `Denom` sign invariant with no error. Fixed by rejecting `math.MinInt64` explicitly before any negation.

Round 2 confirmed both fixes correct and complete, and found nothing further: "SECURITY REVIEW PASSED — no vulnerabilities found."

## Test plan

- [x] `cargo test` — 28 test binaries, all green (including 5 new tests in `tests/sir23_symbolic.rs`, all executing under a real `go run`, not skipped)
- [x] `cargo clippy --all-targets` — clean
- [x] New tests prove `//.`'s fixed-point behavior, `/.`'s single-pass behavior, typed-blank head-constraint matching, rational reduction, and the depth-limit guard (verified against a **real runtime-built** 600-level-deep term via a compiled `Stmt::ForRange` loop, not a hand-built static AST — the emitted Go program must `panic` cleanly instead of crashing)
- [x] Downstream consumers (`sir-conformance`, `sir-bench`) build clean against the version bump (0.41.0 → 0.42.0)
- [x] `/security-review` — 2 rounds, passed with no remaining findings after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)