### PR TITLE
feat(wasm): SIMD widen PR23 -- vendor simd_select.wast + simd_address.wast, zero new opcodes

### DIFF
--- a/code/packages/rust/wasm-conformance/CHANGELOG.md
+++ b/code/packages/rust/wasm-conformance/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — wasm-conformance
 
+## 0.1.58 — 2026-08-19 — vendor simd_select.wast + simd_address.wast: pure vendoring, zero new opcodes (task #186-187)
+
+### Added
+
+- Vendored `simd_select.wast` and `simd_address.wast` (both new files,
+  not re-fetches of already-vendored ones) at the existing pinned commit
+  `28864811cf03bdbf880733786148feaba339582d`. Unlike every prior PR in
+  this SIMD widening campaign, this PR adds ZERO new opcodes to
+  `wasm-opcodes` -- both files were confirmed, before vendoring, to use
+  only opcodes already fully implemented: `simd_select.wast` exercises
+  untyped `select` (`0x1B`) with `v128` operands (the parametric `select`
+  handler and the validator's `select` type-check rule are both already
+  fully generic over `ValueType`, `V128` included, with no SIMD-specific
+  gating anywhere); `simd_address.wast` exercises `v128.load`/
+  `v128.store` memarg offset/align edge cases, both implemented since
+  PR15 (task #162-164). 100% pass on EVERY directive in both files:
+  `simd_select.wast` (1/1 module, 6/6 assert_return); `simd_address.wast`
+  (3/3 modules, 36/36 assert_return, 6/6 assert_trap, 2/2 assert_invalid,
+  2/2 assert_malformed) -- 46 directives total, zero `NotYetSupported`
+  anywhere. Aggregate `assert_return` rose from 24292/24309 to
+  24334/24351 (+42 pass, +42 gradeable, exactly the two files' combined
+  `assert_return` count); `assert_trap` +6, `assert_invalid` +2,
+  `assert_malformed` +2 (all still 100.0% of gradeable directives);
+  `module` pass count rose from 1164 to 1168 (+4). No source changes to
+  `wasm-execution`/`wasm-validator`/`wasm-wast-parser`/`wasm-opcodes` --
+  only this crate's fixtures/baseline/version/changelog are touched. See
+  `tests/fixtures/testsuite/NOTICE` for the full breakdown.
+
 ## 0.1.57 — 2026-08-19 — vendor simd_i16x8_q15mulr_sat_s.wast: i16x8.q15mulr_sat_s Q15 rounding saturating multiply (task #183-185)
 
 ### Added

--- a/code/packages/rust/wasm-conformance/Cargo.toml
+++ b/code/packages/rust/wasm-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-conformance"
-version = "0.1.57"
+version = "0.1.58"
 edition = "2021"
 description = "Runs the official WebAssembly spec testsuite's .wast scripts against wasm-execution and reports a real, git-pinned conformance baseline"
 

--- a/code/packages/rust/wasm-conformance/tests/fixtures/fetch_testsuite.py
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/fetch_testsuite.py
@@ -422,6 +422,21 @@ TESTSUITE_FILES = [
     # this repo did not previously vendor at all -- not a re-fetch of an
     # already-vendored file whose baseline improves via a later PR.
     "simd_i64x2_extmul_i32x4.wast",
+    # SIMD widen PR23 (task #186-187): simd_select.wast/simd_address.wast --
+    # unlike every prior PR in this campaign, ZERO new opcodes. Both files
+    # use only opcodes this interpreter already fully implements:
+    # simd_select.wast exercises untyped `select` with v128 operands (the
+    # parametric `select` (0x1B) opcode is generic over `WasmValue` in both
+    # `wasm-execution` and the validator's type-check rule -- no
+    # SIMD-specific special-casing anywhere gates it to scalar types), and
+    # simd_address.wast exercises v128.load/v128.store (PR15) memarg
+    # offset/align edge cases (including the same `offset=-1` malformed and
+    # `offset=4294967296` invalid cases already covered by the vendored
+    # load.wast/store.wast/simd_load.wast/simd_store.wast). Verified by
+    # actually vendoring and grading both files, not just by static opcode
+    # inventory -- both come back 100% passing.
+    "simd_select.wast",
+    "simd_address.wast",
 ]
 
 # Reference-types/threads-proposal files whose UPSTREAM path lives under

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite-status.json
@@ -3136,6 +3136,62 @@
         "not_yet_supported": 0
       }
     },
+    "simd_address.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 2,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 36,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 6,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 3,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
     "simd_bit_shift.wast": {
       "action": {
         "pass": 0,
@@ -4480,6 +4536,62 @@
         "not_yet_supported": 0
       }
     },
+    "simd_select.wast": {
+      "action": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_exhaustion": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_invalid": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_malformed": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_return": {
+        "pass": 6,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_trap": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "assert_unlinkable": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "module": {
+        "pass": 1,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      },
+      "register": {
+        "pass": 0,
+        "fail": 0,
+        "trap": 0,
+        "not_yet_supported": 0
+      }
+    },
     "simd_splat.wast": {
       "action": {
         "pass": 0,
@@ -5503,25 +5615,25 @@
       "not_yet_supported": 0
     },
     "assert_invalid": {
-      "pass": 1718,
+      "pass": 1720,
       "fail": 0,
       "trap": 0,
       "not_yet_supported": 76
     },
     "assert_malformed": {
-      "pass": 275,
+      "pass": 277,
       "fail": 0,
       "trap": 0,
       "not_yet_supported": 516
     },
     "assert_return": {
-      "pass": 24292,
+      "pass": 24334,
       "fail": 17,
       "trap": 0,
       "not_yet_supported": 588
     },
     "assert_trap": {
-      "pass": 1424,
+      "pass": 1430,
       "fail": 0,
       "trap": 0,
       "not_yet_supported": 938
@@ -5533,7 +5645,7 @@
       "not_yet_supported": 0
     },
     "module": {
-      "pass": 1164,
+      "pass": 1168,
       "fail": 1,
       "trap": 0,
       "not_yet_supported": 68

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/NOTICE
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/NOTICE
@@ -73,6 +73,9 @@ Fetched:       2026-08-13 (initial slice, W05/PR3), extended 2026-08-14 (WASM08)
                no re-pin),
                extended 2026-08-19 (task #180-182 -- simd_i64x2_extmul_
                i32x4.wast, i64x2.extmul_low/high_i32x4_s/_u, same
+               pinned commit, no re-pin),
+               extended 2026-08-19 (task #186-187 -- simd_select.wast/
+               simd_address.wast, pure vendoring, zero new opcodes, same
                pinned commit, no re-pin)
 Fetch method:  code/packages/rust/wasm-conformance/tests/fixtures/fetch_testsuite.py
 
@@ -623,6 +626,37 @@ file's own `assert_return` count); `assert_invalid` rose from
 failures elsewhere in the corpus (17 `assert_return`, 1 `module`, 1
 `assert_unlinkable`, 2 `register`) are unrelated and unchanged by this
 PR.
+
+SIMD widen PR23 (task #186-187) vendors `simd_select.wast`/
+`simd_address.wast` -- UNLIKE every prior entry in this SIMD arc, this PR
+adds ZERO new opcodes to `wasm-opcodes`. Both files were verified, before
+vendoring, to use only opcodes this interpreter already fully implements:
+`simd_select.wast` exercises untyped `select` (`0x1B`) with `v128`
+operands -- the parametric `select` handler in `wasm-execution` pops/
+pushes a generic `WasmValue` with no type inspection at all, and the
+validator's `select` type-check rule (`wasm-validator/src/type_check.rs`)
+accepts any two matching `ValueType`s, `V128` included, with no
+SIMD-specific gating anywhere in either path. `simd_address.wast`
+exercises `v128.load`/`v128.store` memarg offset/align edge cases
+(including the same `offset=-1` `assert_malformed` and
+`offset=4294967296` `assert_invalid` boundary patterns the plain
+`load.wast`/`store.wast`/`simd_load.wast`/`simd_store.wast` files already
+cover) -- both opcodes have existed since PR15 (task #162-164). This is
+not just a static opcode-inventory claim: both files were actually
+vendored and graded. `simd_select.wast`: 100% pass on every directive
+(1/1 module, 6/6 assert_return). `simd_address.wast`: 100% pass on every
+directive (3/3 modules, 36/36 assert_return, 6/6 assert_trap, 2/2
+assert_invalid, 2/2 assert_malformed) -- 46 directives total across 3
+modules, zero `NotYetSupported` anywhere in either file. Aggregate
+`assert_return` rose from 24292/24309 to 24334/24351 (+42 pass, +42
+gradeable, exactly the two new files' own combined `assert_return`
+count); `assert_trap` rose by 6, `assert_invalid` by 2, `assert_malformed`
+by 2 (all still 100.0% of gradeable directives); `module` pass count rose
+from 1164 to 1168 (+4, one per newly-vendored module, all passing). Only
+`wasm-conformance`'s own fixtures/baseline/version/changelog are touched
+by this PR -- no `wasm-execution`/`wasm-validator`/`wasm-wast-parser`/
+`wasm-opcodes` source changes at all, the first PR in this campaign of
+which that is true.
 
 The vendored files are licensed under the Apache License, Version 2.0 --
 see the accompanying LICENSE file, itself vendored verbatim from the same

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/simd_address.wast
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/simd_address.wast
@@ -1,0 +1,157 @@
+;; Load/Store v128 data with different valid offset/alignment
+
+(module
+  (memory 1)
+  (data (i32.const 0) "\00\01\02\03\04\05\06\07\08\09\10\11\12\13\14\15")
+  (data (offset (i32.const 65505)) "\16\17\18\19\20\21\22\23\24\25\26\27\28\29\30\31")
+
+  (func (export "load_data_1") (param $i i32) (result v128)
+    (v128.load offset=0 (local.get $i))                   ;; 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15
+  )
+  (func (export "load_data_2") (param $i i32) (result v128)
+    (v128.load align=1 (local.get $i))                    ;; 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15
+  )
+  (func (export "load_data_3") (param $i i32) (result v128)
+    (v128.load offset=1 align=1 (local.get $i))           ;; 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15 0x00
+  )
+  (func (export "load_data_4") (param $i i32) (result v128)
+    (v128.load offset=2 align=1 (local.get $i))           ;; 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15 0x00 0x00
+  )
+  (func (export "load_data_5") (param $i i32) (result v128)
+    (v128.load offset=15 align=1 (local.get $i))          ;; 0x15 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+  )
+
+  (func (export "store_data_0") (result v128)
+    (v128.store offset=0 (i32.const 0) (v128.const f32x4 0 1 2 3))
+    (v128.load offset=0 (i32.const 0))
+  )
+  (func (export "store_data_1") (result v128)
+    (v128.store align=1 (i32.const 0) (v128.const i32x4 0 1 2 3))
+    (v128.load align=1 (i32.const 0))
+  )
+  (func (export "store_data_2") (result v128)
+    (v128.store offset=1 align=1 (i32.const 0) (v128.const i16x8 0 1 2 3 4 5 6 7))
+    (v128.load offset=1 align=1 (i32.const 0))
+  )
+  (func (export "store_data_3") (result v128)
+    (v128.store offset=2 align=1 (i32.const 0) (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+    (v128.load offset=2 align=1 (i32.const 0))
+  )
+  (func (export "store_data_4") (result v128)
+    (v128.store offset=15 align=1 (i32.const 0) (v128.const i32x4 0 1 2 3))
+    (v128.load offset=15 (i32.const 0))
+  )
+  (func (export "store_data_5") (result v128)
+    (v128.store offset=65520 align=1 (i32.const 0) (v128.const i32x4 0 1 2 3))
+    (v128.load offset=65520 (i32.const 0))
+  )
+  (func (export "store_data_6") (param $i i32)
+    (v128.store offset=1 align=1 (local.get $i) (v128.const i32x4 0 1 2 3))
+  )
+)
+
+(assert_return (invoke "load_data_1" (i32.const 0)) (v128.const i32x4 0x03020100 0x07060504 0x11100908 0x15141312))
+(assert_return (invoke "load_data_2" (i32.const 0)) (v128.const i32x4 0x03020100 0x07060504 0x11100908 0x15141312))
+(assert_return (invoke "load_data_3" (i32.const 0)) (v128.const i32x4 0x04030201 0x08070605 0x12111009 0x00151413))
+(assert_return (invoke "load_data_4" (i32.const 0)) (v128.const i32x4 0x05040302 0x09080706 0x13121110 0x00001514))
+(assert_return (invoke "load_data_5" (i32.const 0)) (v128.const i32x4 0x00000015 0x00000000 0x00000000 0x00000000))
+
+(assert_return (invoke "load_data_1" (i32.const 0)) (v128.const i16x8 0x0100 0x0302 0x0504 0x0706 0x0908 0x1110 0x1312 0x1514))
+(assert_return (invoke "load_data_2" (i32.const 0)) (v128.const i16x8 0x0100 0x0302 0x0504 0x0706 0x0908 0x1110 0x1312 0x1514))
+(assert_return (invoke "load_data_3" (i32.const 0)) (v128.const i16x8 0x0201 0x0403 0x0605 0x0807 0x1009 0x1211 0x1413 0x0015))
+(assert_return (invoke "load_data_4" (i32.const 0)) (v128.const i16x8 0x0302 0x0504 0x0706 0x0908 0x1110 0x1312 0x1514 0x0000))
+(assert_return (invoke "load_data_5" (i32.const 0)) (v128.const i16x8 0x0015 0x0000 0x0000 0x0000 0x0000 0x0000 0x0000 0x0000))
+
+(assert_return (invoke "load_data_1" (i32.const 0)) (v128.const i8x16 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15))
+(assert_return (invoke "load_data_2" (i32.const 0)) (v128.const i8x16 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15))
+(assert_return (invoke "load_data_3" (i32.const 0)) (v128.const i8x16 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15 0x00))
+(assert_return (invoke "load_data_4" (i32.const 0)) (v128.const i8x16 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x10 0x11 0x12 0x13 0x14 0x15 0x00 0x00))
+(assert_return (invoke "load_data_5" (i32.const 0)) (v128.const i8x16 0x15 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00))
+
+(assert_return (invoke "load_data_1" (i32.const 65505)) (v128.const i32x4 0x19181716 0x23222120 0x27262524 0x31302928))
+(assert_return (invoke "load_data_2" (i32.const 65505)) (v128.const i32x4 0x19181716 0x23222120 0x27262524 0x31302928))
+(assert_return (invoke "load_data_3" (i32.const 65505)) (v128.const i32x4 0x20191817 0x24232221 0x28272625 0x00313029))
+(assert_return (invoke "load_data_4" (i32.const 65505)) (v128.const i32x4 0x21201918 0x25242322 0x29282726 0x00003130))
+(assert_return (invoke "load_data_5" (i32.const 65505)) (v128.const i32x4 0x00000031 0x00000000 0x00000000 0x00000000))
+
+(assert_return (invoke "load_data_1" (i32.const 65505)) (v128.const i16x8 0x1716 0x1918 0x2120 0x2322 0x2524 0x2726 0x2928 0x3130))
+(assert_return (invoke "load_data_2" (i32.const 65505)) (v128.const i16x8 0x1716 0x1918 0x2120 0x2322 0x2524 0x2726 0x2928 0x3130))
+(assert_return (invoke "load_data_3" (i32.const 65505)) (v128.const i16x8 0x1817 0x2019 0x2221 0x2423 0x2625 0x2827 0x3029 0x0031))
+(assert_return (invoke "load_data_4" (i32.const 65505)) (v128.const i16x8 0x1918 0x2120 0x2322 0x2524 0x2726 0x2928 0x3130 0x0000))
+(assert_return (invoke "load_data_5" (i32.const 65505)) (v128.const i16x8 0x0031 0x0000 0x0000 0x0000 0x0000 0x0000 0x0000 0x0000))
+
+(assert_return (invoke "load_data_1" (i32.const 65505)) (v128.const i8x16 0x16 0x17 0x18 0x19 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 0x30 0x31))
+(assert_return (invoke "load_data_2" (i32.const 65505)) (v128.const i8x16 0x16 0x17 0x18 0x19 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 0x30 0x31))
+(assert_return (invoke "load_data_3" (i32.const 65505)) (v128.const i8x16 0x17 0x18 0x19 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 0x30 0x31 0x00))
+(assert_return (invoke "load_data_4" (i32.const 65505)) (v128.const i8x16 0x18 0x19 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29 0x30 0x31 0x00 0x00))
+(assert_return (invoke "load_data_5" (i32.const 65505)) (v128.const i8x16 0x31 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00))
+
+(assert_trap (invoke "load_data_3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "load_data_5" (i32.const 65506)) "out of bounds memory access")
+
+(assert_return (invoke "store_data_0") (v128.const f32x4 0 1 2 3))
+(assert_return (invoke "store_data_1") (v128.const i32x4 0 1 2 3))
+(assert_return (invoke "store_data_2") (v128.const i16x8 0 1 2 3 4 5 6 7))
+(assert_return (invoke "store_data_3") (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15))
+(assert_return (invoke "store_data_4") (v128.const i32x4 0 1 2 3))
+(assert_return (invoke "store_data_5") (v128.const i32x4 0 1 2 3))
+
+(assert_trap (invoke "store_data_6" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "store_data_6" (i32.const 65535)) "out of bounds memory access")
+
+;; Load/Store v128 data with invalid offset
+
+(module
+  (memory 1)
+  (func (export "v128.load_offset_65521")
+    (drop (v128.load offset=65521 (i32.const 0)))
+  )
+)
+(assert_trap (invoke "v128.load_offset_65521") "out of bounds memory access")
+
+(assert_malformed
+  (module quote
+    "(memory 1)"
+    "(func"
+    "  (drop (v128.load offset=-1 (i32.const 0)))"
+    ")"
+  )
+  "unknown operator"
+)
+
+(module
+  (memory 1)
+  (func (export "v128.store_offset_65521")
+    (v128.store offset=65521 (i32.const 0) (v128.const i32x4 0 0 0 0))
+  )
+)
+(assert_trap (invoke "v128.store_offset_65521") "out of bounds memory access")
+
+(assert_malformed
+  (module quote
+    "(memory 1)"
+    "(func"
+    "  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 0))"
+    ")"
+  )
+  "unknown operator"
+)
+
+
+;; Offset constant out of range
+
+(assert_invalid
+  (module quote
+    "(memory 1)"
+    "(func (drop (v128.load offset=4294967296 (i32.const 0))))"
+  )
+  "offset out of range"
+)
+
+(assert_invalid
+  (module quote
+    "(memory 1)"
+    "(func (v128.store offset=4294967296 (i32.const 0) (v128.const i32x4 0 0 0 0)))"
+  )
+  "offset out of range"
+)

--- a/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/simd_select.wast
+++ b/code/packages/rust/wasm-conformance/tests/fixtures/testsuite/simd_select.wast
@@ -1,0 +1,61 @@
+;; Test SIMD select instuction
+
+(module
+  (func (export "select_v128_i32") (param v128 v128 i32) (result v128)
+    (select (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const i32x4 1 2 3 4)
+    (v128.const i32x4 5 6 7 8)
+    (i32.const 1)
+  )
+  (v128.const i32x4 1 2 3 4)
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const i32x4 1 2 3 4)
+    (v128.const i32x4 5 6 7 8)
+    (i32.const 0)
+  )
+  (v128.const i32x4 5 6 7 8)
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const f32x4 1.0 2.0 3.0 4.0)
+    (v128.const f32x4 5.0 6.0 7.0 8.0)
+    (i32.const -1)
+  )
+  (v128.const f32x4 1.0 2.0 3.0 4.0)
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const f32x4 -1.5 -2.5 -3.5 -4.5)
+    (v128.const f32x4 9.5 8.5 7.5 6.5)
+    (i32.const 0)
+  )
+  (v128.const f32x4 9.5 8.5 7.5 6.5)
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)
+    (v128.const i8x16 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1)
+    (i32.const 123)
+  )
+  (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)
+)
+
+(assert_return
+  (invoke "select_v128_i32"
+    (v128.const i8x16 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1)
+    (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+    (i32.const 0)
+  )
+  (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
+)


### PR DESCRIPTION
## Summary

- Pure vendoring PR in the SIMD opcode-widening campaign -- unlike every prior PR here, this one adds **zero new opcodes** to `wasm-opcodes`.
- Vendors two upstream `WebAssembly/testsuite` files at the existing pinned commit `28864811cf03bdbf880733786148feaba339582d`: `simd_select.wast` and `simd_address.wast`.
- Both files were verified, before vendoring, to use only opcodes this interpreter already fully implements:
  - `simd_select.wast` exercises untyped `select` (`0x1B`) with `v128` operands -- the parametric `select` handler in `wasm-execution` pops/pushes a generic `WasmValue` with no type inspection, and the validator's `select` type-check rule accepts any two matching `ValueType`s (`V128` included) with no SIMD-specific gating.
  - `simd_address.wast` exercises `v128.load`/`v128.store` memarg offset/align edge cases (including `offset=-1` malformed and `offset=4294967296` invalid boundary cases already covered by `load.wast`/`store.wast`/`simd_load.wast`/`simd_store.wast`) -- both opcodes implemented since PR15.
- Actually vendored and graded both files (not just a static opcode-inventory claim): **100% pass on every directive in both files.**
- Only `wasm-conformance`'s own fixtures/baseline/version/changelog are touched -- no `wasm-execution`/`wasm-validator`/`wasm-wast-parser`/`wasm-opcodes` source changes.

## Pass-rate outcome

- `simd_select.wast`: 1/1 module, 6/6 assert_return -- 100%, zero NotYetSupported.
- `simd_address.wast`: 3/3 modules, 36/36 assert_return, 6/6 assert_trap, 2/2 assert_invalid, 2/2 assert_malformed -- 100%, zero NotYetSupported (46 directives total).
- Aggregate `assert_return` rose from 24292/24309 to 24334/24351 (+42, exactly the two files' combined count).

## Test plan

- [x] `cargo test -p wasm-conformance` passes (including `corpus_matches_the_committed_baseline`)
- [x] `cargo clippy -p wasm-conformance -- -D warnings` clean
- [x] Security review sub-agent: PASSED, no vulnerabilities found
- [x] Synced with latest `origin/main` before committing (already up to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)