### PR TITLE
docs(sir22,sir23): close out Phase A Slice 5 -- backend-impact sections reflect completed rollout

### DIFF
--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -327,24 +327,33 @@ is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
   hands it a bare number (fixed in `sir-runtime-array` 0.4.0, reusing the
   `elementwise.ts` module's existing `toArrayValue` bare-scalar
   normaliser rather than re-solving the same problem a third time).
-- **C/Go/Rust/Python/Ruby backends** — **second wave, planned**: the
-  original text here named only Rust/Go/Python as declining this domain
-  "in the first wave... no code changes required" — C and Ruby decline
-  identically today (same capability-rejection path, same panic-stub
-  match arms forced by Rust's exhaustiveness checking) but were never
-  actually named, an omission fixed here since all five behave the same
-  way. This is now a planned second wave, not a permanent scope boundary:
-  **C/Go/Rust/Ruby** will
-  follow JS's *inlined* runtime-port model (new source text ported from
-  `semantic-ir-to-javascript`'s own `ArrayRt` sub-runtime, appended to
-  each backend's own `RUNTIME` constant); **Python** will follow TS's
-  *imported-package* model (a new `code/packages/python/sir-runtime-array`
-  pip package, ported from `code/packages/typescript/sir-runtime-array`,
-  wired via Python's existing gated-import pattern). The base cut
-  (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
-  `IndexSet`) and the nine-node APL addendum are separate rollout slices
-  on each backend, mirroring how JS/TS themselves shipped the addendum
-  as a later, separate PR rather than bundled with the base cut.
+- **C/Go/Rust/Python/Ruby backends** — **done**: this was originally
+  scoped as a second wave ("no code changes required to these backends
+  for this spec to land safely"), naming only Rust/Go/Python as the
+  first wave's decliners (C and Ruby declined identically at the time
+  but were never actually named). That second wave has since landed in
+  full, in two rollout slices per backend, mirroring how JS/TS
+  themselves shipped the APL addendum as a later, separate PR rather
+  than bundled with the base cut:
+  - **Base cut** (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/
+    `Transpose`/`IndexGet`/`IndexSet`): **C/Go/Rust/Ruby** followed JS's
+    *inlined* runtime-port model (source text ported from
+    `semantic-ir-to-javascript`'s own `ArrayRt` sub-runtime, appended to
+    each backend's own `RUNTIME` constant); **Python** followed TS's
+    *imported-package* model (`code/packages/python/sir-runtime-array`,
+    ported from `code/packages/typescript/sir-runtime-array`, wired via
+    Python's existing gated-import pattern).
+  - **APL addendum** (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+    `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`): real codegen landed
+    on all five backends, replacing each backend's own
+    `find_unimplemented_sir22_addendum_node`-equivalent tree-walk
+    rejection check the same way JS/TS's own checks were retired once
+    they became dead code.
+
+  All seven backends (JS, TS, C, Go, Rust, Python, Ruby) now declare
+  `NDArrays`/`MatrixOps`/`ArrayColumnMajor` in `ACCEPTED_FEATURES` and
+  emit real codegen for every SIR22 node, base cut and addendum alike.
+  There is no longer a backend that declines this domain.
 
 ## Versioning
 

--- a/code/specs/SIR23-symbolic-pattern-semantic-ir.md
+++ b/code/specs/SIR23-symbolic-pattern-semantic-ir.md
@@ -187,32 +187,62 @@ isn't SIR" boundary the native runtimes already draw.)
 
 ## Backend impact
 
-- **JS/TS**: new `match` arms construct/consume a tagged term-tree value at
-  runtime via `sir-runtime-symbolic` (`__SirSym.apply(head, args)`,
-  `__SirSym.replaceAll(expr, rules)`, `__SirSym.replaceRepeated(expr, rules,
-  cap)`), imported only when `Feature::SymbolicExpr`/`PatternMatching` is in
-  the manifest. Per this spec's own Addendum below, this is the **matcher
-  only** (Tier A) — `SymApply` compiles to a pure, inert term constructor;
-  no backend has an evaluator (Tier B) as of this writing.
-- **C/Go/Rust/Python/Ruby backends** — **second wave, planned**: the
-  original text here named only Rust/Go/Python as declining this domain
-  "in this first wave" — C and Ruby decline identically today but were
-  never actually named, an omission fixed here since all five behave the
-  same way. This is now a planned second wave, scoped explicitly
-  to **Tier A (the matcher) only** — the evaluator remains out of scope
-  for every backend, including JS/TS, and is its own later, per-backend
-  arc. **C/Go/Rust/Ruby** will port the matcher subset only of JS's
-  `Symbolic` IIFE (`matchPattern`/`substituteTerm`/`applyRuleTerm`/
-  `replaceAllTerm`/`replaceRepeatedTerm` — explicitly excluding
-  `evalTerm` and the environment/held-form/function-dispatch machinery)
-  into each backend's own runtime; **Python** will get a new
+- **JS**: new `match` arms construct/consume a tagged term-tree value at
+  runtime via an inlined `Symbolic` IIFE (`__Sir.Symbolic.apply(head,
+  args)`, `__Sir.Symbolic.replaceAll(expr, rules)`,
+  `__Sir.Symbolic.replaceRepeated(expr, rules, cap)`), gated on
+  `Feature::SymbolicExpr`/`PatternMatching`. This backend has since gone
+  beyond the matcher: per this spec's own Addendum below,
+  `Symbolic.evalTerm` gives JS a real Tier B evaluator too, making it the
+  only backend with both tiers as of this writing.
+- **TS**: new `match` arms construct/consume the same tagged term-tree
+  shape via the *imported* `sir-runtime-symbolic` package
+  (`__SirSym.apply`/`replaceAll`/`replaceRepeated`), imported only when
+  `Feature::SymbolicExpr`/`PatternMatching` is in the manifest. This
+  remains **matcher only** (Tier A) — `sir-runtime-symbolic` re-exports
+  no evaluator, so `SymApply` compiles to a pure, inert term constructor
+  here; Tier B for TS is still deferred (see the Addendum's own "Why
+  now" section).
+- **C/Go/Rust/Python/Ruby backends** — **done**: the original text here
+  named only Rust/Go/Python as declining this domain "in this first
+  wave" — C and Ruby declined identically at the time but were never
+  actually named. That second wave has since landed in full, scoped
+  exactly as planned to **Tier A (the matcher) only** — the evaluator
+  remains out of scope for these five backends (and for TS), and is its
+  own later, per-backend arc. **C/Go/Rust/Ruby** ported the matcher
+  subset only of JS's `Symbolic` IIFE (`matchPattern`/`substituteTerm`/
+  `applyRuleTerm`/`replaceAllTerm`/`replaceRepeatedTerm` — explicitly
+  excluding `evalTerm` and the environment/held-form/function-dispatch
+  machinery) into each backend's own runtime; **Python** got a new
   `code/packages/python/sir-runtime-symbolic` package ported from
-  `code/packages/typescript/sir-runtime-symbolic`, which per this spec's
-  own scope boundary already re-exports the matcher only — already
-  exactly Tier A, the ideal minimal port source. Each backend's
-  `SymReplaceAll` depth cap must be its own empirically-measured constant
-  (this spec's own CWE-674 methodology below) — JS's `512` does not
-  transfer to a different language's stack-frame cost.
+  `code/packages/typescript/sir-runtime-symbolic`, which per this
+  spec's own scope boundary already re-exported the matcher only —
+  already exactly Tier A, the ideal minimal port source. Each backend's
+  `SymReplaceAll` depth cap is its own empirically-measured constant
+  (this spec's own CWE-674 methodology below) — JS's `512` did not
+  transfer to any other language's stack-frame cost. Independent
+  security review of this rollout also surfaced a shared gap none of
+  the ports had originally caught: the depth cap covered only the
+  target-tree side of `replace_all`/`replace_repeated`, not the
+  rule-pattern (`lhs`/`rhs`) side — a `SymRule`'s operands are ordinary
+  `Expr`s that can reference a runtime-built term of unbounded depth via
+  a variable reference, not just author-written literals, so a rule
+  shaped `Blank() -> <deep RHS>` could still overflow the native stack
+  substituting into a shallow target. Every backend closes this, though
+  the mechanism differs by language: C/Go/Rust/Ruby thread a `depth`
+  parameter through their matcher/substitution functions; Python
+  validates every rule's `lhs`/`rhs` against the depth cap up front with
+  an iterative (non-recursive) pre-flight check before the target-tree
+  walk ever starts, so that checking a maliciously deep rule cannot
+  itself overflow the stack. Both approaches raise a typed depth-limit
+  error rather than truncating or overflowing silently.
+
+  All seven backends (JS, TS, C, Go, Rust, Python, Ruby) now declare
+  `SymbolicExpr`/`PatternMatching`/`Rationals` in `ACCEPTED_FEATURES`
+  and implement Tier A in full. Tier B (the `evalTerm`-style arithmetic/
+  calculus evaluator) exists only on JS; TS and the five second-wave
+  backends all still decline to evaluate — they construct and
+  pattern-match terms but never fold them.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Phase A Slice 4 (all 5 parallel backend PRs — Ruby #12128, Python #12130, Go #12129, C #12131, Rust #12132) has merged. This closes out Phase A Slice 5: updating the SIR22/SIR23 specs' "Backend impact" sections to describe the actual, verified end state instead of the pre-rollout plan they still described as "second wave, planned."

- **SIR22**: all seven backends (JS/TS/C/Go/Rust/Python/Ruby) now declare `NDArrays`/`MatrixOps`/`ArrayColumnMajor` and emit real codegen for both the base cut and the nine-node APL addendum — no backend declines this domain anymore.
- **SIR23**: all seven backends implement Tier A (the pattern matcher) in full. Split the previous combined "JS/TS" bullet in two, since it was stale in a way this closure needed to catch: JS gained a real Tier B evaluator (`Symbolic.evalTerm`) via this spec's own Addendum, making it the only backend with both tiers; TS still has matcher-only, same as the five second-wave backends. Also documents the shared CWE-674 gap independent security review found across the rollout (rule-pattern `lhs`/`rhs` depth was uncapped even though target-tree depth was) and the two different fixes backends applied (threaded `depth` parameter vs. Python's iterative pre-flight check).

Every claim was checked against the current backend source (`ACCEPTED_FEATURES`, `emit.rs` match arms, runtime depth-cap mechanisms) rather than assumed from the original rollout plan.

## Test plan

- [x] Docs-only change (two spec Markdown files) — no code, no tests to run
- [x] Verified every backend-support claim against actual source: grepped `ACCEPTED_FEATURES`/`emit.rs` for `NDArrays`/`MatrixOps`/`SymbolicExpr`/`PatternMatching`/`Rationals` across all 7 backends
- [x] Verified Tier B (`evalTerm`) is present only in JS's inline runtime, absent from TS's package and Python's package
- [x] Verified depth-cap mechanism differs by backend (threaded parameter vs. Python's iterative pre-flight check) by reading each backend's actual runtime source
- [x] /security-review passed (docs-only diff, no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)