### PR TITLE
feat(semantic-ir-to-rust): implement SIR23 Tier A pattern matcher (Phase A Slice 4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## 0.44.0 — SIR23 Tier A pattern matcher (Phase A Slice 4)
+
+Part of the SIR22/SIR23 backend-expansion initiative — one of 5 parallel,
+independent backend PRs for this slice (C, Go, Python, Ruby, Rust). This
+backend now implements SIR23's Tier A pattern matcher:
+`SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/`SymPatternNamed`/
+`SymRule`/`SymReplaceAll`, gated on three new feature flags —
+`Feature::SymbolicExpr`, `Feature::PatternMatching`, and `Feature::
+Rationals` (already existed in `semantic_ir::Feature`, shared with the
+SIR22 array/matrix domain rather than owned by SIR23). Tier B (the
+`evalTerm` arithmetic/calculus/user-function evaluator) is explicitly OUT
+OF SCOPE — a `SymApply` builds an inert term tree, nothing more; no
+`Add`/`Sin`/`D`/... folding exists here.
+
+**Value model** (`runtime.rs`, new "SIR23 symbolic expressions + pattern/
+rewrite" section, inserted at the end of `mod __sir`): a new
+`Value::SymTerm(Rc<SirSymTerm>)` variant, following the SAME shared-
+mutable-handle pattern SIR16's `Value::Seq`/`Value::Map` and SIR22's
+`Value::NDArray` already establish for this backend — except a term is
+*never* mutated in place once built (SIR23 adds no mutation statement at
+all), so plain `Rc` suffices with no `RefCell`. `SirSymTerm` is a genuine
+Rust `enum` (`Symbol`/`Integer`/`Rational`/`Float`/`Str`/`Apply`), not a
+transliteration of the JS/Ruby ports' `{kind, ...}` object / `Struct` with
+unused fields — this gets exhaustiveness checking for free from `rustc`.
+Adding the variant required new arms in this backend's two other
+exhaustive `Value` matches (`format_d`, `ruby_class_name`) — the same two
+sites the `Value::Instance` variant's own doc comment already flagged as
+"the" exhaustive sites to update, confirmed by compiling the runtime text
+standalone via `rustc --crate-type lib` before wiring it into the emitter
+(Slice 2's own Rust PR caught 2 missing exhaustive-match arms this way;
+repeated here).
+
+**New runtime functions**: term constructors `sir_sym_symbol`/
+`sir_sym_int`/`sir_sym_rational`/`sir_sym_float`/`sir_sym_string`/
+`sir_sym_apply`; pattern/rule vocabulary `sir_sym_blank`/
+`sir_sym_blank_typed`/`sir_sym_named`/`sir_sym_rule`/
+`sir_sym_rule_delayed`; the matcher itself `sir_sym_match_pattern`/
+`sir_sym_substitute`/`sir_sym_apply_rule`; and `sir_sym_replace_all`/
+`sir_sym_replace_repeated`. **DoS guards (CWE-674)**: `SIR_SYM_MAX_TERM_
+DEPTH = 512` guards `replace_all`'s single-pass and `replace_repeated`'s
+fixed-point tree WALK only — never the matcher functions themselves,
+which recurse only as deep as a single rule's own author-written shape.
+`replace_repeated` also enforces a separate `SIR_SYM_MAX_REWRITE_
+ITERATIONS = 100` cap on total rule firings across the whole call,
+implemented as an iterative Rust `loop {}` at the firing site (never a
+recursive call per firing), so a rule refiring repeatedly at ONE tree
+position costs O(1) native stack frames. Both caps signal failure by
+calling into THIS backend's existing SIR17 exception convention
+(`raise("RuntimeError", …)`, the same `std::panic::panic_any` +
+`catch_unwind` mechanism `array_raise` already uses) rather than the JS/
+Ruby ports' own sentinel-object-threaded-through-every-return-path
+plumbing — Rust's own unwinding panic already propagates a raised error
+through every intermediate stack frame automatically, so no
+`sir_sym_unwrap`-equivalent boundary function is needed here. A minimal
+`sir_sym_to_s` display helper (wired into `format_d`) lets `print`/`puts`
+render a term via the generic `head(args, ...)` form, independently
+depth-capped (a term is not capped at CONSTRUCTION time, only at WALK
+time) — the Derive-specific precedence-aware pretty-printer (SIR23
+addendum item 4) is separate follow-up work, not part of this port.
+
+**New `emit.rs` arms**: the seven node kinds each lower to a call into
+their matching `sir_sym_*` helper, plus a new `emit_sym_operand` helper
+(mirrors the JS/Ruby backends' identically-named function) that wraps a
+bare `IntLit`/`FloatLit`/`StrLit` operand through the matching leaf-term
+constructor before it can sit inside a term tree. Also fixes a
+`collect_expr_assigned` no-op-recursion gap for these seven nodes (the
+same shape of gap Slice 3 found and fixed for the nine SIR22 addendum
+nodes): `SymApply.args`, `SymPatternBlank.head`, `SymPatternNamed.
+pattern`, `SymRule.lhs`/`.rhs`, and `SymReplaceAll.expr`/`.rules` are all
+ordinary `Expr` operand slots that CAN legitimately nest an `Assign`, so
+they now recurse for real instead of silently doing nothing.
+
+**New tests**: `tests/sir23_symbolic.rs` — 5 real-`rustc`-compile-and-run
+tests (ported from `semantic-ir-to-javascript`'s own `tests/
+sir23_symbolic.rs`, Tier A cases only, cross-checked against `semantic-
+ir-to-ruby`'s own port) proving `//.`'s fixed-point behavior, `/.`'s
+single-pass behavior, typed-blank head-constraint matching, rational
+reduction at construction time, and the depth-limit guard — the last
+built via a REAL compiled `for`-loop (600 runtime firings of
+`Wrap(acc)`), not a hand-built static AST, asserting the emitted binary
+exits non-zero with a readable `RuntimeError: sir-runtime-symbolic:
+depth-limit` on stderr rather than overflowing the native stack.
+
 ## 0.43.0 — SIR22 "APL addendum" (Phase A Slice 3, second-wave backend rollout)
 
 Implements the 9-node SIR22 "APL addendum" this backend deferred in Slice 2:

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -323,6 +323,30 @@ surface-syntax exception documented on `array_index_generator`/
 `array_index_of` in `runtime.rs`. See
 [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
 
+**`SymbolicExpr` / `PatternMatching` / `Rationals`** (SIR23 symbolic-
+expression/pattern-matcher domain, Tier A only, Phase A Slice 4):
+`Expr::SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+`SymPatternNamed`/`SymRule`/`SymReplaceAll` route into a new
+`__sir::sir_sym_*` sub-runtime — an inlined port of `semantic-ir-to-
+javascript`'s already-proven `Symbolic` sub-runtime's Tier A (matcher)
+slice: term construction, `matchPattern`/`substituteTerm`/`applyRuleTerm`,
+and `replaceAll`/`replaceRepeated`. **Tier A only** — no `evalTerm`-
+equivalent arithmetic/calculus/user-function-dispatch evaluator exists; a
+`SymApply` builds an inert `head(args…)` term tree, nothing more.
+`Rationals` is not a new flag this slice introduces — it already exists in
+`semantic_ir::Feature`, shared with the SIR22 array/matrix domain, and
+`SymRational` observes it.
+A new `Value::SymTerm(Rc<SirSymTerm>)` handle carries a term — plain `Rc`,
+no `RefCell`, since SIR23 adds no in-place mutation statement (every
+matcher/substitution helper produces a fresh term). Both tree-WALK
+functions (`sir_sym_replace_all`'s single pass, `sir_sym_replace_repeated`'s
+fixed point) are depth-capped at `SIR_SYM_MAX_TERM_DEPTH = 512`
+(CWE-674); `replace_repeated` additionally caps total rule firings across
+one call at `SIR_SYM_MAX_REWRITE_ITERATIONS = 100`, looping iteratively so
+a rule refiring at one tree position costs O(1) stack frames. Both caps
+`raise` through this backend's existing SIR17 exception convention. See
+[SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md).
+
 Rejects: `TailCalls` (Rust does not guarantee TCO), `Intrinsics`
 (empty whitelist in v0), `StringInterpolation`, a stateful (non-empty
 body) `Class`/`Module` or a non-name-slot `Const` reference (rejected
@@ -342,9 +366,19 @@ enum Value {
     Map(Rc<RefCell<Vec<(Value, Value)>>>),   // SIR16 Maps (insertion-ordered)
     Instance(u64),                           // SIR17 O5 user-object handle
     NDArray(Rc<RefCell<SirNDArray>>),        // SIR22 array/matrix base cut
+    SymTerm(Rc<SirSymTerm>),                 // SIR23 symbolic-expression term (Tier A)
 }
 
 struct SirNDArray { shape: Vec<usize>, data: Vec<f64> }  // rank <= 2, column-major
+
+enum SirSymTerm {                            // immutable — no RefCell needed
+    Symbol { name: String },
+    Integer { value: i64 },
+    Rational { numer: i64, denom: i64 },     // always reduced
+    Float { value: f64 },
+    Str { value: String },
+    Apply { head: Rc<SirSymTerm>, args: Vec<Rc<SirSymTerm>> },
+}
 ```
 
 - Single-threaded (`Rc`, not `Arc`).

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -593,16 +593,41 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
         Expr::Convert { .. } => {}
-        // SIR23 symbolic-expression/pattern nodes: same rationale as the
-        // SIR22 nodes above — rejected before emit, so none of these carry
-        // a reachable `Assign` for this backend.
-        Expr::SymSymbol { .. }
-        | Expr::SymRational { .. }
-        | Expr::SymApply { .. }
-        | Expr::SymPatternBlank { .. }
-        | Expr::SymPatternNamed { .. }
-        | Expr::SymRule { .. }
-        | Expr::SymReplaceAll { .. } => {}
+        // SIR23 symbolic-expression/pattern nodes (Tier A, Phase A Slice 4):
+        // now ACCEPTED (see `ACCEPTED_FEATURES` in lib.rs and the real
+        // codegen arms in `emit_expr` below), so — unlike the stale "rejected
+        // before emit" comment this replaces — each of these CAN legitimately
+        // nest an `Assign` the same as any other operand position (e.g. a
+        // `SymApply` arg, or a `SymReplaceAll`'s `expr`, is an ordinary
+        // `Expr` slot; a validated module may put anything expression-shaped
+        // there, exactly as `ArrayLit`'s `rows` elements can). Real recursion
+        // now, mirroring the SIR22 (base cut + addendum) arms just above —
+        // this is the same "no-op recursion gap" Slice 3 found and fixed for
+        // the nine SIR22 addendum nodes.
+        Expr::SymSymbol { .. } => {}
+        Expr::SymRational { .. } => {}
+        Expr::SymApply { head, args, .. } => {
+            collect_expr_assigned(head, out);
+            for a in args {
+                collect_expr_assigned(a, out);
+            }
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            if let Some(head) = head {
+                collect_expr_assigned(head, out);
+            }
+        }
+        Expr::SymPatternNamed { pattern, .. } => collect_expr_assigned(pattern, out),
+        Expr::SymRule { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            collect_expr_assigned(expr, out);
+            for r in rules {
+                collect_expr_assigned(r, out);
+            }
+        }
     }
 }
 
@@ -1364,23 +1389,82 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 span
             );
         }
-        // SIR23 symbolic-expression/pattern nodes — `Feature::SymbolicExpr` /
-        // `Feature::PatternMatching` are not in this backend's accepted-
-        // features list, so `check_module` rejects any module using them
-        // before it ever reaches emit.  Defensive panic covers internal
-        // bugs only (matches the SIR22/SIR26 arm above).
-        Expr::SymSymbol { span, .. }
-        | Expr::SymRational { span, .. }
-        | Expr::SymApply { span, .. }
-        | Expr::SymPatternBlank { span, .. }
-        | Expr::SymPatternNamed { span, .. }
-        | Expr::SymRule { span, .. }
-        | Expr::SymReplaceAll { span, .. } => {
-            panic!(
-                "rust backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
-                e.kind_name(),
-                span
-            );
+        // ── SIR23: symbolic expression + pattern/rewrite (Tier A, Phase A
+        // Slice 4) ──────────────────────────────────────────────────────
+        // Mirrors the JS/Ruby backends' SIR23 arms, but calls into the
+        // INLINED `__sir::sir_sym_*` runtime (runtime.rs) rather than an
+        // imported package — this backend's existing "self-contained, no
+        // external crate" convention (same as `array_*`/`seq_*`/`map_*`).
+        // Tier A (the pattern matcher) only — no `evalTerm`-equivalent
+        // arithmetic/calculus folding exists here (see runtime.rs's own
+        // SIR23 section doc for the full Tier A/Tier B rationale).
+        Expr::SymSymbol { name, .. } => {
+            out.push_str("__sir::sir_sym_symbol(");
+            out.push_str(&quote_rs_string(name));
+            out.push(')');
+        }
+        Expr::SymRational { numer, denom, .. } => {
+            let _ = write!(out, "__sir::sir_sym_rational({numer}i64, {denom}i64)");
+        }
+        Expr::SymApply { head, args, .. } => {
+            out.push_str("__sir::sir_sym_apply(");
+            emit_sym_operand(out, head, indent);
+            out.push_str(", vec![");
+            emit_sym_args(out, args, indent);
+            out.push_str("])");
+        }
+        Expr::SymPatternBlank { head: None, .. } => {
+            out.push_str("__sir::sir_sym_blank()");
+        }
+        Expr::SymPatternBlank {
+            head: Some(head), ..
+        } => match head.as_ref() {
+            Expr::SymSymbol { name, .. } => {
+                out.push_str("__sir::sir_sym_blank_typed(");
+                out.push_str(&quote_rs_string(name));
+                out.push(')');
+            }
+            _ => panic!(
+                "rust backend: SymPatternBlank's head-constraint must be a SymSymbol, got {} at {}",
+                head.kind_name(),
+                head.span()
+            ),
+        },
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            out.push_str("__sir::sir_sym_named(");
+            out.push_str(&quote_rs_string(name));
+            out.push_str(", ");
+            emit_sym_operand(out, pattern, indent);
+            out.push(')');
+        }
+        Expr::SymRule {
+            lhs, rhs, delayed, ..
+        } => {
+            out.push_str(if *delayed {
+                "__sir::sir_sym_rule_delayed("
+            } else {
+                "__sir::sir_sym_rule("
+            });
+            emit_sym_operand(out, lhs, indent);
+            out.push_str(", ");
+            emit_sym_operand(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::SymReplaceAll {
+            expr,
+            rules,
+            repeated,
+            ..
+        } => {
+            out.push_str(if *repeated {
+                "__sir::sir_sym_replace_repeated("
+            } else {
+                "__sir::sir_sym_replace_all("
+            });
+            emit_sym_operand(out, expr, indent);
+            out.push_str(", vec![");
+            emit_sym_args(out, rules, indent);
+            out.push_str("])");
         }
     }
 }
@@ -1422,6 +1506,46 @@ fn emit_args(out: &mut String, args: &[Expr], indent: usize) {
             out.push_str(", ");
         }
         emit_expr(out, a, indent);
+    }
+}
+
+/// Wrap a `SymApply`/`SymPatternNamed`/`SymRule`/`SymReplaceAll` operand
+/// that is a bare literal (`IntLit`/`FloatLit`/`StrLit`) through the
+/// matching `__sir::sir_sym_*` leaf-term constructor — a raw
+/// `Value::Int`/`Value::Float`/`Value::Str` is never a valid Symbolic term
+/// on its own, so it must become one before it can sit inside a term tree.
+/// Any other operand (already a Symbolic-producing expression, e.g. a
+/// nested `SymApply` or a `VarRef` bound to a term) emits unchanged.
+/// Mirrors the JavaScript/Ruby backends' identically-named helper.
+fn emit_sym_operand(out: &mut String, e: &Expr, indent: usize) {
+    match e {
+        Expr::IntLit { .. } => {
+            out.push_str("__sir::sir_sym_int(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::FloatLit { .. } => {
+            out.push_str("__sir::sir_sym_float(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::StrLit { .. } => {
+            out.push_str("__sir::sir_sym_string(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        _ => emit_expr(out, e, indent),
+    }
+}
+
+/// `emit_args`, but each element passes through `emit_sym_operand` — used
+/// for a `SymApply`'s `args` and a `SymReplaceAll`'s `rules` list.
+fn emit_sym_args(out: &mut String, args: &[Expr], indent: usize) {
+    for (i, a) in args.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        emit_sym_operand(out, a, indent);
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -230,6 +230,29 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::NDArrays,
     Feature::MatrixOps,
     Feature::ArrayColumnMajor,
+    // ── SIR23 symbolic-expression/pattern-matcher domain, Tier A (Phase A
+    // Slice 4) ─────────────────────────────────────────────────────────
+    // `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+    // `SymPatternNamed`/`SymRule`/`SymReplaceAll` route into
+    // `__sir::sir_sym_*` helpers, an inlined port of the already-proven
+    // `semantic-ir-to-javascript` `Symbolic` sub-runtime's Tier A (matcher)
+    // slice — see `runtime.rs`'s "SIR23 symbolic expressions" section for
+    // the full value-model / DoS-guard rationale, and `emit.rs`'s SIR23
+    // arms for the lowering. Tier A ONLY: no `evalTerm`-equivalent
+    // arithmetic/calculus/user-function-dispatch evaluator exists — a
+    // `SymApply` builds an inert term tree, nothing more (Tier B is
+    // explicitly out of scope for this slice, matching the SIR23 spec's
+    // own split).
+    //
+    // `Rationals` (a `SirType::Rational`) is NOT a new flag introduced by
+    // this slice — it already exists in `semantic_ir::Feature`, shared with
+    // the SIR22 array/matrix domain rather than owned by SIR23, matching
+    // the JS reference's own comment on the same point. `SymRational`
+    // observes it (see `semantic-ir`'s `validator.rs`), so it must be
+    // declared here too for a module using `SymRational` to validate.
+    Feature::SymbolicExpr,
+    Feature::PatternMatching,
+    Feature::Rationals,
 ];
 
 impl Backend for RustBackend {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -127,6 +127,19 @@ pub const RUNTIME: &str = r##"mod __sir {
         // `SeqSet`/`MapSet`. Cloning a `Value::NDArray` clones the `Rc`,
         // not the backing storage.
         NDArray(Rc<RefCell<SirNDArray>>),
+        // ── SIR23 symbolic-expression/pattern-matcher domain (Tier A,
+        // Phase A Slice 4) ──────────────────────────────────────────
+        // An immutable symbolic-expression term (Wolfram-style `head[args…]`
+        // data — see the "SIR23 symbolic expressions" section further down
+        // this file for the full value-model rationale). Plain `Rc`, no
+        // `RefCell`: unlike `Seq`/`Map`/`NDArray`, a term is NEVER mutated
+        // in place once built — every `sir_sym_*` constructor and every
+        // matcher/substitution helper below produces a FRESH term rather
+        // than editing an existing one (mirroring the JS reference's
+        // `Object.freeze` discipline). Cloning a `Value::SymTerm` clones the
+        // `Rc` (a cheap shared handle onto the same immutable tree), not the
+        // tree itself.
+        SymTerm(Rc<SirSymTerm>),
     }
 
     pub struct Pair {
@@ -982,6 +995,16 @@ pub const RUNTIME: &str = r##"mod __sir {
                 s.push(']');
                 s
             }
+            // A symbolic term renders in the generic Wolfram `head(args,
+            // …)` form — see `sir_sym_to_s` (SIR23 section, below) for the
+            // full per-kind breakdown and its own depth cap (a term built
+            // via `sir_sym_apply` is not depth-capped at CONSTRUCTION time,
+            // only at WALK time, so a runtime-built term can be arbitrarily
+            // deep — `sir_sym_to_s` guards against that independently of
+            // this `visited`-based cycle guard, since a term tree can never
+            // actually cycle — it is built bottom-up from immutable,
+            // already-frozen sub-terms, unlike `Seq`/`Map`).
+            Value::SymTerm(t) => sir_sym_to_s(t, 0),
         }
     }
 
@@ -2448,6 +2471,15 @@ pub const RUNTIME: &str = r##"mod __sir {
             // the same class and message; no backend does that today, and
             // matching Ruby here alone would create a fresh divergence.)
             (Value::Exception(x), Value::Exception(y)) => Rc::ptr_eq(x, y),
+            // Two symbolic terms compare STRUCTURALLY (Wolfram `SameQ`-
+            // style value equality, not identity) — matching how `Pair`/
+            // `Seq`/`Map` above compare, and reusing the SAME depth-capped
+            // `sir_sym_term_equals` the pattern matcher itself uses for a
+            // repeated pattern-variable's "same term every occurrence"
+            // check. No cycle guard is needed here (unlike `Seq`/`Map`): a
+            // term tree is immutable and built bottom-up from already-
+            // frozen sub-terms, so it can never contain itself.
+            (Value::SymTerm(x), Value::SymTerm(y)) => sir_sym_term_equals(x, y, 0),
             _ => false,
         }
     }
@@ -2639,6 +2671,17 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Instance(id) => instance_class(*id),
             Value::Missing => "Object".to_string(),
             Value::NDArray(_) => "NDArray".to_string(),
+            // Neither Ruby nor a symbolic term has a real Ruby class of its
+            // own — this mirrors `semantic-ir-to-javascript`'s own
+            // `rubyClassName`, which does not special-case its `Symbolic`
+            // term shape either and falls through to its generic "Object"
+            // default (that function's final `return "Object"`). This arm
+            // exists only because THIS backend's `ruby_class_name` is an
+            // exhaustive match (no wildcard) — every `Value` variant needs
+            // an arm to compile — not because a symbolic term is expected
+            // to reach a `NoMethodError` message in practice (Tier A never
+            // calls a method ON a term; see this section's own doc note).
+            Value::SymTerm(_) => "Object".to_string(),
         }
     }
 
@@ -5958,6 +6001,640 @@ pub const RUNTIME: &str = r##"mod __sir {
             });
         }
         val
+    }
+
+    // ── SIR23 symbolic expressions + pattern/rewrite (Tier A, Phase A
+    // Slice 4) ──────────────────────────────────────────────────────────
+    //
+    // `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+    // `SymPatternNamed`/`SymRule`/`SymReplaceAll` lower to calls into the
+    // `sir_sym_*` helpers below — an inlined port of
+    // `semantic-ir-to-javascript`'s already-proven `Symbolic` sub-runtime's
+    // Tier A (matcher) slice: term construction, `matchPattern`/
+    // `substituteTerm`/`applyRuleTerm`, and `replaceAll`/`replaceRepeated`
+    // with their `MAX_TERM_DEPTH` guard — cross-checked against
+    // `semantic-ir-to-ruby`'s own (also-Tier-A-only) port for algorithm
+    // parity. Tier B (`evalTerm`, the arithmetic/calculus/user-function
+    // evaluator) is explicitly OUT OF SCOPE for this slice — matching the
+    // SIR23 spec's own Tier A/Tier B split — so no `Add`/`Sin`/`D`/…
+    // folding exists here; a `SymApply` builds an inert term tree, nothing
+    // more.
+    //
+    // ## Value model
+    //
+    // Unlike the JS/Ruby ports (a `{kind, ...}` frozen object / a single
+    // `Struct` with unused fields left `nil`), this port uses a genuine
+    // Rust `enum` — `SirSymTerm` — discriminated at the TYPE level, one
+    // variant per term kind, each carrying only the fields that kind uses.
+    // This is the idiomatic-Rust shape for exactly this "closed sum of
+    // heterogeneous leaf/compound node kinds" problem (the same reason
+    // `Expr`/`Stmt` in `semantic-ir` itself are enums), and it gets
+    // exhaustiveness checking for free: every `match node { … }` below is
+    // required by `rustc` to cover every kind, so a future SIR23 addendum
+    // adding an 8th term kind cannot silently fall through a forgotten arm.
+    //
+    // A `SirSymTerm::Apply`'s `head`/`args` are `Rc<SirSymTerm>` (not
+    // `Value`) — the matcher/substitution helpers work directly on terms
+    // without re-checking "is this really a symbolic term" at every
+    // recursive step; only the OUTERMOST boundary (a `sir_sym_*` function
+    // called from emitted code, which always deals in `Value`) needs to
+    // unwrap/wrap between `Value::SymTerm(Rc<SirSymTerm>)` and a bare
+    // `Rc<SirSymTerm>` — see `sir_sym_term_of`.
+    //
+    // A term is never mutated in place once built (mirroring the JS
+    // reference's `Object.freeze` discipline): every constructor and every
+    // matcher/substitution helper below produces a FRESH `Rc<SirSymTerm>`
+    // rather than editing an existing one, so `Value::SymTerm`'s plain `Rc`
+    // (no `RefCell`) is sufficient — unlike `Value::Seq`/`Value::Map`/
+    // `Value::NDArray`, which all need `Rc<RefCell<…>>` because SIR16/
+    // SIR22 give them real in-place mutation statements (`SeqSet`/`MapSet`/
+    // `IndexSet`). SIR23 adds NO mutation statement at all (its own spec
+    // note: building, matching, and substituting a symbolic term has no
+    // observable side effect distinct from the value it computes).
+    //
+    // This backend's own `Expr::IntLit`/`Expr::FloatLit`/`Expr::StrLit`
+    // already emit UNBOUNDED-capacity `Value::Int(i64)`/`Value::Float(f64)`/
+    // `Value::Str(Rc<str>)` (no `Number.isSafeInteger`-style ceiling the
+    // JS backend's own `Symbolic.int`/`.rational` must enforce for THAT
+    // runtime's untagged-`number` value model) — so `sir_sym_int`/
+    // `sir_sym_float` here need no extra range check beyond "is this
+    // already the `Value` variant we expect" / "is this float finite".
+    #[derive(Debug)]
+    pub enum SirSymTerm {
+        /// A bare symbolic-expression symbol — Wolfram `x`, `Plus`, `f`
+        /// used as DATA rather than evaluated as a variable reference.
+        Symbol { name: String },
+        Integer { value: i64 },
+        /// Always held in REDUCED form (numerator/denominator share no
+        /// common factor; denominator positive) — `sir_sym_rational`
+        /// normalizes at construction time, exactly as the JS/Ruby
+        /// references do; this type itself does not re-validate that
+        /// invariant (SIR10 "types carry, don't verify").
+        Rational { numer: i64, denom: i64 },
+        Float { value: f64 },
+        Str { value: String },
+        /// `head[args…]` / `head(args…)` as data. `head` is itself a full
+        /// term (not a bare name) because a COMPUTED head is legal Wolfram
+        /// (`f[x][y]` applies the result of `f[x]` to `y`) — usually a
+        /// `Symbol`, but this type does not narrow it.
+        Apply {
+            head: Rc<SirSymTerm>,
+            args: Vec<Rc<SirSymTerm>>,
+        },
+    }
+
+    /// Generic term → `String` rendering (`head(args, …)`) — wired into
+    /// `format_d`'s `Value::SymTerm` arm (above) so `print`/`puts` on a
+    /// term behaves like every other displayable SIR value. A direct port
+    /// of the JS reference's `toDisplayString`'s generic (non-`SIR_DISPLAY_
+    /// DERIVE`) branch ONLY — the Derive-specific infix/precedence
+    /// pretty-printer (SIR23 addendum item 4) is separate follow-up work,
+    /// not part of this Tier A matcher port.
+    ///
+    /// SECURITY (CWE-674): depth-capped with the SAME `SIR_SYM_MAX_TERM_
+    /// DEPTH` guard the matcher's own tree walks use below, for the
+    /// identical reason: a term built via `sir_sym_apply` is not depth-
+    /// capped at CONSTRUCTION time (only the tree WALK below enforces the
+    /// cap), so a runtime-built term (e.g. a compiled loop lowered to
+    /// repeated `SymApply` nesting — see the `depth_limit_*` test in
+    /// `tests/sir23_symbolic.rs`) can be arbitrarily deep. Past the cap,
+    /// `"..."` is the safe, contained answer — this function DOES NOT
+    /// `raise` (unlike `sir_sym_walk_once`/`sir_sym_replace_repeated`
+    /// below): a `print` on a too-deep term should degrade to a truncated
+    /// string, not abort the whole program, matching the JS/Ruby
+    /// references' own choice for this specific function.
+    ///
+    /// ## Whether an `NDArray` display precedent applies here
+    ///
+    /// SIR22's `Value::NDArray` DOES participate in `format_d` (see that
+    /// arm's own doc note: "a defensive rendering only… not the primary
+    /// display story for this domain"), so there is no "arrays opt out of
+    /// display entirely" precedent to follow either way. This port wires
+    /// symbolic terms into `format_d` because `tests/sir23_symbolic.rs`
+    /// (ported from the JS reference's own execution-proof suite) asserts
+    /// on PRINTED term output — e.g. a `replace_repeated` result reducing
+    /// to the bare symbol `z`, or a rejected-match term round-tripping as
+    /// `"f(z)"` — so a real display path is load-bearing for this slice's
+    /// own tests, not merely a nice-to-have.
+    fn sir_sym_to_s(node: &SirSymTerm, depth: usize) -> String {
+        if depth > SIR_SYM_MAX_TERM_DEPTH {
+            return "...".to_string();
+        }
+        match node {
+            SirSymTerm::Symbol { name } => name.clone(),
+            SirSymTerm::Integer { value } => value.to_string(),
+            SirSymTerm::Rational { numer, denom } => format!("{numer}/{denom}"),
+            SirSymTerm::Float { value } => format_float(*value),
+            // `{:?}` (Debug) quotes and escapes the string, matching the
+            // JS reference's `JSON.stringify` / the Ruby reference's
+            // `.inspect` — a term's OWN string leaf renders quoted, unlike
+            // `Value::Str`'s bare (unquoted) `format_d` arm above, exactly
+            // as the JS/Ruby references' generic term renderer does.
+            SirSymTerm::Str { value } => format!("{:?}", value),
+            SirSymTerm::Apply { head, args } => {
+                let head_s = sir_sym_to_s(head, depth + 1);
+                let args_s: Vec<String> =
+                    args.iter().map(|a| sir_sym_to_s(a, depth + 1)).collect();
+                format!("{head_s}({})", args_s.join(", "))
+            }
+        }
+    }
+
+    /// Raise a catchable `RuntimeError` from this domain — mirrors
+    /// `array_raise` (SIR22 section, above) exactly: every symbolic-domain
+    /// error is a `raise` (`std::panic::panic_any` with a `SirError`
+    /// payload, via `raise` in the exceptions section above), never a bare
+    /// Rust panic, so a malformed rational/non-finite float/depth-limit/
+    /// rewrite-cycle fails with a clean, `TryCatch`-rescuable error instead
+    /// of an uncatchable process abort. This is ALSO why `sir_sym_walk_once`/
+    /// `sir_sym_replace_repeated` below need no JS/Ruby-style sentinel-
+    /// value-threaded-through-every-return-path plumbing (their `{kind:
+    /// "depth_limit", …}` objects / `{kind: :depth_limit, …}` Hashes, plus
+    /// every caller checking for one and propagating it up): Rust's own
+    /// unwinding panic IS that propagation mechanism, automatically, at
+    /// every stack frame — `sir_sym_raise` below simply never returns, and
+    /// the existing `catch_unwind`/`report_uncaught` machinery the
+    /// exceptions section already provides handles the rest, exactly as it
+    /// does for `array_raise`.
+    fn sir_sym_raise(msg: String) -> ! {
+        raise("RuntimeError", Value::Str(Rc::from(msg.as_str())))
+    }
+
+    /// Unwrap a `Value` that must already be a symbolic term (every
+    /// `sir_sym_*` function taking a term OPERAND — as opposed to a raw
+    /// `Value::Int`/`Value::Float`/`Value::Str` LEAF constructor input —
+    /// goes through this). A non-`SymTerm` `Value` reaching here is an
+    /// internal bug (the emitter's own `emit_sym_operand`, mirrored from
+    /// the JS/Ruby backends, wraps every bare `IntLit`/`FloatLit`/`StrLit`
+    /// operand through the matching leaf constructor before it can sit
+    /// inside a term tree — see `emit.rs`), so this panics with a plain
+    /// Rust panic (never a catchable `raise`) exactly like the `Intrinsic`/
+    /// `Convert` "backend should have rejected it" arms in `emit.rs`.
+    fn sir_sym_term_of(v: &Value) -> Rc<SirSymTerm> {
+        match v {
+            Value::SymTerm(t) => t.clone(),
+            other => panic!(
+                "sir_sym: expected a Symbolic term operand, got a {}",
+                ruby_class_name(other)
+            ),
+        }
+    }
+
+    pub fn sir_sym_symbol(name: &str) -> Value {
+        Value::SymTerm(Rc::new(SirSymTerm::Symbol { name: name.to_string() }))
+    }
+
+    /// `v` must already be a `Value::Int` — the emitter routes a bare
+    /// `Expr::IntLit` operand through this via `emit_sym_operand` (see
+    /// `emit.rs`), so `v` is always `__sir::Value::Int(<literal>)` in
+    /// practice; the `other` arm is defensive only.
+    pub fn sir_sym_int(v: Value) -> Value {
+        match v {
+            Value::Int(value) => Value::SymTerm(Rc::new(SirSymTerm::Integer { value })),
+            other => panic!("sir_sym_int: expected an Int value, got a {}", ruby_class_name(&other)),
+        }
+    }
+
+    fn sir_sym_gcd_abs(a: i64, b: i64) -> i64 {
+        let mut a = a.abs();
+        let mut b = b.abs();
+        while b != 0 {
+            let t = b;
+            b = a % b;
+            a = t;
+        }
+        if a == 0 { 1 } else { a }
+    }
+
+    /// `numer`/`denom` are Rust `i64` CONSTANTS the emitter bakes directly
+    /// from `Expr::SymRational`'s own fields — not routed through
+    /// `emit_sym_operand`/`Value`, since `SymRational` carries its
+    /// numerator/denominator as plain IR-level integers, not sub-`Expr`s.
+    pub fn sir_sym_rational(numer: i64, denom: i64) -> Value {
+        if denom == 0 {
+            sir_sym_raise("sir_sym_rational: denominator cannot be zero".to_string());
+        }
+        let (mut numer, mut denom) = (numer, denom);
+        if denom < 0 {
+            numer = -numer;
+            denom = -denom;
+        }
+        let g = sir_sym_gcd_abs(numer, denom);
+        Value::SymTerm(Rc::new(SirSymTerm::Rational { numer: numer / g, denom: denom / g }))
+    }
+
+    /// `v` must already be a `Value::Float` — see `sir_sym_int`'s doc for
+    /// why (the `emit_sym_operand` wrapping contract).
+    pub fn sir_sym_float(v: Value) -> Value {
+        match v {
+            Value::Float(value) if value.is_finite() => {
+                Value::SymTerm(Rc::new(SirSymTerm::Float { value }))
+            }
+            Value::Float(_) => sir_sym_raise("sir_sym_float: value must be finite".to_string()),
+            other => panic!("sir_sym_float: expected a Float value, got a {}", ruby_class_name(&other)),
+        }
+    }
+
+    /// `v` must already be a `Value::Str` — see `sir_sym_int`'s doc for why.
+    pub fn sir_sym_string(v: Value) -> Value {
+        match v {
+            Value::Str(s) => Value::SymTerm(Rc::new(SirSymTerm::Str { value: s.to_string() })),
+            other => panic!("sir_sym_string: expected a Str value, got a {}", ruby_class_name(&other)),
+        }
+    }
+
+    pub fn sir_sym_apply(head: Value, args: Vec<Value>) -> Value {
+        let head_t = sir_sym_term_of(&head);
+        let arg_ts: Vec<Rc<SirSymTerm>> = args.iter().map(sir_sym_term_of).collect();
+        Value::SymTerm(Rc::new(SirSymTerm::Apply { head: head_t, args: arg_ts }))
+    }
+
+    /// Structural equality — used by the matcher (a repeated pattern
+    /// variable must bind to the SAME term every occurrence), by
+    /// `sir_sym_bindings_bind`'s "already bound to this exact term" fast
+    /// path, by `sir_sym_replace_repeated`'s "did this firing actually
+    /// change anything" fixed-point check, and by `value_eq_d`'s
+    /// `Value::SymTerm` arm (above).
+    ///
+    /// SECURITY (CWE-674): depth-capped with the SAME `SIR_SYM_MAX_TERM_
+    /// DEPTH` guard `sir_sym_walk_once`/`sir_sym_replace_repeated` use
+    /// below — a term built via `sir_sym_apply` is not depth-capped at
+    /// CONSTRUCTION time (only the tree WALK below enforces the cap), so a
+    /// runtime-built term could be arbitrarily deep. Past the cap, `false`
+    /// ("not structurally equal") is the safe, contained answer, mirroring
+    /// `sir_sym_match_pattern`'s own "give up cleanly" contract for a
+    /// failed match.
+    fn sir_sym_term_equals(a: &SirSymTerm, b: &SirSymTerm, depth: usize) -> bool {
+        if depth > SIR_SYM_MAX_TERM_DEPTH {
+            return false;
+        }
+        match (a, b) {
+            (SirSymTerm::Symbol { name: x }, SirSymTerm::Symbol { name: y }) => x == y,
+            (SirSymTerm::Integer { value: x }, SirSymTerm::Integer { value: y }) => x == y,
+            (
+                SirSymTerm::Rational { numer: xn, denom: xd },
+                SirSymTerm::Rational { numer: yn, denom: yd },
+            ) => xn == yn && xd == yd,
+            (SirSymTerm::Float { value: x }, SirSymTerm::Float { value: y }) => x == y,
+            (SirSymTerm::Str { value: x }, SirSymTerm::Str { value: y }) => x == y,
+            (
+                SirSymTerm::Apply { head: xh, args: xa },
+                SirSymTerm::Apply { head: yh, args: ya },
+            ) => {
+                sir_sym_term_equals(xh, yh, depth + 1)
+                    && xa.len() == ya.len()
+                    && xa.iter().zip(ya.iter()).all(|(x, y)| sir_sym_term_equals(x, y, depth + 1))
+            }
+            _ => false,
+        }
+    }
+
+    fn sir_sym_head_name(node: &SirSymTerm) -> &str {
+        match node {
+            SirSymTerm::Symbol { name } => name,
+            _ => "",
+        }
+    }
+
+    // ── pattern/rule vocabulary (cas-pattern-matching) ──────────────────
+    const SIR_SYM_BLANK: &str = "Blank";
+    const SIR_SYM_PATTERN: &str = "Pattern";
+    const SIR_SYM_RULE: &str = "Rule";
+    const SIR_SYM_RULE_DELAYED: &str = "RuleDelayed";
+
+    fn sir_sym_is_head(node: &SirSymTerm, name: &str) -> bool {
+        if let SirSymTerm::Apply { head, .. } = node {
+            if let SirSymTerm::Symbol { name: n } = head.as_ref() {
+                return n == name;
+            }
+        }
+        false
+    }
+    fn sir_sym_is_blank(node: &SirSymTerm) -> bool {
+        sir_sym_is_head(node, SIR_SYM_BLANK)
+    }
+    fn sir_sym_is_pattern(node: &SirSymTerm) -> bool {
+        sir_sym_is_head(node, SIR_SYM_PATTERN)
+    }
+    fn sir_sym_is_rule(node: &SirSymTerm) -> bool {
+        if let SirSymTerm::Apply { head, args } = node {
+            if let SirSymTerm::Symbol { name } = head.as_ref() {
+                return (name == SIR_SYM_RULE || name == SIR_SYM_RULE_DELAYED) && args.len() == 2;
+            }
+        }
+        false
+    }
+
+    pub fn sir_sym_blank() -> Value {
+        sir_sym_apply(sir_sym_symbol(SIR_SYM_BLANK), vec![])
+    }
+    pub fn sir_sym_blank_typed(head: &str) -> Value {
+        sir_sym_apply(sir_sym_symbol(SIR_SYM_BLANK), vec![sir_sym_symbol(head)])
+    }
+    pub fn sir_sym_named(name: &str, inner: Value) -> Value {
+        sir_sym_apply(sir_sym_symbol(SIR_SYM_PATTERN), vec![sir_sym_symbol(name), inner])
+    }
+    pub fn sir_sym_rule(lhs: Value, rhs: Value) -> Value {
+        sir_sym_apply(sir_sym_symbol(SIR_SYM_RULE), vec![lhs, rhs])
+    }
+    pub fn sir_sym_rule_delayed(lhs: Value, rhs: Value) -> Value {
+        sir_sym_apply(sir_sym_symbol(SIR_SYM_RULE_DELAYED), vec![lhs, rhs])
+    }
+
+    /// A pattern match's captured variable bindings: name → the term it
+    /// matched. Persistent / copy-on-write (mirrors `cas-pattern-
+    /// matching`'s `Bindings` class and the JS/Ruby ports' own Map/Hash
+    /// discipline) so a failed match attempt never mutates a binding set
+    /// an earlier attempt still holds a reference to — `sir_sym_bindings_
+    /// bind` always returns a NEW map, never mutates `bindings` in place.
+    type SirSymBindings = HashMap<String, Rc<SirSymTerm>>;
+
+    fn sir_sym_bindings_bind(
+        bindings: &SirSymBindings,
+        name: &str,
+        value: &Rc<SirSymTerm>,
+    ) -> SirSymBindings {
+        if let Some(existing) = bindings.get(name) {
+            if sir_sym_term_equals(existing, value, 0) {
+                return bindings.clone();
+            }
+        }
+        let mut next = bindings.clone();
+        next.insert(name.to_string(), value.clone());
+        next
+    }
+
+    fn sir_sym_blank_head_constraint(node: &SirSymTerm) -> Option<String> {
+        if let SirSymTerm::Apply { args, .. } = node {
+            if let Some(first) = args.first() {
+                if let SirSymTerm::Symbol { name } = first.as_ref() {
+                    return Some(name.clone());
+                }
+            }
+        }
+        None
+    }
+    fn sir_sym_pattern_name(node: &SirSymTerm) -> String {
+        if let SirSymTerm::Apply { args, .. } = node {
+            if let Some(first) = args.first() {
+                if let SirSymTerm::Symbol { name } = first.as_ref() {
+                    return name.clone();
+                }
+            }
+        }
+        sir_sym_raise("Symbolic: Pattern name must be a Symbol".to_string());
+    }
+    fn sir_sym_pattern_inner(node: &SirSymTerm) -> Rc<SirSymTerm> {
+        if let SirSymTerm::Apply { args, .. } = node {
+            if args.len() >= 2 {
+                return args[1].clone();
+            }
+        }
+        sir_sym_raise("Symbolic: Pattern requires an inner expression".to_string());
+    }
+    fn sir_sym_effective_head_name(node: &SirSymTerm) -> String {
+        match node {
+            SirSymTerm::Apply { head, .. } => {
+                let hn = sir_sym_head_name(head);
+                if hn.is_empty() { "Apply".to_string() } else { hn.to_string() }
+            }
+            SirSymTerm::Integer { .. } => "Integer".to_string(),
+            SirSymTerm::Rational { .. } => "Rational".to_string(),
+            SirSymTerm::Float { .. } => "Float".to_string(),
+            SirSymTerm::Str { .. } => "String".to_string(),
+            SirSymTerm::Symbol { .. } => "Symbol".to_string(),
+        }
+    }
+
+    /// Five-case structural matcher: `Blank()`, `Blank(T)`, `Pattern(name,
+    /// inner)`, compound-vs-compound (recurse head + every arg, same arity
+    /// required), and plain structural equality — a direct port of
+    /// `cas-pattern-matching::matchPattern`.
+    ///
+    /// Recurses only as deep as a single RULE's own (author-written, not
+    /// runtime-controlled) pattern shape — always shallow regardless of how
+    /// deep `target` is, since a compound-vs-compound match only ever
+    /// descends into `pattern`'s own `args` (bounded by the rule's literal
+    /// source text), never into `target`'s full depth independent of
+    /// `pattern`'s shape. No `SIR_SYM_MAX_TERM_DEPTH` guard is needed here
+    /// — see `sir_sym_walk_once`'s own doc note for why the tree-WALK
+    /// functions below need one and this one does not.
+    fn sir_sym_match_pattern(
+        pattern: &Rc<SirSymTerm>,
+        target: &Rc<SirSymTerm>,
+        bindings: &SirSymBindings,
+    ) -> Option<SirSymBindings> {
+        if sir_sym_is_blank(pattern) {
+            return match sir_sym_blank_head_constraint(pattern) {
+                None => Some(bindings.clone()),
+                Some(constraint) => {
+                    if sir_sym_effective_head_name(target) == constraint {
+                        Some(bindings.clone())
+                    } else {
+                        None
+                    }
+                }
+            };
+        }
+        if sir_sym_is_pattern(pattern) {
+            let name = sir_sym_pattern_name(pattern);
+            let inner = sir_sym_pattern_inner(pattern);
+            let matched = sir_sym_match_pattern(&inner, target, bindings)?;
+            return match matched.get(&name) {
+                Some(existing) => {
+                    if sir_sym_term_equals(existing, target, 0) {
+                        Some(matched)
+                    } else {
+                        None
+                    }
+                }
+                None => Some(sir_sym_bindings_bind(&matched, &name, target)),
+            };
+        }
+        if let SirSymTerm::Apply { head: p_head, args: p_args } = pattern.as_ref() {
+            let SirSymTerm::Apply { head: t_head, args: t_args } = target.as_ref() else {
+                return None;
+            };
+            let mut current = sir_sym_match_pattern(p_head, t_head, bindings)?;
+            if p_args.len() != t_args.len() {
+                return None;
+            }
+            for (p, t) in p_args.iter().zip(t_args.iter()) {
+                current = sir_sym_match_pattern(p, t, &current)?;
+            }
+            return Some(current);
+        }
+        if sir_sym_term_equals(pattern, target, 0) { Some(bindings.clone()) } else { None }
+    }
+
+    fn sir_sym_substitute(template: &Rc<SirSymTerm>, bindings: &SirSymBindings) -> Rc<SirSymTerm> {
+        if sir_sym_is_pattern(template) {
+            let name = sir_sym_pattern_name(template);
+            if let Some(captured) = bindings.get(&name) {
+                return captured.clone();
+            }
+            return template.clone();
+        }
+        if let SirSymTerm::Apply { head, args } = template.as_ref() {
+            let new_head = sir_sym_substitute(head, bindings);
+            let new_args: Vec<Rc<SirSymTerm>> =
+                args.iter().map(|a| sir_sym_substitute(a, bindings)).collect();
+            return Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+        }
+        template.clone()
+    }
+
+    /// Match `rewrite_rule`'s `lhs` against `expr` and, on success,
+    /// substitute the captured bindings into `rhs` — `None` on a failed
+    /// match (the "no match, no rewrite" contract every caller relies on).
+    fn sir_sym_apply_rule(
+        rewrite_rule: &Rc<SirSymTerm>,
+        expr: &Rc<SirSymTerm>,
+    ) -> Option<Rc<SirSymTerm>> {
+        if !sir_sym_is_rule(rewrite_rule) {
+            sir_sym_raise("Symbolic.applyRule: expected Rule/RuleDelayed".to_string());
+        }
+        let SirSymTerm::Apply { args, .. } = rewrite_rule.as_ref() else {
+            unreachable!("sir_sym_is_rule guarantees an Apply shape");
+        };
+        let bindings = sir_sym_match_pattern(&args[0], expr, &SirSymBindings::new())?;
+        Some(sir_sym_substitute(&args[1], &bindings))
+    }
+
+    // ── replaceAll / replaceRepeated (`/.` / `//.`) + DoS guards ────────
+    //
+    // `sir_sym_match_pattern`/`sir_sym_substitute`/`sir_sym_apply_rule`
+    // recurse, but only as deep as a single RULE's own (author-written)
+    // pattern/RHS shape — always shallow regardless of how deep the TARGET
+    // expression is. `sir_sym_walk_once`/`sir_sym_replace_repeated_walk`,
+    // by contrast, walk the ENTIRE target expression tree, which ordinary
+    // compiled-program data can build up to unbounded depth (a `for` loop
+    // repeatedly firing `sir_sym_apply` — see `tests/sir23_symbolic.rs`'s
+    // depth-limit test) — so these two need an explicit cap (CWE-674
+    // stack-overflow DoS guard), mirroring the JS reference's
+    // `MAX_TERM_DEPTH = 512` exactly (cross-validated against the
+    // published TypeScript `sir-runtime-symbolic` package, which uses the
+    // identical constant, and against `semantic-ir-to-ruby`'s own port).
+    const SIR_SYM_MAX_TERM_DEPTH: usize = 512;
+
+    /// `expr /. rules` — one pass, bottom-up: a node's head/args are
+    /// walked (and possibly replaced) before the node itself is tried
+    /// against `rules`; the first matching rule wins and the freshly
+    /// substituted replacement is NOT re-walked or retried at that same
+    /// position (Wolfram's single-pass `/.` contract, distinct from
+    /// `sir_sym_replace_repeated`'s fixed point below).
+    fn sir_sym_walk_once(node: &Rc<SirSymTerm>, rules: &[Rc<SirSymTerm>], depth: usize) -> Rc<SirSymTerm> {
+        if depth > SIR_SYM_MAX_TERM_DEPTH {
+            sir_sym_raise_depth_limit();
+        }
+        let mut current = node.clone();
+        if let SirSymTerm::Apply { head, args } = node.as_ref() {
+            let new_head = sir_sym_walk_once(head, rules, depth + 1);
+            let new_args: Vec<Rc<SirSymTerm>> =
+                args.iter().map(|a| sir_sym_walk_once(a, rules, depth + 1)).collect();
+            current = Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+        }
+        for rule in rules {
+            if let Some(replacement) = sir_sym_apply_rule(rule, &current) {
+                return replacement;
+            }
+        }
+        current
+    }
+
+    pub fn sir_sym_replace_all(expr: Value, rules: Vec<Value>) -> Value {
+        let expr_t = sir_sym_term_of(&expr);
+        let rule_ts: Vec<Rc<SirSymTerm>> = rules.iter().map(sir_sym_term_of).collect();
+        Value::SymTerm(sir_sym_walk_once(&expr_t, &rule_ts, 0))
+    }
+
+    /// A GLOBAL cap, shared across one whole `sir_sym_replace_repeated`
+    /// call, on the total number of rule FIRINGS (not tree-walk recursion
+    /// depth) — guards against a non-terminating rule set (SIR23 spec
+    /// "Matcher semantics" point 6: every backend implementing `repeated:
+    /// true` MUST enforce an iteration cap). Matches the JS/Ruby
+    /// references' own default of 100.
+    const SIR_SYM_MAX_REWRITE_ITERATIONS: usize = 100;
+
+    /// `expr //. rules` — a fixed point: at each subtree, keep retrying
+    /// `rules` until none fire (re-walking any fresh replacement so its own
+    /// sub-parts also converge) before moving up to the parent.
+    ///
+    /// SECURITY (CWE-674, the "must cost O(1) stack frames per firing"
+    /// requirement): a rule firing repeatedly at ONE tree position loops
+    /// LOCALLY in the `loop { … }` below — never via a recursive call on
+    /// the freshly-substituted replacement — so however many times a rule
+    /// fires at one position costs O(1) native stack frames, not
+    /// O(firings). `depth` (checked against `SIR_SYM_MAX_TERM_DEPTH`) only
+    /// increases on a genuine descent into `head`/`args`; `counter`
+    /// (checked against `SIR_SYM_MAX_REWRITE_ITERATIONS`, threaded through
+    /// every recursive call via `&mut usize` — the Rust analogue of the
+    /// JS/Ruby references' closure-captured counter variable, since Rust
+    /// has no ambient mutable-closure-capture for a plain recursive `fn`)
+    /// bounds iteration COUNT (CPU time) only, and is a GLOBAL budget
+    /// shared across the ENTIRE walk (every tree position draws from the
+    /// same counter) — never native recursion depth, which `depth` alone
+    /// governs.
+    fn sir_sym_replace_repeated_walk(
+        node: &Rc<SirSymTerm>,
+        rules: &[Rc<SirSymTerm>],
+        depth: usize,
+        counter: &mut usize,
+    ) -> Rc<SirSymTerm> {
+        if depth > SIR_SYM_MAX_TERM_DEPTH {
+            sir_sym_raise_depth_limit();
+        }
+        let mut current = node.clone();
+        loop {
+            if let SirSymTerm::Apply { head, args } = current.as_ref() {
+                let new_head = sir_sym_replace_repeated_walk(head, rules, depth + 1, counter);
+                let new_args: Vec<Rc<SirSymTerm>> = args
+                    .iter()
+                    .map(|a| sir_sym_replace_repeated_walk(a, rules, depth + 1, counter))
+                    .collect();
+                current = Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+            }
+            let mut fired = false;
+            for rule in rules {
+                if let Some(replacement) = sir_sym_apply_rule(rule, &current) {
+                    if sir_sym_term_equals(&replacement, &current, 0) {
+                        // A rule that "fires" but reproduces an identical
+                        // term makes no progress — do not count it (and do
+                        // not loop on it again below), matching the JS/Ruby
+                        // references' identical short-circuit.
+                        continue;
+                    }
+                    *counter += 1;
+                    if *counter > SIR_SYM_MAX_REWRITE_ITERATIONS {
+                        sir_sym_raise_rewrite_cycle();
+                    }
+                    current = replacement;
+                    fired = true;
+                    break;
+                }
+            }
+            if !fired {
+                return current;
+            }
+        }
+    }
+
+    pub fn sir_sym_replace_repeated(expr: Value, rules: Vec<Value>) -> Value {
+        let expr_t = sir_sym_term_of(&expr);
+        let rule_ts: Vec<Rc<SirSymTerm>> = rules.iter().map(sir_sym_term_of).collect();
+        let mut counter: usize = 0;
+        Value::SymTerm(sir_sym_replace_repeated_walk(&expr_t, &rule_ts, 0, &mut counter))
+    }
+
+    fn sir_sym_raise_depth_limit() -> ! {
+        sir_sym_raise(format!(
+            "sir-runtime-symbolic: depth-limit (term nesting exceeded {SIR_SYM_MAX_TERM_DEPTH} levels)"
+        ))
+    }
+    fn sir_sym_raise_rewrite_cycle() -> ! {
+        sir_sym_raise(format!(
+            "sir-runtime-symbolic: rewrite-cycle (exceeded {SIR_SYM_MAX_REWRITE_ITERATIONS} rule firings at one position — the rule set is likely non-terminating)"
+        ))
     }
 }
 "##;

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -6059,6 +6059,53 @@ pub const RUNTIME: &str = r##"mod __sir {
     // runtime's untagged-`number` value model) — so `sir_sym_int`/
     // `sir_sym_float` here need no extra range check beyond "is this
     // already the `Value` variant we expect" / "is this float finite".
+    //
+    // ## `Apply`'s cached `depth`/`size` fields (/security-review finding)
+    //
+    // An earlier revision of this port capped `SIR_SYM_MAX_TERM_DEPTH` only
+    // at tree-WALK time (`sir_sym_to_s`/`sir_sym_walk_once`/`sir_sym_
+    // replace_repeated_walk`), matching the JS/Ruby references. A security
+    // review found that insufficient for a Rust value model specifically,
+    // two independent ways:
+    //
+    //  1. **Recursive `Drop`, not just recursive walk.** Rust's compiler-
+    //     generated `Drop` glue for `Apply { head, args }` recurses into
+    //     `head`/every `args` element exactly like any other tree walk —
+    //     but it is NOT one of "the matcher/walk functions below," so a
+    //     walk-time-only cap does nothing to protect it. Dropping the LAST
+    //     `Rc` reference to a too-deep term (an ordinary scope exit,
+    //     reassignment, or `Vec` clear — no explicit "walk" call needed)
+    //     recurses just as deep, with no cap anywhere in that path,
+    //     producing an UNCATCHABLE native stack overflow.
+    //  2. **`Rc`-sharing collapses PATH depth without bounding LOGICAL
+    //     size.** `args` may legally hold the SAME `Rc<SirSymTerm>` more
+    //     than once (an ordinary, cheap `Rc::clone` — see the doc note
+    //     above on cloning a `Value::SymTerm`). Doubling a shared subterm
+    //     at each nesting level (`t_k = f(t_{k-1}, t_{k-1})`) grows the
+    //     REPRESENTED tree size exponentially (`2^k` leaf positions) while
+    //     PATH depth grows only linearly (`k`) — `k` in the low dozens
+    //     already represents more nodes than the observable universe has
+    //     atoms, yet sits nowhere near `SIR_SYM_MAX_TERM_DEPTH`. None of
+    //     the matcher/walk functions below memoize on `Rc` pointer
+    //     identity, so walking such a term costs `O(2^k)` — an
+    //     effectively-infinite hang a depth cap alone cannot prevent.
+    //
+    // Both are closed the same way: `Apply` caches its own `depth` (max
+    // over `head`/`args`, +1) and `size` (sum over `head`/`args` — the
+    // node count the term would expand to if fully unshared, i.e. exactly
+    // what a non-memoizing walk actually visits — +1), computed ONCE, in
+    // O(1)/O(`args.len()`) from the ALREADY-cached fields of `head`/`args`
+    // (never a re-walk), by `sir_sym_make_apply` — the ONE choke point
+    // every `Apply` node in this file is built through (`sir_sym_apply`,
+    // `sir_sym_substitute`, `sir_sym_walk_once`, and `sir_sym_replace_
+    // repeated_walk` all route their `Apply`-(re)building through it
+    // rather than constructing the variant directly). Enforcing both caps
+    // at that ONE place — rather than trying to re-derive "is this term
+    // too big" ad hoc at every possible future call/drop site — means NO
+    // `Apply` node deeper than `SIR_SYM_MAX_TERM_DEPTH` or logically larger
+    // than `SIR_SYM_MAX_TERM_SIZE` can exist ANYWHERE in this runtime, so
+    // every walker (recursive `Drop` included) is safe by construction,
+    // with no per-walker bookkeeping needed.
     #[derive(Debug)]
     pub enum SirSymTerm {
         /// A bare symbolic-expression symbol — Wolfram `x`, `Plus`, `f`
@@ -6076,11 +6123,137 @@ pub const RUNTIME: &str = r##"mod __sir {
         /// `head[args…]` / `head(args…)` as data. `head` is itself a full
         /// term (not a bare name) because a COMPUTED head is legal Wolfram
         /// (`f[x][y]` applies the result of `f[x]` to `y`) — usually a
-        /// `Symbol`, but this type does not narrow it.
+        /// `Symbol`, but this type does not narrow it. `depth`/`size` are
+        /// cached DoS-guard bookkeeping — see this enum's own doc note
+        /// above — always built by `sir_sym_make_apply`, never by hand.
         Apply {
             head: Rc<SirSymTerm>,
             args: Vec<Rc<SirSymTerm>>,
+            depth: usize,
+            size: usize,
         },
+    }
+
+    /// SECURITY (CWE-674): bounds `Apply`'s cached PATH depth — see this
+    /// section's "`Apply`'s cached `depth`/`size` fields" doc note (above,
+    /// on `SirSymTerm` itself) for the full rationale. Mirrors the JS
+    /// reference's `MAX_TERM_DEPTH = 512` exactly (cross-validated against
+    /// the published TypeScript `sir-runtime-symbolic` package, which uses
+    /// the identical constant, and against `semantic-ir-to-ruby`'s own
+    /// port) — enforced HERE at construction time (`sir_sym_make_apply`)
+    /// rather than only at walk time as the JS/Ruby references do, for
+    /// Rust-specific reasons (recursive `Drop`) those garbage-collected
+    /// runtimes don't share.
+    const SIR_SYM_MAX_TERM_DEPTH: usize = 512;
+
+    /// SECURITY (CWE-400): bounds `Apply`'s cached logical SIZE — the
+    /// count of node instances the term would expand to if fully unshared,
+    /// i.e. exactly what a non-memoizing walk (every walker below) visits
+    /// — INDEPENDENT of `SIR_SYM_MAX_TERM_DEPTH`, which bounds only PATH
+    /// depth and does nothing to stop the `Rc`-sharing doubling attack
+    /// this section's own doc note (above) describes. A doubling attack
+    /// hits this cap within about 20 iterations (`2^20` ≈ 1,048,576),
+    /// long before either the exponential blow-up or any real resource
+    /// exhaustion could occur. Same order of magnitude as this file's
+    /// SIR22 `ARRAY_MAX_ELEMENTS` (`1 << 26`) — smaller here because a
+    /// `SirSymTerm` node is a heap-allocated `String`/`Vec`-bearing enum,
+    /// not a flat `f64`, so a term of this size is already a much larger
+    /// real footprint than an equally-sized `f64` array.
+    const SIR_SYM_MAX_TERM_SIZE: usize = 1 << 20; // 1,048,576
+
+    /// A term's cached PATH depth (0 for every leaf; `Apply`'s own cached
+    /// `depth` otherwise) — read in O(1), never re-walked.
+    fn sir_sym_depth_of(node: &SirSymTerm) -> usize {
+        match node {
+            SirSymTerm::Apply { depth, .. } => *depth,
+            _ => 0,
+        }
+    }
+
+    /// A term's cached logical SIZE (1 for every leaf; `Apply`'s own
+    /// cached `size` otherwise — see `SIR_SYM_MAX_TERM_SIZE`'s doc for
+    /// what this counts and why). Read in O(1), never re-walked.
+    fn sir_sym_size_of(node: &SirSymTerm) -> usize {
+        match node {
+            SirSymTerm::Apply { size, .. } => *size,
+            _ => 1,
+        }
+    }
+
+    /// Raise a catchable `RuntimeError` from this domain — mirrors
+    /// `array_raise` (SIR22 section, above) exactly: every symbolic-domain
+    /// error is a `raise` (`std::panic::panic_any` with a `SirError`
+    /// payload, via `raise` in the exceptions section above), never a bare
+    /// Rust panic, so a malformed rational/non-finite float/depth-limit/
+    /// term-too-large/rewrite-cycle fails with a clean, `TryCatch`-
+    /// rescuable error instead of an uncatchable process abort. This is
+    /// ALSO why `sir_sym_walk_once`/`sir_sym_replace_repeated` below need
+    /// no JS/Ruby-style sentinel-value-threaded-through-every-return-path
+    /// plumbing (their `{kind: "depth_limit", …}` objects / `{kind:
+    /// :depth_limit, …}` Hashes, plus every caller checking for one and
+    /// propagating it up): Rust's own unwinding panic IS that propagation
+    /// mechanism, automatically, at every stack frame — `sir_sym_raise`
+    /// below simply never returns, and the existing `catch_unwind`/
+    /// `report_uncaught` machinery the exceptions section already provides
+    /// handles the rest, exactly as it does for `array_raise`.
+    fn sir_sym_raise(msg: String) -> ! {
+        raise("RuntimeError", Value::Str(Rc::from(msg.as_str())))
+    }
+
+    fn sir_sym_raise_depth_limit() -> ! {
+        sir_sym_raise(format!(
+            "sir-runtime-symbolic: depth-limit (term nesting exceeded {SIR_SYM_MAX_TERM_DEPTH} levels)"
+        ))
+    }
+    fn sir_sym_raise_term_too_large() -> ! {
+        sir_sym_raise(format!(
+            "sir-runtime-symbolic: term-too-large (logical size exceeded {SIR_SYM_MAX_TERM_SIZE} nodes — a shared or repeatedly-rewritten term is likely growing exponentially)"
+        ))
+    }
+    fn sir_sym_raise_rewrite_cycle() -> ! {
+        sir_sym_raise(format!(
+            "sir-runtime-symbolic: rewrite-cycle (exceeded {SIR_SYM_MAX_REWRITE_ITERATIONS} rule firings at one position — the rule set is likely non-terminating)"
+        ))
+    }
+
+    /// THE single choke point that constructs every `SirSymTerm::Apply`
+    /// node in this runtime. `sir_sym_apply` (the public constructor
+    /// `Expr::SymApply` lowers to), `sir_sym_substitute`, `sir_sym_walk_
+    /// once`, and `sir_sym_replace_repeated_walk` all route their
+    /// `Apply`-(re)building through this rather than writing `Rc::new(
+    /// SirSymTerm::Apply { .. })` directly — see `SirSymTerm`'s own doc
+    /// note ("`Apply`'s cached `depth`/`size` fields") for why a SINGLE
+    /// choke point, rather than scattered per-call-site checks, is the
+    /// right shape for this guard: it makes "no `Apply` node deeper/larger
+    /// than the cap exists ANYWHERE in this runtime" an invariant
+    /// established once, rather than something every future construction
+    /// site (including `sir_sym_substitute`'s rewrite of a rule's `rhs`,
+    /// which can itself duplicate a bound pattern variable's term into
+    /// multiple sibling positions — the SAME sharing hazard as a hand-
+    /// written `SymApply`) has to independently remember to re-derive.
+    ///
+    /// `depth`/`size` are computed from the ALREADY-cached fields of
+    /// `head`/`args` — O(1) and O(`args.len()`) respectively, never a
+    /// re-walk of either subtree — so this check is never the expensive
+    /// part of building a term. Saturating arithmetic throughout: neither
+    /// sum nor max can silently wrap past `usize::MAX`, and either cap
+    /// being exceeded is reported the same clean, catchable way.
+    fn sir_sym_make_apply(head: Rc<SirSymTerm>, args: Vec<Rc<SirSymTerm>>) -> Rc<SirSymTerm> {
+        let depth = args
+            .iter()
+            .fold(sir_sym_depth_of(&head), |acc, a| acc.max(sir_sym_depth_of(a)))
+            .saturating_add(1);
+        if depth > SIR_SYM_MAX_TERM_DEPTH {
+            sir_sym_raise_depth_limit();
+        }
+        let size = args
+            .iter()
+            .fold(sir_sym_size_of(&head), |acc, a| acc.saturating_add(sir_sym_size_of(a)))
+            .saturating_add(1);
+        if size > SIR_SYM_MAX_TERM_SIZE {
+            sir_sym_raise_term_too_large();
+        }
+        Rc::new(SirSymTerm::Apply { head, args, depth, size })
     }
 
     /// Generic term → `String` rendering (`head(args, …)`) — wired into
@@ -6091,18 +6264,17 @@ pub const RUNTIME: &str = r##"mod __sir {
     /// pretty-printer (SIR23 addendum item 4) is separate follow-up work,
     /// not part of this Tier A matcher port.
     ///
-    /// SECURITY (CWE-674): depth-capped with the SAME `SIR_SYM_MAX_TERM_
-    /// DEPTH` guard the matcher's own tree walks use below, for the
-    /// identical reason: a term built via `sir_sym_apply` is not depth-
-    /// capped at CONSTRUCTION time (only the tree WALK below enforces the
-    /// cap), so a runtime-built term (e.g. a compiled loop lowered to
-    /// repeated `SymApply` nesting — see the `depth_limit_*` test in
-    /// `tests/sir23_symbolic.rs`) can be arbitrarily deep. Past the cap,
-    /// `"..."` is the safe, contained answer — this function DOES NOT
-    /// `raise` (unlike `sir_sym_walk_once`/`sir_sym_replace_repeated`
-    /// below): a `print` on a too-deep term should degrade to a truncated
-    /// string, not abort the whole program, matching the JS/Ruby
-    /// references' own choice for this specific function.
+    /// Depth-capped with the same `SIR_SYM_MAX_TERM_DEPTH` every `Apply`
+    /// is ALREADY capped to at construction time (via `sir_sym_make_
+    /// apply`) — this check can in practice never fire for a term this
+    /// runtime itself built, but stays as defense-in-depth (cheap, and
+    /// robust against a future construction path that might bypass the
+    /// choke point). Past the cap, `"..."` is the safe, contained answer —
+    /// this function DOES NOT `raise` (unlike `sir_sym_walk_once`/
+    /// `sir_sym_replace_repeated` below): a `print` on a too-deep term
+    /// should degrade to a truncated string, not abort the whole program,
+    /// matching the JS/Ruby references' own choice for this specific
+    /// function.
     ///
     /// ## Whether an `NDArray` display precedent applies here
     ///
@@ -6131,33 +6303,13 @@ pub const RUNTIME: &str = r##"mod __sir {
             // `Value::Str`'s bare (unquoted) `format_d` arm above, exactly
             // as the JS/Ruby references' generic term renderer does.
             SirSymTerm::Str { value } => format!("{:?}", value),
-            SirSymTerm::Apply { head, args } => {
+            SirSymTerm::Apply { head, args, .. } => {
                 let head_s = sir_sym_to_s(head, depth + 1);
                 let args_s: Vec<String> =
                     args.iter().map(|a| sir_sym_to_s(a, depth + 1)).collect();
                 format!("{head_s}({})", args_s.join(", "))
             }
         }
-    }
-
-    /// Raise a catchable `RuntimeError` from this domain — mirrors
-    /// `array_raise` (SIR22 section, above) exactly: every symbolic-domain
-    /// error is a `raise` (`std::panic::panic_any` with a `SirError`
-    /// payload, via `raise` in the exceptions section above), never a bare
-    /// Rust panic, so a malformed rational/non-finite float/depth-limit/
-    /// rewrite-cycle fails with a clean, `TryCatch`-rescuable error instead
-    /// of an uncatchable process abort. This is ALSO why `sir_sym_walk_once`/
-    /// `sir_sym_replace_repeated` below need no JS/Ruby-style sentinel-
-    /// value-threaded-through-every-return-path plumbing (their `{kind:
-    /// "depth_limit", …}` objects / `{kind: :depth_limit, …}` Hashes, plus
-    /// every caller checking for one and propagating it up): Rust's own
-    /// unwinding panic IS that propagation mechanism, automatically, at
-    /// every stack frame — `sir_sym_raise` below simply never returns, and
-    /// the existing `catch_unwind`/`report_uncaught` machinery the
-    /// exceptions section already provides handles the rest, exactly as it
-    /// does for `array_raise`.
-    fn sir_sym_raise(msg: String) -> ! {
-        raise("RuntimeError", Value::Str(Rc::from(msg.as_str())))
     }
 
     /// Unwrap a `Value` that must already be a symbolic term (every
@@ -6195,9 +6347,19 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
     }
 
+    /// SECURITY (CWE-190): `i64::MIN.abs()` overflows (panics under
+    /// overflow-checked builds; silently stays `i64::MIN`, still NEGATIVE,
+    /// under release builds where overflow checks are off — either way an
+    /// uncontrolled/incorrect result). `numer`/`denom` originate from the
+    /// SIR module being compiled (see `sir_sym_rational`'s own doc note),
+    /// not a fixed, trusted, hand-authored constant set, so — mirroring
+    /// this file's own `array_checked_shape_size` precedent (checked
+    /// arithmetic + a clean `raise` on overflow, never a silent wrap or an
+    /// uncontrolled panic) — this uses `checked_abs`, `raise`-ing the same
+    /// way a zero denominator already does.
     fn sir_sym_gcd_abs(a: i64, b: i64) -> i64 {
-        let mut a = a.abs();
-        let mut b = b.abs();
+        let mut a = sir_sym_checked_abs(a);
+        let mut b = sir_sym_checked_abs(b);
         while b != 0 {
             let t = b;
             b = a % b;
@@ -6206,18 +6368,34 @@ pub const RUNTIME: &str = r##"mod __sir {
         if a == 0 { 1 } else { a }
     }
 
+    fn sir_sym_checked_abs(n: i64) -> i64 {
+        n.checked_abs().unwrap_or_else(|| {
+            sir_sym_raise(format!(
+                "sir_sym_rational: {n} has no representable absolute value (i64::MIN)"
+            ))
+        })
+    }
+
     /// `numer`/`denom` are Rust `i64` CONSTANTS the emitter bakes directly
     /// from `Expr::SymRational`'s own fields — not routed through
     /// `emit_sym_operand`/`Value`, since `SymRational` carries its
     /// numerator/denominator as plain IR-level integers, not sub-`Expr`s.
+    /// Those integers still originate from whatever produced the SIR
+    /// `Module` being compiled, so they are treated as untrusted input
+    /// here (see `sir_sym_gcd_abs`'s own doc note on the `i64::MIN` edge
+    /// case this implies for the sign-flip below).
     pub fn sir_sym_rational(numer: i64, denom: i64) -> Value {
         if denom == 0 {
             sir_sym_raise("sir_sym_rational: denominator cannot be zero".to_string());
         }
         let (mut numer, mut denom) = (numer, denom);
         if denom < 0 {
-            numer = -numer;
-            denom = -denom;
+            numer = numer.checked_neg().unwrap_or_else(|| {
+                sir_sym_raise("sir_sym_rational: numerator overflow (i64::MIN cannot be negated)".to_string())
+            });
+            denom = denom.checked_neg().unwrap_or_else(|| {
+                sir_sym_raise("sir_sym_rational: denominator overflow (i64::MIN cannot be negated)".to_string())
+            });
         }
         let g = sir_sym_gcd_abs(numer, denom);
         Value::SymTerm(Rc::new(SirSymTerm::Rational { numer: numer / g, denom: denom / g }))
@@ -6246,7 +6424,7 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn sir_sym_apply(head: Value, args: Vec<Value>) -> Value {
         let head_t = sir_sym_term_of(&head);
         let arg_ts: Vec<Rc<SirSymTerm>> = args.iter().map(sir_sym_term_of).collect();
-        Value::SymTerm(Rc::new(SirSymTerm::Apply { head: head_t, args: arg_ts }))
+        Value::SymTerm(sir_sym_make_apply(head_t, arg_ts))
     }
 
     /// Structural equality — used by the matcher (a repeated pattern
@@ -6256,12 +6434,10 @@ pub const RUNTIME: &str = r##"mod __sir {
     /// change anything" fixed-point check, and by `value_eq_d`'s
     /// `Value::SymTerm` arm (above).
     ///
-    /// SECURITY (CWE-674): depth-capped with the SAME `SIR_SYM_MAX_TERM_
-    /// DEPTH` guard `sir_sym_walk_once`/`sir_sym_replace_repeated` use
-    /// below — a term built via `sir_sym_apply` is not depth-capped at
-    /// CONSTRUCTION time (only the tree WALK below enforces the cap), so a
-    /// runtime-built term could be arbitrarily deep. Past the cap, `false`
-    /// ("not structurally equal") is the safe, contained answer, mirroring
+    /// Depth-capped with the same `SIR_SYM_MAX_TERM_DEPTH` every `Apply`
+    /// is already capped to at construction time — see `sir_sym_to_s`'s
+    /// identical defense-in-depth note. Past the cap, `false` ("not
+    /// structurally equal") is the safe, contained answer, mirroring
     /// `sir_sym_match_pattern`'s own "give up cleanly" contract for a
     /// failed match.
     fn sir_sym_term_equals(a: &SirSymTerm, b: &SirSymTerm, depth: usize) -> bool {
@@ -6278,8 +6454,8 @@ pub const RUNTIME: &str = r##"mod __sir {
             (SirSymTerm::Float { value: x }, SirSymTerm::Float { value: y }) => x == y,
             (SirSymTerm::Str { value: x }, SirSymTerm::Str { value: y }) => x == y,
             (
-                SirSymTerm::Apply { head: xh, args: xa },
-                SirSymTerm::Apply { head: yh, args: ya },
+                SirSymTerm::Apply { head: xh, args: xa, .. },
+                SirSymTerm::Apply { head: yh, args: ya, .. },
             ) => {
                 sir_sym_term_equals(xh, yh, depth + 1)
                     && xa.len() == ya.len()
@@ -6317,7 +6493,7 @@ pub const RUNTIME: &str = r##"mod __sir {
         sir_sym_is_head(node, SIR_SYM_PATTERN)
     }
     fn sir_sym_is_rule(node: &SirSymTerm) -> bool {
-        if let SirSymTerm::Apply { head, args } = node {
+        if let SirSymTerm::Apply { head, args, .. } = node {
             if let SirSymTerm::Symbol { name } = head.as_ref() {
                 return (name == SIR_SYM_RULE || name == SIR_SYM_RULE_DELAYED) && args.len() == 2;
             }
@@ -6451,8 +6627,8 @@ pub const RUNTIME: &str = r##"mod __sir {
                 None => Some(sir_sym_bindings_bind(&matched, &name, target)),
             };
         }
-        if let SirSymTerm::Apply { head: p_head, args: p_args } = pattern.as_ref() {
-            let SirSymTerm::Apply { head: t_head, args: t_args } = target.as_ref() else {
+        if let SirSymTerm::Apply { head: p_head, args: p_args, .. } = pattern.as_ref() {
+            let SirSymTerm::Apply { head: t_head, args: t_args, .. } = target.as_ref() else {
                 return None;
             };
             let mut current = sir_sym_match_pattern(p_head, t_head, bindings)?;
@@ -6467,6 +6643,12 @@ pub const RUNTIME: &str = r##"mod __sir {
         if sir_sym_term_equals(pattern, target, 0) { Some(bindings.clone()) } else { None }
     }
 
+    /// Rebuilds via `sir_sym_make_apply` (never `Rc::new(SirSymTerm::Apply
+    /// { .. })` directly) — see that function's own doc note on why: a
+    /// substitution can duplicate a single BOUND term into more than one
+    /// position in `rhs` (e.g. a rule `x_ -> f(x_, x_)`), the exact same
+    /// `Rc`-sharing shape `sir_sym_apply` itself must guard against, so
+    /// this rebuild needs the identical depth/size re-check.
     fn sir_sym_substitute(template: &Rc<SirSymTerm>, bindings: &SirSymBindings) -> Rc<SirSymTerm> {
         if sir_sym_is_pattern(template) {
             let name = sir_sym_pattern_name(template);
@@ -6475,11 +6657,11 @@ pub const RUNTIME: &str = r##"mod __sir {
             }
             return template.clone();
         }
-        if let SirSymTerm::Apply { head, args } = template.as_ref() {
+        if let SirSymTerm::Apply { head, args, .. } = template.as_ref() {
             let new_head = sir_sym_substitute(head, bindings);
             let new_args: Vec<Rc<SirSymTerm>> =
                 args.iter().map(|a| sir_sym_substitute(a, bindings)).collect();
-            return Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+            return sir_sym_make_apply(new_head, new_args);
         }
         template.clone()
     }
@@ -6504,19 +6686,17 @@ pub const RUNTIME: &str = r##"mod __sir {
     // ── replaceAll / replaceRepeated (`/.` / `//.`) + DoS guards ────────
     //
     // `sir_sym_match_pattern`/`sir_sym_substitute`/`sir_sym_apply_rule`
-    // recurse, but only as deep as a single RULE's own (author-written)
-    // pattern/RHS shape — always shallow regardless of how deep the TARGET
-    // expression is. `sir_sym_walk_once`/`sir_sym_replace_repeated_walk`,
-    // by contrast, walk the ENTIRE target expression tree, which ordinary
-    // compiled-program data can build up to unbounded depth (a `for` loop
-    // repeatedly firing `sir_sym_apply` — see `tests/sir23_symbolic.rs`'s
-    // depth-limit test) — so these two need an explicit cap (CWE-674
-    // stack-overflow DoS guard), mirroring the JS reference's
-    // `MAX_TERM_DEPTH = 512` exactly (cross-validated against the
-    // published TypeScript `sir-runtime-symbolic` package, which uses the
-    // identical constant, and against `semantic-ir-to-ruby`'s own port).
-    const SIR_SYM_MAX_TERM_DEPTH: usize = 512;
-
+    // recurse, but only as deep as a single RULE's own pattern/RHS shape —
+    // always shallow regardless of how deep the TARGET expression is
+    // (and, as of the `sir_sym_make_apply` choke point above, that shape
+    // is ITSELF already depth/size-capped, since it was built the same
+    // way as any other term). `sir_sym_walk_once`/`sir_sym_replace_
+    // repeated_walk`, by contrast, walk the ENTIRE target expression tree
+    // — so these two keep their OWN `depth` check too (on top of the
+    // construction-time cap every `Apply` they touch already carries): a
+    // walk starts from an arbitrary already-built term and re-descends it,
+    // so re-checking here is cheap, exact, and needs no assumption about
+    // how that term was built.
     /// `expr /. rules` — one pass, bottom-up: a node's head/args are
     /// walked (and possibly replaced) before the node itself is tried
     /// against `rules`; the first matching rule wins and the freshly
@@ -6528,11 +6708,11 @@ pub const RUNTIME: &str = r##"mod __sir {
             sir_sym_raise_depth_limit();
         }
         let mut current = node.clone();
-        if let SirSymTerm::Apply { head, args } = node.as_ref() {
+        if let SirSymTerm::Apply { head, args, .. } = node.as_ref() {
             let new_head = sir_sym_walk_once(head, rules, depth + 1);
             let new_args: Vec<Rc<SirSymTerm>> =
                 args.iter().map(|a| sir_sym_walk_once(a, rules, depth + 1)).collect();
-            current = Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+            current = sir_sym_make_apply(new_head, new_args);
         }
         for rule in rules {
             if let Some(replacement) = sir_sym_apply_rule(rule, &current) {
@@ -6586,13 +6766,13 @@ pub const RUNTIME: &str = r##"mod __sir {
         }
         let mut current = node.clone();
         loop {
-            if let SirSymTerm::Apply { head, args } = current.as_ref() {
+            if let SirSymTerm::Apply { head, args, .. } = current.as_ref() {
                 let new_head = sir_sym_replace_repeated_walk(head, rules, depth + 1, counter);
                 let new_args: Vec<Rc<SirSymTerm>> = args
                     .iter()
                     .map(|a| sir_sym_replace_repeated_walk(a, rules, depth + 1, counter))
                     .collect();
-                current = Rc::new(SirSymTerm::Apply { head: new_head, args: new_args });
+                current = sir_sym_make_apply(new_head, new_args);
             }
             let mut fired = false;
             for rule in rules {
@@ -6624,17 +6804,6 @@ pub const RUNTIME: &str = r##"mod __sir {
         let rule_ts: Vec<Rc<SirSymTerm>> = rules.iter().map(sir_sym_term_of).collect();
         let mut counter: usize = 0;
         Value::SymTerm(sir_sym_replace_repeated_walk(&expr_t, &rule_ts, 0, &mut counter))
-    }
-
-    fn sir_sym_raise_depth_limit() -> ! {
-        sir_sym_raise(format!(
-            "sir-runtime-symbolic: depth-limit (term nesting exceeded {SIR_SYM_MAX_TERM_DEPTH} levels)"
-        ))
-    }
-    fn sir_sym_raise_rewrite_cycle() -> ! {
-        sir_sym_raise(format!(
-            "sir-runtime-symbolic: rewrite-cycle (exceeded {SIR_SYM_MAX_REWRITE_ITERATIONS} rule firings at one position — the rule set is likely non-terminating)"
-        ))
     }
 }
 "##;

--- a/code/packages/rust/semantic-ir-to-rust/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/sir23_symbolic.rs
@@ -1,0 +1,292 @@
+//! SIR23 execution proof, Tier A pattern matcher (Phase A Slice 4):
+//! `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+//! `SymPatternNamed`/`SymRule`/`SymReplaceAll` on the Rust backend — hand-
+//! builds a module calling each node directly (bypassing the frontend,
+//! since no frontend targets this backend for SIR23 yet), emits Rust,
+//! compiles it with a real `rustc`, runs the binary, and asserts stdout/
+//! exit status. Mirrors `sir22_array.rs`'s pattern; skips (does not fail)
+//! when no `rustc`/usable linker is on the host, exactly like every other
+//! `compile_and_run_*`/`sir22_array.rs` test in this crate.
+//!
+//! Ported from `semantic-ir-to-javascript`'s own already-proven
+//! `tests/sir23_symbolic.rs` (Tier A cases only — the JS reference's
+//! remaining tests exercise `evalTerm`, Tier B, explicitly out of scope
+//! for this slice) and cross-checked against `semantic-ir-to-ruby`'s own
+//! (also Tier-A-only) port for algorithm parity.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol { name: name.into(), span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn sym_apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply { head: Box::new(head), args, span: s() }
+}
+fn blank() -> Expr {
+    Expr::SymPatternBlank { head: None, span: s() }
+}
+fn blank_typed(head: &str) -> Expr {
+    Expr::SymPatternBlank { head: Some(Box::new(sym(head))), span: s() }
+}
+fn named(name: &str, pattern: Expr) -> Expr {
+    Expr::SymPatternNamed { name: name.into(), pattern: Box::new(pattern), span: s() }
+}
+fn rule(lhs: Expr, rhs: Expr, delayed: bool) -> Expr {
+    Expr::SymRule { lhs: Box::new(lhs), rhs: Box::new(rhs), delayed, span: s() }
+}
+fn replace_all(expr: Expr, rules: Vec<Expr>, repeated: bool) -> Expr {
+    Expr::SymReplaceAll { expr: Box::new(expr), rules, repeated, span: s() }
+}
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__sys_write__".into(),
+            args: vec![
+                Expr::StrLit { value: "stdout".into(), span: s() },
+                Expr::StrLit { value: "once".into(), span: s() },
+                Expr::BoolLit { value: false, span: s() },
+                expr,
+            ],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn let_binding(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+
+const SYMBOLIC_FEATURES: &[Feature] =
+    &[Feature::SymbolicExpr, Feature::PatternMatching, Feature::Rationals];
+
+fn symbolic_module(stmts: Vec<Stmt>, extra_features: &[Feature]) -> Module {
+    let mut features = vec![Feature::ConsoleIO, Feature::Strings];
+    features.extend_from_slice(SYMBOLIC_FEATURES);
+    features.extend_from_slice(extra_features);
+    Module {
+        name: "sir23symbolic".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile `m` to Rust, run it with a real `rustc`, and return
+/// `(stdout, success)` — or `None` to skip when no `rustc`/usable linker is
+/// on the host, matching `sir22_array.rs::run_array_program` exactly.
+/// Unique temp-file names per call (PID + a monotonic counter) — a
+/// constant name would let concurrently-running `cargo test` threads
+/// collide on the same path.
+fn run_symbolic_program(m: &Module) -> Option<(String, bool, String)> {
+    static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    if !rustc_available() {
+        return None;
+    }
+
+    let artifact =
+        semantic_ir_to_rust::compile(m).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed));
+    let src_path = dir.join(format!("sir_rust_symbolic_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_rust_symbolic_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out =
+        cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    let stdout = String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n");
+    let stderr = String::from_utf8_lossy(&run_out.stderr).replace("\r\n", "\n");
+    Some((stdout, run_out.status.success(), stderr))
+}
+
+#[test]
+fn replace_repeated_reduces_nested_add_zero_to_bare_symbol() {
+    // Rule: x_ + 0 -> x_ (Wolfram `x_ + 0 :> x_`, held as `RuleDelayed`
+    // here so the RHS is exactly the same pattern-bound `x_` node).
+    let x_pat = named("x", blank());
+    let r = rule(sym_apply(sym("Add"), vec![x_pat.clone(), ilit(0)]), x_pat, true);
+
+    // expr: Add(Add(z, 0), 0) — both `+ 0`s should fire, to a fixed point.
+    let inner = sym_apply(sym("Add"), vec![sym("z"), ilit(0)]);
+    let expr = sym_apply(sym("Add"), vec![inner, ilit(0)]);
+
+    let m = symbolic_module(vec![print_stmt(replace_all(expr, vec![r], true))], &[]);
+    if let Some((stdout, success, stderr)) = run_symbolic_program(&m) {
+        assert!(success, "expected success, got stderr:\n{stderr}");
+        assert_eq!(stdout.trim_end(), "z");
+    }
+}
+
+#[test]
+fn replace_all_single_pass_does_not_retry_at_same_position() {
+    // `/.` (single pass): a -> b applied to Pair(a, a) fires once at EACH
+    // occurrence of `a` (bottom-up, one visit per node), not repeatedly —
+    // there is nothing to retry here since `a`'s replacement `b` doesn't
+    // itself match the rule, so replaceAll and replaceRepeated agree on
+    // this particular input; the real single-pass-vs-fixed-point contrast
+    // is `replace_repeated_reduces_nested_add_zero_to_bare_symbol` above
+    // (repeated=true fires at TWO nested positions in one call).
+    let r = rule(sym("a"), sym("b"), false);
+    let expr = sym_apply(sym("Pair"), vec![sym("a"), sym("a")]);
+    let m = symbolic_module(vec![print_stmt(replace_all(expr, vec![r], false))], &[]);
+    if let Some((stdout, success, stderr)) = run_symbolic_program(&m) {
+        assert!(success, "expected success, got stderr:\n{stderr}");
+        assert_eq!(stdout.trim_end(), "Pair(b, b)");
+    }
+}
+
+#[test]
+fn typed_blank_matches_only_constrained_head() {
+    // f(x_Integer) -> x_ matched against f(5) and f(z) (a bare Symbol):
+    // only the Integer-headed argument matches; the Symbol one is left
+    // unchanged by replaceAll's "no match, no rewrite" fallthrough.
+    let x_pat = named("x", blank_typed("Integer"));
+    let r = rule(sym_apply(sym("f"), vec![x_pat.clone()]), x_pat, false);
+    let e_int_term = sym_apply(sym("f"), vec![ilit(5)]);
+    let e_sym_term = sym_apply(sym("f"), vec![sym("z")]);
+    let m = symbolic_module(
+        vec![
+            print_stmt(replace_all(e_int_term, vec![r.clone()], false)),
+            print_stmt(replace_all(e_sym_term, vec![r], false)),
+        ],
+        &[],
+    );
+    if let Some((stdout, success, stderr)) = run_symbolic_program(&m) {
+        assert!(success, "expected success, got stderr:\n{stderr}");
+        let lines: Vec<&str> = stdout.trim_end().lines().collect();
+        assert_eq!(lines, vec!["5", "f(z)"]);
+    }
+}
+
+#[test]
+fn a_rational_term_prints_reduced() {
+    // `sir_sym_rational` reduces numer/denom by their gcd at construction
+    // time, mirroring the JS/Ruby references — 6/8 must print as "3/4".
+    let r = Expr::SymRational { numer: 6, denom: 8, span: s() };
+    let m = symbolic_module(vec![print_stmt(r)], &[]);
+    if let Some((stdout, success, stderr)) = run_symbolic_program(&m) {
+        assert!(success, "expected success, got stderr:\n{stderr}");
+        assert_eq!(stdout.trim_end(), "3/4");
+    }
+}
+
+#[test]
+fn depth_limit_guard_raises_a_catchable_error_instead_of_crashing() {
+    // A runtime-built term nested past SIR_SYM_MAX_TERM_DEPTH (512) must
+    // `raise` (a catchable `SirError` panic, per this backend's existing
+    // SIR17 exception convention — see runtime.rs's `sir_sym_raise`), not
+    // overflow the native Rust stack. Built via a REAL compiled `for`-loop
+    // in the emitted program (600 runtime firings of `Wrap(acc)`, not a
+    // hand-built 600-node static AST — mirrors the JS reference's own
+    // `print_on_deeply_nested_term_truncates_instead_of_crashing_node` and
+    // the Ruby reference's `depth_limit_guard_raises_a_ruby_error_instead_
+    // of_crashing`), then run through `replaceAll` with an empty rule set
+    // (no rule ever fires, so every level of the walk is exercised).
+    //
+    // `Feature::Exceptions` is declared so this backend's `emit_main` wraps
+    // the program in the `catch_unwind`/`install_panic_hook`/
+    // `report_uncaught` machinery — WITHOUT it an uncaught `raise` would
+    // still abort with a non-zero exit (Rust's default panic behaviour),
+    // but stderr would carry Rust's generic "Box<dyn Any>" panic banner
+    // instead of the readable `RuntimeError: sir-runtime-symbolic:
+    // depth-limit` message `report_uncaught` prints — declaring the
+    // feature is what this test needs to assert on that readable message.
+    let stmts = vec![
+        let_binding("acc", sym("leaf")),
+        Stmt::ForRange {
+            var: "i".into(),
+            start: ilit(0),
+            stop: ilit(600),
+            step: ilit(1),
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "acc".into(),
+                    scope: Scope::Local,
+                    value: sym_apply(sym("Wrap"), vec![local("acc")]),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        },
+        print_stmt(replace_all(local("acc"), vec![], false)),
+    ];
+    let m = symbolic_module(
+        stmts,
+        &[Feature::Exceptions, Feature::Loops, Feature::MutableBindings],
+    );
+
+    if let Some((stdout, success, stderr)) = run_symbolic_program(&m) {
+        assert!(
+            !success,
+            "expected a non-zero exit from the depth-limit raise, got success; stdout:\n{stdout}"
+        );
+        assert!(
+            stderr.contains("sir-runtime-symbolic: depth-limit"),
+            "expected a depth-limit error, got:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Part of the SIR22/SIR23 backend-expansion initiative (task #33, Phase A Slice 4) — one of 5 parallel, independent backend PRs for this slice (C, Go, Python, Ruby merged as #12128, Rust). Implements SIR23's **Tier A pattern matcher** on the Rust backend: `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`.

- New `Value::SymTerm(Rc<SirSymTerm>)` value-model variant and `sir_sym_*` runtime functions in `runtime.rs`, ported from `semantic-ir-to-javascript`'s already-proven `Symbolic` sub-runtime's Tier A slice — term construction, `matchPattern`/`substituteTerm`/`applyRuleTerm`, and `replaceAll`/`replaceRepeated`, cross-checked against `semantic-ir-to-ruby`'s own port (#12128) for algorithm parity. `SirSymTerm` is a genuine Rust `enum`, not a transliteration of the JS/Ruby ports' tagged-object shape, so `rustc` enforces exhaustiveness.
- **Tier B (`evalTerm` — arithmetic/calculus/user-function evaluation) is explicitly out of scope**, matching the SIR23 spec's own Tier A/Tier B split — a `SymApply` here builds an inert term tree only.
- New `Feature::SymbolicExpr`/`Feature::PatternMatching`/`Feature::Rationals` acceptance in `lib.rs`.
- New `emit.rs` arms for the 7 node kinds, plus an `emit_sym_operand` helper (mirrors JS/Ruby) wrapping bare literal operands through the matching leaf-term constructor. Also fixes a `collect_expr_assigned` no-op-recursion gap for these seven nodes (same shape as the gap Slice 3 fixed for the SIR22 addendum).
- A minimal `sir_sym_to_s` display helper wired into `format_d` so `print`/`puts` can render a term via the generic `head(args, ...)` form (the Derive-specific pretty-printer is separate follow-up work).
- Verified the `RUNTIME` string compiles standalone via `rustc --crate-type lib` before wiring it into the emitter (per Slice 2's own lesson — this caught the exhaustive-match-arm gaps in `format_d`/`ruby_class_name` early).

**DoS guards — two layers of Rust, both audited.** Because this backend runs on two layers of Rust (its own compiler-backend code, and the Rust text it emits and which a real `rustc` later compiles and runs), `/security-review` found gaps a GC-based JS/Ruby runtime doesn't share:
- Depth capping only at tree-*walk* time left Rust's compiler-generated recursive `Drop` glue for `Apply{head,args}` uncapped — dropping the last `Rc` to a too-deep term (an ordinary scope exit) could stack-overflow uncatchably.
- `Rc`-shared sibling args let a term's *represented* size grow exponentially (`t_k = f(t_{k-1}, t_{k-1})`) while *path* depth grows only linearly, defeating a depth cap alone since no walker memoized on `Rc` identity.

Fix: `Apply` now caches its own `depth`/`size` (computed in O(1)/O(args.len()) from already-cached children, never a re-walk), enforced by a single choke-point constructor (`sir_sym_make_apply`) every `Apply` node in the runtime is built through (`sir_sym_apply`, `sir_sym_substitute`, `sir_sym_walk_once`, `sir_sym_replace_repeated_walk`), raising a clean `RuntimeError` via this backend's existing SIR17 exception convention the moment `SIR_SYM_MAX_TERM_DEPTH` (512) or the new `SIR_SYM_MAX_TERM_SIZE` (1<<20) would be exceeded. Also fixed a MEDIUM `i64::MIN` overflow in `sir_sym_rational`/`sir_sym_gcd_abs` (now `checked_neg`/`checked_abs`). Two rounds of review — round 1 found 2 CRITICAL + 1 HIGH + 1 MEDIUM, round 2 (post-fix) passed clean.

## Test plan

- [x] `cargo test` — 130 lib tests + all integration tests (including 5 new in `tests/sir23_symbolic.rs`) pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] New tests actually compile the emitted Rust with a real `rustc` and run the binary (skip gracefully if absent), proving `//.`'s fixed-point behavior, `/.`'s single-pass behavior, typed-blank head-constraint matching, rational reduction, and the depth-limit guard — the last built via a **real compiled `for`-loop** (600 runtime firings of `Wrap(acc)`), not a hand-built static AST, asserting the binary exits non-zero with a readable `RuntimeError: sir-runtime-symbolic: depth-limit` on stderr
- [x] `/security-review` — 2 rounds; round 1 findings (2 CRITICAL, 1 HIGH, 1 MEDIUM) fixed; round 2 passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)