### PR TITLE
feat(adj-facts-stdlib): add consumer-trophic-level.adj (ecosystems, new source)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_consumertrophiclevel_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_consumertrophiclevel_e2e.rs
@@ -1,0 +1,110 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/consumer-trophic-level.adj`) driven through the
+//! built CLI: a native `table` naming the three consumer trophic levels an
+//! ecosystem's food chain runs on and what each one eats, grounding National
+//! Geographic Education's "Consumers" article. 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_consumertrophiclevel_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("biology/consumer-trophic-level.adj");
+    std::fs::copy(&src, dir.join("consumer-trophic-level.adj"))
+        .expect("copy shipped consumer-trophic-level.adj");
+}
+
+#[test]
+fn consumer_trophic_level_recall_binds_what_each_level_eats() {
+    let dir = scratch("direct");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"consumer-trophic-level.adj\"\n\
+         ? consumer_trophic_level(primary_consumer, $Eats)\n\
+         ? consumer_trophic_level(secondary_consumer, $Eats)\n\
+         ? consumer_trophic_level(tertiary_consumer, $Eats)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Eats\":\"primary_producers\""),
+        "a primary consumer eats primary producers: {out}"
+    );
+    assert!(
+        out.contains("\"Eats\":\"primary_consumers\""),
+        "a secondary consumer eats primary consumers: {out}"
+    );
+    assert!(
+        out.contains("\"Eats\":\"other_carnivores\""),
+        "a tertiary consumer eats other carnivores: {out}"
+    );
+    assert!(
+        out.contains("nationalgeographic.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the National Geographic Education citation at consensus trust: {out}"
+    );
+}
+
+#[test]
+fn consumer_trophic_level_reverse_binds_the_level_from_what_it_eats() {
+    let dir = scratch("reverse");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"consumer-trophic-level.adj\"\n\
+         ? consumer_trophic_level($L, primary_consumers)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"L\":\"secondary_consumer\""),
+        "the level that eats primary consumers is the secondary consumer: {out}"
+    );
+}
+
+#[test]
+fn consumer_trophic_level_abstains_honestly_on_decomposer() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"consumer-trophic-level.adj\"\n\
+         ? consumer_trophic_level(decomposer, $Eats)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a decomposer is a real ecosystem role the cited article also discusses, but its own \
+         structure keeps decomposers outside the three consumer trophic levels this table \
+         grounds -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -5,6 +5,36 @@ landed and why, not a semver-tracked API.
 
 ## Unreleased
 
+- `biology/consumer-trophic-level.adj` (new) — a `table` naming the three consumer trophic levels
+  an ecosystem's food chain runs on (primary, secondary, tertiary consumer) and what each one eats,
+  quoted verbatim from National Geographic Education's "Consumers" article (curl- and
+  WebFetch-verified against the raw page HTML, a new source never before cited in this stdlib):
+  `consumer_trophic_level(level, eats)`, primary_consumer → primary_producers, secondary_consumer →
+  primary_consumers, tertiary_consumer → other_carnivores. This is the SECOND instance of the
+  "ecosystems" Major Gap (ADJ-STDLIB-COVERAGE.md §5.1/§5.2), after `animal-habitat-definition.adj`,
+  and the first to ground it with a fresh source rather than composing two already-shipped tables —
+  a scoping pass across the three remaining single-instance K-8-science gaps (Earth-processes,
+  observation/measurement, ecosystems) checked composition first (a full-tree literal-atom census
+  restricted to each gap's relevant subject directories) and found every candidate pair either
+  already-disqualified as a trivial column-split of siblings sharing ONE citation (e.g.
+  `geology/fossil-preservation-subtype.adj` + `geology/fossil-preservation-type.adj`, and
+  `geology/rock-type-formation-component.adj` + `earth-science/metamorphism-cause.adj`, both pairs
+  decoding the SAME USGS/NPS sentence already used once), or too thin to generalize from (a single
+  matching row). Grounds NGSS MS-LS2-3/5-LS2-1 ("matter and energy... among living... parts of an
+  ecosystem") — the finer-grained "who eats whom" chain the already-shipped `food-chain-roles.adj`
+  (NOAA, producer/consumer/decomposer) has no room for in its own flat `consumer` row. Honest
+  abstention on `producer` and `decomposer` (the cited article's own structure keeps both OUTSIDE
+  the three consumer trophic levels — its decomposer paragraph opens "In addition to consumers...");
+  on `quaternary_consumer` (WebFetch-confirmed absent, two passes); and deliberately does NOT assert
+  a numbered trophic-level rank, since the cited article's own body text ("the second trophic
+  level") and its own embedded vocabulary glossary ("three" total positions, collapsing secondary
+  and tertiary into one shared "third") disagree with each other on the count — encoding only the
+  unambiguous "eats" relationship and abstaining on the level-number question entirely rather than
+  picking a side. `trust consensus` (National Geographic Education, the same tier
+  `animal-habitat-definition.adj`'s own `biome-type.adj` dependency already uses). New manifest
+  objective `adj.science.6to8.consumer_trophic_level` (recall, NGSS, band 6-8). New e2e test
+  `facts_consumertrophiclevel_e2e.rs` (3 tests: direct recall across all three levels, reverse
+  binding, honest abstention on `decomposer`).
 - `physics/energy-conversion-example.adj` (new) — a `table` naming four everyday processes and
   which form of energy goes IN and which comes OUT of each, grounding the U.S. EIA's own "law of
   conservation of energy" statement that energy is never created or destroyed, only changed from
@@ -91,6 +121,61 @@ landed and why, not a semver-tracked API.
   band since the derivation's ceiling is set by the more advanced source table). New e2e test
   `facts_animalhabitatdefinition_e2e.rs` (3 tests: derivation with dual citations, reverse binding,
   honest abstention).
+- `engineering/engineering-design-step.adj` (new) — a `table` naming the six-step engineering
+  design process (identify the problem, identify criteria and constraints, brainstorm possible
+  solutions, select a design, build/test/refine, share the design), quoted verbatim from a NASA
+  classroom worksheet PDF: `engineering_design_step(step, action)`. The first table in a new
+  `engineering/` subject directory, and the FIRST fresh-WebFetch slice into the "engineering
+  design" Major Gap (ADJ-STDLIB-COVERAGE.md §5.1/§5.2) after six prior cycles' exhaustive
+  causal-composition sweep found no composable pair anywhere in the stdlib for it (the existing
+  `physics/simple-machines.adj` family all decodes the SAME NASA sentence and shares no atom with
+  any independently-sourced second table; "engineering design" as an NGSS practice is the
+  repeatable PROCESS an engineer follows, not "name the six simple machines"). `trust
+  authoritative` (nasa.gov). New manifest objective `adj.science.6to8.engineering_design_step`.
+  New e2e test `facts_engineeringdesignstep_e2e.rs`.
+- `science/scientific-method-step.adj` (new) — a `table` naming the seven steps of the scientific
+  method (ask a question/state a hypothesis, define variables and controls, research, design the
+  experiment, run it and record data, analyze the data, draw conclusions and write a report),
+  quoted verbatim from NASA Space Place's student science-fair page:
+  `scientific_method_step(step, action)`. The first table in a new `science/` subject directory,
+  and grounds the "experiments" Major Gap, fully untouched through six prior causal-composition
+  cycles (a full-tree atom-overlap census found no table anywhere addressing the scientific
+  method, hypotheses, variables, or experimental design). Explicitly a DIFFERENT process from
+  `engineering-design-step.adj` (scientist testing an existing idea vs. engineer building
+  something new) — the two tables share zero atoms. `trust authoritative` (nasa.gov, spaceplace
+  subdomain). New manifest objective `adj.science.3to5.scientific_method_step`. New e2e test
+  `facts_scientificmethodstep_e2e.rs`.
+- `science/scientific-model-type.adj` (new) — a `table` naming three kinds of scientific model
+  (physical, conceptual, mathematical) and each one's one-sentence definition, quoted verbatim from
+  a K12 LibreTexts Earth Science chapter on "Scientific Models": `scientific_model_type(type,
+  definition)`. Closes the THIRD and last of the three K-8-science Major Gaps flagged as fully
+  untouched (alongside "experiments" and "engineering design") — two prior cycles flagged "models"
+  as harder to source than its siblings; this cycle tried and rejected three angles (a historical
+  atomic-model sequence from MIT OCW — presented as separate narrative paragraphs, not a unified
+  table; several NASA/NOAA/NIST "types of models" pages — dead links or no dedicated table; the
+  NGSS Framework Appendix F's own definitional sentence — a flat six-noun list with no
+  per-item definition) before landing on the K12 LibreTexts chapter, which gives each of three
+  model types (a fourth, "computer models," is described only as a special case of mathematical
+  models, not a fourth peer type) its own clean defining sentence. `trust consensus` (LibreTexts, a
+  curated open-education resource, not a primary standards body). New manifest objective
+  `adj.science.6to8.scientific_model_type`. New e2e test `facts_scientificmodeltype_e2e.rs`.
+- `biology/heredity-term.adj` (new) — a `table` naming seven core NGSS MS-LS3 heredity vocabulary
+  terms (gene, allele, dominant, recessive, genotype, phenotype, trait), each definition quoted
+  verbatim from NHGRI's (National Human Genome Research Institute, genome.gov) Talking Glossary of
+  Genomic and Genetic Terms: `heredity_term(term, definition)`. The FOURTH fresh-WebFetch slice
+  into this item, and the first to ground "heredity" via a genuinely new primary source rather than
+  the causal-composition rule-joining technique (two prior cycles had only ever checked, and
+  rejected, whether an already-shipped heredity table joins another on a literal key — `biology/
+  dna-base-pairs.adj` and `biology/cell-division-genetic-outcome.adj` each have no honest
+  composable second table). FIRST CANDIDATE REJECTED: the classic K-8 "dominant/recessive human
+  trait" worksheets (widow's peak, earlobe attachment, tongue rolling, dimples) — University of
+  Utah's Genetic Science Learning Center and a University of Delaware genetics-myths page each
+  independently confirm no published study supports single-gene Mendelian inheritance for any of
+  these classroom staples, so shipping it would have encoded a documented genetics-education myth
+  as fact. Shipped instead: NHGRI's own glossary, sidestepping the myth trap by grounding the
+  VOCABULARY a correct heredity claim is built from rather than a specific (and wrong)
+  trait-inheritance claim. `trust authoritative` (genome.gov). New manifest objective
+  `adj.science.6to8.heredity_term`. New e2e test `facts_heredityterm_e2e.rs`.
 
 - `chemistry/measuring-tool-si-unit.adj` (new) — a `rule` composing the already-shipped
   `measuring_tool(tool, quantity)` table (`chemistry/measuring-tools.adj`, Chemistry LibreTexts)

--- a/code/specs/data/adj-facts-stdlib/biology/consumer-trophic-level.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/consumer-trophic-level.adj
@@ -1,0 +1,130 @@
+% ============================================================================
+% consumer-trophic-level — for each of the three consumer trophic levels an
+% ecosystem's food chain names, WHAT that level actually eats, a fresh
+% WebFetch-sourced National Geographic Education table (adj-facts-stdlib,
+% BIOLOGY). Grounds the "ecosystems" Major Gap ADJ-STDLIB-COVERAGE.md
+% §5.1/§5.2 names for K-8 science — the SECOND instance of that gap (after
+% `animal-habitat-definition.adj`), and the first to ground it with a fresh
+% source rather than composing two already-shipped tables.
+% ============================================================================
+% The already-shipped `biology/food-chain-roles.adj` (NOAA-sourced) names
+% THREE coarse roles every ecosystem needs — producer, consumer, decomposer —
+% but its own `consumer` row is a single flat label with no room for the
+% "who eats whom" CHAIN a real food web actually runs on. National Geographic
+% Education's own "Consumers" article (a DIFFERENT source, never before cited
+% in this stdlib) names that chain directly, splitting "consumer" into three
+% named trophic levels and stating, in clean back-to-back sentences, exactly
+% what each one eats:
+%
+%   "Primary consumers make up the second trophic level. They are also
+%    called herbivores. They eat primary producers—plants or algae—and
+%    nothing else."
+%
+%   "Next are the secondary consumers, which eat primary consumers.
+%    Secondary consumers are mostly carnivores, from the Latin words meaning
+%    'meat eater.'"
+%
+%   "Ecosystems can also have tertiary consumers, carnivores that eat other
+%    carnivores."
+%
+% Recall is a binding query:
+%
+%     ? consumer_trophic_level(primary_consumer, $Eats)    % primary_producers
+%     ? consumer_trophic_level(secondary_consumer, $Eats)  % primary_consumers
+%     ? consumer_trophic_level(tertiary_consumer, $Eats)   % other_carnivores
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `consumer_trophic_level(level, eats)` carrying the citation, so the
+% lookups above are ordinary SLD binding queries — the engine returns each
+% level's diet WITH its source, on the CPU, with zero model calls, and
+% abstains on a level not one of these three. The query also runs BACKWARD —
+% bind an eaten group and recall which level eats it:
+%
+%     ? consumer_trophic_level($L, primary_consumers)   % secondary_consumer
+%
+% The three levels and what each one eats, as a little truth table, chained
+% end to end (a primary consumer eats producers; a secondary consumer eats
+% primary consumers; a tertiary consumer eats the carnivores below it):
+%
+%     level                eats                 the cited quote
+%     -------------------  -------------------  --------------------------------------------------------
+%     primary_consumer     primary_producers     "They eat primary producers—plants or algae—and nothing
+%                                                  else."
+%     secondary_consumer   primary_consumers     "Next are the secondary consumers, which eat primary
+%                                                  consumers."
+%     tertiary_consumer    other_carnivores      "Ecosystems can also have tertiary consumers, carnivores
+%                                                  that eat other carnivores."
+%
+% WHY this is a genuine "ecosystems" fact, not a coincidental relabeling of
+% `food-chain-roles.adj`'s own `consumer` row: NGSS MS-LS2-3/5-LS2-1 both name
+% "matter and energy... among living... parts of an ecosystem" as the actual
+% K-8 competency — that requires knowing the CHAIN energy moves along, not
+% just that "consumers eat things." `food-chain-roles.adj`'s own `consumer`
+% row has no room for that chain (one flat label, `eats_others`); this table
+% closes exactly that gap with the finer-grained trophic-level axis its own
+% cited NOAA source never breaks out.
+%
+% HONEST ABSTENTION — the crux of why this table is narrow rather than
+% overreaching:
+%
+% 1. `producer` and `decomposer` are deliberately NOT rows here, even though
+%    both are real ecosystem roles this same NatGeo article also discusses.
+%    The article's own structure treats them as OUTSIDE the three consumer
+%    trophic levels — producers are what primary consumers eat, not
+%    themselves a consumer level, and its own decomposer paragraph opens "In
+%    addition to consumers... ecosystems have decomposers," explicitly
+%    setting decomposers apart from the consumer chain rather than naming
+%    them a fourth trophic level. This table is scoped to consumer trophic
+%    levels only, matching its own title's scope ("Consumers").
+% 2. `quaternary_consumer` is deliberately NOT a row: WebFetch-confirmed
+%    (two passes) that the cited article names no fourth consumer trophic
+%    level — primary, secondary, and tertiary are presented as the complete
+%    set.
+% 3. This table deliberately does NOT assert a numbered trophic-LEVEL rank
+%    (e.g. "primary consumer is the second trophic level") even though the
+%    cited article's body text states this once for `primary_consumer`
+%    ("the second trophic level"): the SAME article's own embedded vocabulary
+%    glossary entry for "trophic level" instead describes only THREE total
+%    positions ("autotrophs (first), herbivores (second), and carnivores and
+%    omnivores (third)"), collapsing secondary and tertiary consumers into
+%    one shared "third" position — an internal inconsistency in the source
+%    itself about whether there are three or four numbered levels. Rather
+%    than pick a side or invent a resolution, this table encodes only the
+%    unambiguous, consistently-stated part of the source (what each level
+%    EATS), and abstains on the level-NUMBER question entirely.
+% 4. `herbivore`, `carnivore`, and `omnivore` are deliberately NOT rows in
+%    this table's `level` column: the source uses them as DESCRIPTIVE
+%    synonyms/qualifiers for the three named levels (primary consumers "are
+%    also called herbivores"; secondary consumers "are mostly carnivores";
+%    "some secondary consumers... are called omnivores"), never as a fourth
+%    kind of level alongside primary/secondary/tertiary. Forcing them into
+%    this table's `level` column would double-count the same three levels
+%    under a second vocabulary, not add new content.
+%
+% Provenance: WebFetch- and curl-verified directly against the raw page HTML
+% (not just an AI-summarized fetch) before writing this file, confirming
+% every quoted span byte-for-byte, including the full paragraph context
+% around each sentence and the absence of any fourth consumer level.
+% `education.nationalgeographic.org/resource/consumers/` ("Consumers",
+% National Geographic Society, tagged for grades 5-8) — the same National
+% Geographic Education domain `animal-habitat-definition.adj`'s own
+% `biome-type.adj` dependency already cites at `trust consensus` (a curated
+% educational resource, not a primary standards body). Nothing here is
+% asserted from memory. (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table consumer_trophic_level {
+    columns level, eats
+
+    row (primary_consumer, primary_producers)
+    row (secondary_consumer, primary_consumers)
+    row (tertiary_consumer, other_carnivores)
+
+    source "Primary consumers make up the second trophic level. They are also called herbivores. They eat primary producers—plants or algae—and nothing else."
+    locator "https://education.nationalgeographic.org/resource/consumers/"
+    trust consensus
+
+    cites "Next are the secondary consumers, which eat primary consumers. Secondary consumers are mostly carnivores, from the Latin words meaning \"meat eater.\"" locator "https://education.nationalgeographic.org/resource/consumers/"
+    cites "Ecosystems can also have tertiary consumers, carnivores that eat other carnivores." locator "https://education.nationalgeographic.org/resource/consumers/"
+}

--- a/code/specs/data/adj-facts-stdlib/biology/consumer-trophic-level.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/consumer-trophic-level.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% consumer-trophic-level.query.adj — worked recall over the biology
+% consumer-trophic-level library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does a secondary
+% consumer eat?" (direct binding) or "which trophic level eats primary
+% consumers?" (reverse binding) — it states no biology fact of its own, it
+% only `import`s the grounded table and asks binding queries. The final query
+% demonstrates honest abstention: `decomposer` is a real ecosystem role this
+% table's own cited article discusses, but the article's own structure keeps
+% decomposers outside the three consumer trophic levels this table grounds,
+% so recalling it abstains rather than inventing a fourth level.
+% ============================================================================
+
+import "consumer-trophic-level.adj"
+
+? consumer_trophic_level(primary_consumer, $Eats)     % expect primary_producers (direct)
+? consumer_trophic_level(secondary_consumer, $Eats)   % expect primary_consumers (direct)
+? consumer_trophic_level(tertiary_consumer, $Eats)    % expect other_carnivores (direct)
+? consumer_trophic_level($L, primary_consumers)       % expect secondary_consumer (reverse)
+? consumer_trophic_level(decomposer, $Eats)           % expect abstain -- not one of the three consumer trophic levels

--- a/code/specs/data/adj-stdlib-coverage/COVERAGE.md
+++ b/code/specs/data/adj-stdlib-coverage/COVERAGE.md
@@ -10,7 +10,7 @@ exists. Semantic coverage is tracked in `code/specs/ADJ-STDLIB-COVERAGE.md`.
 
 | Collection | Content libraries | Clauses | Query companions | Test references | Source envelopes | Byte-verified |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| facts | 324 | 327 | 323 (99.7%) | 324 (100.0%) | 324 (100.0%) | 0 (0.0%) |
+| facts | 325 | 328 | 324 (99.7%) | 325 (100.0%) | 325 (100.0%) | 0 (0.0%) |
 | formulas | 163 | 404 | 163 (100.0%) | 163 (100.0%) | 163 (100.0%) | 0 (0.0%) |
 | medical-recall | 63 | 634 | 63 (100.0%) | 63 (100.0%) | 60 (95.2%) | 0 (0.0%) |
 
@@ -27,7 +27,7 @@ provenance bundle whose CAS graph proves all cited source bytes.
 | `facts/anatomy` | 32 | 32 | 32 | 32 | 32 | 0 |
 | `facts/art` | 1 | 1 | 1 | 1 | 1 | 0 |
 | `facts/astronomy` | 18 | 18 | 18 | 18 | 18 | 0 |
-| `facts/biology` | 60 | 60 | 59 | 60 | 60 | 0 |
+| `facts/biology` | 61 | 61 | 60 | 61 | 61 | 0 |
 | `facts/calendar` | 2 | 2 | 2 | 2 | 2 | 0 |
 | `facts/chemistry` | 19 | 19 | 19 | 19 | 19 | 0 |
 | `facts/earth-science` | 11 | 11 | 11 | 11 | 11 | 0 |
@@ -73,7 +73,7 @@ None.
 - `code/specs/data/mycin-2026/recall/endocrine-edges.adj`
 - `code/specs/data/mycin-2026/recall/iem-edges.adj`
 
-### Missing pinned source bytes (550)
+### Missing pinned source bytes (551)
 
 See the JSON form of this report for the complete machine-readable list.
 

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1459,6 +1459,21 @@
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     },
     {
+      "id": "adj.science.6to8.consumer_trophic_level",
+      "title": "Recall what each consumer trophic level (primary, secondary, tertiary) eats in an ecosystem's food chain",
+      "band": "6-8",
+      "domain": "science",
+      "competency": "recall",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/biology/consumer-trophic-level.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
       "id": "adj.science.k2.season_start_month_number",
       "title": "Derive which numbered month a meteorological season starts in, by bridging a season fact to a calendar fact",
       "band": "K-2",


### PR DESCRIPTION
## Summary

- Second instance of the "ecosystems" Major Gap (ADJ-STDLIB-COVERAGE.md §5.1/§5.2), after `biology/animal-habitat-definition.adj`. New `biology/consumer-trophic-level.adj` tables the three consumer trophic levels an ecosystem's food chain runs on (primary/secondary/tertiary consumer) and what each one eats, grounded in a fresh National Geographic Education source ("Consumers"), curl- and WebFetch-verified against the raw page HTML.
- Composition (joining two already-shipped tables on a literal key) was tried first across all three remaining single-instance K-8-science gaps — Earth-processes, observation/measurement, ecosystems — via a full-tree literal-atom census. Every candidate pair either turned out to be a trivial column-split of two tables that already decode the SAME single citation (e.g. `geology/fossil-preservation-subtype.adj` + `geology/fossil-preservation-type.adj`, both from the same NPS page; `geology/rock-type-formation-component.adj` + `earth-science/metamorphism-cause.adj`, both from the same USGS page), or was too thin (a single matching row) to generalize from. Fresh-WebFetch sourcing turned up a genuinely richer (3-row) instance instead.
- Honest abstention documented on `producer`/`decomposer` (the source's own structure keeps both outside the three consumer trophic levels), `quaternary_consumer` (confirmed absent from the source), and on asserting a numbered trophic-level rank at all (the source's own body text and its own embedded vocabulary glossary disagree with each other about whether there are three or four levels — so this table encodes only the unambiguous "eats" relationship, not the level-number claim).
- Backfills four CHANGELOG.md entries (`engineering-design-step.adj` #11964, `scientific-method-step.adj` #11970, `scientific-model-type.adj` #11975, `heredity-term.adj` #12096) that shipped in prior cycles without one, per this repo's "changelogs required" standard, found while checking this cycle's own changelog convention.

## Test plan

- [x] `cargo build -p adj-lang-cli --bins`
- [x] Manual CLI check against `consumer-trophic-level.query.adj` — all 5 queries resolve as expected (3 direct, 1 reverse, 1 honest abstention on `decomposer`)
- [x] `cargo test -p adj-lang-cli --test facts_consumertrophiclevel_e2e` (3/3 pass)
- [x] Full `cargo test -p adj-lang-cli` suite green
- [x] `python3 code/scripts/adj_stdlib_report.py --fail-on-unreferenced-tests` (exit 0; `COVERAGE.md` regenerated and committed)
- [x] `python3 code/scripts/adj_stdlib_manifest.py --validate-json-schema` (21 pre-existing baseline errors, byte-identical set to origin/main; zero new errors from this objective)
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` clean
- [x] Security review sub-agent: PASSED, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)