### PR TITLE
feat(vault-pm): Bitwarden JSON and browser CSV import adapters (VLT-PM49)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -787,6 +787,8 @@ members = [
     "vault-search",
     "vault-attachments",
     "vault-import-export",
+    "vault-import-bitwarden",
+    "vault-import-csv",
     "vault-pm-format",
     "vault-pm-domain",
     "vault-pm-audit",

--- a/code/packages/rust/vault-import-bitwarden/BUILD
+++ b/code/packages/rust/vault-import-bitwarden/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_import_bitwarden -- --nocapture

--- a/code/packages/rust/vault-import-bitwarden/CHANGELOG.md
+++ b/code/packages/rust/vault-import-bitwarden/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-08-19
+
+### Added
+
+- Initial implementation of the Bitwarden JSON format adapter named by
+  VLT15's reuse map and VLT-PM00 §23 item 13
+  (`code/specs/VLT-PM49-cli-external-import.md`).
+- `BitwardenJsonImporter` — implements `vault-import-export`'s `Importer`
+  trait (`name()` returns `"bitwarden-json"`).
+- `decode(&[u8]) -> Result<Vec<PortableRecord>, ImportError>` — the free
+  function the trait impl calls, exposed directly for callers that don't
+  need a trait object.
+- Maps Bitwarden `type: 1` (login) to `PortableRecordKind::Login`, `2`
+  (secure note) to `SecureNote`, `3` (card) to `Card` (fields carried in
+  `custom_fields`), and `4` (identity) or any unrecognized type to
+  `Custom("bitwarden-type-N")` rather than dropping the record.
+- A login's TOTP seed becomes a second, separate `Totp` record, because
+  vault-pm's own `Login` record has no TOTP slot.
+- A login's extra `uris[]` entries beyond the first are kept as
+  `custom_fields["uri_2"]`, `["uri_3"]`, … instead of silently dropped.
+- Bounded parsing built on this repo's existing depth-capped
+  `json-lexer`/`json-parser`/`json-value` pipeline rather than a new
+  hand-rolled JSON decoder: `MAX_SOURCE_BYTES` (64 MiB), `MAX_ITEMS`
+  (50,000), `MAX_URIS_PER_LOGIN` (32), `MAX_CUSTOM_FIELDS_PER_ITEM` (64),
+  `MAX_FIELD_LEN` (64 KiB).
+- 27 unit tests: happy-path decode of each mapped kind, TOTP-splits-into-
+  two-records, extra-URIs-preserved, card-field mapping, identity/unknown-
+  type preservation as `Custom`, custom-field decode and override
+  precedence, and a broad adversarial matrix — empty input, oversize
+  input, invalid UTF-8, malformed JSON, non-object root, missing/wrong-
+  typed `items`, non-object item, missing/empty `name`, missing/wrong-
+  typed `type`, non-object `login`, over-bound items/URIs/custom-fields/
+  field-length, duplicate-key last-write-wins (both nested and top-level),
+  a 10,000-deep nested array proving the inherited depth cap prevents a
+  stack overflow instead of only being cited, null-vs-absent field
+  handling, and `Send + Sync`.
+- `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+
+### Out of scope (documented, not silently dropped)
+
+- The Bitwarden *encrypted* JSON export variant.
+- Folder/collection assignment and the `favorite` flag.
+- Attachment bytes (the export carries only metadata).

--- a/code/packages/rust/vault-import-bitwarden/CHANGELOG.md
+++ b/code/packages/rust/vault-import-bitwarden/CHANGELOG.md
@@ -27,21 +27,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `custom_fields["uri_2"]`, `["uri_3"]`, … instead of silently dropped.
 - Bounded parsing built on this repo's existing depth-capped
   `json-lexer`/`json-parser`/`json-value` pipeline rather than a new
-  hand-rolled JSON decoder: `MAX_SOURCE_BYTES` (64 MiB), `MAX_ITEMS`
-  (50,000), `MAX_URIS_PER_LOGIN` (32), `MAX_CUSTOM_FIELDS_PER_ITEM` (64),
-  `MAX_FIELD_LEN` (64 KiB).
-- 27 unit tests: happy-path decode of each mapped kind, TOTP-splits-into-
+  hand-rolled JSON decoder: `MAX_SOURCE_BYTES` (16 MiB), `MAX_ITEMS`
+  (50,000), `MAX_KEYS_PER_OBJECT` (128), `MAX_URIS_PER_LOGIN` (32),
+  `MAX_CUSTOM_FIELDS_PER_ITEM` (64), `MAX_FIELD_LEN` (64 KiB).
+- 36 unit tests: happy-path decode of each mapped kind, TOTP-splits-into-
   two-records, extra-URIs-preserved, card-field mapping, identity/unknown-
   type preservation as `Custom`, custom-field decode and override
   precedence, and a broad adversarial matrix — empty input, oversize
   input, invalid UTF-8, malformed JSON, non-object root, missing/wrong-
   typed `items`, non-object item, missing/empty `name`, missing/wrong-
   typed `type`, non-object `login`, over-bound items/URIs/custom-fields/
-  field-length, duplicate-key last-write-wins (both nested and top-level),
-  a 10,000-deep nested array proving the inherited depth cap prevents a
-  stack overflow instead of only being cited, null-vs-absent field
-  handling, and `Send + Sync`.
+  keys-per-object/field-length, duplicate-key last-write-wins (both
+  nested and top-level), a 10,000-deep nested array proving the inherited
+  depth cap prevents a stack overflow instead of only being cited,
+  null-vs-absent field handling, the recursive zeroize pass wiping every
+  string in a parsed tree, and `Send + Sync`.
 - `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+
+### Security hardening (pre-merge review)
+
+Three findings flagged across four review rounds before push, all fixed
+inline:
+
+- **HIGH** — `decode_external_totp_field`/`parse_otpauth_totp_uri` (in
+  `vault-pm-cli`, the consumer of this crate's output) indexed an
+  untrusted `&str` at a fixed byte offset (`&s[..10]`), which panics —
+  a straight DoS via `vault-pm import bitwarden` — if a multi-byte UTF-8
+  character straddles that offset. Fixed with `str::get(..N)`; noted
+  here because it was found while reviewing this crate's consumer, not
+  this crate itself.
+- **MEDIUM** — `MAX_ITEMS`/`MAX_URIS_PER_LOGIN`/`MAX_CUSTOM_FIELDS_PER_ITEM`
+  bounded *array* lengths but not the number of keys in an arbitrary JSON
+  *object*; `json-value` has no per-object key-count limit of its own,
+  only a nesting-depth cap. A single object padded with many short junk
+  keys could amplify past the raw byte count before any check ran.
+  Mitigated by lowering `MAX_SOURCE_BYTES` from an earlier 64 MiB draft
+  to 16 MiB (real exports are low single-digit megabytes) and adding
+  `MAX_KEYS_PER_OBJECT`, checked at every object-destructuring site
+  (root, item, `login`, `card`, each `uris[]`/`fields[]` entry).
+- **LOW/MEDIUM** — every parsed JSON string (including every password,
+  TOTP seed, card PAN, and CVV) lived in an ordinary, non-zeroizing
+  `String` inside the `json-value` parse tree until `decode()` returned,
+  so a secret already extracted into a `Zeroizing` `PortableRecord`
+  field left an unwiped copy in freed heap. Fixed with a recursive
+  `zeroize_object`/`zeroize_json_value` pass over the whole tree, run
+  unconditionally on every return path out of `decode()` — including a
+  decode error partway through the file, which an earlier version of
+  this fix missed (the zeroize call initially ran only after every item
+  decoded successfully, silently skipping the wipe on exactly the
+  malformed/adversarial input this crate's threat model exists to
+  survive).
 
 ### Out of scope (documented, not silently dropped)
 

--- a/code/packages/rust/vault-import-bitwarden/Cargo.toml
+++ b/code/packages/rust/vault-import-bitwarden/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding_adventures_vault_import_bitwarden"
+version = "0.1.0"
+edition = "2021"
+description = "VLT-PM49 -- Bitwarden JSON export adapter. Implements vault-import-export's (VLT15) Importer trait, decoding an unencrypted Bitwarden `json` export into PortableRecords for vault-pm's `import bitwarden` ceremony."
+license = "MIT"
+
+[dependencies]
+coding_adventures_vault_import_export = { path = "../vault-import-export" }
+coding-adventures-json-value = { path = "../json-value" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-import-bitwarden/README.md
+++ b/code/packages/rust/vault-import-bitwarden/README.md
@@ -51,14 +51,23 @@ JSON export to import in the first place).
 
 Untrusted bytes in, so every array this adapter walks is bounded
 (`MAX_ITEMS`, `MAX_URIS_PER_LOGIN`, `MAX_CUSTOM_FIELDS_PER_ITEM`), every
-string it copies is bounded (`MAX_FIELD_LEN`), and the whole source is
-bounded before parsing even starts (`MAX_SOURCE_BYTES`). JSON parsing
-reuses this repo's existing depth-capped `json-lexer`/`json-parser`/
-`json-value` pipeline rather than a new hand-rolled decoder, so an
-adversarial deeply-nested document is refused instead of overflowing the
-stack. Duplicate JSON object keys resolve last-write-wins, matching every
-mainstream JSON parser, and are covered by an explicit regression test
-rather than left as an accident of iteration order.
+object it destructures is bounded (`MAX_KEYS_PER_OBJECT`), every string it
+copies is bounded (`MAX_FIELD_LEN`), and the whole source is bounded
+before parsing even starts (`MAX_SOURCE_BYTES`, kept to 16 MiB precisely
+because the underlying parser has no per-object key-count limit of its
+own, only a nesting-depth cap — a smaller byte ceiling directly bounds
+how far a crafted object's junk-key amplification can go before
+`MAX_KEYS_PER_OBJECT` rejects it). JSON parsing reuses this repo's
+existing depth-capped `json-lexer`/`json-parser`/`json-value` pipeline
+rather than a new hand-rolled decoder, so an adversarial deeply-nested
+document is refused instead of overflowing the stack. Duplicate JSON
+object keys resolve last-write-wins, matching every mainstream JSON
+parser, and are covered by an explicit regression test rather than left
+as an accident of iteration order. Every secret-shaped source string
+inside the parsed JSON tree — not just the copies extracted into
+`Zeroizing` `PortableRecord` fields — is recursively zeroized in place
+before the tree drops, on every return path including a decode error
+partway through the file.
 
 ## Usage
 
@@ -79,9 +88,9 @@ assert_eq!(importer.name(), "bitwarden-json");
 
 ## Bounds
 
-`MAX_SOURCE_BYTES = 64 MiB`, `MAX_ITEMS = 50_000`,
-`MAX_URIS_PER_LOGIN = 32`, `MAX_CUSTOM_FIELDS_PER_ITEM = 64`,
-`MAX_FIELD_LEN = 64 KiB`.
+`MAX_SOURCE_BYTES = 16 MiB`, `MAX_ITEMS = 50_000`,
+`MAX_KEYS_PER_OBJECT = 128`, `MAX_URIS_PER_LOGIN = 32`,
+`MAX_CUSTOM_FIELDS_PER_ITEM = 64`, `MAX_FIELD_LEN = 64 KiB`.
 
 ## Out of scope
 

--- a/code/packages/rust/vault-import-bitwarden/README.md
+++ b/code/packages/rust/vault-import-bitwarden/README.md
@@ -1,0 +1,93 @@
+# `coding_adventures_vault_import_bitwarden` — VLT-PM49
+
+Decodes an **unencrypted Bitwarden JSON export** into the shared
+`PortableRecord` vocabulary defined by
+[`vault-import-export`](../vault-import-export) (VLT15).
+
+This is a format adapter, one of the sibling crates VLT15's own README
+names as future work. It does no vault-pm-specific work — no crypto, no
+item identity, no audit events — and is consumed by `vault-pm`'s
+`import bitwarden FILE` ceremony (`VLT-PM49-cli-external-import.md`),
+which maps each `PortableRecord` onto a real vault-pm item through the
+same `item add` machinery a human typing at the CLI uses.
+
+## Where this fits in the vault-pm stack
+
+```text
+Bitwarden "Export vault" (json format)
+            |
+            v
+  vault-import-bitwarden::decode()   <- this crate
+            |
+            v
+   Vec<PortableRecord>               <- VLT15's shared vocabulary
+            |
+            v
+  vault-pm-cli's `import bitwarden`  <- maps to AnyRecord, calls
+                                         the existing audited
+                                         add_item path once per record
+```
+
+## Mapping
+
+| Bitwarden `type` | Produces |
+|---|---|
+| `1` login | one `Login` record, plus a separate `Totp` record when `login.totp` is present |
+| `2` secure note | one `SecureNote` record |
+| `3` card | one `Card` record; cardholder/number/expiry/CVV land in `custom_fields` under vault-pm's own `Card` field names (`holder`, `number`, `expiry_month`, `expiry_year`, `cvv`) |
+| `4` identity, or any unrecognized type | one `Custom("bitwarden-type-N")` record — kept, not dropped, so the host can report an honest skipped count |
+
+A login's first `uris[]` entry becomes `url`; any further URIs are kept
+as `custom_fields["uri_2"]`, `["uri_3"]`, … rather than silently lost.
+Bitwarden's per-item `fields` (the person's own custom fields) are merged
+into `custom_fields` last, so a same-named custom field wins over a
+kind-specific one.
+
+Not carried across: folder/collection assignment, the `favorite` flag,
+and attachment metadata (there are no attachment bytes in a Bitwarden
+JSON export to import in the first place).
+
+## Threat model
+
+Untrusted bytes in, so every array this adapter walks is bounded
+(`MAX_ITEMS`, `MAX_URIS_PER_LOGIN`, `MAX_CUSTOM_FIELDS_PER_ITEM`), every
+string it copies is bounded (`MAX_FIELD_LEN`), and the whole source is
+bounded before parsing even starts (`MAX_SOURCE_BYTES`). JSON parsing
+reuses this repo's existing depth-capped `json-lexer`/`json-parser`/
+`json-value` pipeline rather than a new hand-rolled decoder, so an
+adversarial deeply-nested document is refused instead of overflowing the
+stack. Duplicate JSON object keys resolve last-write-wins, matching every
+mainstream JSON parser, and are covered by an explicit regression test
+rather than left as an accident of iteration order.
+
+## Usage
+
+```rust
+use coding_adventures_vault_import_bitwarden::{decode, BitwardenJsonImporter};
+use coding_adventures_vault_import_export::Importer;
+
+let json = br#"{"items":[{"type":1,"name":"GitHub",
+    "login":{"username":"alice","password":"hunter2","uris":[]}}]}"#;
+
+let records = decode(json).unwrap();
+assert_eq!(records.len(), 1);
+
+// Or through the trait object every adapter implements:
+let importer = BitwardenJsonImporter;
+assert_eq!(importer.name(), "bitwarden-json");
+```
+
+## Bounds
+
+`MAX_SOURCE_BYTES = 64 MiB`, `MAX_ITEMS = 50_000`,
+`MAX_URIS_PER_LOGIN = 32`, `MAX_CUSTOM_FIELDS_PER_ITEM = 64`,
+`MAX_FIELD_LEN = 64 KiB`.
+
+## Out of scope
+
+- The Bitwarden *encrypted* JSON export format (needs an account
+  encryption key this crate never has access to).
+- Identity records — mapped to `Custom(...)` and skipped by the host,
+  because vault-pm has no identity item type yet.
+- Attachments — Bitwarden's export carries only attachment metadata, not
+  bytes.

--- a/code/packages/rust/vault-import-bitwarden/src/lib.rs
+++ b/code/packages/rust/vault-import-bitwarden/src/lib.rs
@@ -1,0 +1,762 @@
+//! # `coding_adventures_vault_import_bitwarden` — VLT-PM49
+//!
+//! ## What this crate is
+//!
+//! A **format adapter** for the import/export tier defined by VLT15
+//! (`coding_adventures_vault_import_export`). It decodes an unencrypted
+//! Bitwarden JSON export — the file Bitwarden's "Export vault" screen
+//! produces when the format is `.json` (not the encrypted `.json`
+//! variant, which needs an account key this crate never sees) — into the
+//! shared [`PortableRecord`] vocabulary every adapter in this tier
+//! produces.
+//!
+//! This crate does no vault-pm-specific work: no crypto, no item IDs, no
+//! audit events. It answers exactly one question — "what records does
+//! this file describe?" — and leaves everything about *storing* those
+//! records to the host (`vault-pm-cli`'s `import bitwarden` ceremony,
+//! specified by `VLT-PM49-cli-external-import.md`).
+//!
+//! ## Why a hand-rolled walk instead of `serde_json`
+//!
+//! Same reasoning VLT15 itself gives: this monorepo has a
+//! zero-external-dependency policy, and untrusted import bytes are
+//! exactly the place a permissive or surprising deserializer turns into
+//! a real bug (VLT-PM00 §7.1 adversary 6, "malicious imported data").
+//! Rather than write a *fourth* hand-rolled JSON decoder in this
+//! workspace, this crate reuses the already-audited, already-tested
+//! generic JSON pipeline (`json-lexer` → `json-parser` → `json-value`)
+//! that other consumers in this repo already depend on. That pipeline
+//! caps parse-tree nesting depth (`DEFAULT_MAX_RULE_DEPTH` inside
+//! `json-parser`), so a deeply nested adversarial document — the classic
+//! `[[[[...]]]]` stack-overflow shape — returns a clean `Err` instead of
+//! taking down the process. See [`decode`]'s tests for a payload that
+//! exercises exactly that path.
+//!
+//! ## Bitwarden's shape, and where this adapter is deliberately narrower
+//!
+//! A Bitwarden export is one JSON object with (at least) `"items"`, an
+//! array of records. Each item carries an integer `"type"`: `1` = login,
+//! `2` = secure note, `3` = card, `4` = identity. This adapter maps:
+//!
+//! | Bitwarden `type` | Produces |
+//! |---|---|
+//! | `1` login | one [`PortableRecordKind::Login`], plus a *second*, separate [`PortableRecordKind::Totp`] record when `login.totp` is present |
+//! | `2` secure note | one [`PortableRecordKind::SecureNote`] |
+//! | `3` card | one [`PortableRecordKind::Card`], card fields carried in `custom_fields` (see below) |
+//! | `4` identity, or any other value | one [`PortableRecordKind::Custom`] record — the host's mapping layer counts these as *skipped*, because vault-pm has no identity record type yet, rather than silently dropping them from the file |
+//!
+//! A login can hold several `login.uris` entries; [`PortableRecord`] has
+//! room for exactly one `url`. The first URI becomes `url`; any further
+//! URIs are kept, not dropped, as `custom_fields["uri_2"]`,
+//! `["uri_3"]`, … up to [`MAX_URIS_PER_LOGIN`]. A card's cardholder
+//! name, PAN, expiry, and CVV have no first-class slot in the shared
+//! vocabulary either, so they land in `custom_fields` under the same key
+//! names vault-pm's own `Card` record uses (`holder`, `number`,
+//! `expiry_month`, `expiry_year`, `cvv`, `billing_zip`) — every
+//! `custom_fields` value is already `Zeroizing` in the shared type, so
+//! the PAN and CVV are exactly as protected as `password` is.
+//!
+//! Folder/collection assignment, Bitwarden's `favorite` flag, and
+//! attachments referenced by an item are not carried across: vault-pm's
+//! `context.document` always creates a new item unfavorited and with no
+//! collections (matching plain `item add`), and Bitwarden's exported
+//! attachment metadata has no accompanying bytes to import in the first
+//! place. Recorded here rather than silently assumed.
+//!
+//! ## Threat model
+//!
+//! * **Untrusted bytes.** [`MAX_SOURCE_BYTES`] bounds the whole input
+//!   before any parsing begins. [`MAX_ITEMS`], [`MAX_URIS_PER_LOGIN`],
+//!   and [`MAX_CUSTOM_FIELDS_PER_ITEM`] bound every array this adapter
+//!   walks; [`MAX_FIELD_LEN`] bounds every string it copies out. None of
+//!   these can be exceeded by a file within the byte cap producing an
+//!   unbounded *decoded* structure, because JSON (unlike XML) has no
+//!   entity-expansion mechanism — a bounded-length document cannot decode
+//!   to an unboundedly large tree.
+//! * **Deeply nested documents.** Handled by `json-parser`'s built-in
+//!   depth cap, exercised in this crate's own test suite rather than
+//!   only trusted by citation.
+//! * **Duplicate JSON keys.** Real Bitwarden exports never repeat a key
+//!   within one object; a crafted file might. This adapter resolves
+//!   duplicates the same way every mainstream JSON parser does: **last
+//!   key wins**. Tested explicitly so the behavior is a documented
+//!   contract, not an accident of iteration order.
+//! * **Field-name confusion / type confusion.** Every field this adapter
+//!   reads is type-checked (`JsonValue::String`, `JsonValue::Object`,
+//!   …); an item where `"login"` is itself a string, an array, or `42`
+//!   is rejected rather than coerced.
+//! * **CSV formula injection.** Not applicable to this adapter — Bitwarden
+//!   exports are JSON. `vault-import-csv`'s docs carry that concern.
+//! * **Plaintext residue.** Every secret-shaped field this adapter
+//!   produces — `password`, `totp_seed`, and every `custom_fields` value
+//!   — is `Zeroizing` at the [`PortableRecord`] boundary already; this
+//!   crate introduces no separate plaintext buffer that outlives the
+//!   call.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_json_value::{JsonNumber, JsonValue};
+use coding_adventures_vault_import_export::{
+    ImportError, Importer, PortableRecord, PortableRecordKind,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::BTreeMap;
+
+// === Bounds =================================================================
+
+/// Maximum accepted raw source bytes, checked before any parsing begins.
+pub const MAX_SOURCE_BYTES: usize = 64 * 1024 * 1024;
+/// Maximum accepted `items` array length.
+pub const MAX_ITEMS: usize = 50_000;
+/// Maximum accepted `login.uris` entries kept per login (first becomes
+/// `url`; the rest become bounded `custom_fields` entries).
+pub const MAX_URIS_PER_LOGIN: usize = 32;
+/// Maximum accepted `fields` (Bitwarden custom fields) per item.
+pub const MAX_CUSTOM_FIELDS_PER_ITEM: usize = 64;
+/// Maximum accepted bytes for any single string field this adapter reads.
+pub const MAX_FIELD_LEN: usize = 64 * 1024;
+
+/// Decodes an unencrypted Bitwarden JSON export into [`PortableRecord`]s.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BitwardenJsonImporter;
+
+impl Importer for BitwardenJsonImporter {
+    fn name(&self) -> &str {
+        "bitwarden-json"
+    }
+
+    fn import(&self, input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
+        decode(input)
+    }
+}
+
+/// Decode a Bitwarden JSON export into [`PortableRecord`]s.
+///
+/// Exposed as a free function (in addition to the [`Importer`] impl above)
+/// so callers that already have a concrete adapter type in hand don't need
+/// a trait object just to call it.
+pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
+    if input.is_empty() {
+        return Err(ImportError::InvalidParameter("empty source"));
+    }
+    if input.len() > MAX_SOURCE_BYTES {
+        return Err(ImportError::TooLarge("MAX_SOURCE_BYTES"));
+    }
+    let text = core::str::from_utf8(input)
+        .map_err(|_| ImportError::Decode("source is not valid UTF-8"))?;
+    let root = coding_adventures_json_value::parse(text)
+        .map_err(|_| ImportError::Decode("source is not valid JSON"))?;
+    let JsonValue::Object(root_pairs) = root else {
+        return Err(ImportError::Decode("root value must be a JSON object"));
+    };
+    let items = match find(&root_pairs, "items") {
+        Some(JsonValue::Array(items)) => items,
+        Some(_) => return Err(ImportError::Decode("`items` must be an array")),
+        None => return Err(ImportError::Decode("missing `items` array")),
+    };
+    if items.len() > MAX_ITEMS {
+        return Err(ImportError::TooLarge("MAX_ITEMS"));
+    }
+    let mut records = Vec::with_capacity(items.len());
+    for item in items {
+        decode_item(item, &mut records)?;
+    }
+    Ok(records)
+}
+
+/// Resolve a key in an object's pair list, **last write wins** on
+/// duplicates — the same rule every mainstream JSON parser applies, made
+/// an explicit, tested contract here rather than an accident of iteration
+/// order (see `reject...duplicate_key` tests below).
+fn find<'a>(pairs: &'a [(String, JsonValue)], key: &str) -> Option<&'a JsonValue> {
+    pairs.iter().rev().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+fn as_str<'a>(value: &'a JsonValue, what: &'static str) -> Result<&'a str, ImportError> {
+    match value {
+        JsonValue::String(s) => {
+            if s.len() > MAX_FIELD_LEN {
+                Err(ImportError::TooLarge(what))
+            } else {
+                Ok(s.as_str())
+            }
+        }
+        _ => Err(ImportError::Decode(what)),
+    }
+}
+
+/// Look up an optional, nullable string field. `None`/`Null`/absent all
+/// mean "not present"; a present-but-wrong-typed value is still a hard
+/// decode error, because Bitwarden never emits e.g. a number here and a
+/// crafted file doing so is exactly the "malformed / ambiguous" shape
+/// VLT-PM00 §7.1 names.
+fn optional_str<'a>(
+    pairs: &'a [(String, JsonValue)],
+    key: &str,
+    what: &'static str,
+) -> Result<Option<&'a str>, ImportError> {
+    match find(pairs, key) {
+        None | Some(JsonValue::Null) => Ok(None),
+        Some(value) => Ok(Some(as_str(value, what)?)),
+    }
+}
+
+fn decode_item(item: &JsonValue, out: &mut Vec<PortableRecord>) -> Result<(), ImportError> {
+    let JsonValue::Object(pairs) = item else {
+        return Err(ImportError::Decode("each item must be a JSON object"));
+    };
+    let title = match find(pairs, "name") {
+        Some(value) => as_str(value, "name")?,
+        None => return Err(ImportError::Decode("item missing `name`")),
+    };
+    if title.is_empty() {
+        return Err(ImportError::InvalidParameter(
+            "item `name` must not be empty",
+        ));
+    }
+    let notes = optional_str(pairs, "notes", "notes")?.map(str::to_owned);
+    let kind_number = match find(pairs, "type") {
+        Some(JsonValue::Number(JsonNumber::Integer(n))) => *n,
+        Some(_) => return Err(ImportError::Decode("`type` must be an integer")),
+        None => return Err(ImportError::Decode("item missing `type`")),
+    };
+    match kind_number {
+        1 => decode_login(pairs, title, notes, out),
+        2 => {
+            let mut custom_fields = BTreeMap::new();
+            decode_custom_fields(pairs, &mut custom_fields)?;
+            out.push(PortableRecord {
+                kind: PortableRecordKind::SecureNote,
+                title: title.to_owned(),
+                username: None,
+                password: None,
+                url: None,
+                notes,
+                totp_seed: None,
+                tags: Vec::new(),
+                custom_fields,
+            });
+            Ok(())
+        }
+        3 => decode_card(pairs, title, notes, out),
+        _ => {
+            // Identity (4) or any future/unknown type. Kept as a Custom
+            // record rather than dropped, so a host counting "skipped"
+            // items can prove it saw every item in the file.
+            let mut custom_fields = BTreeMap::new();
+            decode_custom_fields(pairs, &mut custom_fields)?;
+            out.push(PortableRecord {
+                kind: PortableRecordKind::Custom(format!("bitwarden-type-{kind_number}")),
+                title: title.to_owned(),
+                username: None,
+                password: None,
+                url: None,
+                notes,
+                totp_seed: None,
+                tags: Vec::new(),
+                custom_fields,
+            });
+            Ok(())
+        }
+    }
+}
+
+fn decode_login(
+    pairs: &[(String, JsonValue)],
+    title: &str,
+    notes: Option<String>,
+    out: &mut Vec<PortableRecord>,
+) -> Result<(), ImportError> {
+    let login = match find(pairs, "login") {
+        Some(JsonValue::Object(login_pairs)) => login_pairs.as_slice(),
+        Some(_) => return Err(ImportError::Decode("`login` must be an object")),
+        None => &[],
+    };
+    let username = optional_str(login, "username", "login.username")?.map(str::to_owned);
+    let password =
+        optional_str(login, "password", "login.password")?.map(|s| Zeroizing::new(s.to_owned()));
+    let totp = optional_str(login, "totp", "login.totp")?.map(|s| Zeroizing::new(s.to_owned()));
+
+    let mut custom_fields: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
+    let mut url: Option<String> = None;
+    if let Some(value) = find(login, "uris") {
+        let JsonValue::Array(uris) = value else {
+            return Err(ImportError::Decode("`login.uris` must be an array"));
+        };
+        if uris.len() > MAX_URIS_PER_LOGIN {
+            return Err(ImportError::TooLarge("MAX_URIS_PER_LOGIN"));
+        }
+        for (index, entry) in uris.iter().enumerate() {
+            let JsonValue::Object(uri_pairs) = entry else {
+                return Err(ImportError::Decode("`login.uris[]` must be an object"));
+            };
+            let Some(uri) = optional_str(uri_pairs, "uri", "login.uris[].uri")? else {
+                continue;
+            };
+            if uri.is_empty() {
+                continue;
+            }
+            if url.is_none() {
+                url = Some(uri.to_owned());
+            } else {
+                custom_fields.insert(format!("uri_{}", index + 1), Zeroizing::new(uri.to_owned()));
+            }
+        }
+    }
+    decode_custom_fields(pairs, &mut custom_fields)?;
+
+    out.push(PortableRecord {
+        kind: PortableRecordKind::Login,
+        title: title.to_owned(),
+        username,
+        password,
+        url,
+        notes,
+        totp_seed: None,
+        tags: Vec::new(),
+        custom_fields,
+    });
+
+    if let Some(totp) = totp {
+        // A separate record: vault-pm's own `Login` record has no TOTP
+        // slot (TOTP is its own item kind), so a Bitwarden login carrying
+        // a TOTP seed becomes two vault-pm items. Kept as its own
+        // top-level PortableRecord rather than a custom field so the
+        // host's mapping layer can route it through the same TOTP
+        // decode path (raw Base32 or `otpauth://`) used for a
+        // Custom/Totp kind.
+        out.push(PortableRecord {
+            kind: PortableRecordKind::Totp,
+            title: title.to_owned(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: Some(totp),
+            tags: Vec::new(),
+            custom_fields: BTreeMap::new(),
+        });
+    }
+    Ok(())
+}
+
+fn decode_card(
+    pairs: &[(String, JsonValue)],
+    title: &str,
+    notes: Option<String>,
+    out: &mut Vec<PortableRecord>,
+) -> Result<(), ImportError> {
+    let card = match find(pairs, "card") {
+        Some(JsonValue::Object(card_pairs)) => card_pairs.as_slice(),
+        Some(_) => return Err(ImportError::Decode("`card` must be an object")),
+        None => &[],
+    };
+    let mut custom_fields: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
+    let mapped = [
+        ("cardholderName", "holder"),
+        ("number", "number"),
+        ("expMonth", "expiry_month"),
+        ("expYear", "expiry_year"),
+        ("code", "cvv"),
+    ];
+    for (bitwarden_key, portable_key) in mapped {
+        if let Some(value) = optional_str(card, bitwarden_key, bitwarden_key)? {
+            if !value.is_empty() {
+                custom_fields.insert(portable_key.to_owned(), Zeroizing::new(value.to_owned()));
+            }
+        }
+    }
+    decode_custom_fields(pairs, &mut custom_fields)?;
+    out.push(PortableRecord {
+        kind: PortableRecordKind::Card,
+        title: title.to_owned(),
+        username: None,
+        password: None,
+        url: None,
+        notes,
+        totp_seed: None,
+        tags: Vec::new(),
+        custom_fields,
+    });
+    Ok(())
+}
+
+/// Decode Bitwarden's item-level `fields` array (custom fields the person
+/// added themselves) into `custom_fields`, merged in on top of whatever
+/// kind-specific fields the caller already inserted. A name collision
+/// with a kind-specific key (e.g. a custom field literally named
+/// `"number"` on a card) overwrites it — last write wins, same rule as
+/// duplicate JSON object keys, and it is the person's own custom field
+/// that wins because it is decoded second.
+fn decode_custom_fields(
+    pairs: &[(String, JsonValue)],
+    custom_fields: &mut BTreeMap<String, Zeroizing<String>>,
+) -> Result<(), ImportError> {
+    let Some(value) = find(pairs, "fields") else {
+        return Ok(());
+    };
+    let JsonValue::Array(fields) = value else {
+        return Err(ImportError::Decode("`fields` must be an array"));
+    };
+    if fields.len() > MAX_CUSTOM_FIELDS_PER_ITEM {
+        return Err(ImportError::TooLarge("MAX_CUSTOM_FIELDS_PER_ITEM"));
+    }
+    for field in fields {
+        let JsonValue::Object(field_pairs) = field else {
+            return Err(ImportError::Decode(
+                "each `fields[]` entry must be an object",
+            ));
+        };
+        let name = match find(field_pairs, "name") {
+            Some(JsonValue::Null) | None => continue,
+            Some(value) => as_str(value, "fields[].name")?,
+        };
+        if name.is_empty() {
+            continue;
+        }
+        let field_value = optional_str(field_pairs, "value", "fields[].value")?.unwrap_or_default();
+        if custom_fields.len() >= MAX_CUSTOM_FIELDS_PER_ITEM && !custom_fields.contains_key(name) {
+            return Err(ImportError::TooLarge("MAX_CUSTOM_FIELDS_PER_ITEM"));
+        }
+        custom_fields.insert(name.to_owned(), Zeroizing::new(field_value.to_owned()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(pw: &PortableRecord, name: &str) -> String {
+        pw.custom_fields
+            .get(name)
+            .map(|z| (**z).clone())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn decodes_one_login() {
+        let json = br#"{"items":[{"type":1,"name":"GitHub","notes":null,
+            "login":{"username":"alice","password":"hunter2",
+            "uris":[{"uri":"https://github.com"}]}}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.kind, PortableRecordKind::Login);
+        assert_eq!(r.title, "GitHub");
+        assert_eq!(r.username.as_deref(), Some("alice"));
+        assert_eq!(r.password.as_deref().map(String::as_str), Some("hunter2"));
+        assert_eq!(r.url.as_deref(), Some("https://github.com"));
+    }
+
+    #[test]
+    fn login_with_totp_becomes_two_records() {
+        let json = br#"{"items":[{"type":1,"name":"AWS",
+            "login":{"username":"root","password":"pw",
+            "totp":"JBSWY3DPEHPK3PXP","uris":[]}}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].kind, PortableRecordKind::Login);
+        assert_eq!(records[1].kind, PortableRecordKind::Totp);
+        assert_eq!(records[1].title, "AWS");
+        assert_eq!(
+            records[1].totp_seed.as_deref().map(String::as_str),
+            Some("JBSWY3DPEHPK3PXP")
+        );
+    }
+
+    #[test]
+    fn extra_uris_kept_as_custom_fields_not_dropped() {
+        let json = br#"{"items":[{"type":1,"name":"Multi",
+            "login":{"uris":[{"uri":"https://a.example"},
+                              {"uri":"https://b.example"},
+                              {"uri":"https://c.example"}]}}]}"#;
+        let records = decode(json).unwrap();
+        let r = &records[0];
+        assert_eq!(r.url.as_deref(), Some("https://a.example"));
+        assert_eq!(field(r, "uri_2"), "https://b.example");
+        assert_eq!(field(r, "uri_3"), "https://c.example");
+    }
+
+    #[test]
+    fn decodes_secure_note() {
+        let json = br#"{"items":[{"type":2,"name":"WiFi","notes":"password: hunter2"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records[0].kind, PortableRecordKind::SecureNote);
+        assert_eq!(records[0].notes.as_deref(), Some("password: hunter2"));
+    }
+
+    #[test]
+    fn decodes_card_fields_into_custom_fields() {
+        let json = br#"{"items":[{"type":3,"name":"Amex","card":{
+            "cardholderName":"Ada Lovelace","number":"378282246310005",
+            "expMonth":"1","expYear":"2030","code":"1234"}}]}"#;
+        let records = decode(json).unwrap();
+        let r = &records[0];
+        assert_eq!(r.kind, PortableRecordKind::Card);
+        assert_eq!(field(r, "holder"), "Ada Lovelace");
+        assert_eq!(field(r, "number"), "378282246310005");
+        assert_eq!(field(r, "expiry_month"), "1");
+        assert_eq!(field(r, "expiry_year"), "2030");
+        assert_eq!(field(r, "cvv"), "1234");
+    }
+
+    #[test]
+    fn identity_becomes_custom_kind_not_dropped() {
+        let json = br#"{"items":[{"type":4,"name":"My Passport"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].kind,
+            PortableRecordKind::Custom("bitwarden-type-4".into())
+        );
+    }
+
+    #[test]
+    fn unknown_type_becomes_custom_kind() {
+        let json = br#"{"items":[{"type":99,"name":"???"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(
+            records[0].kind,
+            PortableRecordKind::Custom("bitwarden-type-99".into())
+        );
+    }
+
+    #[test]
+    fn custom_fields_are_decoded() {
+        let json = br#"{"items":[{"type":2,"name":"n","notes":null,
+            "fields":[{"name":"pin","value":"1234","type":1},
+                      {"name":"note","value":"x","type":0}]}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(field(&records[0], "pin"), "1234");
+        assert_eq!(field(&records[0], "note"), "x");
+    }
+
+    // --- Adversarial / malformed input ---
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(matches!(decode(b""), Err(ImportError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn rejects_oversize_input() {
+        let big = vec![b' '; MAX_SOURCE_BYTES + 1];
+        assert!(matches!(decode(&big), Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn rejects_invalid_utf8() {
+        let bytes = vec![0xFF, 0xFE, 0xFD];
+        assert!(matches!(decode(&bytes), Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        assert!(matches!(decode(b"{not json"), Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn rejects_non_object_root() {
+        assert!(matches!(decode(b"[1,2,3]"), Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn rejects_missing_items_key() {
+        assert!(matches!(
+            decode(br#"{"folders":[]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_items_not_an_array() {
+        assert!(matches!(
+            decode(br#"{"items":"nope"}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_item_not_an_object() {
+        assert!(matches!(
+            decode(br#"{"items":[42]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_name() {
+        assert!(matches!(
+            decode(br#"{"items":[{"type":1}]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(matches!(
+            decode(br#"{"items":[{"type":1,"name":""}]}"#),
+            Err(ImportError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_type() {
+        assert!(matches!(
+            decode(br#"{"items":[{"name":"x"}]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_type_as_string() {
+        assert!(matches!(
+            decode(br#"{"items":[{"type":"1","name":"x"}]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_login_as_non_object() {
+        assert!(matches!(
+            decode(br#"{"items":[{"type":1,"name":"x","login":"nope"}]}"#),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_items() {
+        let mut json = String::from(r#"{"items":["#);
+        for i in 0..(MAX_ITEMS + 1) {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(r#"{"type":2,"name":"n"}"#);
+        }
+        json.push_str("]}");
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_uris() {
+        let mut uris = String::from("[");
+        for i in 0..(MAX_URIS_PER_LOGIN + 1) {
+            if i > 0 {
+                uris.push(',');
+            }
+            uris.push_str(r#"{"uri":"https://example.com"}"#);
+        }
+        uris.push(']');
+        let json = format!(r#"{{"items":[{{"type":1,"name":"x","login":{{"uris":{uris}}}}}]}}"#);
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_custom_fields() {
+        let mut fields = String::from("[");
+        for i in 0..(MAX_CUSTOM_FIELDS_PER_ITEM + 1) {
+            if i > 0 {
+                fields.push(',');
+            }
+            fields.push_str(&format!(r#"{{"name":"k{i}","value":"v"}}"#));
+        }
+        fields.push(']');
+        let json = format!(r#"{{"items":[{{"type":2,"name":"x","fields":{fields}}}]}}"#);
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_oversize_field() {
+        let big = "x".repeat(MAX_FIELD_LEN + 1);
+        let json = format!(r#"{{"items":[{{"type":1,"name":"{big}"}}]}}"#);
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn duplicate_keys_resolve_last_write_wins() {
+        let json = br#"{"items":[{"type":2,"name":"first","name":"second"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records[0].title, "second");
+    }
+
+    #[test]
+    fn duplicate_top_level_items_key_resolves_last_write_wins() {
+        let json = br#"{"items":[{"type":2,"name":"ignored"}],
+            "items":[{"type":2,"name":"used"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].title, "used");
+    }
+
+    #[test]
+    fn deeply_nested_document_does_not_crash_and_is_rejected() {
+        // Not a real Bitwarden shape at all -- this only proves the
+        // depth cap inherited from json-parser turns an adversarial
+        // `[[[[...]]]]` into a clean `Err` instead of a stack overflow.
+        let mut nested = String::new();
+        for _ in 0..10_000 {
+            nested.push('[');
+        }
+        for _ in 0..10_000 {
+            nested.push(']');
+        }
+        let result = decode(nested.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn null_login_fields_are_treated_as_absent() {
+        let json = br#"{"items":[{"type":1,"name":"x",
+            "login":{"username":null,"password":null,"totp":null,"uris":null}}]}"#;
+        // `uris: null` is not an array, so this is a decode error --
+        // Bitwarden always emits `[]`, never `null`, for that field.
+        assert!(matches!(decode(json), Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn missing_login_object_is_treated_as_empty() {
+        let json = br#"{"items":[{"type":1,"name":"x"}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].username, None);
+        assert!(records[0].password.is_none());
+    }
+
+    #[test]
+    fn importer_trait_name_and_import() {
+        let importer = BitwardenJsonImporter;
+        assert_eq!(importer.name(), "bitwarden-json");
+        let json = br#"{"items":[{"type":2,"name":"n"}]}"#;
+        let records = importer.import(json).unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn importer_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BitwardenJsonImporter>();
+    }
+
+    #[test]
+    fn custom_field_can_override_kind_specific_card_field() {
+        let json = br#"{"items":[{"type":3,"name":"x",
+            "card":{"number":"111"},
+            "fields":[{"name":"number","value":"overridden"}]}]}"#;
+        let records = decode(json).unwrap();
+        assert_eq!(field(&records[0], "number"), "overridden");
+    }
+}

--- a/code/packages/rust/vault-import-bitwarden/src/lib.rs
+++ b/code/packages/rust/vault-import-bitwarden/src/lib.rs
@@ -67,12 +67,18 @@
 //!
 //! * **Untrusted bytes.** [`MAX_SOURCE_BYTES`] bounds the whole input
 //!   before any parsing begins. [`MAX_ITEMS`], [`MAX_URIS_PER_LOGIN`],
-//!   and [`MAX_CUSTOM_FIELDS_PER_ITEM`] bound every array this adapter
-//!   walks; [`MAX_FIELD_LEN`] bounds every string it copies out. None of
-//!   these can be exceeded by a file within the byte cap producing an
-//!   unbounded *decoded* structure, because JSON (unlike XML) has no
-//!   entity-expansion mechanism — a bounded-length document cannot decode
-//!   to an unboundedly large tree.
+//!   [`MAX_CUSTOM_FIELDS_PER_ITEM`], and [`MAX_KEYS_PER_OBJECT`] bound
+//!   every array and object this adapter walks; [`MAX_FIELD_LEN`] bounds
+//!   every string it copies out. A file within the byte cap cannot decode
+//!   to an *unboundedly* large tree — JSON, unlike XML, has no
+//!   entity-expansion mechanism — but the underlying parser has no
+//!   per-object key-count limit of its own (only a nesting-depth cap), so
+//!   a single object padded with many short junk keys still amplifies
+//!   somewhat past the raw byte count before [`MAX_KEYS_PER_OBJECT`] gets
+//!   a chance to reject it. [`MAX_SOURCE_BYTES`] is kept deliberately
+//!   small (real exports are low single-digit megabytes) precisely to
+//!   bound how large that worst case can get, rather than claiming the
+//!   amplification factor is zero.
 //! * **Deeply nested documents.** Handled by `json-parser`'s built-in
 //!   depth cap, exercised in this crate's own test suite rather than
 //!   only trusted by citation.
@@ -89,9 +95,12 @@
 //!   exports are JSON. `vault-import-csv`'s docs carry that concern.
 //! * **Plaintext residue.** Every secret-shaped field this adapter
 //!   produces — `password`, `totp_seed`, and every `custom_fields` value
-//!   — is `Zeroizing` at the [`PortableRecord`] boundary already; this
-//!   crate introduces no separate plaintext buffer that outlives the
-//!   call.
+//!   — is `Zeroizing` at the [`PortableRecord`] boundary. The *source*
+//!   copies inside the generic parsed JSON tree are ordinary `String`s —
+//!   `json-value` has no reason to know any of them are sensitive — so
+//!   [`decode`] recursively zeroizes the whole parsed tree in place
+//!   (`zeroize_object`/`zeroize_json_value`) immediately after every
+//!   record has been extracted from it, before that tree drops.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -100,15 +109,31 @@ use coding_adventures_json_value::{JsonNumber, JsonValue};
 use coding_adventures_vault_import_export::{
     ImportError, Importer, PortableRecord, PortableRecordKind,
 };
-use coding_adventures_zeroize::Zeroizing;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use std::collections::BTreeMap;
 
 // === Bounds =================================================================
 
 /// Maximum accepted raw source bytes, checked before any parsing begins.
-pub const MAX_SOURCE_BYTES: usize = 64 * 1024 * 1024;
+///
+/// A real Bitwarden export for even a very large personal vault is low
+/// single-digit megabytes; this ceiling is generous headroom over that,
+/// not an estimate of a plausible file. Kept deliberately smaller than an
+/// earlier 64 MiB draft: the underlying JSON parser has no per-object key
+/// count limit (only a nesting-depth cap), so an adversarial object with
+/// millions of short junk keys inside this byte ceiling still amplifies
+/// into a materially larger in-memory `Vec<(String, JsonValue)>` before
+/// [`MAX_KEYS_PER_OBJECT`] below ever gets a chance to reject it — a
+/// smaller byte ceiling directly bounds how bad that worst case can get.
+pub const MAX_SOURCE_BYTES: usize = 16 * 1024 * 1024;
 /// Maximum accepted `items` array length.
 pub const MAX_ITEMS: usize = 50_000;
+/// Maximum accepted key-value pairs in any single JSON object this adapter
+/// destructures (root, one item, `login`, `card`, one `fields[]`/`uris[]`
+/// entry). Bounds a single crafted object with many junk keys; see
+/// [`MAX_SOURCE_BYTES`] for why this cannot bound *peak* memory during
+/// parsing, only how much further processing a pathological object gets.
+pub const MAX_KEYS_PER_OBJECT: usize = 128;
 /// Maximum accepted `login.uris` entries kept per login (first becomes
 /// `url`; the rest become bounded `custom_fields` entries).
 pub const MAX_URIS_PER_LOGIN: usize = 32;
@@ -147,9 +172,10 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
         .map_err(|_| ImportError::Decode("source is not valid UTF-8"))?;
     let root = coding_adventures_json_value::parse(text)
         .map_err(|_| ImportError::Decode("source is not valid JSON"))?;
-    let JsonValue::Object(root_pairs) = root else {
+    let JsonValue::Object(mut root_pairs) = root else {
         return Err(ImportError::Decode("root value must be a JSON object"));
     };
+    check_object_size(&root_pairs)?;
     let items = match find(&root_pairs, "items") {
         Some(JsonValue::Array(items)) => items,
         Some(_) => return Err(ImportError::Decode("`items` must be an array")),
@@ -162,7 +188,41 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
     for item in items {
         decode_item(item, &mut records)?;
     }
+    // Every secret-shaped value this adapter reads (password, TOTP seed,
+    // card number/CVV, custom-field values) is copied out into a
+    // `Zeroizing`-held `PortableRecord` field above, but the *source*
+    // copy inside this generic JSON parse tree is an ordinary `String`
+    // that the general-purpose `json-value` crate has no reason to know
+    // is sensitive. Left alone, that source copy would be freed with the
+    // rest of `root_pairs` at the end of this function without ever
+    // being overwritten -- recoverable plaintext in freed heap. Scrub the
+    // whole tree in place before it drops, the same property
+    // `read_external_import_source`'s `Zeroizing` buffer already gives
+    // the raw bytes this tree was parsed from.
+    zeroize_object(&mut root_pairs);
     Ok(records)
+}
+
+/// Recursively wipe every string in a parsed object's pair list, in place.
+fn zeroize_object(pairs: &mut [(String, JsonValue)]) {
+    for (key, value) in pairs.iter_mut() {
+        key.zeroize();
+        zeroize_json_value(value);
+    }
+}
+
+/// Recursively wipe every string reachable from a parsed JSON value.
+fn zeroize_json_value(value: &mut JsonValue) {
+    match value {
+        JsonValue::String(s) => s.zeroize(),
+        JsonValue::Object(pairs) => zeroize_object(pairs),
+        JsonValue::Array(items) => {
+            for item in items.iter_mut() {
+                zeroize_json_value(item);
+            }
+        }
+        JsonValue::Number(_) | JsonValue::Bool(_) | JsonValue::Null => {}
+    }
 }
 
 /// Resolve a key in an object's pair list, **last write wins** on
@@ -171,6 +231,20 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
 /// order (see `reject...duplicate_key` tests below).
 fn find<'a>(pairs: &'a [(String, JsonValue)], key: &str) -> Option<&'a JsonValue> {
     pairs.iter().rev().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+/// Reject an object with more keys than [`MAX_KEYS_PER_OBJECT`], regardless
+/// of which keys this adapter actually reads. Called at every point this
+/// adapter destructures a `JsonValue::Object`, so a crafted object padded
+/// with junk keys is refused before any further per-key work is spent on
+/// it, rather than only bounding the handful of key names this adapter
+/// happens to look up.
+fn check_object_size(pairs: &[(String, JsonValue)]) -> Result<(), ImportError> {
+    if pairs.len() > MAX_KEYS_PER_OBJECT {
+        Err(ImportError::TooLarge("MAX_KEYS_PER_OBJECT"))
+    } else {
+        Ok(())
+    }
 }
 
 fn as_str<'a>(value: &'a JsonValue, what: &'static str) -> Result<&'a str, ImportError> {
@@ -206,6 +280,7 @@ fn decode_item(item: &JsonValue, out: &mut Vec<PortableRecord>) -> Result<(), Im
     let JsonValue::Object(pairs) = item else {
         return Err(ImportError::Decode("each item must be a JSON object"));
     };
+    check_object_size(pairs)?;
     let title = match find(pairs, "name") {
         Some(value) => as_str(value, "name")?,
         None => return Err(ImportError::Decode("item missing `name`")),
@@ -269,7 +344,10 @@ fn decode_login(
     out: &mut Vec<PortableRecord>,
 ) -> Result<(), ImportError> {
     let login = match find(pairs, "login") {
-        Some(JsonValue::Object(login_pairs)) => login_pairs.as_slice(),
+        Some(JsonValue::Object(login_pairs)) => {
+            check_object_size(login_pairs)?;
+            login_pairs.as_slice()
+        }
         Some(_) => return Err(ImportError::Decode("`login` must be an object")),
         None => &[],
     };
@@ -291,6 +369,7 @@ fn decode_login(
             let JsonValue::Object(uri_pairs) = entry else {
                 return Err(ImportError::Decode("`login.uris[]` must be an object"));
             };
+            check_object_size(uri_pairs)?;
             let Some(uri) = optional_str(uri_pairs, "uri", "login.uris[].uri")? else {
                 continue;
             };
@@ -348,7 +427,10 @@ fn decode_card(
     out: &mut Vec<PortableRecord>,
 ) -> Result<(), ImportError> {
     let card = match find(pairs, "card") {
-        Some(JsonValue::Object(card_pairs)) => card_pairs.as_slice(),
+        Some(JsonValue::Object(card_pairs)) => {
+            check_object_size(card_pairs)?;
+            card_pairs.as_slice()
+        }
         Some(_) => return Err(ImportError::Decode("`card` must be an object")),
         None => &[],
     };
@@ -408,6 +490,7 @@ fn decode_custom_fields(
                 "each `fields[]` entry must be an object",
             ));
         };
+        check_object_size(field_pairs)?;
         let name = match find(field_pairs, "name") {
             Some(JsonValue::Null) | None => continue,
             Some(value) => as_str(value, "fields[].name")?,
@@ -640,6 +723,65 @@ mod tests {
             decode(json.as_bytes()),
             Err(ImportError::TooLarge(_))
         ));
+    }
+
+    #[test]
+    fn rejects_item_object_with_too_many_junk_keys() {
+        let mut item = String::from(r#"{"type":2,"name":"n""#);
+        for i in 0..(MAX_KEYS_PER_OBJECT + 1) {
+            item.push_str(&format!(r#","junk{i}":0"#));
+        }
+        item.push('}');
+        let json = format!(r#"{{"items":[{item}]}}"#);
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_root_object_with_too_many_junk_keys() {
+        let mut json = String::from(r#"{"items":[]"#);
+        for i in 0..(MAX_KEYS_PER_OBJECT + 1) {
+            json.push_str(&format!(r#","junk{i}":0"#));
+        }
+        json.push('}');
+        assert!(matches!(
+            decode(json.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn zeroize_json_value_wipes_strings_in_place() {
+        let mut value = JsonValue::Object(vec![
+            (
+                "password".to_owned(),
+                JsonValue::String("hunter2".to_owned()),
+            ),
+            (
+                "uris".to_owned(),
+                JsonValue::Array(vec![JsonValue::String("https://example.com".to_owned())]),
+            ),
+        ]);
+        zeroize_json_value(&mut value);
+        let JsonValue::Object(pairs) = &value else {
+            panic!("expected object");
+        };
+        for (key, val) in pairs {
+            assert!(key.is_empty(), "key not wiped: {key:?}");
+            match val {
+                JsonValue::String(s) => assert!(s.is_empty(), "string not wiped: {s:?}"),
+                JsonValue::Array(items) => {
+                    for item in items {
+                        if let JsonValue::String(s) = item {
+                            assert!(s.is_empty(), "array string not wiped: {s:?}");
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 
     #[test]

--- a/code/packages/rust/vault-import-bitwarden/src/lib.rs
+++ b/code/packages/rust/vault-import-bitwarden/src/lib.rs
@@ -175,32 +175,43 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
     let JsonValue::Object(mut root_pairs) = root else {
         return Err(ImportError::Decode("root value must be a JSON object"));
     };
-    check_object_size(&root_pairs)?;
-    let items = match find(&root_pairs, "items") {
-        Some(JsonValue::Array(items)) => items,
-        Some(_) => return Err(ImportError::Decode("`items` must be an array")),
-        None => return Err(ImportError::Decode("missing `items` array")),
-    };
-    if items.len() > MAX_ITEMS {
-        return Err(ImportError::TooLarge("MAX_ITEMS"));
-    }
-    let mut records = Vec::with_capacity(items.len());
-    for item in items {
-        decode_item(item, &mut records)?;
-    }
     // Every secret-shaped value this adapter reads (password, TOTP seed,
     // card number/CVV, custom-field values) is copied out into a
-    // `Zeroizing`-held `PortableRecord` field above, but the *source*
+    // `Zeroizing`-held `PortableRecord` field below, but the *source*
     // copy inside this generic JSON parse tree is an ordinary `String`
     // that the general-purpose `json-value` crate has no reason to know
     // is sensitive. Left alone, that source copy would be freed with the
     // rest of `root_pairs` at the end of this function without ever
-    // being overwritten -- recoverable plaintext in freed heap. Scrub the
-    // whole tree in place before it drops, the same property
+    // being overwritten -- recoverable plaintext in freed heap. `outcome`
+    // captures every return path below (success *and* every early
+    // `Err`) precisely so the zeroize pass a few lines down is
+    // unconditional: a malformed/adversarial item that makes this
+    // function return early is the *normal* case this crate's threat
+    // model exists to survive, and it must not silently skip the wipe
+    // just because it was also the input that triggered an error.
+    let outcome: Result<Vec<PortableRecord>, ImportError> = (|| {
+        check_object_size(&root_pairs)?;
+        let items = match find(&root_pairs, "items") {
+            Some(JsonValue::Array(items)) => items,
+            Some(_) => return Err(ImportError::Decode("`items` must be an array")),
+            None => return Err(ImportError::Decode("missing `items` array")),
+        };
+        if items.len() > MAX_ITEMS {
+            return Err(ImportError::TooLarge("MAX_ITEMS"));
+        }
+        let mut records = Vec::with_capacity(items.len());
+        for item in items {
+            decode_item(item, &mut records)?;
+        }
+        Ok(records)
+    })();
+    // Scrub the whole tree in place before it drops, the same property
     // `read_external_import_source`'s `Zeroizing` buffer already gives
-    // the raw bytes this tree was parsed from.
+    // the raw bytes this tree was parsed from -- run unconditionally,
+    // before `outcome` is inspected, so no early return above can skip
+    // it.
     zeroize_object(&mut root_pairs);
-    Ok(records)
+    outcome
 }
 
 /// Recursively wipe every string in a parsed object's pair list, in place.

--- a/code/packages/rust/vault-import-csv/BUILD
+++ b/code/packages/rust/vault-import-csv/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_import_csv -- --nocapture

--- a/code/packages/rust/vault-import-csv/CHANGELOG.md
+++ b/code/packages/rust/vault-import-csv/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delegates all CSV structural parsing (quoting, embedded commas/
   newlines, `""` escaping, ragged rows) to this repository's existing
   RFC 4180 `csv-parser` crate rather than writing new CSV-syntax parsing.
-- Bounded: `MAX_SOURCE_BYTES` (32 MiB), `MAX_ROWS` (200,000),
+- Bounded: `MAX_SOURCE_BYTES` (16 MiB), `MAX_ROWS` (200,000),
   `MAX_COLUMNS` (256), `MAX_FIELD_LEN` (64 KiB).
-- 20 unit tests: happy-path decode for each vendor's column shape,
+- 22 unit tests: happy-path decode for each vendor's column shape,
   case-insensitive/whitespace-trimmed header matching, embedded comma/
   newline preservation, multi-row decoding, an explicit CSV
   formula-injection test proving `=`/`+`/`-`/`@`-prefixed payloads round-
@@ -37,6 +37,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ragged short/long rows, over-bound rows/columns/field-length, and
   `Send + Sync`.
 - `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+
+### Security hardening (pre-merge review)
+
+Three findings flagged across four review rounds before push, all fixed
+inline:
+
+- **MEDIUM** — `MAX_COLUMNS` could only reject a wide row after
+  `csv-parser` had already fully materialized it into a `HashMap`, so a
+  crafted file within the byte cap could amplify past its raw size before
+  that check ran. Mitigated by lowering `MAX_SOURCE_BYTES` from an
+  earlier 32 MiB draft to 16 MiB, directly shrinking the worst case (real
+  exports are low single-digit megabytes).
+- **LOW/MEDIUM** — every parsed CSV cell value lived in an ordinary,
+  non-zeroizing `String` inside `rows: Vec<HashMap<String, String>>`
+  until the function returned, so a password or TOTP seed already
+  extracted into a `Zeroizing` `PortableRecord` field left an unwiped
+  copy in freed heap. Fixed by zeroizing every cell value in `rows` in
+  place before it drops.
+- **MEDIUM** — that zeroize pass initially ran only after every row
+  decoded successfully, so a malformed row partway through the file (an
+  over-`MAX_COLUMNS` row, an over-`MAX_FIELD_LEN` cell) skipped the wipe
+  for every row already decoded before it — exactly the adversarial
+  input this crate's threat model exists to survive. Fixed by capturing
+  the decode loop's result and running the zeroize pass unconditionally,
+  on both its `Ok` and `Err` paths, before propagating it.
 
 ### Out of scope (documented, not silently dropped)
 

--- a/code/packages/rust/vault-import-csv/CHANGELOG.md
+++ b/code/packages/rust/vault-import-csv/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this package are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-08-19
+
+### Added
+
+- Initial implementation of the browser/LastPass-style CSV format adapter
+  named by VLT15's reuse map and VLT-PM00 §23 item 13
+  (`code/specs/VLT-PM49-cli-external-import.md`).
+- `CsvLoginImporter` — implements `vault-import-export`'s `Importer`
+  trait (`name()` returns `"browser-csv"`).
+- `decode(&[u8]) -> Result<Vec<PortableRecord>, ImportError>` — the free
+  function the trait impl calls, exposed directly for callers that don't
+  need a trait object.
+- Case-insensitive header-alias resolution covering Chrome/Edge/Brave,
+  Firefox, LastPass, and Bitwarden CSV column names in one adapter
+  instead of one crate per vendor.
+- Title fallback chain (title column -> url -> username -> generated
+  `"Imported login N"`) so exports with no title column (Firefox) still
+  produce a usable item.
+- Delegates all CSV structural parsing (quoting, embedded commas/
+  newlines, `""` escaping, ragged rows) to this repository's existing
+  RFC 4180 `csv-parser` crate rather than writing new CSV-syntax parsing.
+- Bounded: `MAX_SOURCE_BYTES` (32 MiB), `MAX_ROWS` (200,000),
+  `MAX_COLUMNS` (256), `MAX_FIELD_LEN` (64 KiB).
+- 20 unit tests: happy-path decode for each vendor's column shape,
+  case-insensitive/whitespace-trimmed header matching, embedded comma/
+  newline preservation, multi-row decoding, an explicit CSV
+  formula-injection test proving `=`/`+`/`-`/`@`-prefixed payloads round-
+  trip as inert literal text, and an adversarial matrix — empty input,
+  oversize input, invalid UTF-8, unclosed quote, header-only file,
+  ragged short/long rows, over-bound rows/columns/field-length, and
+  `Send + Sync`.
+- `#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`.
+
+### Out of scope (documented, not silently dropped)
+
+- Non-login record kinds (secure notes, cards) — no CSV shape in the
+  supported vendor set carries them; use `vault-import-bitwarden` for
+  Bitwarden's JSON export instead.
+- CSV export / writing, and therefore the formula-injection
+  *neutralization* an export path would need — there is no writer yet
+  for that mitigation to belong to.

--- a/code/packages/rust/vault-import-csv/Cargo.toml
+++ b/code/packages/rust/vault-import-csv/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding_adventures_vault_import_csv"
+version = "0.1.0"
+edition = "2021"
+description = "VLT-PM49 -- browser/LastPass-style CSV export adapter. Implements vault-import-export's (VLT15) Importer trait, decoding a header-keyed login CSV (Chrome, Edge, Firefox, LastPass, Bitwarden CSV) into PortableRecords for vault-pm's `import csv` ceremony."
+license = "MIT"
+
+[dependencies]
+coding_adventures_vault_import_export = { path = "../vault-import-export" }
+coding-adventures-csv-parser = { path = "../csv-parser" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-import-csv/README.md
+++ b/code/packages/rust/vault-import-csv/README.md
@@ -37,7 +37,7 @@ CSV structure (quoting, embedded commas/newlines, `""` escaping, ragged
 rows) is handled entirely by this repository's existing RFC 4180
 state-machine parser (`coding_adventures_csv_parser`); this adapter adds
 no CSV-syntax parsing of its own. Untrusted-input bounds:
-`MAX_SOURCE_BYTES` (32 MiB), `MAX_ROWS` (200,000), `MAX_COLUMNS` (256),
+`MAX_SOURCE_BYTES` (16 MiB), `MAX_ROWS` (200,000), `MAX_COLUMNS` (256),
 `MAX_FIELD_LEN` (64 KiB).
 
 **CSV formula injection** — a cell starting with `=`, `+`, `-`, or `@`

--- a/code/packages/rust/vault-import-csv/README.md
+++ b/code/packages/rust/vault-import-csv/README.md
@@ -1,0 +1,72 @@
+# `coding_adventures_vault_import_csv` — VLT-PM49
+
+Decodes a **header-keyed login CSV** — the shape Chrome, Edge, Brave,
+Firefox, LastPass, and Bitwarden's own CSV export all produce — into the
+shared `PortableRecord` vocabulary defined by
+[`vault-import-export`](../vault-import-export) (VLT15).
+
+This is a format adapter, consumed by `vault-pm`'s `import csv FILE`
+ceremony (`VLT-PM49-cli-external-import.md`), which maps each
+`PortableRecord` onto a real vault-pm item through the same `item add`
+machinery a human typing at the CLI uses.
+
+## Why one crate instead of one per vendor
+
+VLT15's own README names `vault-import-lastpass`, `vault-import-chrome`,
+and `vault-import-firefox` as separate future sibling crates. This
+adapter instead recognizes the *union* of the column names those (and
+Bitwarden's CSV export) all use, case-insensitively:
+
+| Concept | Recognized headers |
+|---|---|
+| title | `name`, `title` |
+| url | `url`, `login_uri`, `httpRealm`, `formActionOrigin`, `web site`, `website` |
+| username | `username`, `login_username`, `user name` |
+| password | `password`, `login_password` |
+| totp | `totp`, `login_totp` |
+| notes | `notes`, `note`, `extra` |
+
+Only logins are in scope — every export shape in the table above is
+exclusively a login list. When no title-shaped column is present at all
+(Firefox's export has none), the title falls back to the URL, then the
+username, then a generated `"Imported login N"`.
+
+## Threat model
+
+CSV structure (quoting, embedded commas/newlines, `""` escaping, ragged
+rows) is handled entirely by this repository's existing RFC 4180
+state-machine parser (`coding_adventures_csv_parser`); this adapter adds
+no CSV-syntax parsing of its own. Untrusted-input bounds:
+`MAX_SOURCE_BYTES` (32 MiB), `MAX_ROWS` (200,000), `MAX_COLUMNS` (256),
+`MAX_FIELD_LEN` (64 KiB).
+
+**CSV formula injection** — a cell starting with `=`, `+`, `-`, or `@`
+can execute as a formula if the CSV is later opened in a spreadsheet
+application. This crate only *reads* CSV; it has no export/writer path,
+so there is nothing for such a payload to trigger here. It is decoded
+and stored as inert literal text, proven by a dedicated test. If vault-pm
+ever grows a CSV *export* path, that writer — not this reader — is where
+OWASP's standard mitigation (prefixing a leading `'`) belongs.
+
+## Usage
+
+```rust
+use coding_adventures_vault_import_csv::{decode, CsvLoginImporter};
+use coding_adventures_vault_import_export::Importer;
+
+let csv = "name,url,username,password\nGitHub,https://github.com,alice,hunter2\n";
+let records = decode(csv.as_bytes()).unwrap();
+assert_eq!(records.len(), 1);
+
+let importer = CsvLoginImporter;
+assert_eq!(importer.name(), "browser-csv");
+```
+
+## Out of scope
+
+- Non-login rows — Bitwarden's CSV format can in principle carry other
+  `type` values in a `type` column; this adapter does not read that
+  column and treats every row as a login. (Bitwarden's *JSON* export,
+  handled by the sibling `vault-import-bitwarden` crate, is the
+  supported path for non-login items.)
+- CSV export / writing.

--- a/code/packages/rust/vault-import-csv/src/lib.rs
+++ b/code/packages/rust/vault-import-csv/src/lib.rs
@@ -54,7 +54,12 @@
 //!
 //! * **Untrusted bytes.** [`MAX_SOURCE_BYTES`] bounds the whole input
 //!   before parsing. [`MAX_ROWS`] and [`MAX_COLUMNS`] bound the decoded
-//!   shape; [`MAX_FIELD_LEN`] bounds every string copied out.
+//!   shape; [`MAX_FIELD_LEN`] bounds every string copied out. `MAX_COLUMNS`
+//!   can only reject a wide row *after* `coding_adventures_csv_parser` has
+//!   already fully materialized it into a `HashMap`, so
+//!   [`MAX_SOURCE_BYTES`] is kept deliberately small (real exports are low
+//!   single-digit megabytes) to directly bound how far that amplification
+//!   can go, rather than claiming it is zero.
 //! * **CSV structure attacks.** Parsing is delegated to this
 //!   repository's existing RFC 4180 state-machine parser
 //!   (`coding_adventures_csv_parser`), which already handles embedded
@@ -75,8 +80,11 @@
 //!   guidance; that responsibility does not exist yet because there is
 //!   no writer to carry it.
 //! * **Plaintext residue.** `password` and `totp_seed` are `Zeroizing` at
-//!   the `PortableRecord` boundary already; this crate introduces no
-//!   separate plaintext buffer that outlives the call.
+//!   the `PortableRecord` boundary, but the source cell values inside the
+//!   parsed `rows: Vec<HashMap<String, String>>` are ordinary `String`s --
+//!   `coding_adventures_csv_parser` has no reason to know any column is
+//!   sensitive. [`decode`] zeroizes every cell value in `rows` in place
+//!   once every record has been extracted from it, before `rows` drops.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -85,13 +93,22 @@ use coding_adventures_csv_parser::{parse_csv, CsvError};
 use coding_adventures_vault_import_export::{
     ImportError, Importer, PortableRecord, PortableRecordKind,
 };
-use coding_adventures_zeroize::Zeroizing;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use std::collections::{BTreeMap, HashMap};
 
 // === Bounds =================================================================
 
 /// Maximum accepted raw source bytes, checked before any parsing begins.
-pub const MAX_SOURCE_BYTES: usize = 32 * 1024 * 1024;
+///
+/// A real login-manager CSV export, even a large one, is low single-digit
+/// megabytes; this ceiling is generous headroom over that, not an estimate
+/// of a plausible file. Kept deliberately smaller than an earlier 32 MiB
+/// draft: [`MAX_COLUMNS`] can only reject a wide row *after*
+/// `coding_adventures_csv_parser` has already fully materialized it into a
+/// `HashMap`, so a smaller byte ceiling directly bounds how large that
+/// worst case can get rather than claiming the amplification factor is
+/// zero.
+pub const MAX_SOURCE_BYTES: usize = 16 * 1024 * 1024;
 /// Maximum accepted data rows (header excluded).
 pub const MAX_ROWS: usize = 200_000;
 /// Maximum accepted columns in the header row.
@@ -148,7 +165,7 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
     }
     let text = core::str::from_utf8(input)
         .map_err(|_| ImportError::Decode("source is not valid UTF-8"))?;
-    let rows = parse_csv(text).map_err(|error| match error {
+    let mut rows = parse_csv(text).map_err(|error| match error {
         CsvError::UnclosedQuote => ImportError::Decode("unclosed quoted CSV field"),
     })?;
     if rows.len() > MAX_ROWS {
@@ -160,6 +177,23 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
             return Err(ImportError::TooLarge("MAX_COLUMNS"));
         }
         records.push(decode_row(row, index + 1)?);
+    }
+    // Every secret-shaped *value* this adapter reads (password, TOTP
+    // seed) is copied out into a `Zeroizing`-held `PortableRecord` field
+    // above, but the source copy inside `rows` is an ordinary `String` --
+    // `coding_adventures_csv_parser` has no reason to know any column is
+    // sensitive. Left alone, that source copy would be freed with `rows`
+    // at the end of this function without ever being overwritten. Scrub
+    // every cell value in place before `rows` drops, the same property
+    // `read_external_import_source`'s `Zeroizing` buffer already gives
+    // the raw bytes this table was parsed from. Keys are column *names*
+    // (`"password"`, `"url"`, ...), never secret-shaped, and `HashMap`
+    // only exposes them as `&String` through `values_mut`/`iter_mut`
+    // regardless, so they are left alone.
+    for row in rows.iter_mut() {
+        for value in row.values_mut() {
+            value.zeroize();
+        }
     }
     Ok(records)
 }

--- a/code/packages/rust/vault-import-csv/src/lib.rs
+++ b/code/packages/rust/vault-import-csv/src/lib.rs
@@ -1,0 +1,447 @@
+//! # `coding_adventures_vault_import_csv` — VLT-PM49
+//!
+//! ## What this crate is
+//!
+//! A **format adapter** for the import/export tier defined by VLT15
+//! (`coding_adventures_vault_import_export`). It decodes a header-keyed
+//! login CSV — the shape every mainstream browser password manager
+//! (Chrome, Edge, Brave, Firefox) and several third-party managers
+//! (LastPass, Bitwarden's CSV export) all produce — into the shared
+//! [`PortableRecord`] vocabulary every adapter in this tier produces.
+//!
+//! Real exports do not agree on column names:
+//!
+//! | Source | Header row |
+//! |---|---|
+//! | Chrome / Edge / Brave | `name,url,username,password` |
+//! | Firefox | `url,username,password,httpRealm,formActionOrigin,guid,...` |
+//! | LastPass | `url,username,password,totp,extra,name,grouping,fav` |
+//! | Bitwarden CSV | `folder,favorite,type,name,notes,fields,reprompt,login_uri,login_username,login_password,login_totp` |
+//!
+//! Rather than ship one crate per vendor (VLT15's own README enumerates
+//! `vault-import-lastpass`, `vault-import-chrome`, `vault-import-firefox`
+//! as separate future crates), this adapter recognizes the union of
+//! these header names, case-insensitively, and maps whichever ones are
+//! present. That covers "browser CSV" as VLT-PM00 §23 item 13 names it
+//! with one crate instead of three near-duplicates; per-vendor crates
+//! remain available later if header drift ever makes that necessary.
+//!
+//! Only logins are in scope. Every export in the table above is
+//! exclusively a login list — unlike Bitwarden's JSON export, none of
+//! these CSV shapes carry secure notes or payment cards.
+//!
+//! ## Column resolution
+//!
+//! A column is matched by a case-insensitive, trimmed comparison against
+//! a fixed alias list (see [`TITLE_ALIASES`] and friends). The **first**
+//! header in a row that matches an alias set wins; a file with more than
+//! one column matching the same alias set (e.g. both `name` and `title`
+//! present) uses whichever [`coding_adventures_csv_parser`] happens to
+//! keep — which, because CSV headers are turned into a
+//! `HashMap<String, String>` per row upstream, is simply "the value
+//! under that literal header text," so two *differently spelled* aliases
+//! for the same concept in one file cannot collide; the CSV parser's own
+//! row-shape rules (short rows padded, long rows truncated) govern
+//! everything else.
+//!
+//! When a row has no title-shaped column at all (Firefox's export has
+//! none), the title falls back to the URL, then the username, then a
+//! generated `"Imported login N"` — never an empty string, because
+//! vault-pm's own record validation rejects one and a fallback here is
+//! far more useful than a whole-file rejection over one blank cell.
+//!
+//! ## Threat model
+//!
+//! * **Untrusted bytes.** [`MAX_SOURCE_BYTES`] bounds the whole input
+//!   before parsing. [`MAX_ROWS`] and [`MAX_COLUMNS`] bound the decoded
+//!   shape; [`MAX_FIELD_LEN`] bounds every string copied out.
+//! * **CSV structure attacks.** Parsing is delegated to this
+//!   repository's existing RFC 4180 state-machine parser
+//!   (`coding_adventures_csv_parser`), which already handles embedded
+//!   quotes, embedded newlines and commas inside quoted fields, `""`
+//!   escaping, and ragged rows. This adapter adds no CSV-syntax parsing
+//!   of its own.
+//! * **CSV formula injection.** A cell beginning with `=`, `+`, `-`, `@`,
+//!   a tab, or a carriage return is a well-known attack when a CSV is
+//!   later *opened* in a spreadsheet application — the leading character
+//!   can make the cell evaluate as a formula. This adapter only ever
+//!   **reads** CSV; it has no CSV-writing/export path, so there is
+//!   nothing here for such a payload to trigger. It is decoded and
+//!   stored as inert literal text — [`decode`]'s test suite proves a
+//!   formula-shaped username/password/notes value round-trips byte-for-
+//!   byte and is never interpreted. If a CSV **export** path is ever
+//!   added to vault-pm, it must neutralize these leading characters
+//!   (e.g. a leading `'`) on the way out per standard OWASP CSV-injection
+//!   guidance; that responsibility does not exist yet because there is
+//!   no writer to carry it.
+//! * **Plaintext residue.** `password` and `totp_seed` are `Zeroizing` at
+//!   the `PortableRecord` boundary already; this crate introduces no
+//!   separate plaintext buffer that outlives the call.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_csv_parser::{parse_csv, CsvError};
+use coding_adventures_vault_import_export::{
+    ImportError, Importer, PortableRecord, PortableRecordKind,
+};
+use coding_adventures_zeroize::Zeroizing;
+use std::collections::{BTreeMap, HashMap};
+
+// === Bounds =================================================================
+
+/// Maximum accepted raw source bytes, checked before any parsing begins.
+pub const MAX_SOURCE_BYTES: usize = 32 * 1024 * 1024;
+/// Maximum accepted data rows (header excluded).
+pub const MAX_ROWS: usize = 200_000;
+/// Maximum accepted columns in the header row.
+pub const MAX_COLUMNS: usize = 256;
+/// Maximum accepted bytes for any single cell this adapter reads.
+pub const MAX_FIELD_LEN: usize = 64 * 1024;
+
+/// Case-insensitive header aliases this adapter recognizes as the title.
+pub const TITLE_ALIASES: &[&str] = &["name", "title"];
+/// Case-insensitive header aliases this adapter recognizes as the URL.
+pub const URL_ALIASES: &[&str] = &[
+    "url",
+    "login_uri",
+    "httprealm",
+    "formactionorigin",
+    "web site",
+    "website",
+];
+/// Case-insensitive header aliases this adapter recognizes as the username.
+pub const USERNAME_ALIASES: &[&str] = &["username", "login_username", "user name"];
+/// Case-insensitive header aliases this adapter recognizes as the password.
+pub const PASSWORD_ALIASES: &[&str] = &["password", "login_password"];
+/// Case-insensitive header aliases this adapter recognizes as a TOTP seed.
+pub const TOTP_ALIASES: &[&str] = &["totp", "login_totp"];
+/// Case-insensitive header aliases this adapter recognizes as free-form notes.
+pub const NOTES_ALIASES: &[&str] = &["notes", "note", "extra"];
+
+/// Decodes a header-keyed browser/LastPass/Bitwarden-style login CSV into
+/// [`PortableRecord`]s.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CsvLoginImporter;
+
+impl Importer for CsvLoginImporter {
+    fn name(&self) -> &str {
+        "browser-csv"
+    }
+
+    fn import(&self, input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
+        decode(input)
+    }
+}
+
+/// Decode a login CSV into [`PortableRecord`]s.
+///
+/// Exposed as a free function (in addition to the [`Importer`] impl above)
+/// so callers that already have a concrete adapter type in hand don't need
+/// a trait object just to call it.
+pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
+    if input.is_empty() {
+        return Err(ImportError::InvalidParameter("empty source"));
+    }
+    if input.len() > MAX_SOURCE_BYTES {
+        return Err(ImportError::TooLarge("MAX_SOURCE_BYTES"));
+    }
+    let text = core::str::from_utf8(input)
+        .map_err(|_| ImportError::Decode("source is not valid UTF-8"))?;
+    let rows = parse_csv(text).map_err(|error| match error {
+        CsvError::UnclosedQuote => ImportError::Decode("unclosed quoted CSV field"),
+    })?;
+    if rows.len() > MAX_ROWS {
+        return Err(ImportError::TooLarge("MAX_ROWS"));
+    }
+    let mut records = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
+        if row.len() > MAX_COLUMNS {
+            return Err(ImportError::TooLarge("MAX_COLUMNS"));
+        }
+        records.push(decode_row(row, index + 1)?);
+    }
+    Ok(records)
+}
+
+fn lookup<'a>(
+    row: &'a HashMap<String, String>,
+    aliases: &[&str],
+) -> Result<Option<&'a str>, ImportError> {
+    for alias in aliases {
+        if let Some(value) = row
+            .iter()
+            .find(|(key, _)| key.trim().eq_ignore_ascii_case(alias))
+            .map(|(_, value)| value.as_str())
+        {
+            if value.len() > MAX_FIELD_LEN {
+                return Err(ImportError::TooLarge("CSV field"));
+            }
+            if !value.is_empty() {
+                return Ok(Some(value));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn decode_row(
+    row: &HashMap<String, String>,
+    ordinal: usize,
+) -> Result<PortableRecord, ImportError> {
+    let url = lookup(row, URL_ALIASES)?;
+    let username = lookup(row, USERNAME_ALIASES)?;
+    let password = lookup(row, PASSWORD_ALIASES)?;
+    let totp = lookup(row, TOTP_ALIASES)?;
+    let notes = lookup(row, NOTES_ALIASES)?;
+    let title = lookup(row, TITLE_ALIASES)?
+        .or(url)
+        .or(username)
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("Imported login {ordinal}"));
+
+    Ok(PortableRecord {
+        kind: PortableRecordKind::Login,
+        title,
+        username: username.map(str::to_owned),
+        password: password.map(|s| Zeroizing::new(s.to_owned())),
+        url: url.map(str::to_owned),
+        notes: notes.map(str::to_owned),
+        totp_seed: totp.map(|s| Zeroizing::new(s.to_owned())),
+        tags: Vec::new(),
+        custom_fields: BTreeMap::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_chrome_style_csv() {
+        let csv = "name,url,username,password\nGitHub,https://github.com,alice,hunter2\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records.len(), 1);
+        let r = &records[0];
+        assert_eq!(r.kind, PortableRecordKind::Login);
+        assert_eq!(r.title, "GitHub");
+        assert_eq!(r.url.as_deref(), Some("https://github.com"));
+        assert_eq!(r.username.as_deref(), Some("alice"));
+        assert_eq!(r.password.as_deref().map(String::as_str), Some("hunter2"));
+    }
+
+    #[test]
+    fn decodes_firefox_style_csv_without_title_column() {
+        let csv = "url,username,password,httpRealm,formActionOrigin,guid\n\
+                   https://example.com,bob,pw,,https://example.com,abc123\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        // No name/title column at all -- falls back to the URL.
+        assert_eq!(records[0].title, "https://example.com");
+        assert_eq!(records[0].username.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn decodes_lastpass_style_csv_with_totp() {
+        let csv = "url,username,password,totp,extra,name,grouping,fav\n\
+                   https://aws.amazon.com,root,pw,JBSWY3DPEHPK3PXP,,AWS,,0\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "AWS");
+        assert_eq!(
+            records[0].totp_seed.as_deref().map(String::as_str),
+            Some("JBSWY3DPEHPK3PXP")
+        );
+    }
+
+    #[test]
+    fn decodes_bitwarden_csv_style_headers() {
+        let csv = "folder,favorite,type,name,notes,fields,reprompt,login_uri,login_username,login_password,login_totp\n\
+                   ,0,login,Work Email,,,0,https://mail.example.com,carol,pw,\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Work Email");
+        assert_eq!(records[0].url.as_deref(), Some("https://mail.example.com"));
+        assert_eq!(records[0].username.as_deref(), Some("carol"));
+    }
+
+    #[test]
+    fn falls_back_to_generated_title_when_nothing_else_present() {
+        let csv = "password\nonlyapassword\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Imported login 1");
+    }
+
+    #[test]
+    fn header_matching_is_case_insensitive_and_trims_whitespace() {
+        let csv = " Name , URL \nSite,https://example.com\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Site");
+        assert_eq!(records[0].url.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn embedded_comma_and_newline_in_quoted_field_are_preserved() {
+        let csv = "name,notes\n\"Site\",\"line one, with comma\nline two\"\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(
+            records[0].notes.as_deref(),
+            Some("line one, with comma\nline two")
+        );
+    }
+
+    #[test]
+    fn multiple_rows_decode_independently() {
+        let csv = "name,url,username,password\n\
+                   A,https://a.example,ua,pa\n\
+                   B,https://b.example,ub,pb\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].title, "A");
+        assert_eq!(records[1].title, "B");
+    }
+
+    // --- CSV formula injection: stored as inert literal text ---
+
+    #[test]
+    fn formula_injection_payloads_are_stored_literally_not_interpreted() {
+        let payloads = [
+            "=cmd|'/c calc'!A1",
+            "+1+1",
+            "-2+3+cmd|' /C calc'!A0",
+            "@SUM(1+1)",
+            "=HYPERLINK(\"http://evil.example\",\"click\")",
+        ];
+        for payload in payloads {
+            // Quoted per RFC 4180 since some payloads contain commas --
+            // this is what a real CSV writer would do, and the point of
+            // the test is what *this adapter* does with the decoded
+            // value, not CSV-quoting mechanics (already covered above).
+            let quoted = payload.replace('"', "\"\"");
+            let csv =
+                format!("name,url,username,password\nSite,https://x.example,\"{quoted}\",pw\n");
+            let records = decode(csv.as_bytes()).unwrap();
+            // Stored exactly as given -- no character stripped, no
+            // interpretation, and decoding itself never fails on it.
+            assert_eq!(records[0].username.as_deref(), Some(payload));
+        }
+    }
+
+    // --- Adversarial / malformed input ---
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(matches!(decode(b""), Err(ImportError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn rejects_oversize_input() {
+        let big = vec![b' '; MAX_SOURCE_BYTES + 1];
+        assert!(matches!(decode(&big), Err(ImportError::TooLarge(_))));
+    }
+
+    #[test]
+    fn rejects_invalid_utf8() {
+        let bytes = vec![0xFF, 0xFE, 0xFD];
+        assert!(matches!(decode(&bytes), Err(ImportError::Decode(_))));
+    }
+
+    #[test]
+    fn rejects_unclosed_quote() {
+        let csv = "name,url\n\"unterminated,https://x.example\n";
+        assert!(matches!(
+            decode(csv.as_bytes()),
+            Err(ImportError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn header_only_csv_decodes_to_zero_rows() {
+        let csv = "name,url,username,password\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn ragged_short_row_is_padded_with_empty_and_still_decodes() {
+        let csv = "name,url,username,password\nSite,https://x.example\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Site");
+        assert_eq!(records[0].username, None);
+        assert!(records[0].password.is_none());
+    }
+
+    #[test]
+    fn ragged_long_row_extra_fields_are_discarded_by_the_parser() {
+        let csv = "name,url\nSite,https://x.example,unexpected,extra\n";
+        // The upstream RFC 4180 parser truncates extra fields on a long
+        // row; this adapter just proves it does not error or panic.
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Site");
+    }
+
+    #[test]
+    fn rejects_too_many_rows() {
+        let mut csv = String::from("name,url\n");
+        for i in 0..(MAX_ROWS + 1) {
+            csv.push_str(&format!("Site{i},https://x.example\n"));
+        }
+        assert!(matches!(
+            decode(csv.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_too_many_columns() {
+        let mut header = String::new();
+        let mut row = String::new();
+        for i in 0..(MAX_COLUMNS + 1) {
+            if i > 0 {
+                header.push(',');
+                row.push(',');
+            }
+            header.push_str(&format!("col{i}"));
+            row.push('v');
+        }
+        let csv = format!("{header}\n{row}\n");
+        assert!(matches!(
+            decode(csv.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_oversize_field() {
+        let big = "x".repeat(MAX_FIELD_LEN + 1);
+        let csv = format!("name,url\n{big},https://x.example\n");
+        assert!(matches!(
+            decode(csv.as_bytes()),
+            Err(ImportError::TooLarge(_))
+        ));
+    }
+
+    #[test]
+    fn importer_trait_name_and_import() {
+        let importer = CsvLoginImporter;
+        assert_eq!(importer.name(), "browser-csv");
+        let csv = "name,url\nSite,https://x.example\n";
+        let records = importer.import(csv.as_bytes()).unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn importer_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CsvLoginImporter>();
+    }
+
+    #[test]
+    fn unicode_fields_round_trip() {
+        let csv = "name,url,username,password\n\
+                   Café,https://café.example,alice@éxample.com,naïve-Päßwôrd-🔑\n";
+        let records = decode(csv.as_bytes()).unwrap();
+        assert_eq!(records[0].title, "Café");
+        assert_eq!(
+            records[0].password.as_deref().map(String::as_str),
+            Some("naïve-Päßwôrd-🔑")
+        );
+    }
+}

--- a/code/packages/rust/vault-import-csv/src/lib.rs
+++ b/code/packages/rust/vault-import-csv/src/lib.rs
@@ -168,34 +168,44 @@ pub fn decode(input: &[u8]) -> Result<Vec<PortableRecord>, ImportError> {
     let mut rows = parse_csv(text).map_err(|error| match error {
         CsvError::UnclosedQuote => ImportError::Decode("unclosed quoted CSV field"),
     })?;
-    if rows.len() > MAX_ROWS {
-        return Err(ImportError::TooLarge("MAX_ROWS"));
-    }
-    let mut records = Vec::with_capacity(rows.len());
-    for (index, row) in rows.iter().enumerate() {
-        if row.len() > MAX_COLUMNS {
-            return Err(ImportError::TooLarge("MAX_COLUMNS"));
-        }
-        records.push(decode_row(row, index + 1)?);
-    }
     // Every secret-shaped *value* this adapter reads (password, TOTP
     // seed) is copied out into a `Zeroizing`-held `PortableRecord` field
-    // above, but the source copy inside `rows` is an ordinary `String` --
+    // below, but the source copy inside `rows` is an ordinary `String` --
     // `coding_adventures_csv_parser` has no reason to know any column is
-    // sensitive. Left alone, that source copy would be freed with `rows`
-    // at the end of this function without ever being overwritten. Scrub
-    // every cell value in place before `rows` drops, the same property
-    // `read_external_import_source`'s `Zeroizing` buffer already gives
-    // the raw bytes this table was parsed from. Keys are column *names*
-    // (`"password"`, `"url"`, ...), never secret-shaped, and `HashMap`
-    // only exposes them as `&String` through `values_mut`/`iter_mut`
-    // regardless, so they are left alone.
+    // sensitive. `outcome` captures every return path below (success
+    // *and* every early `Err`, e.g. an over-`MAX_COLUMNS` row or an
+    // over-`MAX_FIELD_LEN` cell reached partway through the file) so the
+    // zeroize pass a few lines down is unconditional: a malformed row is
+    // the normal case this crate's threat model exists to survive, and
+    // it must not silently skip the wipe of every row already decoded
+    // before that point just because it was also the input that
+    // triggered the error.
+    let outcome: Result<Vec<PortableRecord>, ImportError> = (|| {
+        if rows.len() > MAX_ROWS {
+            return Err(ImportError::TooLarge("MAX_ROWS"));
+        }
+        let mut records = Vec::with_capacity(rows.len());
+        for (index, row) in rows.iter().enumerate() {
+            if row.len() > MAX_COLUMNS {
+                return Err(ImportError::TooLarge("MAX_COLUMNS"));
+            }
+            records.push(decode_row(row, index + 1)?);
+        }
+        Ok(records)
+    })();
+    // Scrub every cell value in place before `rows` drops, the same
+    // property `read_external_import_source`'s `Zeroizing` buffer
+    // already gives the raw bytes this table was parsed from -- run
+    // unconditionally, before `outcome` is inspected. Keys are column
+    // *names* (`"password"`, `"url"`, ...), never secret-shaped, and
+    // `HashMap` only exposes them as `&String` through
+    // `values_mut`/`iter_mut` regardless, so they are left alone.
     for row in rows.iter_mut() {
         for value in row.values_mut() {
             value.zeroize();
         }
     }
-    Ok(records)
+    outcome
 }
 
 fn lookup<'a>(

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Added `read_external_import_source`** (`VLT-PM49-cli-external-import.md`),
+  the filesystem half of `vault-pm import bitwarden`/`import csv`. Same
+  exact-length-read shape as `read_attachment_source` and for the same
+  reason: a Bitwarden or browser-CSV export *is* the person's plaintext
+  secrets rather than an already-encrypted artifact, so the returned buffer
+  is `Zeroizing`, opens with `O_NONBLOCK | O_NOCTTY` on Unix, and never
+  reallocates mid-read. Reuses the existing `InvalidImportSource`/
+  `ImportReadFailed` error variants rather than adding new ones, since "the
+  import source was empty/not-a-file/over-bound/unreadable" is exactly what
+  those already mean.
+
 - **Added `read_attachment_source` and `write_attachment_export`**, the
   filesystem halves of `VLT-PM47-cli-attachments.md`. The read returns
   `Zeroizing` bytes because what it holds is the person's file rather than an

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -18,6 +18,11 @@ auditable adapters:
   bytes, and requests owner-only mode on Unix; and
 - `read_portable_export` reads one non-empty regular artifact under an exact
   metadata and streaming byte ceiling before application authentication; and
+- `read_attachment_source` and `read_external_import_source` read one
+  non-empty regular *plaintext* source (an attachment, or a Bitwarden/CSV
+  import file respectively) into a `Zeroizing` buffer under the same exact
+  ceiling discipline, so a failed read leaves no copy of the person's
+  plaintext in freed heap; and
 - `clipboard` delivers one already-authorized secret to the platform clipboard
   and schedules a **verified** clear of it (VLT-PM46).
 

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -736,6 +736,63 @@ pub fn read_portable_export(source: &Path, max_bytes: usize) -> Result<Vec<u8>, 
     Ok(artifact)
 }
 
+/// Read one explicit external-format import source (Bitwarden JSON, CSV,
+/// ...) under an exact host ceiling.
+///
+/// The same exact-length-read shape as [`read_attachment_source`], and for
+/// the same reason: unlike [`read_portable_export`]'s artifact (already
+/// vault-pm ciphertext), this file *is* the person's plaintext secrets —
+/// every password a Bitwarden or browser export names, in the clear — so
+/// the buffer is `Zeroizing` and never reallocates mid-read (see that
+/// function's doc comment for why reallocation would leak a copy of the
+/// plaintext into freed, unwiped heap). Decoding and format validation
+/// remain the caller's (adapter crate's) responsibility; this function only
+/// gets the bytes off disk safely.
+pub fn read_external_import_source(
+    source: &Path,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    if source.as_os_str().is_empty() || max_bytes == 0 {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NONBLOCK | libc::O_NOCTTY);
+    let mut file = options
+        .open(source)
+        .map_err(|_| CliHostError::InvalidImportSource)?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| CliHostError::ImportReadFailed)?;
+    if !metadata.is_file()
+        || metadata.len() == 0
+        || metadata.len() > u64::try_from(max_bytes).unwrap_or(u64::MAX)
+    {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    let declared =
+        usize::try_from(metadata.len()).map_err(|_| CliHostError::InvalidImportSource)?;
+    let mut contents = Zeroizing::new(vec![0_u8; declared]);
+    file.read_exact(&mut contents).map_err(|error| {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            CliHostError::InvalidImportSource
+        } else {
+            CliHostError::ImportReadFailed
+        }
+    })?;
+    let mut beyond = [0_u8; 1];
+    match file.read(&mut beyond) {
+        Ok(0) => {}
+        Ok(_) => return Err(CliHostError::InvalidImportSource),
+        Err(_) => return Err(CliHostError::ImportReadFailed),
+    }
+    if contents.is_empty() || contents.len() > max_bytes {
+        return Err(CliHostError::InvalidImportSource);
+    }
+    Ok(contents)
+}
+
 /// Stateless cryptographic entropy adapter backed by the repository OS CSPRNG.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct OsEntropy;
@@ -1309,6 +1366,72 @@ mod tests {
         assert_eq!(
             read_attachment_source(&file, 1_024).unwrap().as_slice(),
             b"first-more"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn an_external_import_source_round_trips_and_refuses_what_it_cannot_take() {
+        let root = attachment_scratch("external-import");
+        let file = root.join("export.json");
+        fs::write(&file, b"{\"items\":[]}").unwrap();
+        assert_eq!(
+            read_external_import_source(&file, 1_024)
+                .unwrap()
+                .as_slice(),
+            b"{\"items\":[]}"
+        );
+
+        // Exactly at the ceiling is accepted; one byte over is refused.
+        let exact = b"{\"items\":[]}".len();
+        assert!(read_external_import_source(&file, exact).is_ok());
+        assert_eq!(
+            source_err(read_external_import_source(&file, exact - 1)),
+            CliHostError::InvalidImportSource
+        );
+
+        let empty = root.join("empty.json");
+        fs::write(&empty, b"").unwrap();
+        for (path, bound) in [
+            (empty.as_path(), 1_024),
+            (root.as_path(), 1_024),
+            (root.join("absent.json").as_path(), 1_024),
+            (file.as_path(), 0),
+            (std::path::Path::new(""), 1_024),
+        ] {
+            assert_eq!(
+                source_err(read_external_import_source(path, bound)),
+                CliHostError::InvalidImportSource,
+                "{path:?} must be refused"
+            );
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Same growth-during-read protection `read_attachment_source` has, for
+    /// the same reason: this is the person's plaintext secrets, and a
+    /// reallocation on the way to reading it would leave an unwiped copy in
+    /// freed heap.
+    #[test]
+    fn an_external_import_source_longer_than_its_measured_length_is_refused() {
+        let root = attachment_scratch("external-import-grew");
+        let file = root.join("growing.csv");
+        fs::write(&file, b"name,url\n").unwrap();
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&file)
+            .unwrap()
+            .write_all(b"Site,https://x.example\n")
+            .unwrap();
+        assert_eq!(
+            source_err(read_external_import_source(&file, 9)),
+            CliHostError::InvalidImportSource
+        );
+        assert_eq!(
+            read_external_import_source(&file, 1_024)
+                .unwrap()
+                .as_slice(),
+            b"name,url\nSite,https://x.example\n"
         );
         let _ = fs::remove_dir_all(&root);
     }

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+- **`import portable|bitwarden|csv|kdbx FILE`**, `VLT-PM00` §23 item 13.
+  Specified by `VLT-PM49-cli-external-import.md`. The bare `import FILE`
+  grammar (VLT-PM18) is now `import portable FILE`; `import bitwarden FILE`
+  and `import csv FILE` join it, each decoding an unencrypted external
+  export with a new dependency-light adapter crate
+  (`vault-import-bitwarden`, `vault-import-csv`) implementing
+  `vault-import-export`'s (VLT15) `Importer` trait — the first real
+  consumer of that trait in this workspace. `import kdbx FILE` still parses
+  but always fails closed with the `unsupported` exit class before opening
+  its file: KDBX's own encrypted-container format is explicitly deferred
+  (VLT-PM49 §8), not silently missing from the documented command surface.
+
+  Every mapped record is created through the exact same audited `item add`
+  publication path a person typing at the CLI uses, once per record —
+  `add_item`'s session-consuming design already makes "one authenticated
+  session creates one item" structural, so this reuses that path N times
+  rather than inventing a new bulk-mutation primitive. No new audit event
+  kind was introduced: each created item carries the same `ItemCreate`
+  event `item add` already produces. Imports always create brand-new items
+  with fresh identities and never merge or conflict-resolve against an
+  existing item, because an external format's records carry no vault-pm
+  item ID to collide with in the first place — the same "always new
+  identity" answer VLT-PM18 §7 gives portable restore, reached here for a
+  simpler reason.
+
+  A Bitwarden login carrying a TOTP seed becomes two vault-pm items (a
+  `LOGIN_V1` and a separate `TOTP_SEED_V1`), because vault-pm's own `Login`
+  record has no TOTP slot. TOTP fields are decoded from either raw
+  (possibly padded/lowercase) Base32 or an `otpauth://totp/...` URI,
+  through the same `decode_totp_base32` the interactive `item add totp`
+  form already uses. Output is aggregate-only —
+  `Import complete: created=C skipped=S failed=F` — with no source path,
+  title, username, URL, or secret ever printed.
+
+  Adds `read_external_import_source` to the `CliHost` trait, backed by a
+  new bounded, `Zeroizing`-returning reader in `vault-pm-cli-host`
+  (`read_external_import_source`), modeled on the existing attachment
+  reader rather than the portable-export one: unlike a vault-pm portable
+  artifact (already ciphertext), a Bitwarden/CSV export *is* the person's
+  plaintext secrets.
+
 - **`agent start|stop|status|unlock|lock`**, `VLT-PM00` §23 item 12.
   Specified by `VLT-PM48-local-agent-ipc.md`. `agent start` re-executes this
   same binary, detached, as the hidden `agent run-foreground` verb, which

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -19,6 +19,9 @@ coding_adventures_vault_pm_password_policy = { path = "../vault-pm-password-poli
 coding_adventures_vault_records = { path = "../vault-records" }
 coding_adventures_vault_pm_storage_storage_core = { path = "../vault-pm-storage-storage-core" }
 coding_adventures_zeroize = { path = "../zeroize" }
+coding_adventures_vault_import_export = { path = "../vault-import-export" }
+coding_adventures_vault_import_bitwarden = { path = "../vault-import-bitwarden" }
+coding_adventures_vault_import_csv = { path = "../vault-import-csv" }
 
 [features]
 # Test-only real-process crash injection (VLT-PM41). Only

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -21,10 +21,17 @@ complete user-authored login/secure-note merges.
 `item reveal ITEM FIELD` adds explicitly confirmed, publish-before-release
 interactive access to one schema-specific current secret without returning the
 revision capability or complete document to CLI orchestration.
-`export FILE`, `import FILE`, `restore verify FILE`, and the
+`export FILE`, `import portable FILE`, `restore verify FILE`, and the
 composed `--vault TARGET restore FILE` add the encrypted recovery-artifact
 round trip, retryable independent verification, and a completed-and-verified
-ceremony. The executable is a thin caller of this package.
+ceremony. `import bitwarden FILE` and `import csv FILE`
+(`VLT-PM49-cli-external-import.md`) add two more, unencrypted, format
+adapters: each decodes a competing product's plaintext export and creates new
+items through the unmodified `item add` publication path, once per record,
+rather than the disaster-recovery ceremony `import portable` uses.
+`import kdbx FILE` parses but always fails closed with the `unsupported`
+class before opening its file — KDBX's own encrypted container format is
+explicitly deferred. The executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -285,16 +292,37 @@ writes and synchronizes the complete artifact, and returns only a path-free
 success line. A destination write failure occurs after artifact release and
 therefore does not rewrite the truthful successful access event.
 
-`import FILE` requires the configured target to be independently initialized,
-logically empty, and audit-enabled. After target unlock it reads one bounded
-regular artifact, collects its passphrase through the fixed hidden
-`Import passphrase:` prompt, authenticates and validates the complete snapshot
-without writes, and obtains the exact count-derived CSPRNG block. Host,
-artifact, and target failures publish a failed itemless `PortableImport`
-before their error; success re-identifies every item/candidate and publishes
-its event atomically with the new catalog. Output contains aggregate item and
-candidate counts only. A later list/show reopens the target through the
-ordinary audited redacted-read boundary.
+`import portable FILE` requires the configured target to be independently
+initialized, logically empty, and audit-enabled. After target unlock it reads
+one bounded regular artifact, collects its passphrase through the fixed
+hidden `Import passphrase:` prompt, authenticates and validates the complete
+snapshot without writes, and obtains the exact count-derived CSPRNG block.
+Host, artifact, and target failures publish a failed itemless
+`PortableImport` before their error; success re-identifies every
+item/candidate and publishes its event atomically with the new catalog.
+Output contains aggregate item and candidate counts only. A later list/show
+reopens the target through the ordinary audited redacted-read boundary.
+
+`import bitwarden FILE` and `import csv FILE`
+(`VLT-PM49-cli-external-import.md`) take a different shape entirely, because
+the source is a plaintext export from a different product rather than
+another vault-pm vault: no source passphrase, no empty-target requirement,
+and no shared item-identity space to merge or restore against. Each reads
+one bounded plaintext source through a new `Zeroizing`-returning host method
+(`read_external_import_source`), decodes it with a small adapter crate
+(`vault-import-bitwarden`, `vault-import-csv`) that has no vault-pm
+dependency at all, and maps each decoded record onto vault-pm's own typed
+records. Every mapped record is then created through the unmodified `item
+add` publication path, once per record — no new mutation or audit primitive
+was introduced — so it carries the exact same `ItemCreate` audit event and
+crash-resumable publication a manually typed item does. A record whose kind
+has no vault-pm equivalent (an SSH key, a Bitwarden identity) is *skipped*,
+counted, and never silently dropped. Output is
+`Import complete: created=C skipped=S failed=F` — aggregate counts only,
+never a title, username, URL, or secret. `import kdbx FILE` parses the same
+shape but always answers the closed `unsupported` exit class before opening
+its file: KDBX's own Argon2d/AES-or-ChaCha20 encrypted container is
+explicitly deferred (VLT-PM49 §8), not silently missing from the grammar.
 
 `restore verify FILE` is a separately retryable, no-mutation ceremony against
 the currently configured target. It reserves its trace/time/randomness before

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -3366,7 +3366,16 @@ fn decode_external_totp_field(title: &str, raw: &str) -> Result<TotpSeed, ()> {
     if trimmed.is_empty() || trimmed.len() > MAX_EXTERNAL_TOTP_FIELD_BYTES {
         return Err(());
     }
-    if trimmed.len() >= 10 && trimmed[..10].eq_ignore_ascii_case("otpauth://") {
+    // `str::get` rather than direct indexing: a byte offset that lands
+    // inside a multi-byte UTF-8 character panics on `&trimmed[..10]`, and
+    // this field comes straight from an untrusted imported file (VLT-PM00
+    // §7.1 adversary 6). `get` returns `None` instead of panicking, which
+    // this cleanly treats as "not the otpauth prefix" and falls through to
+    // the Base32 path.
+    if trimmed
+        .get(..10)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("otpauth://"))
+    {
         return parse_otpauth_totp_uri(title, trimmed);
     }
     let normalized: String = trimmed
@@ -3387,7 +3396,13 @@ fn decode_external_totp_field(title: &str, raw: &str) -> Result<TotpSeed, ()> {
 
 fn parse_otpauth_totp_uri(title: &str, uri: &str) -> Result<TotpSeed, ()> {
     const PREFIX: &str = "otpauth://totp/";
-    if uri.len() < PREFIX.len() || !uri[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+    // Same reasoning as the `get(..10)` check above: `uri[..PREFIX.len()]`
+    // would panic instead of refusing the record if a multi-byte character
+    // straddles that byte offset in an untrusted field.
+    let Some(prefix) = uri.get(..PREFIX.len()) else {
+        return Err(());
+    };
+    if !prefix.eq_ignore_ascii_case(PREFIX) {
         return Err(());
     }
     let rest = &uri[PREFIX.len()..];
@@ -8400,6 +8415,32 @@ mod tests {
         assert!(decode_external_totp_field("L", "otpauth://totp/x?issuer=Y").is_err());
         assert!(decode_external_totp_field("L", "").is_err());
         assert!(decode_external_totp_field("L", "not-base32-or-a-uri!!").is_err());
+    }
+
+    /// A multi-byte UTF-8 character straddling the fixed byte offset this
+    /// prefix check compares against must be refused, not panic. Direct
+    /// `&s[..10]` indexing panics when the boundary falls inside a
+    /// character; a crafted TOTP field in an imported file is exactly the
+    /// untrusted input that can put one there (VLT-PM00 §7.1 adversary 6).
+    #[test]
+    fn decode_external_totp_field_does_not_panic_on_a_boundary_splitting_character() {
+        // "123456789" is 9 ASCII bytes; "é" is 2 bytes starting at byte 9,
+        // so byte offset 10 lands on its second byte -- not a boundary.
+        assert!(decode_external_totp_field("L", "123456789\u{e9}").is_err());
+        // Same shape, deliberately resembling the otpauth prefix so the
+        // check is actually exercised rather than short-circuited.
+        assert!(decode_external_totp_field("L", "otpauth:/\u{e9}").is_err());
+    }
+
+    /// Same class of bug, one level deeper: `parse_otpauth_totp_uri`'s own
+    /// fixed-prefix check must not panic either, once a caller has passed
+    /// the first ten bytes.
+    #[test]
+    fn parse_otpauth_totp_uri_does_not_panic_on_a_boundary_splitting_character() {
+        // "otpauth://" (10 ASCII bytes) + "abcd" (4 ASCII bytes, total 14)
+        // + "é" (2 bytes starting at byte 14) puts byte offset 15 --
+        // `"otpauth://totp/".len()` -- on the character's second byte.
+        assert!(parse_otpauth_totp_uri("L", "otpauth://abcd\u{e9}").is_err());
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -23,6 +23,9 @@ mod crash;
 /// the instrumentation out of a product binary; refusing to compile with it is.
 pub const CRASH_INJECTION_COMPILED: bool = cfg!(feature = "crash-injection");
 
+use coding_adventures_vault_import_bitwarden::BitwardenJsonImporter;
+use coding_adventures_vault_import_csv::CsvLoginImporter;
+use coding_adventures_vault_import_export::{Importer, PortableRecord, PortableRecordKind};
 use coding_adventures_vault_pm_application::{
     attachment_name_from_path, attachment_random_bytes, complete_generation_zero,
     open_portable_with_passphrase, portable_import_random_bytes, prepare_audited_generation_zero,
@@ -48,8 +51,9 @@ use coding_adventures_vault_pm_cli_host::clipboard::{
     copy_and_schedule_clear, read_clear_request_from_stdin, run_scheduled_clear, PlatformClipboard,
 };
 use coding_adventures_vault_pm_cli_host::{
-    read_attachment_source, read_portable_export, write_attachment_export, write_portable_export,
-    CliHostError, ControllingTerminal, OsEntropy, SecretPrompt, TextPrompt,
+    read_attachment_source, read_external_import_source, read_portable_export,
+    write_attachment_export, write_portable_export, CliHostError, ControllingTerminal, OsEntropy,
+    SecretPrompt, TextPrompt,
 };
 use coding_adventures_vault_pm_config::{
     parse_config, render_config, ConfigName, CredentialRef, StorageConfigV1, StorageKind,
@@ -86,6 +90,11 @@ const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
+/// Host-level ceiling for a `vault-pm import bitwarden|csv` source file
+/// (VLT-PM49 §4). Each adapter crate enforces its own, generally tighter,
+/// internal bound after this one; this is only the metadata/read-time
+/// ceiling before any format-specific decoding begins.
+const MAX_EXTERNAL_IMPORT_SOURCE_BYTES: usize = 64 * 1024 * 1024;
 
 /// The verb this binary re-executes itself with to perform a timed clear.
 ///
@@ -95,7 +104,7 @@ const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
 /// everything sensitive travels on the child's standard input, because argv is
 /// readable by every account on the machine through `ps` (VLT-PM46 §2.2).
 const CLIPBOARD_CLEAR_ARGUMENTS: &[&str] = &["clipboard", "clear"];
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm agent start\n  vault-pm agent stop\n  vault-pm agent status [--json]\n  vault-pm [--vault NAME] agent unlock\n  vault-pm [--vault NAME] agent lock\n  vault-pm agent run-foreground\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase] [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] totp code ITEM (--reveal|--copy)\n  vault-pm clipboard clear\n  vault-pm [--vault NAME] attachment add ITEM FILE\n  vault-pm [--vault NAME] attachment list ITEM\n  vault-pm [--vault NAME] attachment export ITEM ATTACHMENT FILE\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm agent start\n  vault-pm agent stop\n  vault-pm agent status [--json]\n  vault-pm [--vault NAME] agent unlock\n  vault-pm [--vault NAME] agent lock\n  vault-pm agent run-foreground\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase] [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import portable FILE\n  vault-pm [--vault NAME] import bitwarden FILE\n  vault-pm [--vault NAME] import csv FILE\n  vault-pm [--vault NAME] import kdbx FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] totp code ITEM (--reveal|--copy)\n  vault-pm clipboard clear\n  vault-pm [--vault NAME] attachment add ITEM FILE\n  vault-pm [--vault NAME] attachment list ITEM\n  vault-pm [--vault NAME] attachment export ITEM ATTACHMENT FILE\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -364,6 +373,13 @@ pub trait CliHost {
 
     /// Collect the passphrase for an existing portable artifact without echo.
     fn read_import_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
+
+    /// Read one explicit external-format import source (Bitwarden JSON,
+    /// CSV, ...) under the V1 size ceiling (VLT-PM49 §4).
+    ///
+    /// The buffer is `Zeroizing`: unlike a vault-pm portable artifact
+    /// (already ciphertext), this file *is* the person's plaintext secrets.
+    fn read_external_import_source(&self, source: &Path) -> Result<Zeroizing<Vec<u8>>, HostError>;
 
     /// Fill the entire generation-zero randomness block.
     fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
@@ -658,6 +674,11 @@ impl CliHost for NativeCliHost {
             .map_err(map_native_cli_host)
     }
 
+    fn read_external_import_source(&self, source: &Path) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        read_external_import_source(source, MAX_EXTERNAL_IMPORT_SOURCE_BYTES)
+            .map_err(map_native_cli_host)
+    }
+
     fn read_attachment_source(&self, source: &Path) -> Result<Zeroizing<Vec<u8>>, HostError> {
         read_attachment_source(source, MAX_ATTACHMENT_BYTES).map_err(map_native_cli_host)
     }
@@ -888,6 +909,22 @@ enum Command {
         destination: PathBuf,
     },
     PortableImport {
+        source: PathBuf,
+    },
+    /// Decode an unencrypted Bitwarden JSON export and create new items from
+    /// it (VLT-PM49).
+    ImportBitwarden {
+        source: PathBuf,
+    },
+    /// Decode a header-keyed browser/LastPass-style login CSV export and
+    /// create new items from it (VLT-PM49).
+    ImportCsv {
+        source: PathBuf,
+    },
+    /// Parses, but always fails closed with the `unsupported` exit class
+    /// before opening `source` (VLT-PM49 §8): KDBX's own encrypted-container
+    /// format is explicitly deferred, not silently missing from the grammar.
+    ImportKdbx {
         source: PathBuf,
     },
     PortableRestore {
@@ -1215,9 +1252,30 @@ fn parse_restore(arguments: &[String]) -> Result<Command, CliFailure> {
     }
 }
 
+/// Parse the `import` verb (VLT-PM49 §3).
+///
+/// V1 requires an explicit format keyword -- `portable`, `bitwarden`,
+/// `csv`, or `kdbx` -- rather than letting one format own the bare
+/// `import FILE` form VLT-PM18 originally specified. `kdbx` still parses
+/// (VLT-PM49 §8): the grammar names every format VLT-PM00 §14.4
+/// documents, and a format missing from `--help` with no explanation is
+/// worse than one that always answers `unsupported`.
 fn parse_import(arguments: &[String]) -> Result<Command, CliFailure> {
     match arguments {
-        [source] if !source.is_empty() => Ok(Command::PortableImport {
+        [format, source] if !source.is_empty() && format == "portable" => {
+            Ok(Command::PortableImport {
+                source: PathBuf::from(source),
+            })
+        }
+        [format, source] if !source.is_empty() && format == "bitwarden" => {
+            Ok(Command::ImportBitwarden {
+                source: PathBuf::from(source),
+            })
+        }
+        [format, source] if !source.is_empty() && format == "csv" => Ok(Command::ImportCsv {
+            source: PathBuf::from(source),
+        }),
+        [format, source] if !source.is_empty() && format == "kdbx" => Ok(Command::ImportKdbx {
             source: PathBuf::from(source),
         }),
         _ => Err(CliFailure::InvalidCommand),
@@ -1871,6 +1929,25 @@ fn dispatch(
         Command::PortableImport { source } => {
             portable_import(host, paths, writer, selected_vault, &source)
         }
+        Command::ImportBitwarden { source } => import_external(
+            host,
+            paths,
+            writer,
+            selected_vault,
+            &source,
+            &BitwardenJsonImporter,
+        ),
+        Command::ImportCsv { source } => import_external(
+            host,
+            paths,
+            writer,
+            selected_vault,
+            &source,
+            &CsvLoginImporter,
+        ),
+        // VLT-PM49 §8: always fails closed before opening `source`. KDBX's
+        // own encrypted-container format is explicitly deferred.
+        Command::ImportKdbx { source: _ } => Err(CliFailure::Unsupported),
         Command::PortableRestore { source } => {
             portable_restore(host, paths, writer, selected_vault, &source)
         }
@@ -3110,6 +3187,322 @@ fn parse_card_expiry_year(value: &str) -> Result<u16, CliFailure> {
     (year != 0)
         .then_some(year)
         .ok_or(CliFailure::InvalidCommand)
+}
+
+// === VLT-PM49: Bitwarden JSON / browser CSV external import ================
+
+/// Read, decode, and create vault-pm items from an external plaintext
+/// export (VLT-PM49). Each mapped record is created through the exact same
+/// audited `item add` publication path a person typing at the CLI uses,
+/// once per record -- see VLT-PM49 §4 for why this reuses that path rather
+/// than a new bulk-mutation primitive.
+fn import_external(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    source: &Path,
+    importer: &dyn Importer,
+) -> Result<CliOutput, CliFailure> {
+    // No vault is opened yet: a missing/oversize/malformed source is
+    // refused before any authentication prompt, and needs no audit event,
+    // because nothing vault-side has happened (VLT-PM49 §4 step 1-2).
+    let bytes = host.read_external_import_source(source).map_err(map_host)?;
+    let records = importer
+        .import(&bytes)
+        .map_err(|_| CliFailure::InvalidCommand)?;
+    drop(bytes);
+
+    let mut skipped: u64 = 0;
+    let mut failed: u64 = 0;
+    let mut to_create: Vec<(&'static str, AnyRecord)> = Vec::new();
+    for record in &records {
+        match map_portable_record(record) {
+            None => skipped += 1,
+            Some(outcomes) => {
+                for outcome in outcomes {
+                    match outcome {
+                        Ok(item) => to_create.push(item),
+                        Err(()) => failed += 1,
+                    }
+                }
+            }
+        }
+    }
+    drop(records);
+
+    // Nothing to create: report the outcome and open no vault at all. An
+    // import that creates nothing is not a mutation (VLT-PM49 §4 step 4).
+    if to_create.is_empty() {
+        return Ok(CliOutput::success(format!(
+            "Import complete: created=0 skipped={skipped} failed={failed}\n"
+        )));
+    }
+
+    let mut created: u64 = 0;
+    for (content_type, record) in to_create {
+        // Re-authenticates every iteration by construction: `add_item`
+        // consumes its session so a successful caller cannot keep using
+        // stale pins or catalog contents (VLT-PM49 §4.1). A failure here
+        // (e.g. locked) aborts the remaining import; whatever was already
+        // durably created stays created (VLT-PM49 §6).
+        let context = prepare_item_create(host, paths, writer, selected_vault)?;
+        match context.document(content_type, record) {
+            Ok(document) => match context.complete(document) {
+                Ok(_) => created += 1,
+                Err(_) => failed += 1,
+            },
+            Err(error) => {
+                // Publishes its own audited host-failure event, matching
+                // every interactive `item add` form's existing behavior on
+                // a document-construction failure.
+                let _ = context.fail(error);
+                failed += 1;
+            }
+        }
+    }
+
+    Ok(CliOutput::success(format!(
+        "Import complete: created={created} skipped={skipped} failed={failed}\n"
+    )))
+}
+
+/// Map one decoded external record onto zero, one, or two vault-pm records
+/// (VLT-PM49 §5). `None` means the record's kind has no vault-pm
+/// equivalent and is counted as *skipped*; `Some` carries one outcome per
+/// vault-pm item this record should become, each independently `Ok` (ready
+/// to create) or `Err` (mapping failed, counted as *failed*).
+fn map_portable_record(
+    record: &PortableRecord,
+) -> Option<Vec<Result<(&'static str, AnyRecord), ()>>> {
+    match &record.kind {
+        PortableRecordKind::Login => {
+            let mut outcomes = Vec::with_capacity(2);
+            outcomes.push(Ok((
+                LOGIN_V1,
+                AnyRecord::Login(Login {
+                    title: record.title.clone(),
+                    username: record.username.clone().unwrap_or_default(),
+                    password: record.password.as_deref().cloned().unwrap_or_default(),
+                    urls: record.url.clone().into_iter().collect(),
+                    notes: record.notes.clone(),
+                }),
+            )));
+            if let Some(seed) = &record.totp_seed {
+                outcomes.push(
+                    decode_external_totp_field(&record.title, seed)
+                        .map(|totp| (TOTP_SEED_V1, AnyRecord::TotpSeed(totp))),
+                );
+            }
+            Some(outcomes)
+        }
+        PortableRecordKind::SecureNote => Some(vec![Ok((
+            SECURE_NOTE_V1,
+            AnyRecord::SecureNote(SecureNote {
+                title: record.title.clone(),
+                body: record.notes.clone().unwrap_or_default(),
+            }),
+        ))]),
+        PortableRecordKind::Card => Some(vec![map_card_record(record)]),
+        PortableRecordKind::Totp => Some(vec![match &record.totp_seed {
+            Some(seed) => decode_external_totp_field(&record.title, seed)
+                .map(|totp| (TOTP_SEED_V1, AnyRecord::TotpSeed(totp))),
+            None => Err(()),
+        }]),
+        // `SshKey` has no vault-pm item type yet; `Custom(_)` is every
+        // format adapter's catch-all for a kind it recognized but this
+        // product doesn't model (e.g. Bitwarden identities). Both are
+        // *skipped*, not silently dropped: the caller still counts them.
+        // `PortableRecordKind` is `#[non_exhaustive]` upstream, so a future
+        // added variant also falls through here rather than failing to
+        // compile -- it is treated the same as any other unmapped kind
+        // until this match is deliberately extended.
+        PortableRecordKind::SshKey | PortableRecordKind::Custom(_) => None,
+        _ => None,
+    }
+}
+
+fn map_card_record(record: &PortableRecord) -> Result<(&'static str, AnyRecord), ()> {
+    let holder = card_custom_field(record, "holder").ok_or(())?;
+    let number = card_custom_field(record, "number").ok_or(())?;
+    validate_ascii_digits(&number, 8, 19).map_err(|_| ())?;
+    let expiry_month =
+        parse_card_expiry_month(&card_custom_field(record, "expiry_month").ok_or(())?)
+            .map_err(|_| ())?;
+    let expiry_year = parse_card_expiry_year(&card_custom_field(record, "expiry_year").ok_or(())?)
+        .map_err(|_| ())?;
+    let cvv = card_custom_field(record, "cvv").ok_or(())?;
+    validate_ascii_digits(&cvv, 3, 4).map_err(|_| ())?;
+    let billing_zip = card_custom_field(record, "billing_zip");
+    Ok((
+        CARD_V1,
+        AnyRecord::Card(Card {
+            title: record.title.clone(),
+            holder,
+            number,
+            expiry_month,
+            expiry_year,
+            cvv,
+            billing_zip,
+        }),
+    ))
+}
+
+fn card_custom_field(record: &PortableRecord, key: &str) -> Option<String> {
+    record.custom_fields.get(key).map(|value| (**value).clone())
+}
+
+/// Maximum accepted bytes for a raw TOTP field or an `otpauth://` query
+/// string (VLT-PM49 §5.3) -- generous for any real export, and small
+/// enough that a crafted field cannot force meaningful extra work.
+const MAX_EXTERNAL_TOTP_FIELD_BYTES: usize = 2_048;
+
+/// Decode a TOTP seed carried by an external record, as either a raw
+/// (possibly padded/lowercase/whitespace-separated) Base32 string or an
+/// `otpauth://totp/...` URI (VLT-PM49 §5.3). `hotp` URIs are refused,
+/// matching VLT-PM29's TOTP-only scope.
+fn decode_external_totp_field(title: &str, raw: &str) -> Result<TotpSeed, ()> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_EXTERNAL_TOTP_FIELD_BYTES {
+        return Err(());
+    }
+    if trimmed.len() >= 10 && trimmed[..10].eq_ignore_ascii_case("otpauth://") {
+        return parse_otpauth_totp_uri(title, trimmed);
+    }
+    let normalized: String = trimmed
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '=')
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+    let secret = decode_totp_base32(&normalized).map_err(|_| ())?;
+    Ok(TotpSeed {
+        label: title.to_owned(),
+        issuer: None,
+        secret: secret.into_inner(),
+        algorithm: "SHA1".to_owned(),
+        digits: 6,
+        period: 30,
+    })
+}
+
+fn parse_otpauth_totp_uri(title: &str, uri: &str) -> Result<TotpSeed, ()> {
+    const PREFIX: &str = "otpauth://totp/";
+    if uri.len() < PREFIX.len() || !uri[..PREFIX.len()].eq_ignore_ascii_case(PREFIX) {
+        return Err(());
+    }
+    let rest = &uri[PREFIX.len()..];
+    let query = match rest.find('?') {
+        Some(position) => &rest[position + 1..],
+        None => return Err(()),
+    };
+    if query.len() > MAX_EXTERNAL_TOTP_FIELD_BYTES {
+        return Err(());
+    }
+    let mut secret: Option<Zeroizing<Vec<u8>>> = None;
+    let mut issuer: Option<String> = None;
+    let mut algorithm = "SHA1".to_owned();
+    let mut digits: u8 = 6;
+    let mut period: u32 = 30;
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let Some(equals) = pair.find('=') else {
+            return Err(());
+        };
+        let key = &pair[..equals];
+        let value = percent_decode(&pair[equals + 1..])?;
+        match key {
+            "secret" => {
+                let normalized: String = value
+                    .chars()
+                    .filter(|c| !c.is_whitespace() && *c != '=')
+                    .map(|c| c.to_ascii_uppercase())
+                    .collect();
+                secret = Some(decode_totp_base32(&normalized).map_err(|_| ())?);
+            }
+            "issuer" => {
+                if value.is_empty() || value.len() > 256 {
+                    return Err(());
+                }
+                issuer = Some(value);
+            }
+            "algorithm" => {
+                let upper = value.to_ascii_uppercase();
+                if !matches!(upper.as_str(), "SHA1" | "SHA256" | "SHA512") {
+                    return Err(());
+                }
+                algorithm = upper;
+            }
+            "digits" => {
+                digits = match value.as_str() {
+                    "6" => 6,
+                    "8" => 8,
+                    _ => return Err(()),
+                };
+            }
+            "period" => {
+                period = parse_totp_period(&value).map_err(|_| ())?;
+            }
+            // Unknown query parameters (e.g. a peer's future extension)
+            // are ignored rather than rejected -- the same
+            // forward-compatible stance VLT-PM49 §2 takes for unknown
+            // Bitwarden JSON top-level keys.
+            _ => {}
+        }
+    }
+    let secret = secret.ok_or(())?;
+    Ok(TotpSeed {
+        label: title.to_owned(),
+        issuer,
+        secret: secret.into_inner(),
+        algorithm,
+        digits,
+        period,
+    })
+}
+
+/// Bounded percent-decoder for one `otpauth://` query value. `+` decodes
+/// to a literal space (the `application/x-www-form-urlencoded` convention
+/// real `otpauth://` producers use for an issuer containing spaces).
+fn percent_decode(value: &str) -> Result<String, ()> {
+    if value.len() > MAX_EXTERNAL_TOTP_FIELD_BYTES {
+        return Err(());
+    }
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' => {
+                if index + 2 >= bytes.len() {
+                    return Err(());
+                }
+                let high = hex_nibble(bytes[index + 1]).ok_or(())?;
+                let low = hex_nibble(bytes[index + 2]).ok_or(())?;
+                out.push((high << 4) | low);
+                index += 3;
+            }
+            b'+' => {
+                out.push(b' ');
+                index += 1;
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8(out).map_err(|_| ())
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn item_list(
@@ -6129,6 +6522,18 @@ mod tests {
             read_attachment_source(source, MAX_ATTACHMENT_BYTES).map_err(map_native_cli_host)
         }
 
+        // Real filesystem, like the pair above: the point of this crate's
+        // tests is the ceremony around the read, and a fake that never
+        // touched a disk could not show that a malformed/oversize source is
+        // refused before any vault is opened.
+        fn read_external_import_source(
+            &self,
+            source: &Path,
+        ) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            read_external_import_source(source, MAX_EXTERNAL_IMPORT_SOURCE_BYTES)
+                .map_err(map_native_cli_host)
+        }
+
         fn write_attachment_export(
             &self,
             destination: &Path,
@@ -6985,14 +7390,52 @@ mod tests {
     #[test]
     fn portable_import_parser_accepts_exactly_one_explicit_source() {
         assert_eq!(
-            parse(["import", "backup.vpm"]),
+            parse(["import", "portable", "backup.vpm"]),
             default_invocation(Command::PortableImport {
                 source: PathBuf::from("backup.vpm")
             })
         );
         assert_eq!(parse(["import"]), Err(CliFailure::InvalidCommand));
         assert_eq!(
-            parse(["import", "backup.vpm", "extra"]),
+            parse(["import", "portable"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["import", "portable", "backup.vpm", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn external_import_parser_requires_an_explicit_format_keyword() {
+        assert_eq!(
+            parse(["import", "bitwarden", "export.json"]),
+            default_invocation(Command::ImportBitwarden {
+                source: PathBuf::from("export.json")
+            })
+        );
+        assert_eq!(
+            parse(["import", "csv", "export.csv"]),
+            default_invocation(Command::ImportCsv {
+                source: PathBuf::from("export.csv")
+            })
+        );
+        assert_eq!(
+            parse(["import", "kdbx", "export.kdbx"]),
+            default_invocation(Command::ImportKdbx {
+                source: PathBuf::from("export.kdbx")
+            })
+        );
+        assert_eq!(
+            parse(["import", "bitwarden"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["import", "bitwarden", "export.json", "extra"]),
+            Err(CliFailure::InvalidCommand)
+        );
+        assert_eq!(
+            parse(["import", "1password", "export.1pux"]),
             Err(CliFailure::InvalidCommand)
         );
     }
@@ -7526,6 +7969,447 @@ mod tests {
         assert!(!audit.stdout().contains("portable failure passphrase"));
     }
 
+    // === VLT-PM49: Bitwarden JSON / browser CSV external import ============
+
+    #[test]
+    fn import_bitwarden_creates_a_login_item_and_leaks_no_secret() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"bitwarden import passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("bitwarden.json");
+        fs::write(
+            &source,
+            br#"{"items":[{"type":1,"name":"GitHub Import","notes":null,
+                "login":{"username":"alice","password":"hunter2-super-secret",
+                "uris":[{"uri":"https://github.com"}]}}]}"#,
+        )
+        .unwrap();
+
+        let import_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let imported = run(
+            ["import", "bitwarden", source.to_str().unwrap()],
+            &import_host,
+        );
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert_eq!(
+            imported.stdout(),
+            "Import complete: created=1 skipped=0 failed=0\n"
+        );
+        assert!(!imported.stdout().contains("hunter2"));
+        assert!(!imported.stdout().contains("GitHub"));
+
+        let list_host = TestHost::new(paths, [passphrase]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed.stdout().contains("GitHub Import"));
+        assert!(listed.stdout().contains(LOGIN_V1));
+        assert!(!listed.stdout().contains("hunter2"));
+    }
+
+    /// A Bitwarden login carrying a TOTP seed becomes two `to_create`
+    /// entries, and the command attempts both through independent
+    /// authenticated sessions (VLT-PM49 §4). `mapping_login_with_totp_
+    /// produces_two_outcomes` above proves the actual splitting/mapping
+    /// logic in isolation; what this end-to-end test can additionally
+    /// prove without a real OS CSPRNG is that the command runs both
+    /// attempts to completion, reports a real outcome for each, and never
+    /// echoes the seed -- not that a fixed-pattern *test* entropy source
+    /// happens to avoid a same-length collision across the two attempts
+    /// the way a genuine CSPRNG always would.
+    #[test]
+    fn import_bitwarden_login_with_totp_attempts_both_items_and_leaks_no_seed() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"bitwarden totp import passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("bitwarden-totp.json");
+        fs::write(
+            &source,
+            br#"{"items":[{"type":1,"name":"AWS Root",
+                "login":{"username":"root","password":"pw",
+                "totp":"JBSWY3DPEHPK3PXP","uris":[]}}]}"#,
+        )
+        .unwrap();
+
+        let import_host = TestHost::new(paths, [passphrase.clone(), passphrase]);
+        let imported = run(
+            ["import", "bitwarden", source.to_str().unwrap()],
+            &import_host,
+        );
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert!(!imported.stdout().contains("JBSWY3DPEHPK3PXP"));
+        let counts: Vec<u64> = imported
+            .stdout()
+            .split(|c: char| !c.is_ascii_digit())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.parse().unwrap())
+            .collect();
+        assert_eq!(counts.len(), 3, "{imported:?}");
+        let [created, skipped, failed] = [counts[0], counts[1], counts[2]];
+        assert_eq!(skipped, 0);
+        // Both attempts ran (nothing was silently dropped from the count):
+        // created + failed accounts for both the login and the derived
+        // TOTP item.
+        assert_eq!(created + failed, 2, "{imported:?}");
+        assert!(created >= 1, "the login half must succeed: {imported:?}");
+    }
+
+    #[test]
+    fn import_csv_creates_a_login_item_and_leaks_no_secret() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"csv import passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("chrome-export.csv");
+        fs::write(
+            &source,
+            "name,url,username,password\nExample Site,https://example.test,carol,csv-secret-pw\n",
+        )
+        .unwrap();
+
+        let import_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let imported = run(["import", "csv", source.to_str().unwrap()], &import_host);
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert_eq!(
+            imported.stdout(),
+            "Import complete: created=1 skipped=0 failed=0\n"
+        );
+        assert!(!imported.stdout().contains("csv-secret-pw"));
+
+        let list_host = TestHost::new(paths, [passphrase]);
+        let listed = run(["item", "list"], &list_host);
+        assert_eq!(listed.exit_code(), ExitCode::Success, "{listed:?}");
+        assert!(listed.stdout().contains("Example Site"));
+        assert!(!listed.stdout().contains("csv-secret-pw"));
+    }
+
+    /// A file whose every record is an unsupported kind must never
+    /// authenticate a vault (VLT-PM49 §9 gate 4): an empty secrets queue
+    /// would turn any attempted prompt into a `Provider` failure, not
+    /// `Success`.
+    #[test]
+    fn import_bitwarden_with_only_unsupported_items_opens_no_vault() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"unsupported only passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("identity-only.json");
+        fs::write(&source, br#"{"items":[{"type":4,"name":"My Passport"}]}"#).unwrap();
+
+        let import_host = TestHost::new(paths, []);
+        let imported = run(
+            ["import", "bitwarden", source.to_str().unwrap()],
+            &import_host,
+        );
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert_eq!(
+            imported.stdout(),
+            "Import complete: created=0 skipped=1 failed=0\n"
+        );
+    }
+
+    /// One supported and one unsupported record in the same file: the
+    /// unsupported one is skipped without ever calling `fill_entropy`, so
+    /// this stays within one entropy draw and exercises the mixed count.
+    #[test]
+    fn import_bitwarden_mixed_supported_and_unsupported_reports_both_counts() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"mixed import passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("mixed.json");
+        fs::write(
+            &source,
+            br#"{"items":[
+                {"type":4,"name":"Skipped Identity"},
+                {"type":2,"name":"Kept Note","notes":"body"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let import_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let imported = run(
+            ["import", "bitwarden", source.to_str().unwrap()],
+            &import_host,
+        );
+        assert_eq!(imported.exit_code(), ExitCode::Success, "{imported:?}");
+        assert_eq!(
+            imported.stdout(),
+            "Import complete: created=1 skipped=1 failed=0\n"
+        );
+
+        let list_host = TestHost::new(paths, [passphrase]);
+        let listed = run(["item", "list"], &list_host);
+        assert!(listed.stdout().contains("Kept Note"));
+        assert!(!listed.stdout().contains("Skipped Identity"));
+    }
+
+    /// KDBX always fails closed with the `unsupported` exit class, before
+    /// `source` is ever opened (VLT-PM49 §8): a nonexistent path must fail
+    /// the *same* way a real one would, proving no filesystem access was
+    /// attempted.
+    #[test]
+    fn import_kdbx_always_fails_closed_without_opening_source() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"kdbx unsupported passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let absent_source = root.0.join("does-not-exist.kdbx");
+        let host = TestHost::new(paths, []);
+        let result = run(["import", "kdbx", absent_source.to_str().unwrap()], &host);
+        assert_eq!(result.exit_code(), ExitCode::Unsupported, "{result:?}");
+        assert!(result.stdout().is_empty());
+    }
+
+    #[test]
+    fn import_kdbx_grammar_accepts_exactly_one_source() {
+        assert_eq!(
+            parse(["import", "kdbx", "vault.kdbx"]),
+            default_invocation(Command::ImportKdbx {
+                source: PathBuf::from("vault.kdbx")
+            })
+        );
+    }
+
+    #[test]
+    fn import_bitwarden_rejects_malformed_source_before_any_vault_access() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"malformed bitwarden passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        for (name, bytes) in [
+            ("not-json.json", b"{not json".as_slice()),
+            ("wrong-root.json", b"[1,2,3]".as_slice()),
+            ("missing-items.json", br#"{"folders":[]}"#.as_slice()),
+            ("item-not-object.json", br#"{"items":[42]}"#.as_slice()),
+        ] {
+            let source = root.0.join(name);
+            fs::write(&source, bytes).unwrap();
+            let host = TestHost::new(paths.clone(), []);
+            let result = run(["import", "bitwarden", source.to_str().unwrap()], &host);
+            assert_eq!(
+                result.exit_code(),
+                ExitCode::InvalidInput,
+                "{name}: {result:?}"
+            );
+            assert!(result.stdout().is_empty());
+        }
+    }
+
+    #[test]
+    fn import_csv_rejects_malformed_source_before_any_vault_access() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"malformed csv passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let source = root.0.join("unclosed.csv");
+        fs::write(&source, "name,url\n\"unterminated,https://x.example\n").unwrap();
+        let host = TestHost::new(paths, []);
+        let result = run(["import", "csv", source.to_str().unwrap()], &host);
+        assert_eq!(result.exit_code(), ExitCode::InvalidInput, "{result:?}");
+        assert!(result.stdout().is_empty());
+    }
+
+    // --- Pure mapping/decoding logic (no I/O, no entropy) ---
+
+    fn portable_login(title: &str, username: &str, password: &str, url: &str) -> PortableRecord {
+        PortableRecord {
+            kind: PortableRecordKind::Login,
+            title: title.to_owned(),
+            username: Some(username.to_owned()),
+            password: Some(Zeroizing::new(password.to_owned())),
+            url: Some(url.to_owned()),
+            notes: None,
+            totp_seed: None,
+            tags: Vec::new(),
+            custom_fields: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn mapping_login_produces_one_outcome_without_totp() {
+        let record = portable_login("Site", "user", "pw", "https://x.example");
+        let outcomes = map_portable_record(&record).expect("login must be mapped");
+        assert_eq!(outcomes.len(), 1);
+        let (content_type, item) = outcomes[0].as_ref().unwrap();
+        assert_eq!(*content_type, LOGIN_V1);
+        match item {
+            AnyRecord::Login(login) => {
+                assert_eq!(login.title, "Site");
+                assert_eq!(login.username, "user");
+                assert_eq!(login.password, "pw");
+                assert_eq!(login.urls, vec!["https://x.example".to_string()]);
+            }
+            _ => panic!("expected a Login record"),
+        }
+    }
+
+    #[test]
+    fn mapping_login_with_totp_produces_two_outcomes() {
+        let mut record = portable_login("Site", "user", "pw", "https://x.example");
+        record.totp_seed = Some(Zeroizing::new("JBSWY3DPEHPK3PXP".to_owned()));
+        let outcomes = map_portable_record(&record).expect("login must be mapped");
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[1].is_ok());
+        let (content_type, item) = outcomes[1].as_ref().unwrap();
+        assert_eq!(*content_type, TOTP_SEED_V1);
+        assert!(matches!(item, AnyRecord::TotpSeed(_)));
+    }
+
+    #[test]
+    fn mapping_login_with_malformed_totp_field_fails_only_the_totp_outcome() {
+        let mut record = portable_login("Site", "user", "pw", "https://x.example");
+        record.totp_seed = Some(Zeroizing::new("not valid base32!!".to_owned()));
+        let outcomes = map_portable_record(&record).expect("login must be mapped");
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0].is_ok(), "the login half must still succeed");
+        assert!(outcomes[1].is_err(), "the malformed totp half must fail");
+    }
+
+    #[test]
+    fn mapping_secure_note_and_unsupported_kinds() {
+        let note = PortableRecord {
+            kind: PortableRecordKind::SecureNote,
+            title: "Note".to_owned(),
+            username: None,
+            password: None,
+            url: None,
+            notes: Some("body".to_owned()),
+            totp_seed: None,
+            tags: Vec::new(),
+            custom_fields: BTreeMap::new(),
+        };
+        let outcomes = map_portable_record(&note).expect("secure note must be mapped");
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0].as_ref().unwrap().1,
+            AnyRecord::SecureNote(_)
+        ));
+
+        let ssh = PortableRecord {
+            kind: PortableRecordKind::SshKey,
+            title: "key".to_owned(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: None,
+            tags: Vec::new(),
+            custom_fields: BTreeMap::new(),
+        };
+        assert!(map_portable_record(&ssh).is_none());
+
+        let custom = PortableRecord {
+            kind: PortableRecordKind::Custom("bitwarden-type-4".to_owned()),
+            title: "x".to_owned(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: None,
+            tags: Vec::new(),
+            custom_fields: BTreeMap::new(),
+        };
+        assert!(map_portable_record(&custom).is_none());
+    }
+
+    fn card_fields(omit: Option<&str>) -> BTreeMap<String, Zeroizing<String>> {
+        let mut fields = BTreeMap::new();
+        for (key, value) in [
+            ("holder", "Ada"),
+            ("number", "41111111"),
+            ("expiry_month", "12"),
+            ("expiry_year", "2030"),
+            ("cvv", "123"),
+        ] {
+            if Some(key) == omit {
+                continue;
+            }
+            fields.insert(key.to_owned(), Zeroizing::new(value.to_owned()));
+        }
+        fields
+    }
+
+    fn card_record(custom_fields: BTreeMap<String, Zeroizing<String>>) -> PortableRecord {
+        PortableRecord {
+            kind: PortableRecordKind::Card,
+            title: "Amex".to_owned(),
+            username: None,
+            password: None,
+            url: None,
+            notes: None,
+            totp_seed: None,
+            tags: Vec::new(),
+            custom_fields,
+        }
+    }
+
+    #[test]
+    fn mapping_card_requires_every_field_present_and_valid() {
+        let complete = card_record(card_fields(None));
+        let outcomes = map_portable_record(&complete).expect("card must be mapped");
+        assert_eq!(outcomes.len(), 1);
+        assert!(outcomes[0].is_ok());
+
+        let incomplete = card_record(card_fields(Some("cvv")));
+        let outcomes = map_portable_record(&incomplete).expect("card must still be mapped");
+        assert!(outcomes[0].is_err(), "a missing required field must fail");
+    }
+
+    #[test]
+    fn decode_external_totp_field_accepts_padded_lowercase_base32() {
+        let totp = decode_external_totp_field("Label", "jbswy3dpehpk3pxp===")
+            .expect("padded lowercase base32 must decode");
+        assert_eq!(totp.algorithm, "SHA1");
+        assert_eq!(totp.digits, 6);
+        assert_eq!(totp.period, 30);
+        assert!(!totp.secret.is_empty());
+    }
+
+    #[test]
+    fn decode_external_totp_field_accepts_otpauth_uri_with_all_parameters() {
+        let uri = "otpauth://totp/GitHub:alice?secret=JBSWY3DPEHPK3PXP&issuer=GitHub&\
+                    algorithm=SHA256&digits=8&period=60";
+        let totp = decode_external_totp_field("Label", uri).expect("otpauth URI must decode");
+        assert_eq!(totp.issuer.as_deref(), Some("GitHub"));
+        assert_eq!(totp.algorithm, "SHA256");
+        assert_eq!(totp.digits, 8);
+        assert_eq!(totp.period, 60);
+    }
+
+    #[test]
+    fn decode_external_totp_field_rejects_hotp_and_missing_secret() {
+        assert!(decode_external_totp_field("L", "otpauth://hotp/x?secret=JBSWY3DP").is_err());
+        assert!(decode_external_totp_field("L", "otpauth://totp/x?issuer=Y").is_err());
+        assert!(decode_external_totp_field("L", "").is_err());
+        assert!(decode_external_totp_field("L", "not-base32-or-a-uri!!").is_err());
+    }
+
+    #[test]
+    fn percent_decode_handles_plus_as_space_and_hex_escapes() {
+        assert_eq!(percent_decode("a+b%20c").unwrap(), "a b c");
+        assert_eq!(percent_decode("plain").unwrap(), "plain");
+        assert!(percent_decode("bad%2").is_err());
+        assert!(percent_decode("bad%zz").is_err());
+    }
+
     #[test]
     fn portable_import_logs_failure_then_restores_audit_first_target_independently() {
         let source_root = TestRoot::new();
@@ -7601,6 +8485,7 @@ mod tests {
         let wrong = run(
             [
                 "import",
+                "portable",
                 artifact_path.to_str().expect("UTF-8 test artifact path"),
             ],
             &wrong_host,
@@ -7616,6 +8501,7 @@ mod tests {
         let imported = run(
             [
                 "import",
+                "portable",
                 artifact_path.to_str().expect("UTF-8 test artifact path"),
             ],
             &import_host,
@@ -7901,6 +8787,7 @@ mod tests {
                 "--vault",
                 "retry",
                 "import",
+                "portable",
                 artifact_path.to_str().expect("UTF-8 test artifact path"),
             ],
             &repeated_import,
@@ -10979,6 +11866,15 @@ mod tests {
             assert_eq!(source, Path::new("source"));
             self.record("read_attachment_source");
             Ok(Zeroizing::new(b"read_attachment_source".to_vec()))
+        }
+
+        fn read_external_import_source(
+            &self,
+            source: &Path,
+        ) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            assert_eq!(source, Path::new("source"));
+            self.record("read_external_import_source");
+            Ok(Zeroizing::new(b"read_external_import_source".to_vec()))
         }
 
         fn write_attachment_export(

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -91,10 +91,12 @@ const PRODUCTION_KDF_LANES: u8 = 1;
 const ITEM_OPERATION_RANDOM_BYTES: usize = 32;
 const DEFAULT_SEARCH_RESULT_LIMIT: usize = 100;
 /// Host-level ceiling for a `vault-pm import bitwarden|csv` source file
-/// (VLT-PM49 §4). Each adapter crate enforces its own, generally tighter,
-/// internal bound after this one; this is only the metadata/read-time
-/// ceiling before any format-specific decoding begins.
-const MAX_EXTERNAL_IMPORT_SOURCE_BYTES: usize = 64 * 1024 * 1024;
+/// (VLT-PM49 §4), matching the tightest adapter-level `MAX_SOURCE_BYTES`
+/// (both `vault-import-bitwarden` and `vault-import-csv` currently use
+/// 16 MiB) rather than a looser bound, so a file too large for either
+/// adapter is refused at the read step instead of being fully read into
+/// memory first only to be rejected one function call later.
+const MAX_EXTERNAL_IMPORT_SOURCE_BYTES: usize = 16 * 1024 * 1024;
 
 /// The verb this binary re-executes itself with to perform a timed clear.
 ///

--- a/code/packages/rust/vault-pm-cli/src/shell.rs
+++ b/code/packages/rust/vault-pm-cli/src/shell.rs
@@ -453,6 +453,10 @@ impl CliHost for SessionHost<'_> {
         self.inner.read_import_passphrase()
     }
 
+    fn read_external_import_source(&self, source: &Path) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        self.inner.read_external_import_source(source)
+    }
+
     fn read_attachment_source(&self, source: &Path) -> Result<Zeroizing<Vec<u8>>, HostError> {
         self.inner.read_attachment_source(source)
     }

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Command surface gains `import portable|bitwarden|csv|kdbx FILE`
+  (`VLT-PM49-cli-external-import.md`), replacing the old bare
+  `import FILE`. Added `real_cli_imports_bitwarden_json_and_leaks_no_secret_
+  anywhere` to `tests/local_cli_e2e.rs`: a real Bitwarden JSON export on
+  disk, through the real `vault-pm` binary over a real pseudo-terminal,
+  becomes a real redacted item, and the fixture's plaintext password is
+  proven absent from stdout, `item list`, and every durable `audit list`
+  row — not merely absent from one of them. The same test proves
+  `import kdbx` fails closed against a nonexistent path exactly like it
+  would against a real one, i.e. without ever opening it.
+
 - Fixed the actual cause of PR #12042's "Build and test affected packages"
   step running 2h46m before its 150-minute job timeout fired, with the build
   tool's progress line frozen and zero log output for over two hours:

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -22,7 +22,10 @@ vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase]
                            [--no-digits] [--no-symbols] [--exclude-ambiguous]
                            (--reveal|--copy)
 vault-pm [--vault NAME] export FILE
-vault-pm [--vault NAME] import FILE
+vault-pm [--vault NAME] import portable FILE
+vault-pm [--vault NAME] import bitwarden FILE
+vault-pm [--vault NAME] import csv FILE
+vault-pm [--vault NAME] import kdbx FILE
 vault-pm --vault NAME restore FILE
 vault-pm [--vault NAME] restore verify FILE
 vault-pm [--vault NAME] item add login

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -3109,3 +3109,68 @@ fn real_agent_cache_is_forgotten_immediately_after_a_passphrase_rotation() {
     );
     assert!(after_status.success(), "{after_transcript}");
 }
+
+/// VLT-PM49 §9 gate 6, through the real executable with a real pseudo-
+/// terminal: a Bitwarden JSON export on disk becomes a real, redacted,
+/// separately-reachable vault-pm item, and the plaintext password never
+/// reaches stdout, stderr, or a durable audit row.
+#[test]
+fn real_cli_imports_bitwarden_json_and_leaks_no_secret_anywhere() {
+    const BITWARDEN_PASSWORD: &[u8] = b"e2e-bitwarden-import-secret-4f21c9";
+
+    let home = TestHome::new();
+    assert!(run_init_in_pty(&home).0.success());
+
+    let source = home.0.join("bitwarden-export.json");
+    let mut fixture = Vec::new();
+    fixture.extend_from_slice(br#"{"items":[{"type":1,"name":"Imported GitHub","notes":null,"login":{"username":"e2e-imported-user","password":""#);
+    fixture.extend_from_slice(BITWARDEN_PASSWORD);
+    fixture.extend_from_slice(br#"","uris":[{"uri":"https://github.com"}]}}]}"#);
+    fs::write(&source, &fixture).unwrap();
+
+    let (imported_status, imported_transcript) = run_unlock_in_pty(
+        &home,
+        &[
+            "import",
+            "bitwarden",
+            source.to_str().expect("UTF-8 test source path"),
+        ],
+        b"Import complete: created=1 skipped=0 failed=0",
+    );
+    assert!(imported_status.success(), "{imported_transcript}");
+    assert!(!imported_transcript
+        .as_bytes()
+        .windows(BITWARDEN_PASSWORD.len())
+        .any(|value| value == BITWARDEN_PASSWORD));
+    assert_transcript_excludes_secrets(&imported_transcript);
+
+    let (listed_status, listed_transcript) =
+        run_unlock_in_pty(&home, &["item", "list"], b"Imported GitHub");
+    assert!(listed_status.success(), "{listed_transcript}");
+    assert!(!listed_transcript
+        .as_bytes()
+        .windows(BITWARDEN_PASSWORD.len())
+        .any(|value| value == BITWARDEN_PASSWORD));
+
+    let (audit_status, audit_transcript) = run_unlock_in_pty(&home, &["audit", "list"], b"action=");
+    assert!(audit_status.success(), "{audit_transcript}");
+    assert!(!audit_transcript
+        .as_bytes()
+        .windows(BITWARDEN_PASSWORD.len())
+        .any(|value| value == BITWARDEN_PASSWORD));
+    assert!(!audit_transcript.contains("Imported GitHub"));
+    assert_audit_rows_have_only_closed_fields(&audit_transcript);
+
+    // KDBX always fails closed before opening its source (VLT-PM49 §8) --
+    // an absent path fails the identical way a real one would.
+    let kdbx_result = run_plain(
+        &home,
+        &[
+            "import",
+            "kdbx",
+            home.0.join("absent.kdbx").to_str().unwrap(),
+        ],
+    );
+    assert!(!kdbx_result.status.success());
+    assert!(stdout_string(&kdbx_result).is_empty());
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -983,6 +983,15 @@ default was a peer-authored name resolved against the working directory; and
 `attachment remove` is deferred to `gc run`, because a removal that leaves every
 byte in the store would say something false.
 
+**Bitwarden and browser-CSV import have since shipped**, as
+`VLT-PM49-cli-external-import.md`, per §23 item 13. The bare `import FILE`
+this table originally showed is now `import portable FILE`; `import
+bitwarden FILE` and `import csv FILE` join it, each reusing the unmodified
+`item add` publication path once per decoded record rather than a new
+bulk-mutation primitive. `import kdbx FILE` remains in the grammar and
+fails closed with the `unsupported` exit class, because KDBX's own
+encrypted container format is explicitly deferred.
+
 ### 14.5 Unlock experience
 
 Phase 1A supports:
@@ -1963,7 +1972,39 @@ changelog, focused build, and downstream validation.
       it to expire on its own. Windows named-pipe support is explicitly
       deferred and documented rather than silently unimplemented; every agent
       verb reports the closed `unsupported` exit class there.
-13. Bitwarden/KDBX/browser CSV import adapters.
+13. Bitwarden/KDBX/browser CSV import adapters. **Bitwarden and browser
+      CSV have shipped**, as `VLT-PM49-cli-external-import.md`. `import
+      portable FILE` (VLT-PM18, formerly the bare `import FILE`),
+      `import bitwarden FILE`, and `import csv FILE` each read a
+      plaintext export, decode it with a dependency-light adapter crate
+      (`vault-import-bitwarden`, `vault-import-csv`) implementing
+      `vault-import-export`'s (VLT15) `Importer` trait — the first real
+      consumer of that trait in this workspace, since `import portable`
+      turned out to be vault-pm's own independent snapshot format rather
+      than `PortableBundle` JSON, matching this campaign's repeated
+      finding that vault-pm reimplements generic crypto/envelope layers
+      rather than depending on them directly. Every mapped record is
+      created through the unmodified, already-audited `item add`
+      publication path once per record, not a new bulk-mutation
+      primitive, because `add_item`'s session-consuming design already
+      makes "one authenticated session creates one item" structural
+      rather than a policy this slice could relax. Every created item
+      therefore carries the same `ItemCreate` audit event and
+      crash-resumable publication `item add` does, with no new audit
+      event kind introduced. Imports always create brand-new items with
+      fresh identities and never merge, the same answer VLT-PM18 §7
+      gives the portable-restore path, reached here for a simpler
+      reason: an external format's records have no vault-pm item ID to
+      collide with in the first place. KDBX is explicitly deferred —
+      `import kdbx` stays in the grammar and fails closed with the
+      `unsupported` exit class before opening its file, rather than
+      disappearing from the documented command surface — because KDBX4
+      is a real encrypted container (Argon2d/AES-KDF plus AES-256 or
+      ChaCha20) wrapping a KeePass-flavored inner XML document, a fourth
+      structurally different untrusted-input parser on top of the JSON
+      and CSV ones this slice already reviews, judged too large to
+      review well alongside them in one PR even though this workspace
+      already has the Argon2d/AES/ChaCha20 primitives it would need.
 14. removable/synced-folder mode and mirror decorator.
 
 ### Phase 2 — cloud

--- a/code/specs/VLT-PM49-cli-external-import.md
+++ b/code/specs/VLT-PM49-cli-external-import.md
@@ -1,0 +1,375 @@
+# VLT-PM49 — CLI External Import: Bitwarden JSON and Browser CSV
+
+## Status
+
+Normative Phase 1B contract for VLT-PM00 §23 item 13, "Bitwarden/KDBX/
+browser CSV import adapters." This slice ships the Bitwarden JSON and
+browser/LastPass-style CSV adapters as a complete, well-tested pair.
+KDBX is explicitly deferred; §8 records why and what closes it.
+
+## 1. Purpose
+
+`vault-pm import bitwarden FILE` and `vault-pm import csv FILE` read a
+plaintext export produced by a *different* password manager and create
+new vault-pm items from it, through the same audited, one-item-at-a-time
+creation path `vault-pm item add` already uses. This is the "migrate in"
+half of VLT-PM00 §2.1's import/export promise; `vault-pm import portable
+FILE` (VLT-PM18) remains the disaster-recovery half, restoring a vault-pm
+vault's own encrypted export into an empty target.
+
+These two ceremonies look similar — both start with the word `import` —
+and are deliberately *not* the same machinery, for reasons §2 below
+explains from source, not by assertion.
+
+## 2. Reuse precedent: what this slice builds on, and what it does not
+
+VLT-PM00 §6 lists `vault-import-export` as the reuse target for "actual
+Bitwarden, KDBX, browser, CSV adapters," and that crate's own
+description says format adapters ship as sibling crates implementing its
+`Importer` trait. Before writing any adapter, this slice checked whether
+`vault-pm import portable` (VLT-PM17/18) already consumes
+`vault-import-export`'s types — because this campaign has repeatedly
+found that vault-pm reimplements the generic crypto/envelope layers
+independently rather than consuming the generic packages directly (its
+own object format, its own commit DAG, its own Argon2id/AEAD wrapping),
+and the reuse map's crypto-layer rows have been wrong about direct reuse
+before.
+
+They do not connect. `grep`ing `vault-pm-cli`'s and
+`vault-pm-application`'s dependency graphs for `vault_import_export` or
+`vault-import-export` finds nothing: zero references. `vault-pm import
+FILE`'s actual implementation (`portable_import` in `vault-pm-cli`,
+backed by `open_portable_with_passphrase` /
+`audited_import_opened_portable_snapshot` in `vault-pm-application`) is
+vault-pm's own passphrase-protected, Argon2id-KDF'd, AEAD-sealed,
+signed-bootstrap-bound snapshot format — the same independent-
+implementation pattern this campaign found at the crypto layer
+elsewhere. It is not `PortableBundle` JSON. `PassthroughImporter` in
+`vault-import-export` is not called by any vault-pm code today.
+
+That is the right precedent to *not* copy: an external product's plain
+JSON/CSV export needs no vault-pm cryptography to decode, so there is no
+reason for a format adapter to depend on vault-pm's independent object
+format the way `vault-pm import portable` does. But `vault-import-
+export`'s `PortableRecord`/`Importer` vocabulary genuinely fits this
+different job — decoding an external file into a typed, bounded,
+zeroizing-secret record shape that has no vault-pm-specific content —
+exactly as its own module documentation describes ("format adapters ship
+as sibling crates"). This slice is the first consumer of that vocabulary
+in the whole workspace:
+
+- `code/packages/rust/vault-import-bitwarden` — implements `Importer`,
+  decodes an unencrypted Bitwarden JSON export into
+  `Vec<PortableRecord>`.
+- `code/packages/rust/vault-import-csv` — implements `Importer`, decodes
+  a header-keyed browser/LastPass/Bitwarden-CSV login export into
+  `Vec<PortableRecord>`.
+
+Neither crate touches vault-pm cryptography, item identity, or audit
+events. `vault-pm-cli` is the only place `PortableRecord` values become
+real vault-pm items, and it does that by mapping each one onto the
+*existing* `item add` machinery (§4), not by inventing a second
+mutation/publication path next to the one VLT-PM05 already specifies.
+
+## 3. Grammar
+
+```text
+vault-pm [--vault NAME] import portable FILE
+vault-pm [--vault NAME] import bitwarden FILE
+vault-pm [--vault NAME] import csv FILE
+vault-pm [--vault NAME] import kdbx FILE
+```
+
+This supersedes VLT-PM18 §2's bare `vault-pm import FILE`, which is now
+`vault-pm import portable FILE` — the format keyword is mandatory so the
+grammar names every format VLT-PM00 §14.4 always documented, rather than
+letting one format own the unqualified verb by historical accident.
+Existing scripts written against the bare form must add `portable`; this
+repository's stated policy is to break compatibility deliberately rather
+than carry a silent default. `import kdbx FILE` is accepted by the
+parser and always fails closed with the `unsupported` exit class before
+opening `FILE` (§8) — present in the grammar so the command surface
+matches what VLT-PM00 §14.4 documents, rather than a format silently
+missing from `--help` with no explanation.
+
+V1 accepts exactly one non-empty Unicode path per format, matching
+VLT-PM18 §2's existing discipline: no source-passphrase flag (neither
+external format is encrypted), no overwrite switch, no merge mode.
+
+## 4. What "the same audited creation as `item add`" means, concretely
+
+VLT-PM00's task brief for this slice requires imported items to satisfy
+"the same audited/publish-before-release discipline... exactly like any
+other item creation." `vault-pm-cli`'s existing single-item add path
+already is that discipline: `prepare_item_create` reserves entropy and
+authenticates the vault once, `ItemCreateContext::document` builds and
+validates an `ItemDocument`, and `ItemCreateContext::complete` calls
+`UnlockedVaultV1::add_item`, which VLT-PM05 §7a already specifies as
+crash-resumable, entropy-bound, and audited — the exact function
+`vault-pm item add login` calls today. `UnlockedVaultV1::add_item`'s own
+doc comment states the session is consumed on every return path
+specifically "so a successful caller cannot keep using stale pins,
+catalog contents, or search state" — one authenticated session creates
+*one* item, by construction, not a policy choice this slice could relax.
+
+So the ceremony for N external records is N calls to that exact
+existing pipeline, once per record, not one new bulk-mutation primitive:
+
+1. **Read the source file** through a new bounded host method,
+   `read_external_import_source`, modeled on VLT-PM47's
+   `read_attachment_source` rather than VLT-PM18's
+   `read_portable_export`: the buffer is `Zeroizing`, because unlike a
+   vault-pm portable artifact (already ciphertext) a Bitwarden/CSV export
+   *is* the person's plaintext secrets. No vault is opened yet, so a
+   missing file, wrong permissions, or empty file is refused before any
+   authentication prompt and needs no audit event — nothing vault-side
+   has happened.
+2. **Decode** the bytes with the format's adapter crate
+   (`vault-import-bitwarden::decode` or `vault-import-csv::decode`). Any
+   `ImportError` here is `CliFailure::InvalidCommand` (malformed source),
+   still before any vault access.
+3. **Map** each `PortableRecord` to zero or one vault-pm `(content_type,
+   AnyRecord)` pair (§5). A record whose kind has no vault-pm equivalent
+   (`PortableRecordKind::SshKey`, `Custom(_)`) is *skipped*, counted, and
+   not silently dropped from the reported outcome.
+4. If mapping produces **zero** creatable records (an empty file, or a
+   file whose every record is unsupported), report the outcome and open
+   no vault at all — an import that creates nothing is not a mutation,
+   and `vault-pm password generate`'s Phase 1B precedent already
+   established that not every command needs a vault (VLT-PM44 §2.2).
+5. Otherwise, for **each** mapped record in turn: call
+   `prepare_item_create` (authenticate — through the agent cache first,
+   VLT-PM48, then falling back to the ordinary prompt, exactly like
+   every other authenticated command), build the document, and call
+   `context.complete` on success or `context.fail` on a validation
+   failure. Each of those calls is the unmodified VLT-PM05/VLT-PM15 path:
+   its own `ItemCreate` audit event, its own crash-resumable publication,
+   its own entropy reservation. This slice adds no new audit event kind.
+6. **Aggregate and report** (§6). No item title, URL, username, or
+   secret ever reaches CLI output.
+
+### 4.1 Why re-authentication per record, and its cost
+
+Because step 5 calls the unmodified single-item path once per record,
+importing N records re-derives the vault's Argon2id KEK N times unless a
+running `vault-pm agent` (VLT-PM48) is caching the passphrase — in which
+case only the KDF derivation itself repeats locally, not a passphrase
+prompt. This is the same cost anyone incurs today by running `vault-pm
+item add login` N times from a script; this slice introduces no new
+cost model, and choosing it over a new bulk-session API keeps every
+crash/audit guarantee exactly what VLT-PM41/42 already proved for
+single-item creation, rather than opening a second, unproven mutation
+surface. A bulk-session `add_items` primitive that authenticates once
+and publishes one commit per batch is legitimate future work — starting
+`vault-pm agent start` first is the documented mitigation until it
+lands.
+
+### 4.2 Why no merge/conflict resolution
+
+VLT-PM18's restore path requires its target to be logically empty
+specifically because it is reconstructing *the same* vault-pm identity
+space the export snapshot came from — a source item ID could otherwise
+collide with a live target item. An external Bitwarden/CSV record has no
+vault-pm item ID at all; there is no identity for a target item to
+collide with. So, exactly like `item add`, every imported record becomes
+a brand-new item with a freshly generated `ItemId`, unconditionally.
+This is the same "no merge, always new identity" answer VLT-PM18 §7
+already gives for the *portable* restore path, arrived at for a
+different, simpler reason: there is nothing here to merge against in the
+first place.
+
+## 5. Field mapping
+
+### 5.1 Bitwarden JSON (`vault-import-bitwarden`)
+
+| Bitwarden `type` | vault-pm outcome |
+|---|---|
+| `1` login | one `LOGIN_V1` item (`username`, `password`, first `uris[]` entry as the sole URL, `notes`); a second, separate `TOTP_SEED_V1` item when `login.totp` is present (§5.3) |
+| `2` secure note | one `SECURE_NOTE_V1` item (`notes` becomes the body) |
+| `3` card | one `CARD_V1` item, fields taken from the adapter's `custom_fields` (`holder`, `number`, `expiry_month`, `expiry_year`, `cvv`) |
+| `4` identity, or any other value | **skipped** — vault-pm has no identity item type yet |
+
+A login's extra `uris[]` entries beyond the first, and Bitwarden's
+per-item custom `fields[]`, are preserved on the `PortableRecord` (as
+`custom_fields`) but have no vault-pm-side destination in V1 and are
+therefore also not created as separate fields on the mapped item —
+recorded as a known gap in §8, not silently discarded by the adapter
+(the adapter crate keeps them; the CLI mapping layer is what does not
+yet have anywhere to put them).
+
+### 5.2 Browser/LastPass CSV (`vault-import-csv`)
+
+Every recognized CSV row maps to one `LOGIN_V1` item
+(`username`/`password`/`url`/`notes` from the matched columns), plus a
+separate `TOTP_SEED_V1` item when a `totp`/`login_totp` column is present
+and non-empty (§5.3). CSV carries no secure-note or card rows in any of
+the vendor shapes this adapter recognizes (see the adapter's own
+README), so §5.1's card/note mapping does not apply here.
+
+### 5.3 TOTP field decoding
+
+Both formats can carry a TOTP seed as either raw Base32 (Bitwarden's
+`login.totp`, LastPass CSV's `totp` column) or an `otpauth://totp/...`
+URI (both formats accept either shape in practice). `vault-pm-cli` adds
+one shared decoder, `decode_external_totp_field`, tried in this order:
+
+1. **`otpauth://totp/...` URI** — scheme and type checked exactly
+   (`hotp` is refused, matching VLT-PM29's TOTP-only scope), label and
+   query percent-decoded under a fixed length bound, `secret` required,
+   `issuer`/`algorithm`/`digits`/`period` optional with VLT-PM29's
+   existing defaults (`SHA1`, 6 digits, 30 seconds) when absent.
+2. **Raw Base32** — normalized (uppercased, padding `=` stripped,
+   internal whitespace stripped) and then decoded by the same
+   `decode_totp_base32` the interactive `item add totp` form already
+   uses, so a seed accepted here decodes identically to one a person
+   typed by hand.
+
+A field that is neither is a mapping failure for that one record (does
+not abort the whole import; counted in `failed`, §6).
+
+### 5.4 Not carried across (documented, not silently dropped)
+
+- Folder/collection assignment, and Bitwarden's `favorite` flag: every
+  created item starts with no collections and `favorite = false`,
+  identical to `item add`'s existing default (`ItemCreateContext::
+  document` always builds `LwwRegister::new(false, ...)`).
+- Attachment bytes: neither Bitwarden's JSON export nor any CSV shape
+  here carries attachment content, only (for Bitwarden) metadata this
+  slice does not read.
+- Bitwarden's item-level custom `fields[]` and a login's extra `uris[]`
+  beyond the first (§5.1) — kept by the adapter, no destination on the
+  mapped vault-pm item yet.
+
+## 6. Output and errors
+
+Success reports only aggregate counts, matching VLT-PM18 §8's existing
+style:
+
+```text
+Import complete: created=C skipped=S failed=F
+```
+
+`created` counts items actually published; `skipped` counts records
+whose kind has no vault-pm equivalent (§5); `failed` counts records that
+were mappable but whose `item add` publication itself returned an
+application error (e.g. a bound violation) — the ordinary
+`context.fail` path already publishes that failure's own audited event.
+No source path, title, username, URL, secret, or record body is ever
+printed. Source-file and decode failures (before any vault is opened)
+use the invalid exit class; an authentication failure partway through
+uses the locked class exactly like any other authenticated command, and
+whatever items were already durably created before that point remain —
+this is an ordinary sequence of independent, already-audited mutations,
+not one atomic operation, precisely because §4.2 established there is no
+shared identity space to make atomic in the first place.
+
+## 7. Threat model — VLT-PM00 §7.1 adversary 6, "malicious imported data"
+
+Both adapter crates are designed against oversized, malformed,
+ambiguous, and structurally adversarial input, verified by each crate's
+own broad test matrix rather than asserted here:
+
+- **Bounded everything, before decode.** Whole-source byte ceilings
+  (`MAX_SOURCE_BYTES`), and bounded arrays/fields/rows once inside
+  (`MAX_ITEMS`, `MAX_URIS_PER_LOGIN`, `MAX_CUSTOM_FIELDS_PER_ITEM`,
+  `MAX_ROWS`, `MAX_COLUMNS`, `MAX_FIELD_LEN` — see each crate's README).
+  JSON has no entity-expansion mechanism, so a byte-bounded document
+  cannot decode to an unboundedly large tree.
+- **Deeply nested JSON.** `vault-import-bitwarden` reuses this
+  workspace's existing depth-capped `json-lexer`/`json-parser`/
+  `json-value` pipeline rather than a new hand-rolled decoder; its test
+  suite includes a 10,000-deep nested array proving the inherited cap
+  turns an adversarial `[[[[...]]]]` into a clean `Err` rather than a
+  stack overflow.
+- **Duplicate/ambiguous keys.** JSON duplicate object keys resolve
+  last-write-wins, the same rule every mainstream JSON parser applies,
+  tested explicitly (both a duplicate field inside one item and a
+  duplicate top-level `"items"` key).
+- **Type confusion.** Every field the Bitwarden adapter reads is
+  type-checked; a crafted file where `"login"` is a string, number, or
+  array is rejected rather than coerced.
+- **CSV structure.** Delegated entirely to this workspace's existing
+  RFC 4180 state-machine `csv-parser` (embedded quotes/commas/newlines,
+  `""` escaping, ragged rows); this slice adds no CSV-syntax parsing.
+- **CSV formula injection** (`=cmd|...`, `+`, `-`, `@`-prefixed cells) —
+  named explicitly by this slice's task brief as a known class. This
+  import-only path never writes a CSV, so there is no spreadsheet a
+  crafted cell could later detonate in; such a value is decoded and
+  stored as inert literal text, proven by a dedicated round-trip test.
+  If vault-pm ever grows a CSV *export* path, neutralizing a leading
+  `=`/`+`/`-`/`@` on the way out is that writer's responsibility, not
+  retroactively this reader's — recorded in `vault-import-csv`'s README
+  so the obligation is not lost.
+- **Log-injection.** §6 already gives the answer this adversary needs:
+  no imported field ever reaches CLI stdout/stderr or an audit event: an
+  attacker who puts a fake syslog line, ANSI escape, or `Set-Cookie`-
+  shaped string in an item title cannot get it echoed anywhere this
+  product controls.
+
+## 8. Explicitly deferred: KDBX
+
+KeePass's `.kdbx` (KDBX4) format is a real encrypted container in its
+own right — Argon2d or AES-256-KDF key derivation, then AES-256 or
+ChaCha20 authenticated decryption of an inner XML document — not a
+plaintext export like the other two formats in this slice. Before
+assuming that needs a new dependency, this slice checked what this
+workspace already has: `argon2d`, `aes`, `aes-modes`, and
+`chacha20-poly1305` all exist as standalone crates
+(`code/packages/rust/argon2d`, `.../aes`, `.../aes-modes`,
+`.../chacha20-poly1305`), and vault-pm's *own* vault unlock already
+composes Argon2id with an AEAD cipher for the same "password-derived key
+opens an encrypted container" shape (VLT-PM00 §8.1). So closing this gap
+would not need a new cryptographic primitive — it would need: the KDBX4
+binary container framing (a distinct format from vault-pm's own `VPO1`
+envelope, VLT-PM00 §10.2), an Argon2d parameter block reader with the
+same hard-bounded-before-allocation discipline VLT-PM00 §8.2 requires of
+vault-pm's own KDF parameters, and a hand-rolled bounded KeePass-flavored
+XML reader for the decrypted inner document (a fourth structurally
+different untrusted-input parser, on top of the JSON and CSV parsers
+this slice already reviews).
+
+That is real, separable work at least as large as the Bitwarden and CSV
+adapters combined, and reviewing it well alongside them in one PR was
+judged to cost more than it would return — the same call this campaign
+made for Windows named-pipe support in VLT-PM48 §6, deferred there and
+documented rather than silently missing. `import kdbx FILE` therefore
+stays in the grammar (§3) — VLT-PM00 §14.4 always documented it as part
+of this command surface — and every invocation fails closed with the
+`unsupported` exit class (VLT-PM00 §14.7 code 8) before opening `FILE`,
+the same pattern VLT-PM48 §6 uses for every agent verb on Windows. A
+follow-up slice owns: a `vault-import-keepass` adapter crate producing
+the same `PortableRecord` vocabulary as the other two, and wiring
+`import kdbx` in `vault-pm-cli` to it exactly as this slice wires
+`bitwarden`/`csv`.
+
+## 9. Acceptance gates
+
+1. `import bitwarden`/`import csv`/`import portable` each parse exactly
+   one source path and nothing else; `import kdbx` parses the same shape
+   but fails closed with the `unsupported` exit class before any file
+   access, in a unit test that also proves the file was never opened.
+2. A well-formed Bitwarden JSON export containing one of each mapped
+   kind (login with URIs and a TOTP seed, secure note, card) creates the
+   expected vault-pm items, each independently reachable by `item show`
+   after restart, and the login's TOTP seed becomes a separately
+   reachable `totp code` item.
+3. A well-formed CSV export in each of the four documented column
+   shapes (Chrome, Firefox, LastPass, Bitwarden CSV) creates the
+   expected login items.
+4. A file whose every record is an unsupported kind reports
+   `created=0 skipped=N failed=0` and never authenticates a vault (a
+   fake `CliHost` asserting `read_existing_passphrase`/`fill_entropy`
+   are never called for that case).
+5. Both adapter crates' own malformed-input matrices (§7) are green,
+   plus a `vault-pm-cli`-level test importing a truncated/malformed file
+   of each format and observing the invalid exit class with no vault
+   opened.
+6. Imported secrets never appear in stdout, stderr, or an audit-event
+   field — verified the same way VLT-PM18 §9 verifies it for portable
+   import: grep the real CLI's captured output and the durable audit
+   rows for known fixture plaintext after a real end-to-end run through
+   the actual executable.
+7. Each created item's audit trail is indistinguishable in shape from
+   one created by `item add` — same `ItemCreate` event kind, same
+   crash-resumable publication — because no new mutation or audit path
+   was introduced for this slice.


### PR DESCRIPTION
## Summary

Implements the Bitwarden/browser-CSV half of VLT-PM00 §23 item 13 ("Bitwarden/KDBX/browser CSV import adapters"), specified in full by the new `code/specs/VLT-PM49-cli-external-import.md`.

- New `vault-import-bitwarden` and `vault-import-csv` crates implement VLT15's `Importer` trait — the first real consumer of that trait in this workspace. Investigated first: `vault-pm import portable` turned out to be vault-pm's own independent snapshot format (not `PortableBundle` JSON), matching this campaign's repeated finding that vault-pm reimplements generic crypto/envelope layers rather than depending on them directly. Format *parsing* is different — no vault-pm crypto needed — so these two adapters are the intended reuse.
- `vault-pm import` grammar becomes `portable|bitwarden|csv|kdbx FILE` (the old bare `import FILE` is now `import portable FILE`). Every mapped record is created through the unmodified, already-audited `item add` publication path, once per record — no new mutation or audit primitive, because `add_item`'s session-consuming design already makes "one authenticated session creates one item" structural. Imports always create brand-new items with fresh identities and never merge, matching `item add`'s own semantics.
- `import kdbx FILE` parses but always fails closed with the `unsupported` exit class before opening its file. KDBX4 is a real encrypted container (Argon2d/AES-KDF + AES-256/ChaCha20) wrapping a KeePass-flavored XML document — a fourth structurally different untrusted-input parser on top of the JSON and CSV ones already in this PR — judged too large to review alongside them in one PR, per VLT-PM49 §8.

## Security review

Ran 4 rounds of `/security-review` before push. Each round found real, concrete issues; all fixed:

1. **HIGH** — two panics from direct `&str` byte-offset indexing on untrusted TOTP fields (`decode_external_totp_field`/`parse_otpauth_totp_uri`), reproduced with a real `rustc` repro by the reviewing sub-agent. Fixed with `str::get`.
2. **MEDIUM** — JSON-object-key / CSV-row-column counts were only bounded *after* the parser had already materialized the object/row, allowing some memory amplification within the byte cap. Mitigated: `MAX_SOURCE_BYTES` lowered 64/32→16 MiB in both crates, new `MAX_KEYS_PER_OBJECT` cap added to `vault-import-bitwarden`.
   **LOW/MEDIUM** — intermediate plaintext (passwords, TOTP seeds, card PAN/CVV) sat in non-zeroizing `String`s inside the parsed JSON tree / CSV row maps, unwiped after `decode()` returned. Fixed with a recursive zeroize pass over the whole parse tree.
3. **MEDIUM** — round 2's zeroize fix only ran on the success path; any decode error skipped the wipe for every record already parsed before the error — exactly the adversarial-input case this crate exists to survive. Fixed by running the zeroize pass unconditionally on both `Ok` and `Err`.
4. Verified rounds 1-3's fixes are complete and correct; one cosmetic stale-changelog-number note, fixed in docs.

Final round: **SECURITY REVIEW PASSED**.

## Test plan

- [x] `cargo test` green for `vault-import-bitwarden` (36 tests), `vault-import-csv` (22 tests), `vault-pm-cli-host` (42 tests), `vault-pm-cli` (127 tests)
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean across all four touched crates
- [x] `cargo build`/`cargo test` clean for `programs/rust/vault-pm-cli` (16 real end-to-end tests over a real pseudo-terminal, including a new one proving a real Bitwarden JSON file becomes a real redacted item with the fixture password absent from stdout, `item list`, and every durable `audit list` row) and `programs/rust/vault-pm-cli-drill`
- [x] Broad adversarial-input test matrices in both new crates (malformed JSON/CSV, oversize fields/objects/rows, duplicate keys, deeply-nested documents, CSV formula-injection payloads stored as inert text, UTF-8 boundary-splitting characters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
