### PR TITLE
feat(vault-pm): removable/synced-folder mode and mirror decorator (VLT-PM50)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1125,6 +1125,7 @@ members = [
   "chief-of-staff-agent-stdio-host",
   "vault-pm-storage",
   "vault-pm-storage-storage-core",
+  "vault-pm-storage-removable",
   "vault-pm-repository",
   "vault-pm-application",
   "vault-pm-application-storage-core",

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 ## Unreleased
 
+- **`storage add|list|check|migrate`**, `VLT-PM00` §23 item 14, the last item
+  of Phase 1B. Specified by `VLT-PM50-cli-storage-migration.md`.
+
+  `storage add filesystem|removable NAME PATH` registers a new named
+  filesystem-family storage location in configuration; it neither creates
+  the directory (the backend does that lazily on first use, exactly as
+  `init` already relies on) nor opens any vault.
+  `gdrive|webdav|s3` still parse and are refused with the `unsupported`
+  exit class, the same closed-grammar answer `VLT-PM49` §8 gave `import
+  kdbx` — Phase 2's job. `storage list` lists every configured location.
+  `storage check NAME` reports one location's reachability, runs
+  `vault-pm-storage-removable`'s third-party sync-interference scan for a
+  local-directory kind, and reports any configured mirror's coarse
+  object-count health.
+
+  `storage migrate SOURCE TARGET [--mirror]` implements the
+  filesystem-family slice of `VLT-PM00` §19.1's seven steps:
+  `vault-pm-storage-removable::copy_object_tree` copies and read-back
+  verifies every committed object (steps 2-4), then the freshly collected
+  passphrase is used to independently unlock `TARGET` over a repository
+  factory pointed only at its objects (step 6) — a wrong passphrase or a
+  corrupt copy both fail this exact step before configuration is ever
+  touched, which *is* the "explicit confirmation" step 7 asks for, rather
+  than a second invented ceremony. Only then does configuration switch:
+  without `--mirror`, `local_store` moves to `TARGET`; with it, `TARGET`
+  joins `remote_stores` and `local_store` is unchanged. `SOURCE` is never
+  modified or deleted (step 8's default; no `--delete-source` flag exists in
+  this slice).
+
+  `configured_vault`'s storage-location check, previously hardcoded to the
+  exact two paths this composition root itself creates, now accepts any
+  registered `filesystem`/`removable` location and any `remote_stores` that
+  resolve the same way — the restriction predates `storage add` existing at
+  all and would otherwise make the new command pointless.
+
+  Every repository this composition root opens now goes through
+  `vault-pm-storage::ReplicaSetObjectStore` (with zero configured mirrors by
+  default, a verified no-op pass-through) rather than the bare
+  `StorageCoreObjectStore` — so a vault mirrored via `storage migrate
+  --mirror` gets real, ongoing, best-effort mirror-write propagation on
+  every subsequent mutation, not just at migration time.
+
+  **Deferred**, per `VLT-PM00` §23 item 14's own scoping: the explicit `sync
+  --wait` ceremony with a configurable `one`/`all`/quorum durability target,
+  and treating a change feed rather than write-time propagation and
+  directory-scan counts as the source of replica truth. `storage check`'s
+  replica status line is a labeled structural heuristic (an object-file
+  count comparison), not a cryptographic guarantee, and says so in its own
+  documentation.
+
+  Tests: closed-grammar coverage for all four verbs including `--mirror`
+  and the `--vault` selector split (`add`/`list`/`check` refuse one,
+  `migrate` accepts one); registering and listing a location, duplicate and
+  cloud-kind rejection; `storage check` across unreachable, healthy,
+  sync-interference, missing-name, and cloud-kind-injected states, with an
+  assertion that a conflict-copy filename never appears in the report;
+  `storage migrate` switching primary storage while leaving the source
+  directory untouched and the previously created item still readable;
+  `storage migrate --mirror` adding a replica and proving a *subsequent*
+  item creation actually propagates to it, then that `storage check` reports
+  it `in_sync`; a wrong passphrase leaving configuration unchanged even
+  though the (harmless, verified) copy already happened; and source/target
+  identity and reference-integrity rejections.
+
 - **`import portable|bitwarden|csv|kdbx FILE`**, `VLT-PM00` §23 item 13.
   Specified by `VLT-PM49-cli-external-import.md`. The bare `import FILE`
   grammar (VLT-PM18) is now `import portable FILE`; `import bitwarden FILE`

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -52,6 +52,14 @@
   count comparison), not a cryptographic guarantee, and says so in its own
   documentation.
 
+  `configured_vault`'s cross-vault storage-collision check now falls back
+  to comparing canonicalized paths when two locations' raw strings differ
+  (`same_local_directory`), so a relative path or a symlink cannot make
+  two different-looking `storage add`ed locations silently alias one real
+  directory — found in this PR's own security review, since the previous
+  exact-string comparison predates any location but the two this
+  composition root itself created ever being possible.
+
   Tests: closed-grammar coverage for all four verbs including `--mirror`
   and the `--vault` selector split (`add`/`list`/`check` refuse one,
   `migrate` accepts one); registering and listing a location, duplicate and

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -17,6 +17,8 @@ coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_local_host = { path = "../vault-pm-local-host" }
 coding_adventures_vault_pm_password_policy = { path = "../vault-pm-password-policy" }
 coding_adventures_vault_records = { path = "../vault-records" }
+coding_adventures_vault_pm_storage = { path = "../vault-pm-storage" }
+coding_adventures_vault_pm_storage_removable = { path = "../vault-pm-storage-removable" }
 coding_adventures_vault_pm_storage_storage_core = { path = "../vault-pm-storage-storage-core" }
 coding_adventures_zeroize = { path = "../zeroize" }
 coding_adventures_vault_import_export = { path = "../vault-import-export" }
@@ -35,14 +37,6 @@ crash-injection = ["dep:coding_adventures_vault_pm_crash_injection"]
 
 [dev-dependencies]
 libc = "0.2"
-# VLT-PM42 tests wedge a real on-disk vault the way a crash wedges one: they
-# open it through the ordinary application boundary over a *faulting* view of
-# the very same object root, so the write-ahead journal becomes durable and the
-# publication does not. This adds nothing to the shipped graph -
-# `vault-pm-application` already depends on this crate - and it enables no
-# feature, unlike the crash-injection seam which must stay out of any build the
-# product executable can reach.
-coding_adventures_vault_pm_storage = { path = "../vault-pm-storage" }
 # VLT-PM47's round-trip test re-derives the content hash the attachment
 # listing renders, so it checks the rendered value against an independent
 # computation rather than against the code that produced it. Same argument as

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -31,15 +31,25 @@ items through the unmodified `item add` publication path, once per record,
 rather than the disaster-recovery ceremony `import portable` uses.
 `import kdbx FILE` parses but always fails closed with the `unsupported`
 class before opening its file — KDBX's own encrypted container format is
-explicitly deferred. The executable is a thin caller of this package.
+explicitly deferred. `storage add|list|check|migrate`
+(`VLT-PM50-cli-storage-migration.md`, `VLT-PM00` §23 item 14) add named
+storage locations, third-party sync-tool conflict-copy detection, and
+byte-for-byte migration with a real independent-unlock verification step. The
+executable is a thin caller of this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
 It acquires the persistent cross-process writer lock before loading
 configuration or constructing either backend. Configuration is parsed by the
-closed VLT-PM07 codec. The first vault's filesystem location must exactly match
-the prepared platform object root; named targets use only their
-locator-derived child roots before storage is touched.
+closed VLT-PM07 codec. A vault's storage may be any registered
+`filesystem`/`removable` location — `configured_vault`'s check used to accept
+only the two paths this composition root itself creates, back when `storage
+add` did not exist; that restriction is gone. Every repository this crate
+opens is wrapped in `vault-pm-storage::ReplicaSetObjectStore` (transparently,
+with zero configured mirrors, unless a vault's `remote_stores` names one or
+more `storage add`ed locations), so a vault mirrored with `storage migrate
+--mirror` gets ongoing, best-effort mirror-write propagation on every later
+mutation rather than a one-time copy.
 
 Initialization collects a new passphrase only through the injected fixed
 secret-input boundary, fills the complete generation-zero randomness block

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -69,6 +69,10 @@ use coding_adventures_vault_pm_password_policy::{
     generate_password, CharacterClassesV1, PasswordPolicyError, PasswordPolicyV1,
     DEFAULT_PASSWORD_LENGTH,
 };
+use coding_adventures_vault_pm_storage::ReplicaSetObjectStore;
+use coding_adventures_vault_pm_storage_removable::{
+    copy_object_tree, scan_object_root, CopyError, SyncInterferenceKind,
+};
 use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
 use coding_adventures_vault_records::{
     AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed, API_KEY_V1, CARD_V1,
@@ -106,7 +110,7 @@ const MAX_EXTERNAL_IMPORT_SOURCE_BYTES: usize = 16 * 1024 * 1024;
 /// everything sensitive travels on the child's standard input, because argv is
 /// readable by every account on the machine through `ps` (VLT-PM46 §2.2).
 const CLIPBOARD_CLEAR_ARGUMENTS: &[&str] = &["clipboard", "clear"];
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm agent start\n  vault-pm agent stop\n  vault-pm agent status [--json]\n  vault-pm [--vault NAME] agent unlock\n  vault-pm [--vault NAME] agent lock\n  vault-pm agent run-foreground\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase] [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import portable FILE\n  vault-pm [--vault NAME] import bitwarden FILE\n  vault-pm [--vault NAME] import csv FILE\n  vault-pm [--vault NAME] import kdbx FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] totp code ITEM (--reveal|--copy)\n  vault-pm clipboard clear\n  vault-pm [--vault NAME] attachment add ITEM FILE\n  vault-pm [--vault NAME] attachment list ITEM\n  vault-pm [--vault NAME] attachment export ITEM ATTACHMENT FILE\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm vault create NAME\n  vault-pm [--vault NAME] status [--json]\n  vault-pm [--vault NAME] shell\n  vault-pm agent start\n  vault-pm agent stop\n  vault-pm agent status [--json]\n  vault-pm [--vault NAME] agent unlock\n  vault-pm [--vault NAME] agent lock\n  vault-pm agent run-foreground\n  vault-pm [--vault NAME] audit enable\n  vault-pm [--vault NAME] audit verify\n  vault-pm [--vault NAME] audit list\n  vault-pm [--vault NAME] audit show TRACE\n  vault-pm [--vault NAME] doctor [--unlock]\n  vault-pm [--vault NAME] passphrase rotate\n  vault-pm password generate [--length N] [--no-lowercase] [--no-uppercase] [--no-digits] [--no-symbols] [--exclude-ambiguous] (--reveal|--copy)\n  vault-pm [--vault NAME] export FILE\n  vault-pm [--vault NAME] import portable FILE\n  vault-pm [--vault NAME] import bitwarden FILE\n  vault-pm [--vault NAME] import csv FILE\n  vault-pm [--vault NAME] import kdbx FILE\n  vault-pm --vault NAME restore FILE\n  vault-pm [--vault NAME] restore verify FILE\n  vault-pm [--vault NAME] item add login\n  vault-pm [--vault NAME] item add secure-note\n  vault-pm [--vault NAME] item add card\n  vault-pm [--vault NAME] item add api-key\n  vault-pm [--vault NAME] item add database-credential\n  vault-pm [--vault NAME] item add totp\n  vault-pm [--vault NAME] item edit ITEM\n  vault-pm [--vault NAME] item delete ITEM\n  vault-pm [--vault NAME] item list\n  vault-pm [--vault NAME] item show ITEM\n  vault-pm [--vault NAME] item reveal ITEM FIELD\n  vault-pm [--vault NAME] totp code ITEM (--reveal|--copy)\n  vault-pm clipboard clear\n  vault-pm [--vault NAME] attachment add ITEM FILE\n  vault-pm [--vault NAME] attachment list ITEM\n  vault-pm [--vault NAME] attachment export ITEM ATTACHMENT FILE\n  vault-pm [--vault NAME] search QUERY\n  vault-pm [--vault NAME] history list ITEM\n  vault-pm [--vault NAME] history restore ITEM REVISION\n  vault-pm [--vault NAME] conflict list ITEM\n  vault-pm [--vault NAME] conflict reveal ITEM REVISION FIELD\n  vault-pm [--vault NAME] conflict choose ITEM REVISION\n  vault-pm [--vault NAME] conflict merge login ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge secure-note ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge card ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION\n  vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION\n  vault-pm storage add filesystem NAME PATH\n  vault-pm storage add removable NAME PATH\n  vault-pm storage list\n  vault-pm storage check NAME\n  vault-pm [--vault NAME] storage migrate SOURCE TARGET [--mirror]\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1029,6 +1033,38 @@ enum Command {
         item_id: ItemId,
         base_revision: RevisionId,
     },
+    /// Register a new named storage location (VLT-PM00 §23 item 14).
+    ///
+    /// Does not open or touch any vault -- it only adds one `[storage.NAME]`
+    /// declaration to configuration, exactly like `vault create` adds one
+    /// vault. `gdrive`/`webdav`/`s3` still parse -- the closed-grammar
+    /// principle VLT-PM49 §8 used for `import kdbx` -- but always fail
+    /// closed with the `unsupported` exit class before touching
+    /// configuration, because Phase 1B implements only the local-directory
+    /// kinds (`filesystem`, `removable`).
+    StorageAdd {
+        name: ConfigName,
+        kind: StorageKind,
+        path: PathBuf,
+    },
+    /// List every configured named storage location.
+    StorageList,
+    /// Report one named storage location's reachability and, for a
+    /// local-directory kind, its third-party sync-interference scan
+    /// (VLT-PM00 §12, §23 item 14) and any replica health it owns as a
+    /// vault's configured mirror (§19.2).
+    StorageCheck {
+        name: ConfigName,
+    },
+    /// Copy one storage's committed objects to another, then either switch
+    /// the selected vault's primary storage to it or, with `--mirror`, add
+    /// it as a replica alongside the existing primary (VLT-PM00 §19.1,
+    /// §19.2, §23 item 14).
+    StorageMigrate {
+        source: ConfigName,
+        target: ConfigName,
+        mirror: bool,
+    },
     Help,
 }
 
@@ -1150,6 +1186,7 @@ where
         "attachment" => parse_attachment(tail),
         "history" => parse_history(tail),
         "conflict" => parse_conflict(tail),
+        "storage" => parse_storage(tail),
         _ => Err(CliFailure::InvalidCommand),
     }?;
     // A `--vault` selector names a target for the command to operate on.
@@ -1158,9 +1195,14 @@ where
     // all, and the three agent *lifecycle* verbs act on the agent process
     // itself rather than one vault (VLT-PM48 §6) — `agent unlock` and `agent
     // lock` are the ones that do take a selector, matching every other
-    // authenticated command. For the six listed here the selector would be a
-    // statement with no referent, and accepting it silently would let a
-    // person believe they had aimed a command that was never aimable.
+    // authenticated command. `storage add`/`storage list`/`storage check`
+    // (VLT-PM00 §23 item 14) join the same list for the same reason: they
+    // read or extend configuration itself, not any one vault's contents —
+    // `storage migrate` is the one storage verb that *does* take a selector,
+    // because it names which vault's `local_store`/`remote_stores` to
+    // rewrite. For the nine listed here the selector would be a statement
+    // with no referent, and accepting it silently would let a person believe
+    // they had aimed a command that was never aimable.
     if selected_vault.is_some()
         && matches!(
             &command,
@@ -1172,6 +1214,9 @@ where
                 | Command::AgentStart
                 | Command::AgentStop
                 | Command::AgentRunForeground
+                | Command::StorageAdd { .. }
+                | Command::StorageList
+                | Command::StorageCheck { .. }
         )
     {
         return Err(CliFailure::InvalidCommand);
@@ -1236,6 +1281,41 @@ fn parse_vault(arguments: &[String]) -> Result<Command, CliFailure> {
         [action, name] if action == "create" => Ok(Command::VaultCreate {
             vault: ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?,
         }),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+/// Parse the `storage` verb (VLT-PM00 §23 item 14).
+///
+/// `storage add` takes a location `PATH` as a required fourth argument. §14.4
+/// originally wrote the surface without one; a location cannot be defaulted
+/// the way `init`'s two default names can; the same divergence VLT-PM47 §2.1
+/// recorded for `attachment export`'s destination applies here.
+fn parse_storage(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [action, kind, name, path] if action == "add" && !name.is_empty() && !path.is_empty() => {
+            Ok(Command::StorageAdd {
+                kind: StorageKind::parse(kind).map_err(|_| CliFailure::InvalidCommand)?,
+                name: ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+                path: PathBuf::from(path),
+            })
+        }
+        [action] if action == "list" => Ok(Command::StorageList),
+        [action, name] if action == "check" => Ok(Command::StorageCheck {
+            name: ConfigName::new(name.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+        }),
+        [action, source, target] if action == "migrate" => Ok(Command::StorageMigrate {
+            source: ConfigName::new(source.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+            target: ConfigName::new(target.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+            mirror: false,
+        }),
+        [action, source, target, flag] if action == "migrate" && flag == "--mirror" => {
+            Ok(Command::StorageMigrate {
+                source: ConfigName::new(source.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+                target: ConfigName::new(target.clone()).map_err(|_| CliFailure::InvalidCommand)?,
+                mirror: true,
+            })
+        }
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -2062,6 +2142,14 @@ fn dispatch(
             item_id,
             base_revision,
         } => conflict_merge_opaque(host, paths, writer, selected_vault, item_id, base_revision),
+        Command::StorageAdd { name, kind, path } => storage_add(writer, name, kind, path),
+        Command::StorageList => storage_list(writer),
+        Command::StorageCheck { name } => storage_check(writer, name),
+        Command::StorageMigrate {
+            source,
+            target,
+            mirror,
+        } => storage_migrate(host, paths, writer, selected_vault, source, target, mirror),
         Command::Help
         | Command::Shell
         | Command::PasswordGenerate { .. }
@@ -5685,8 +5773,25 @@ fn decode_config(exact: &[u8]) -> Result<VaultPmConfigV1, CliFailure> {
     parse_config(text).map_err(|_| CliFailure::Integrity)
 }
 
+/// Resolve and validate one configured vault's storage.
+///
+/// Before `storage add`/`storage migrate` (§23 item 14) existed, a vault's
+/// `local_store` could only ever be one of the two paths this composition
+/// root itself created (`paths.object_root()` or its per-target-vault
+/// subdirectory), so this function used to check the location string against
+/// exactly those two values. That restriction is gone: any storage entry of
+/// a local-directory kind (`filesystem` or `removable`, VLT-PM00 §12) is now
+/// a legitimate `local_store`, because a person can register one at an
+/// arbitrary path with `storage add` and switch to it with `storage
+/// migrate`. Cloud kinds remain `Unsupported` — Phase 2's job.
+///
+/// `remote_stores` (VLT-PM07's replica list) is no longer rejected outright
+/// either: every named remote must itself resolve to a local-directory-kind
+/// storage entry with no credential, exactly like the primary. A cloud
+/// mirror is `Unsupported` in Phase 1B for the same reason a cloud primary
+/// is.
 fn configured_vault<'a>(
-    paths: &LocalVaultPaths,
+    _paths: &LocalVaultPaths,
     config: &'a VaultPmConfigV1,
     selected_vault: Option<&ConfigName>,
 ) -> Result<&'a VaultConfigV1, CliFailure> {
@@ -5697,9 +5802,6 @@ fn configured_vault<'a>(
             CliFailure::Integrity
         }
     })?;
-    if !vault.remote_stores().is_empty() {
-        return Err(CliFailure::Unsupported);
-    }
     let storage = config
         .storage()
         .get(vault.local_store())
@@ -5710,24 +5812,25 @@ fn configured_vault<'a>(
                 .storage()
                 .get(candidate.local_store())
                 .is_some_and(|candidate_storage| {
-                    candidate_storage.kind() == StorageKind::Filesystem
+                    candidate_storage.kind().is_local_directory()
                         && candidate_storage.location() == storage.location()
                 })
     }) {
         return Err(CliFailure::Unsupported);
     }
-    let root_location = paths
-        .object_root()
-        .to_str()
-        .ok_or(CliFailure::Unsupported)?;
-    let target_location = target_object_root(paths, vault.locator().as_bytes());
-    let target_location = target_location.to_str().ok_or(CliFailure::Unsupported)?;
-    if storage.kind() != StorageKind::Filesystem
-        || (storage.location().as_str() != root_location
-            && storage.location().as_str() != target_location)
-        || storage.credential_ref().as_str() != "none"
-    {
+    if !storage.kind().is_local_directory() || storage.credential_ref().as_str() != "none" {
         return Err(CliFailure::Unsupported);
+    }
+    for remote_name in vault.remote_stores() {
+        let remote_storage = config
+            .storage()
+            .get(remote_name)
+            .ok_or(CliFailure::Integrity)?;
+        if !remote_storage.kind().is_local_directory()
+            || remote_storage.credential_ref().as_str() != "none"
+        {
+            return Err(CliFailure::Unsupported);
+        }
     }
     Ok(vault)
 }
@@ -5740,21 +5843,355 @@ fn application_store(paths: &LocalVaultPaths) -> StorageCoreApplicationStore<Loc
     StorageCoreApplicationStore::new(crash::backend(paths.application_state_root()))
 }
 
-fn repository_factory(
-    object_root: &Path,
-) -> V1ApplicationRepositoryFactory<StorageCoreObjectStore<LocalBackend>> {
-    V1ApplicationRepositoryFactory::new(StorageCoreObjectStore::new(crash::backend(object_root)))
+/// The concrete object store every repository in this composition root uses:
+/// one primary filesystem-family backend, plus zero or more best-effort
+/// mirror replicas (VLT-PM00 §11.5, §19.2, §23 item 14). With zero
+/// configured mirrors — every vault before `storage migrate --mirror` ever
+/// runs, and every vault today — [`ReplicaSetObjectStore::single`] is a
+/// transparent pass-through, so this rewiring changes no existing behavior.
+type LocalObjectStore = ReplicaSetObjectStore<StorageCoreObjectStore<LocalBackend>>;
+
+fn repository_factory(object_root: &Path) -> V1ApplicationRepositoryFactory<LocalObjectStore> {
+    V1ApplicationRepositoryFactory::new(ReplicaSetObjectStore::single(StorageCoreObjectStore::new(
+        crash::backend(object_root),
+    )))
 }
 
 fn configured_repository_factory(
     config: &VaultPmConfigV1,
     vault: &VaultConfigV1,
-) -> Result<V1ApplicationRepositoryFactory<StorageCoreObjectStore<LocalBackend>>, CliFailure> {
+) -> Result<V1ApplicationRepositoryFactory<LocalObjectStore>, CliFailure> {
     let storage = config
         .storage()
         .get(vault.local_store())
         .ok_or(CliFailure::Integrity)?;
-    Ok(repository_factory(Path::new(storage.location().as_str())))
+    let primary =
+        StorageCoreObjectStore::new(crash::backend(Path::new(storage.location().as_str())));
+    let mut mirrors = Vec::with_capacity(vault.remote_stores().len());
+    for remote_name in vault.remote_stores() {
+        let remote_storage = config
+            .storage()
+            .get(remote_name)
+            .ok_or(CliFailure::Integrity)?;
+        mirrors.push(StorageCoreObjectStore::new(crash::backend(Path::new(
+            remote_storage.location().as_str(),
+        ))));
+    }
+    Ok(V1ApplicationRepositoryFactory::new(
+        ReplicaSetObjectStore::new(primary, mirrors),
+    ))
+}
+
+/// Register one new named storage location (VLT-PM00 §23 item 14).
+///
+/// Touches only configuration -- it neither creates the target directory
+/// (the filesystem-family backend does that lazily, on first
+/// `initialize()`, exactly as it already does for the default storage `init`
+/// creates) nor opens any vault. `gdrive`/`webdav`/`s3` still parse and are
+/// rejected here with the `unsupported` exit class rather than at the
+/// grammar layer, the same closed-grammar answer VLT-PM49 §8 gave `import
+/// kdbx`: Phase 1B implements only the two local-directory kinds.
+fn storage_add(
+    writer: &LocalWriterGuard,
+    name: ConfigName,
+    kind: StorageKind,
+    path: PathBuf,
+) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    if !kind.is_local_directory() {
+        return Err(CliFailure::Unsupported);
+    }
+    if config.storage().contains_key(&name) {
+        return Err(CliFailure::Conflict);
+    }
+    let location = path.to_str().ok_or(CliFailure::Unsupported)?;
+    let storage_config = StorageConfigV1::new(
+        kind,
+        StorageLocation::new(location).map_err(|_| CliFailure::Unsupported)?,
+        CredentialRef::none(),
+    );
+    let mut storage = config.storage().clone();
+    storage.insert(name, storage_config);
+    let replacement = VaultPmConfigV1::new(
+        config.default_vault().clone(),
+        config.vaults().clone(),
+        storage,
+    )
+    .map_err(|_| CliFailure::Conflict)?;
+    let rendered = render_config(&replacement);
+    crash::around_config_replace(|| {
+        writer.compare_exchange_config(&exact_config, rendered.as_bytes())
+    })
+    .map_err(map_local_host)?;
+    Ok(CliOutput::success("Storage added.\n"))
+}
+
+/// List every configured named storage location, one per line as
+/// `NAME<TAB>KIND<TAB>LOCATION`, in deterministic name order.
+///
+/// The location is the operator's own configured value (a local path today),
+/// not attacker-controlled input, so unlike a scanned filename it is safe to
+/// echo back to them -- the same reasoning `item list` already applies to a
+/// person's own item titles.
+fn storage_list(writer: &LocalWriterGuard) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let mut output = String::new();
+    for (name, storage) in config.storage() {
+        output.push_str(name.as_str());
+        output.push('\t');
+        output.push_str(storage.kind().as_str());
+        output.push('\t');
+        output.push_str(storage.location().as_str());
+        output.push('\n');
+    }
+    Ok(CliOutput::success(output))
+}
+
+const INTERFERENCE_KINDS: [SyncInterferenceKind; 4] = [
+    SyncInterferenceKind::ConflictCopy,
+    SyncInterferenceKind::HiddenMetadata,
+    SyncInterferenceKind::PartialTransfer,
+    SyncInterferenceKind::Unknown,
+];
+
+fn interference_kind_label(kind: SyncInterferenceKind) -> &'static str {
+    match kind {
+        SyncInterferenceKind::ConflictCopy => "conflict_copy",
+        SyncInterferenceKind::HiddenMetadata => "hidden_metadata",
+        SyncInterferenceKind::PartialTransfer => "partial_transfer",
+        SyncInterferenceKind::Unknown => "unknown",
+    }
+}
+
+/// Report one named storage location's reachability, third-party
+/// sync-interference scan, and -- for any vault using it as a primary -- its
+/// configured mirrors' coarse health (VLT-PM00 §12, §19.2, §23 item 14).
+///
+/// A scanned filename never appears in the output (`vault-pm-storage-removable`'s
+/// own closed contract); only bounded counts by classification do.
+fn storage_check(writer: &LocalWriterGuard, name: ConfigName) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let storage = config.storage().get(&name).ok_or(CliFailure::NotFound)?;
+    if !storage.kind().is_local_directory() {
+        return Ok(CliOutput {
+            exit_code: ExitCode::Unsupported,
+            stdout: format!("Storage {}: unsupported\n", name.as_str()),
+            stderr: String::new(),
+        });
+    }
+    let scan = scan_object_root(Path::new(storage.location().as_str()));
+    let (label, exit_code) = match &scan {
+        Ok(report) if report.is_clean() => ("healthy", ExitCode::Success),
+        Ok(_) => ("sync_interference_detected", ExitCode::Integrity),
+        Err(_) => ("unreachable", ExitCode::Provider),
+    };
+    let mut output = format!("Storage {}: {label}\n", name.as_str());
+    if let Ok(report) = &scan {
+        for kind in INTERFERENCE_KINDS {
+            let count = report.count_of(kind);
+            if count > 0 {
+                output.push_str(&format!("  {}: {count}\n", interference_kind_label(kind)));
+            }
+        }
+    }
+    output.push_str(&replica_health_lines(&config, &name));
+    Ok(CliOutput {
+        exit_code,
+        stdout: output,
+        stderr: String::new(),
+    })
+}
+
+/// Render one `  replica NAME: STATUS` line per configured mirror of every
+/// vault whose `local_store` is `primary_name`.
+///
+/// `STATUS` is a structural heuristic -- an object-file *count* comparison
+/// between the primary's and the mirror's own directory scan -- not a
+/// cryptographic guarantee. That is deliberately the whole of what this
+/// slice promises (VLT-PM00 §23 item 14's documented deferral): the richer
+/// `sync --wait` durability ceremony with a configurable `one`/`all`/quorum
+/// target is future work built on top of the write-time propagation and
+/// per-mirror `ReplicaHealth` this PR ships in `vault-pm-storage`.
+fn replica_health_lines(config: &VaultPmConfigV1, primary_name: &ConfigName) -> String {
+    let mut output = String::new();
+    let Some(primary_storage) = config.storage().get(primary_name) else {
+        return output;
+    };
+    let primary_objects = scan_object_root(Path::new(primary_storage.location().as_str()))
+        .ok()
+        .map(|report| report.ordinary_objects);
+    for vault in config.vaults().values() {
+        if vault.local_store() != primary_name {
+            continue;
+        }
+        for remote_name in vault.remote_stores() {
+            let status = replica_status(config, remote_name, primary_objects);
+            output.push_str(&format!("  replica {}: {status}\n", remote_name.as_str()));
+        }
+    }
+    output
+}
+
+fn replica_status(
+    config: &VaultPmConfigV1,
+    remote_name: &ConfigName,
+    primary_objects: Option<usize>,
+) -> String {
+    let Some(remote_storage) = config.storage().get(remote_name) else {
+        return "unconfigured".to_owned();
+    };
+    if !remote_storage.kind().is_local_directory() {
+        return "unsupported".to_owned();
+    }
+    match scan_object_root(Path::new(remote_storage.location().as_str())) {
+        Err(_) => "unreachable".to_owned(),
+        Ok(report) => match primary_objects {
+            Some(primary) if report.ordinary_objects < primary => {
+                format!(
+                    "behind_by_approximately_{}_objects",
+                    primary - report.ordinary_objects
+                )
+            }
+            _ => "in_sync".to_owned(),
+        },
+    }
+}
+
+fn map_copy_error(error: CopyError) -> CliFailure {
+    match error {
+        CopyError::SourceUnavailable | CopyError::TargetUnavailable | CopyError::IoFailed => {
+            CliFailure::Provider
+        }
+        CopyError::Conflict => CliFailure::Conflict,
+        CopyError::ObjectTooLarge | CopyError::TooManyEntries => CliFailure::Integrity,
+    }
+}
+
+/// `storage migrate SOURCE TARGET [--mirror]` (VLT-PM00 §19.1, §23 item 14).
+///
+/// Implements the filesystem-family slice of §19.1's seven steps: verifies
+/// and copies every committed object (`copy_object_tree`, itself steps 2-4),
+/// then proves the copy is real by independently unlocking `TARGET` under
+/// the freshly collected passphrase over a repository factory pointed *only*
+/// at `TARGET`'s objects (step 6) -- a wrong passphrase or a corrupt copy
+/// both fail this exact step, before configuration is ever touched. Only
+/// then does it switch `local_store` to `TARGET` (or, with `--mirror`, add
+/// `TARGET` to `remote_stores` and leave `local_store` unchanged) and persist
+/// that with the same compare-and-exchange every other configuration
+/// mutation in this composition root uses (step 7). `SOURCE` is never
+/// deleted or modified (step 8's default).
+///
+/// **Deferred**: the interactive confirmation prompt this step's "explicit
+/// confirmation" language could also describe is not a separate ceremony --
+/// successfully unlocking `TARGET` with the real passphrase *is* the
+/// confirmation, matching every other authenticated command in this grammar
+/// rather than inventing a second one.
+#[allow(clippy::too_many_arguments)]
+fn storage_migrate(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    selected_vault: Option<&ConfigName>,
+    source: ConfigName,
+    target: ConfigName,
+    mirror: bool,
+) -> Result<CliOutput, CliFailure> {
+    if source == target {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let vault_name = selected_vault
+        .cloned()
+        .unwrap_or_else(|| config.default_vault().clone());
+    let vault = configured_vault(paths, &config, Some(&vault_name))?;
+    if vault.local_store() != &source {
+        return Err(CliFailure::InvalidCommand);
+    }
+    let target_storage = config.storage().get(&target).ok_or(CliFailure::NotFound)?;
+    if !target_storage.kind().is_local_directory()
+        || target_storage.credential_ref().as_str() != "none"
+    {
+        return Err(CliFailure::Unsupported);
+    }
+    // `vault` (and therefore `source`) already passed `configured_vault`'s
+    // local-directory check above.
+    let source_storage = config.storage().get(&source).ok_or(CliFailure::Integrity)?;
+    let source_path = Path::new(source_storage.location().as_str());
+    let target_path = Path::new(target_storage.location().as_str());
+
+    copy_object_tree(source_path, target_path).map_err(map_copy_error)?;
+
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    let target_repository_factory = repository_factory(target_path);
+    let mut probe = VaultAccessV1::locked(locator);
+    probe
+        .unlock(
+            passphrase,
+            &application_store,
+            &application_store,
+            &target_repository_factory,
+        )
+        .map_err(map_application)?;
+    probe.lock();
+
+    let updated_vault = if mirror {
+        let mut remotes = vault.remote_stores().to_vec();
+        remotes.push(target.clone());
+        VaultConfigV1::new(
+            vault.locator(),
+            vault.local_store().clone(),
+            remotes,
+            vault.auto_lock_seconds(),
+            vault.clipboard_clear_seconds(),
+        )
+    } else {
+        VaultConfigV1::new(
+            vault.locator(),
+            target.clone(),
+            vault.remote_stores().to_vec(),
+            vault.auto_lock_seconds(),
+            vault.clipboard_clear_seconds(),
+        )
+    }
+    .map_err(|_| CliFailure::Conflict)?;
+
+    let mut vaults = config.vaults().clone();
+    vaults.insert(vault_name, updated_vault);
+    let replacement = VaultPmConfigV1::new(
+        config.default_vault().clone(),
+        vaults,
+        config.storage().clone(),
+    )
+    .map_err(|_| CliFailure::Internal)?;
+    let rendered = render_config(&replacement);
+    crash::around_config_replace(|| {
+        writer.compare_exchange_config(&exact_config, rendered.as_bytes())
+    })
+    .map_err(map_local_host)?;
+
+    Ok(CliOutput::success(if mirror {
+        "Storage mirrored.\n"
+    } else {
+        "Storage migrated.\n"
+    }))
 }
 
 fn target_object_root(paths: &LocalVaultPaths, locator: &[u8; 32]) -> PathBuf {
@@ -6014,6 +6451,14 @@ mod tests {
                 self.0.join("cache"),
             )
             .unwrap()
+        }
+
+        /// A fresh subdirectory path under this root, for a `storage add`
+        /// location distinct from the default vault layout. Not created --
+        /// the filesystem-family backend creates it lazily, exactly as it
+        /// does for the storage `init` itself creates.
+        fn child(&self, name: &str) -> PathBuf {
+            self.0.join(name)
         }
     }
 
@@ -13525,5 +13970,534 @@ mod tests {
         assert_eq!(rendered.len(), 64);
         assert!(rendered.starts_with("0a"));
         assert!(rendered.ends_with("b0"));
+    }
+
+    // -------------------------------------------------------------------
+    // VLT-PM00 §23 item 14: `storage add|list|check|migrate`.
+    // -------------------------------------------------------------------
+
+    /// Read and decode the durable client configuration directly, bypassing
+    /// the CLI grammar -- used by the tests below to assert on
+    /// `local_store`/`remote_stores` the way no `storage list` output alone
+    /// can, and to inject a cloud-kind storage entry `storage add` itself
+    /// refuses to create in this Phase 1B slice.
+    fn loaded_config(paths: &LocalVaultPaths) -> VaultPmConfigV1 {
+        let prepared = paths.prepare().unwrap();
+        let writer = prepared.try_acquire_writer().unwrap();
+        let exact = writer.load_config().unwrap().unwrap();
+        decode_config(&exact).unwrap()
+    }
+
+    #[test]
+    fn storage_grammar_parses_every_documented_shape_and_rejects_malformed_ones() {
+        assert_eq!(
+            parse(["storage", "add", "filesystem", "backup", "/tmp/x"]),
+            default_invocation(Command::StorageAdd {
+                kind: StorageKind::Filesystem,
+                name: ConfigName::new("backup").unwrap(),
+                path: PathBuf::from("/tmp/x"),
+            })
+        );
+        assert_eq!(
+            parse(["storage", "add", "removable", "usb", "/media/usb"]),
+            default_invocation(Command::StorageAdd {
+                kind: StorageKind::Removable,
+                name: ConfigName::new("usb").unwrap(),
+                path: PathBuf::from("/media/usb"),
+            })
+        );
+        assert_eq!(
+            parse(["storage", "add", "gdrive", "cloud", "appDataFolder"]),
+            default_invocation(Command::StorageAdd {
+                kind: StorageKind::GoogleDrive,
+                name: ConfigName::new("cloud").unwrap(),
+                path: PathBuf::from("appDataFolder"),
+            })
+        );
+        assert_eq!(
+            parse(["storage", "list"]),
+            default_invocation(Command::StorageList)
+        );
+        assert_eq!(
+            parse(["storage", "check", "local"]),
+            default_invocation(Command::StorageCheck {
+                name: ConfigName::new("local").unwrap(),
+            })
+        );
+        assert_eq!(
+            parse(["storage", "migrate", "local", "backup"]),
+            default_invocation(Command::StorageMigrate {
+                source: ConfigName::new("local").unwrap(),
+                target: ConfigName::new("backup").unwrap(),
+                mirror: false,
+            })
+        );
+        assert_eq!(
+            parse(["storage", "migrate", "local", "backup", "--mirror"]),
+            default_invocation(Command::StorageMigrate {
+                source: ConfigName::new("local").unwrap(),
+                target: ConfigName::new("backup").unwrap(),
+                mirror: true,
+            })
+        );
+        for arguments in [
+            vec!["storage"],
+            vec!["storage", "add"],
+            vec!["storage", "add", "filesystem"],
+            vec!["storage", "add", "filesystem", "name"],
+            vec!["storage", "add", "unknown-kind", "name", "/tmp/x"],
+            vec!["storage", "add", "filesystem", "bad.name", "/tmp/x"],
+            vec!["storage", "add", "filesystem", "name", ""],
+            vec!["storage", "list", "extra"],
+            vec!["storage", "check"],
+            vec!["storage", "check", "a", "b"],
+            vec!["storage", "migrate"],
+            vec!["storage", "migrate", "a"],
+            vec!["storage", "migrate", "a", "b", "--wrong-flag"],
+            vec!["storage", "migrate", "a", "b", "--mirror", "extra"],
+            vec!["storage", "bogus"],
+        ] {
+            assert_eq!(
+                parse(arguments.clone()),
+                Err(CliFailure::InvalidCommand),
+                "{arguments:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn storage_add_list_and_check_refuse_a_vault_selector_but_migrate_accepts_one() {
+        for arguments in [
+            vec![
+                "--vault",
+                "work",
+                "storage",
+                "add",
+                "filesystem",
+                "n",
+                "/tmp/x",
+            ],
+            vec!["--vault", "work", "storage", "list"],
+            vec!["--vault", "work", "storage", "check", "local"],
+        ] {
+            assert_eq!(
+                parse(arguments.clone()),
+                Err(CliFailure::InvalidCommand),
+                "{arguments:?}"
+            );
+        }
+        assert!(parse(["--vault", "work", "storage", "migrate", "local", "backup"]).is_ok());
+    }
+
+    #[test]
+    fn storage_add_registers_a_location_and_rejects_duplicates_and_cloud_kinds() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let mirror_path = root.child("backup-location");
+        let added = run(
+            [
+                "storage",
+                "add",
+                "filesystem",
+                "backup",
+                mirror_path.to_str().unwrap(),
+            ],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(added.exit_code(), ExitCode::Success, "{added:?}");
+        assert_eq!(added.stdout(), "Storage added.\n");
+
+        let listed = run(["storage", "list"], &TestHost::new(paths.clone(), []));
+        assert_eq!(listed.exit_code(), ExitCode::Success);
+        assert!(listed.stdout().contains("backup\tfilesystem\t"));
+        assert!(listed.stdout().contains("local\tfilesystem\t"));
+
+        let duplicate = run(
+            [
+                "storage",
+                "add",
+                "filesystem",
+                "backup",
+                mirror_path.to_str().unwrap(),
+            ],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(duplicate.exit_code(), ExitCode::Conflict);
+
+        let cloud = run(
+            ["storage", "add", "gdrive", "cloud", "appDataFolder"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(cloud.exit_code(), ExitCode::Unsupported);
+        let after_cloud = run(["storage", "list"], &TestHost::new(paths.clone(), []));
+        assert!(!after_cloud.stdout().contains("cloud"));
+    }
+
+    #[test]
+    fn storage_check_reports_unreachable_healthy_sync_interference_and_unsupported() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let removable_path = root.child("removable-location");
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "removable",
+                    "usb",
+                    removable_path.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        // Registered but not yet materialized on disk.
+        let missing = run(
+            ["storage", "check", "usb"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(missing.exit_code(), ExitCode::Provider);
+        assert_eq!(missing.stdout(), "Storage usb: unreachable\n");
+
+        fs::create_dir_all(&removable_path).unwrap();
+        let healthy = run(
+            ["storage", "check", "usb"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(healthy.exit_code(), ExitCode::Success);
+        assert_eq!(healthy.stdout(), "Storage usb: healthy\n");
+
+        // A Dropbox-style conflict copy sitting next to a real object.
+        let bucket_dir = removable_path.join("2121");
+        fs::create_dir_all(&bucket_dir).unwrap();
+        fs::write(bucket_dir.join("aabbcc"), b"object").unwrap();
+        fs::write(
+            bucket_dir.join("aabbcc (Jane's conflicted copy 2026-08-17)"),
+            b"object",
+        )
+        .unwrap();
+        let dirty = run(
+            ["storage", "check", "usb"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(dirty.exit_code(), ExitCode::Integrity);
+        assert!(dirty.stdout().contains("sync_interference_detected"));
+        assert!(dirty.stdout().contains("conflict_copy: 1"));
+        // The offending filename never appears in the report.
+        assert!(!dirty.stdout().contains("Jane"));
+
+        let missing_name = run(
+            ["storage", "check", "does-not-exist"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(missing_name.exit_code(), ExitCode::NotFound);
+
+        // Inject a cloud-kind entry directly -- `storage add` itself refuses
+        // to create one in this Phase 1B slice -- to exercise `storage
+        // check`'s Phase 2 branch.
+        {
+            let prepared = paths.prepare().unwrap();
+            let writer = prepared.try_acquire_writer().unwrap();
+            let exact = writer.load_config().unwrap().unwrap();
+            let config = decode_config(&exact).unwrap();
+            let mut storage = config.storage().clone();
+            storage.insert(
+                ConfigName::new("cloud").unwrap(),
+                StorageConfigV1::new(
+                    StorageKind::GoogleDrive,
+                    StorageLocation::new("appDataFolder").unwrap(),
+                    CredentialRef::new("token").unwrap(),
+                ),
+            );
+            let replacement = VaultPmConfigV1::new(
+                config.default_vault().clone(),
+                config.vaults().clone(),
+                storage,
+            )
+            .unwrap();
+            writer
+                .compare_exchange_config(&exact, render_config(&replacement).as_bytes())
+                .unwrap();
+        }
+        let cloud_check = run(
+            ["storage", "check", "cloud"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(cloud_check.exit_code(), ExitCode::Unsupported);
+    }
+
+    #[test]
+    fn storage_migrate_switches_primary_storage_and_leaves_source_untouched() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"secret note body".to_vec()],
+            ["Before migrate".to_owned()],
+        );
+        assert_eq!(
+            run(["item", "add", "secure-note"], &add_host).exit_code(),
+            ExitCode::Success
+        );
+
+        let new_location = root.child("new-primary-location");
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "filesystem",
+                    "new",
+                    new_location.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let source_location = loaded_config(&paths).storage()[&ConfigName::new("local").unwrap()]
+            .location()
+            .as_str()
+            .to_owned();
+        let source_entries_before = fs::read_dir(&source_location).unwrap().count();
+        assert!(source_entries_before > 0);
+
+        let migrated = run(
+            ["storage", "migrate", "local", "new"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(migrated.exit_code(), ExitCode::Success, "{migrated:?}");
+        assert_eq!(migrated.stdout(), "Storage migrated.\n");
+
+        let config_after = loaded_config(&paths);
+        let vault = config_after.select_vault(None).unwrap();
+        assert_eq!(vault.local_store().as_str(), "new");
+        assert!(vault.remote_stores().is_empty());
+
+        // The item is still readable through the switched configuration.
+        let list_after = run(
+            ["item", "list"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(list_after.exit_code(), ExitCode::Success, "{list_after:?}");
+        assert!(list_after.stdout().contains(SECURE_NOTE_V1));
+
+        // The source directory was never modified or deleted.
+        assert_eq!(
+            fs::read_dir(&source_location).unwrap().count(),
+            source_entries_before
+        );
+    }
+
+    #[test]
+    fn storage_migrate_mirror_adds_a_replica_and_future_writes_propagate_to_it() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let mirror_location = root.child("mirror-location");
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "filesystem",
+                    "mirror",
+                    mirror_location.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let mirrored = run(
+            ["storage", "migrate", "local", "mirror", "--mirror"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(mirrored.exit_code(), ExitCode::Success, "{mirrored:?}");
+        assert_eq!(mirrored.stdout(), "Storage mirrored.\n");
+
+        let config_after = loaded_config(&paths);
+        let vault = config_after.select_vault(None).unwrap();
+        assert_eq!(vault.local_store().as_str(), "local");
+        assert_eq!(vault.remote_stores().len(), 1);
+        assert_eq!(vault.remote_stores()[0].as_str(), "mirror");
+
+        // A write made *after* mirroring propagates to the replica through
+        // the ordinary authenticated path -- VLT-PM00 §19.2's write-time
+        // propagation, exercised end to end through the real CLI.
+        let add_host = TestHost::with_texts(
+            paths.clone(),
+            [passphrase.clone(), b"mirrored note body".to_vec()],
+            ["After mirror".to_owned()],
+        );
+        assert_eq!(
+            run(["item", "add", "secure-note"], &add_host).exit_code(),
+            ExitCode::Success
+        );
+
+        let mirror_scan = scan_object_root(&mirror_location).unwrap();
+        assert!(mirror_scan.ordinary_objects > 0);
+        assert!(mirror_scan.is_clean());
+
+        let check = run(
+            ["storage", "check", "local"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(check.exit_code(), ExitCode::Success, "{check:?}");
+        assert!(check.stdout().contains("replica mirror: in_sync"));
+    }
+
+    #[test]
+    fn storage_migrate_with_a_wrong_passphrase_copies_but_never_switches_config() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let new_location = root.child("new-primary-location");
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "filesystem",
+                    "new",
+                    new_location.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        let wrong_host = TestHost::new(paths.clone(), [b"totally the wrong passphrase".to_vec()]);
+        let migrated = run(["storage", "migrate", "local", "new"], &wrong_host);
+        assert_eq!(migrated.exit_code(), ExitCode::Locked, "{migrated:?}");
+
+        let config_after = loaded_config(&paths);
+        assert_eq!(
+            config_after
+                .select_vault(None)
+                .unwrap()
+                .local_store()
+                .as_str(),
+            "local"
+        );
+
+        // The verified-by-readback copy happened anyway -- retrying with the
+        // right passphrase does not have to redo it from scratch.
+        assert!(new_location.exists());
+        let retry = run(
+            ["storage", "migrate", "local", "new"],
+            &TestHost::new(paths.clone(), [passphrase.clone()]),
+        );
+        assert_eq!(retry.exit_code(), ExitCode::Success, "{retry:?}");
+    }
+
+    #[test]
+    fn storage_migrate_rejects_matching_names_missing_targets_and_the_wrong_source() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        assert_eq!(
+            run(
+                ["storage", "migrate", "local", "local"],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::InvalidInput
+        );
+        assert_eq!(
+            run(
+                ["storage", "migrate", "local", "does-not-exist"],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::NotFound
+        );
+
+        let other_location = root.child("other-location");
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "filesystem",
+                    "other",
+                    other_location.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+        // "other" is not this vault's current `local_store`.
+        assert_eq!(
+            run(
+                ["storage", "migrate", "other", "local"],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::InvalidInput
+        );
     }
 }

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -5813,7 +5813,7 @@ fn configured_vault<'a>(
                 .get(candidate.local_store())
                 .is_some_and(|candidate_storage| {
                     candidate_storage.kind().is_local_directory()
-                        && candidate_storage.location() == storage.location()
+                        && same_local_directory(candidate_storage.location(), storage.location())
                 })
     }) {
         return Err(CliFailure::Unsupported);
@@ -5833,6 +5833,34 @@ fn configured_vault<'a>(
         }
     }
     Ok(vault)
+}
+
+/// Whether two configured local-directory storage locations name the same
+/// physical directory.
+///
+/// An exact string match is checked first (the only comparison this
+/// function used to make, before `storage add` let a location be any
+/// registered path rather than one of two fixed ones this composition root
+/// created for itself). When the strings differ, both are canonicalized
+/// and compared as resolved paths, so a relative path, a trailing
+/// separator, or a symlink cannot make two configured vaults silently
+/// share one filesystem location behind two different-looking spellings.
+/// A location that does not exist yet (`storage add` deliberately allows
+/// registering one before it is created) fails to canonicalize and is
+/// therefore compared as unequal to anything but its own exact spelling —
+/// the safe direction, since the collision this check exists to prevent
+/// cannot occur between two locations until at least one of them is real.
+fn same_local_directory(a: &StorageLocation, b: &StorageLocation) -> bool {
+    if a.as_str() == b.as_str() {
+        return true;
+    }
+    match (
+        std::fs::canonicalize(a.as_str()),
+        std::fs::canonicalize(b.as_str()),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 fn application_locator(locator: ConfigVaultLocator) -> BootstrapLocator {
@@ -6075,7 +6103,9 @@ fn map_copy_error(error: CopyError) -> CliFailure {
             CliFailure::Provider
         }
         CopyError::Conflict => CliFailure::Conflict,
-        CopyError::ObjectTooLarge | CopyError::TooManyEntries => CliFailure::Integrity,
+        CopyError::ObjectTooLarge | CopyError::TooManyEntries | CopyError::UnexpectedSymlink => {
+            CliFailure::Integrity
+        }
     }
 }
 
@@ -14499,5 +14529,112 @@ mod tests {
             .exit_code(),
             ExitCode::InvalidInput
         );
+    }
+
+    #[test]
+    fn same_local_directory_matches_exact_strings_and_canonicalized_real_paths() {
+        let root = TestRoot::new();
+        let real = root.child("real-storage-location");
+        fs::create_dir_all(&real).unwrap();
+
+        let exact = StorageLocation::new(real.to_str().unwrap()).unwrap();
+        assert!(same_local_directory(&exact, &exact));
+
+        // A relative-looking (but still absolute-rooted) alternate spelling
+        // of the exact same directory, reached through `.`.
+        let via_dot = real.join(".");
+        let alternate_spelling = StorageLocation::new(via_dot.to_str().unwrap()).unwrap();
+        assert_ne!(exact.as_str(), alternate_spelling.as_str());
+        assert!(same_local_directory(&exact, &alternate_spelling));
+
+        // A location that does not exist yet never collides with anything
+        // but its own exact spelling -- `storage add` deliberately allows
+        // registering one before it is created.
+        let not_yet_created =
+            StorageLocation::new(root.child("does-not-exist-yet").to_str().unwrap()).unwrap();
+        assert!(!same_local_directory(&exact, &not_yet_created));
+        assert!(same_local_directory(&not_yet_created, &not_yet_created));
+
+        let different =
+            StorageLocation::new(root.child("a-different-location").to_str().unwrap()).unwrap();
+        assert!(!same_local_directory(&exact, &different));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_vault_catches_a_symlink_aliased_storage_collision() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        assert_eq!(
+            run(
+                ["init"],
+                &TestHost::new(paths.clone(), [passphrase.clone()])
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        // A symlink pointing at the exact same directory `local` already
+        // resolves to, registered under a different name and a different
+        // (non-canonical) spelling.
+        let real_location = loaded_config(&paths).storage()[&ConfigName::new("local").unwrap()]
+            .location()
+            .as_str()
+            .to_owned();
+        let alias_path = root.child("aliased-local-storage");
+        symlink(&real_location, &alias_path).unwrap();
+
+        assert_eq!(
+            run(
+                [
+                    "storage",
+                    "add",
+                    "filesystem",
+                    "alias",
+                    alias_path.to_str().unwrap(),
+                ],
+                &TestHost::new(paths.clone(), []),
+            )
+            .exit_code(),
+            ExitCode::Success
+        );
+
+        // A second vault whose `local_store` is the symlinked alias must be
+        // refused: without canonicalization this would otherwise let two
+        // vaults' object stores silently interleave on one real directory.
+        let mut config = loaded_config(&paths);
+        let mut vaults = config.vaults().clone();
+        let aliased_vault = VaultConfigV1::new(
+            ConfigVaultLocator::new([9; 32]),
+            ConfigName::new("alias").unwrap(),
+            Vec::new(),
+            DEFAULT_AUTO_LOCK_SECONDS,
+            DEFAULT_CLIPBOARD_CLEAR_SECONDS,
+        )
+        .unwrap();
+        vaults.insert(ConfigName::new("second").unwrap(), aliased_vault);
+        config = VaultPmConfigV1::new(
+            config.default_vault().clone(),
+            vaults,
+            config.storage().clone(),
+        )
+        .unwrap();
+        {
+            let prepared = paths.prepare().unwrap();
+            let writer = prepared.try_acquire_writer().unwrap();
+            let exact = writer.load_config().unwrap().unwrap();
+            writer
+                .compare_exchange_config(&exact, render_config(&config).as_bytes())
+                .unwrap();
+        }
+
+        let refused = run(
+            ["--vault", "second", "status"],
+            &TestHost::new(paths.clone(), []),
+        );
+        assert_eq!(refused.exit_code(), ExitCode::Unsupported, "{refused:?}");
     }
 }

--- a/code/packages/rust/vault-pm-config/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-config/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Added `StorageKind::Removable` (`kind = "removable"`), VLT-PM00 §12's
+  removable/synced-folder backend row. It is a variant of `Filesystem` with
+  the identical on-disk immutable object format — `vault-pm-storage-removable`
+  is the layer that treats it differently, by scanning for third-party
+  sync-tool conflict-copy symptoms. Added `StorageKind::is_local_directory`
+  so callers can select the shared filesystem code path for both kinds
+  without a second match arm per call site.
+
 ## 0.1.0
 
 - Added the closed, bounded V1 vault and storage configuration model.

--- a/code/packages/rust/vault-pm-config/README.md
+++ b/code/packages/rust/vault-pm-config/README.md
@@ -12,15 +12,18 @@ locator encodings. The renderer produces deterministic TOML with sorted table
 names, so a host adapter can persist and compare exact bytes.
 
 This package does not read paths, open files, resolve platform directories,
-load credentials, or instantiate a storage provider. Filesystem, Google Drive,
-WebDAV, and S3 are typed adapter selections; the opaque `path` string is
-interpreted only by the selected host adapter.
+load credentials, or instantiate a storage provider. Filesystem, removable,
+Google Drive, WebDAV, and S3 are typed adapter selections; the opaque `path`
+string is interpreted only by the selected host adapter. `removable` (VLT-PM00
+§12, §23 item 14) is a variant of `filesystem` sharing the identical on-disk
+object format — `StorageKind::is_local_directory` reports both as one group so
+a host adapter can route them to the same filesystem code path and reserve the
+distinction for `vault-pm-storage-removable`'s conflict-copy detection.
 
 Sensitive or identifying values use redacted `Debug` output, and all errors
-are stable and payload blind. Eighteen tests cover the closed schema,
+are stable and payload blind. Nineteen tests cover the closed schema,
 cross-references, canonical escaping, all supported storage kinds, bounds,
-malformed input, and redaction. Tarpaulin's LLVM engine measures 397 of 407
-production lines covered (97.54%).
+malformed input, and redaction.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-config/src/lib.rs
+++ b/code/packages/rust/vault-pm-config/src/lib.rs
@@ -179,6 +179,20 @@ fn hex_nibble(byte: u8) -> Result<u8, ConfigError> {
 pub enum StorageKind {
     /// Local or mounted filesystem storage.
     Filesystem,
+    /// A user-managed removable or third-party-synced folder (VLT-PM00 §12,
+    /// §23 item 14).
+    ///
+    /// Same on-disk immutable object format as [`Self::Filesystem`] — this is
+    /// a variant, not a new transport. The only difference is what the
+    /// storage layer *assumes*: a plain `filesystem` location is exclusively
+    /// written by this product, so a foreign file appearing next to its
+    /// objects is always worth investigating, whereas a `removable` location
+    /// may also be written by a third-party sync tool (Dropbox, OneDrive,
+    /// Syncthing, a NAS client) or physically moved between machines, so
+    /// `vault-pm-storage-removable`'s conflict-copy detection is expected to
+    /// fire there in ordinary use and is reported as a warning rather than
+    /// silently proceeding or refusing to open.
+    Removable,
     /// Google Drive storage.
     GoogleDrive,
     /// WebDAV storage.
@@ -188,9 +202,11 @@ pub enum StorageKind {
 }
 
 impl StorageKind {
-    fn parse(value: &str) -> Result<Self, ConfigError> {
+    /// Parse the closed set of TOML/CLI spellings for a storage kind.
+    pub fn parse(value: &str) -> Result<Self, ConfigError> {
         match value {
             "filesystem" => Ok(Self::Filesystem),
+            "removable" => Ok(Self::Removable),
             "gdrive" => Ok(Self::GoogleDrive),
             "webdav" => Ok(Self::WebDav),
             "s3" => Ok(Self::S3),
@@ -198,13 +214,22 @@ impl StorageKind {
         }
     }
 
-    fn as_str(self) -> &'static str {
+    /// Return the canonical TOML/CLI spelling.
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Filesystem => "filesystem",
+            Self::Removable => "removable",
             Self::GoogleDrive => "gdrive",
             Self::WebDav => "webdav",
             Self::S3 => "s3",
         }
+    }
+
+    /// Whether this kind is backed by an ordinary local directory tree in the
+    /// `storage-fs` on-disk shape (VLT-PM00 §12's `filesystem`/`removable`
+    /// rows). Cloud kinds are not, and stay `Unsupported` in Phase 1B.
+    pub const fn is_local_directory(self) -> bool {
+        matches!(self, Self::Filesystem | Self::Removable)
     }
 }
 
@@ -895,6 +920,30 @@ credential_ref = "google-primary"
             config.storage()[&ConfigName::new("backup").unwrap()].kind(),
             StorageKind::GoogleDrive
         );
+    }
+
+    #[test]
+    fn removable_kind_parses_renders_and_is_a_local_directory() {
+        assert_eq!(StorageKind::parse("removable"), Ok(StorageKind::Removable));
+        assert_eq!(StorageKind::Removable.as_str(), "removable");
+        assert!(StorageKind::Removable.is_local_directory());
+        assert!(StorageKind::Filesystem.is_local_directory());
+        assert!(!StorageKind::GoogleDrive.is_local_directory());
+        assert!(!StorageKind::WebDav.is_local_directory());
+        assert!(!StorageKind::S3.is_local_directory());
+
+        let mut config = parse_config(&source()).unwrap();
+        config.storage.insert(
+            ConfigName::new("thumbdrive").unwrap(),
+            StorageConfigV1::new(
+                StorageKind::Removable,
+                StorageLocation::new("/media/usb/vault").unwrap(),
+                CredentialRef::none(),
+            ),
+        );
+        let rendered = render_config(&config);
+        assert!(rendered.contains("kind = \"removable\""));
+        assert_eq!(parse_config(&rendered).unwrap(), config);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-storage-removable/BUILD
+++ b/code/packages/rust/vault-pm-storage-removable/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_storage_removable -- --nocapture

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -142,3 +142,22 @@ All notable changes to this package are documented here.
   exists elsewhere or overwrite one, which is what the leaf-level checks
   (`target` itself, every bucket directory, every object read/write)
   already prevent.
+- **Fifth review round: `scan_object_root`'s and `copy_object_tree`'s own
+  `root`/`source` argument — the currently-configured, already-existing
+  storage location itself — was never checked for being a symlink,
+  unlike every path this crate reads from or writes into one level
+  deeper.** `scan_object_root` validated `root` with `fs::metadata`
+  (which follows symlinks), so a symlinked scan root or migration source
+  was scanned/copied as whatever it actually pointed to, with
+  `ScanReport` reporting back completely clean — confirmed exploitable
+  with a standalone reproduction before being fixed: a symlinked
+  `source` let `copy_object_tree` silently copy an attacker's chosen
+  files into `target` as if they were the vault's own committed objects.
+  Fixed by checking `fs::symlink_metadata` first, exactly the discipline
+  `target`'s own top-level path already had (VLT-PM50 §7). Adds
+  `ScanError::UnexpectedSymlink`, mapped to the existing
+  `CopyError::UnexpectedSymlink` in `copy_object_tree`'s error
+  translation. Two new regression tests, the second confirmed against
+  the actual vulnerable code before the fix landed: a symlinked scan
+  root is refused by `scan_object_root`, and a symlinked migration
+  source is refused before `copy_object_tree` reads anything out of it.

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -34,3 +34,29 @@ All notable changes to this package are documented here.
   already exists with different bytes than the source.
 - Every read is bounded by `MAX_COPY_OBJECT_BYTES` before allocation, and
   every directory walk is bounded by `MAX_SCANNED_ENTRIES`.
+- **Symlinks are refused, never followed, everywhere this crate touches the
+  filesystem** (`CopyError::UnexpectedSymlink`). `source`/`target` are
+  exactly the directories a third-party sync tool, a second machine sharing
+  removable media, or a mirror configuration may also write to, so an
+  attacker-planted symlink here is a real, not merely theoretical, threat:
+  a hex-shaped symlink to an arbitrary local file (e.g. `~/.ssh/id_rsa`)
+  inside `source` would otherwise be read and copied into `target` under
+  an innocuous object name — a data-exfiltration primitive if `target` is
+  itself synced or cloud-backed — and a symlink standing in for a bucket
+  directory or an object file inside `target` would otherwise let
+  `fs::create_dir_all`'s or `File::create`'s symlink-following behavior
+  redirect a write to an attacker-chosen location. Every read and every
+  directory-creation check now inspects `fs::symlink_metadata` (which does
+  not follow the link) before ever calling `fs::metadata`/`File::open`
+  (which do); the migration-copy staging file is opened with
+  `OpenOptions::create_new` rather than `File::create`, closing the
+  TOCTOU window between checking a predictable staging path and writing to
+  it. `scan_object_root` also now positively requires `is_file()` (not a
+  negative `!is_dir()` check) before counting an entry as an ordinary
+  object, so a symlink is reported as an unexpected entry — never silently
+  accepted as healthy — even when its name happens to be hex-shaped. Found
+  in this PR's own security review and fixed before merge; six regression
+  tests cover a symlinked source object, a symlinked source bucket
+  directory, a pre-existing symlinked target bucket directory, a
+  pre-existing symlinked target object, a symlinked top-level target, and
+  `scan_object_root`'s own detection of a hex-named symlink.

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -79,3 +79,27 @@ All notable changes to this package are documented here.
   narrower residual, since `target` is an operator-configured path via
   `storage add`, not content discovered by scanning an untrusted
   directory.
+- **Third review round: the "accepted residual" from the round-2 note
+  above was itself a real HIGH-severity gap, not a narrow one — fixed.**
+  `ensure_real_directory` (the top-level `target` check) still used
+  check-then-`create_dir_all`, and unlike a bucket directory, `target` is
+  the root every bucket and every object in the whole migration lives
+  under; a symlink raced into that exact path redirects the *entire*
+  migration, not one bucket. Fixed by extracting the atomic
+  `fs::create_dir` + `AlreadyExists`/`symlink_metadata` pattern into
+  `create_directory_component_atomically`, shared by both
+  `ensure_real_directory` (which now only uses ordinary
+  `fs::create_dir_all` for `target`'s *parents*, then creates `target`
+  itself atomically) and `ensure_real_bucket_directory`. Also fixed: a
+  bucket directory was validated once per bucket rather than once per
+  object, leaving a window for a concurrent writer to swap it for a
+  symlink between two writes to the same bucket — `copy_object_tree` now
+  re-validates the bucket directory immediately before every object
+  write. Also fixed: `read_bounded`'s `read_to_end` had no cap of its
+  own, so a file a concurrent writer kept appending to could grow the
+  in-memory buffer past `MAX_COPY_OBJECT_BYTES` before the post-read
+  length check fired; now capped during the read with `Read::take`. Two
+  new regression tests: a bucket directory replaced with a symlink
+  between two writes is caught, and nested missing parent directories
+  are still created correctly (a correctness check on the refactor, not
+  a new attack).

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this package are documented here.
+
+## [0.1.0] - 2026-08-19
+
+### Added
+
+- `scan_object_root`, structural detection of third-party sync-tool
+  interference in a `storage-fs`-shaped object-store root: conflict copies
+  (Dropbox/OneDrive/Google-Drive-Desktop "conflicted copy" naming, Syncthing's
+  `.sync-conflict-` infix, Explorer/Finder/rclone's `" (N)"` duplicate-count
+  suffix), OS/client hidden metadata (`.DS_Store`, `Thumbs.db`,
+  `desktop.ini`, LibreOffice lock files), partial transfers (`.crdownload`,
+  `.part`, `.filepart`, `.download`, `~`-prefixed swap files), and an
+  `Unknown` catch-all.
+- `copy_object_tree`, a byte-for-byte object-root copy for `storage migrate`
+  (VLT-PM00 §19.1): write-tmp-then-rename per object, read-back verified
+  before being counted, idempotent on re-run, and refusing (not silently
+  overwriting) a target object whose existing bytes differ from the source.
+- `ScanReport`/`CopyReport` with bounded, name-free findings, and closed
+  `ScanError`/`CopyError` taxonomies.
+- `MAX_SCANNED_ENTRIES` and `MAX_COPY_OBJECT_BYTES` bounds against an
+  adversarially large or padded removable-drive directory.
+
+### Security
+
+- No filename from a scanned or copied directory ever appears in this
+  crate's public API, `Debug` output, or error `Display` text — findings are
+  reported as bounded counts by closed classification only, matching this
+  codebase's convention of never echoing attacker-controlled text.
+- `copy_object_tree` never modifies or deletes anything under `source`, and
+  refuses (`CopyError::Conflict`) rather than overwrites when a target object
+  already exists with different bytes than the source.
+- Every read is bounded by `MAX_COPY_OBJECT_BYTES` before allocation, and
+  every directory walk is bounded by `MAX_SCANNED_ENTRIES`.

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -60,3 +60,22 @@ All notable changes to this package are documented here.
   directory, a pre-existing symlinked target bucket directory, a
   pre-existing symlinked target object, a symlinked top-level target, and
   `scan_object_root`'s own detection of a hex-named symlink.
+- **Second review round: narrowed the remaining check-then-use race
+  window.** The fix above closes the *static* case (a symlink already
+  present when a scan/copy runs) completely, but a second review round
+  correctly noted that a `symlink_metadata` check followed by a separate
+  `File::open`/`fs::create_dir_all` call cannot, on its own, close the
+  *dynamic* case (a symlink planted in the instant between the two).
+  `read_bounded` now opens with `O_NOFOLLOW` on Unix (`open_no_follow`),
+  making the kernel itself refuse a symlink at that exact instant rather
+  than racing a userspace check against it (`libc` is now a Unix-only
+  dependency). Bucket-directory creation (always exactly one path
+  component below an already-validated `target`) now uses the atomic,
+  non-recursive `fs::create_dir` (`ensure_real_bucket_directory`) instead
+  of a check-then-`create_dir_all` pattern, closing the same class of
+  window there. The top-level `target` directory still uses
+  check-then-`create_dir_all` (it needs recursive parent creation);
+  documented in `VLT-PM50-cli-storage-migration.md` §7 as an accepted,
+  narrower residual, since `target` is an operator-configured path via
+  `storage add`, not content discovered by scanning an untrusted
+  directory.

--- a/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage-removable/CHANGELOG.md
@@ -103,3 +103,42 @@ All notable changes to this package are documented here.
   between two writes is caught, and nested missing parent directories
   are still created correctly (a correctness check on the refactor, not
   a new attack).
+- **Fourth review round.** Two more real gaps fixed:
+  - `MAX_SCANNED_ENTRIES` was enforced only *after* `read_dir_sorted`
+    fully collected and sorted an entire directory's raw entries into a
+    `Vec`, defeating its own stated purpose against "a huge or
+    adversarially padded directory" — a directory with millions of
+    cheaply-creatable, zero-byte-named entries would be fully
+    materialized and sorted in memory before the bound was ever
+    consulted. `read_dir_sorted` now takes the running (whole-scan,
+    cross-directory) entry counter and bounds it per entry as each is
+    pulled from the OS iterator, before collecting, so no directory scan
+    ever holds more than the bound at once.
+  - `target` itself was validated once before the bucket loop began, but
+    a concurrent writer capable of removing and replacing `target`
+    mid-migration (already this crate's own threat model) could redirect
+    every subsequent bucket/object write the same way a swapped bucket
+    directory could — `target` is now re-validated (cheap and idempotent
+    once real) alongside the bucket directory, both before creating a
+    bucket and before every object write within it.
+
+  A third finding — that `ensure_real_directory`'s parent creation
+  (`fs::create_dir_all`) transparently resolves through a symlink at any
+  *ancestor* of `target`, not only its final component — was
+  investigated and the natural-looking fix (validate every path
+  component atomically, root to leaf) was **implemented, tested, and
+  reverted**: it broke on real macOS hosts, where `/tmp`/`/var` are
+  themselves symlinks to `/private/tmp`/`/private/var` and are
+  transparently, legitimately, and universally present in the ancestry
+  of essentially any caller-supplied absolute path — the fix could not
+  distinguish that from an attacker-planted one and refused both
+  identically. `ensure_real_directory`'s doc comment now records this as
+  a deliberate, narrower scope limit rather than an oversight: the
+  residual (an attacker who can plant a symlink at a not-yet-created
+  *ancestor* of `target`, before the operator ever configures it) can
+  only relocate this migration's own freshly written ciphertext to a
+  different physical directory the same configured `target` path would
+  still consistently resolve through — never read a file that already
+  exists elsewhere or overwrite one, which is what the leaf-level checks
+  (`target` itself, every bucket directory, every object read/write)
+  already prevent.

--- a/code/packages/rust/vault-pm-storage-removable/Cargo.toml
+++ b/code/packages/rust/vault-pm-storage-removable/Cargo.toml
@@ -5,3 +5,11 @@ edition = "2021"
 description = "VLT-PM00 §12/§23 item 14: removable/synced-folder conflict-copy detection and byte-for-byte object-root migration copy"
 
 [dependencies]
+
+# Unix-only: `read_bounded` opens with `O_NOFOLLOW` as defense in depth
+# against a symlink planted between the `fs::symlink_metadata` check and
+# the open (VLT-PM50 §7) -- the `symlink_metadata` check alone already
+# refuses any symlink present *at* the check, so this closes only the
+# narrower race window, not a new class of gap.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/code/packages/rust/vault-pm-storage-removable/Cargo.toml
+++ b/code/packages/rust/vault-pm-storage-removable/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "coding_adventures_vault_pm_storage_removable"
+version = "0.1.0"
+edition = "2021"
+description = "VLT-PM00 §12/§23 item 14: removable/synced-folder conflict-copy detection and byte-for-byte object-root migration copy"
+
+[dependencies]

--- a/code/packages/rust/vault-pm-storage-removable/README.md
+++ b/code/packages/rust/vault-pm-storage-removable/README.md
@@ -1,0 +1,69 @@
+# `coding_adventures_vault_pm_storage_removable`
+
+VLT-PM00 §12's `removable/synced folder` backend row, and §23 item 14's
+implementation. This crate is not a new storage transport — a removable or
+synced folder uses the exact same `storage-fs` on-disk immutable object
+format as an ordinary `filesystem` storage entry. The difference is entirely
+in what may write to the directory *besides* vault-pm: Dropbox, OneDrive,
+Syncthing, a NAS client's sync agent, or a USB drive opened on more than one
+machine without coordination. None of those tools know vault-pm's immutable
+object invariant, and every mainstream one resolves a same-name write
+collision by keeping both files under different names rather than silently
+overwriting. This crate detects that pattern and reports it, without trying
+to authenticate or defend against a genuinely adversarial storage backend —
+that job already belongs to the content-addressed object IDs, AEAD, and
+signatures above this layer (VLT-PM00 §7.1).
+
+## What it provides
+
+- `scan_object_root(root)` — walks one object-store root directory and
+  reports counts of ordinary vault-pm objects versus entries that look like
+  third-party sync interference, classified into `SyncInterferenceKind`
+  (`ConflictCopy`, `HiddenMetadata`, `PartialTransfer`, `Unknown`) without
+  ever returning a raw filename. Used by `vault-pm storage check NAME` and
+  `vault-pm doctor` to warn rather than silently proceed or silently fail.
+- `copy_object_tree(source, target)` — copies every committed object file
+  from one object-store root to another, write-tmp-then-rename, verified by
+  read-back before being counted, for `vault-pm storage migrate SOURCE
+  TARGET` (VLT-PM00 §19.1 steps 2-4). Re-running after a partial migration is
+  safe: an already-copied, byte-identical object is skipped, and a target
+  object with genuinely different bytes is refused as a conflict rather than
+  overwritten.
+
+## Why no filenames ever leave this crate
+
+A third-party sync tool's filename is attacker-adjacent input the moment a
+vault is shared with anyone else or synced through a service outside this
+product's control. This codebase's established convention — see
+`vault-pm-storage`'s redacted `Debug` implementations and its own error
+taxonomy — is to never echo attacker-controlled text into a terminal, log, or
+error message. Findings are bounded counts by closed classification only.
+
+## Example
+
+```rust
+use coding_adventures_vault_pm_storage_removable::scan_object_root;
+use std::path::Path;
+
+let report = scan_object_root(Path::new("/media/usb/my-vault"))?;
+if !report.is_clean() {
+    eprintln!("{} entries look like sync-tool interference", report.warnings.len());
+}
+# Ok::<(), coding_adventures_vault_pm_storage_removable::ScanError>(())
+```
+
+## Deliberate exclusions
+
+No cryptography and no content interpretation — a scan inspects only names.
+`copy_object_tree` reads bytes solely to compare them for equality or to
+relocate them unchanged; it never decodes an object frame. Neither function
+resolves a name back to an opaque `BucketId`/`ObjectId` — that boundary stays
+inside `vault-pm-storage`, and this crate works one layer below it, directly
+on `storage-fs`'s own even-length-lowercase-hex filename shape.
+
+## Development
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_storage_removable --all-targets -- -D warnings
+```

--- a/code/packages/rust/vault-pm-storage-removable/README.md
+++ b/code/packages/rust/vault-pm-storage-removable/README.md
@@ -30,6 +30,19 @@ signatures above this layer (VLT-PM00 §7.1).
   object with genuinely different bytes is refused as a conflict rather than
   overwritten.
 
+## Symlinks are refused, never followed
+
+Every filesystem touch in this crate — the scan and the migration copy
+alike — checks `fs::symlink_metadata` before `fs::metadata`/`File::open`
+(which follow links), and the migration copy's staging file is created
+with `OpenOptions::create_new` rather than `File::create`, closing the gap
+between checking a predictable path and writing to it. This is not a
+theoretical hardening: `source`/`target` are exactly the directories a
+third-party sync tool, a second machine sharing removable media, or a
+configured mirror can also write to, so a hex-named symlink planted there
+is a realistic way to read an arbitrary local file into the migrated
+copy, or to redirect a write outside the intended object tree.
+
 ## Why no filenames ever leave this crate
 
 A third-party sync tool's filename is attacker-adjacent input the moment a

--- a/code/packages/rust/vault-pm-storage-removable/README.md
+++ b/code/packages/rust/vault-pm-storage-removable/README.md
@@ -43,6 +43,12 @@ configured mirror can also write to, so a hex-named symlink planted there
 is a realistic way to read an arbitrary local file into the migrated
 copy, or to redirect a write outside the intended object tree.
 
+Reads additionally open with `O_NOFOLLOW` on Unix, and bucket-directory
+creation uses the atomic, non-recursive `fs::create_dir` rather than a
+check-then-`create_dir_all` pattern — closing not just the case where a
+symlink is already present, but the narrower window where one is planted
+in the instant between the check and the following call.
+
 ## Why no filenames ever leave this crate
 
 A third-party sync tool's filename is attacker-adjacent input the moment a

--- a/code/packages/rust/vault-pm-storage-removable/required_capabilities.json
+++ b/code/packages/rust/vault-pm-storage-removable/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-storage-removable",
+  "capabilities": ["filesystem"],
+  "justification": "Scans a caller-supplied vault-pm object-store root directory for symptoms of third-party sync-tool interference (VLT-PM00 §12, §23 item 14), and copies an object root's committed files to another caller-supplied root for `storage migrate`. No network, process, environment, clock, entropy, cryptography, key, or custody authority."
+}

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -233,6 +233,18 @@ pub enum ScanError {
     ReadFailed,
     /// [`MAX_SCANNED_ENTRIES`] was exceeded.
     TooManyEntries,
+    /// `root` itself is a symlink, refused rather than followed.
+    ///
+    /// `root` is a currently-configured storage location — the vault's own
+    /// live object store, or a mirror of it — not a scanned-and-reported-on
+    /// entry underneath it, so a symlink here is not merely an interference
+    /// finding to report: following it would scan (and, for
+    /// [`copy_object_tree`], read and copy) whatever directory it actually
+    /// points to while every caller believes it is looking at `root`, and
+    /// [`ScanReport`] would come back clean either way. Refused before any
+    /// other check for the same reason [`copy_object_tree`]'s `target`
+    /// leaf already was (VLT-PM50 §7).
+    UnexpectedSymlink,
 }
 
 impl std::fmt::Display for ScanError {
@@ -241,6 +253,7 @@ impl std::fmt::Display for ScanError {
             Self::RootUnavailable => "vault-pm-storage-removable: root unavailable",
             Self::ReadFailed => "vault-pm-storage-removable: read failed",
             Self::TooManyEntries => "vault-pm-storage-removable: too many entries",
+            Self::UnexpectedSymlink => "vault-pm-storage-removable: unexpected symlink",
         })
     }
 }
@@ -256,8 +269,21 @@ impl std::error::Error for ScanError {}
 /// level, is reported as a warning and never causes this function itself to
 /// fail — a dirty directory is exactly the case the caller wants a report
 /// about, not an error blocking the report.
+///
+/// `root` itself is the one exception: unlike the entries beneath it, `root`
+/// is always a currently-configured, already-existing storage location (a
+/// vault's live object store, or a mirror of it), so a symlink there is
+/// refused outright with [`ScanError::UnexpectedSymlink`] rather than
+/// reported as an interference finding — the same "check the exact path
+/// this operation is about to act on, not something following its own
+/// metadata call" discipline `copy_object_tree` already applies to
+/// `target`. `fs::symlink_metadata` (which does not follow the link) is
+/// used for this check rather than `fs::metadata`, which would have.
 pub fn scan_object_root(root: &Path) -> Result<ScanReport, ScanError> {
-    let metadata = fs::metadata(root).map_err(|_| ScanError::RootUnavailable)?;
+    let metadata = fs::symlink_metadata(root).map_err(|_| ScanError::RootUnavailable)?;
+    if metadata.file_type().is_symlink() {
+        return Err(ScanError::UnexpectedSymlink);
+    }
     if !metadata.is_dir() {
         return Err(ScanError::RootUnavailable);
     }
@@ -428,6 +454,7 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
         ScanError::RootUnavailable => CopyError::SourceUnavailable,
         ScanError::ReadFailed => CopyError::IoFailed,
         ScanError::TooManyEntries => CopyError::TooManyEntries,
+        ScanError::UnexpectedSymlink => CopyError::UnexpectedSymlink,
     })?;
 
     ensure_real_directory(target)?;
@@ -916,6 +943,53 @@ mod tests {
         assert_eq!(scan_object_root(&missing), Err(ScanError::RootUnavailable));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_scan_root_is_refused_not_followed() {
+        use std::os::unix::fs::symlink;
+
+        let attacker_dir = TempDir::new();
+        write_object(
+            attacker_dir.path(),
+            "2121",
+            "aabbcc",
+            b"exfiltrated secret bytes",
+        );
+        let parent = TempDir::new();
+        let root_link = parent.path().join("root-link");
+        symlink(attacker_dir.path(), &root_link).unwrap();
+
+        assert_eq!(
+            scan_object_root(&root_link),
+            Err(ScanError::UnexpectedSymlink)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_migration_source_is_refused_before_anything_is_read() {
+        use std::os::unix::fs::symlink;
+
+        let attacker_dir = TempDir::new();
+        write_object(
+            attacker_dir.path(),
+            "2121",
+            "aabbcc",
+            b"exfiltrated secret bytes",
+        );
+        let parent = TempDir::new();
+        let source_link = parent.path().join("source-link");
+        symlink(attacker_dir.path(), &source_link).unwrap();
+        let target = TempDir::new();
+
+        assert_eq!(
+            copy_object_tree(&source_link, target.path()),
+            Err(CopyError::UnexpectedSymlink)
+        );
+        // Nothing was read out of the attacker's directory and copied.
+        assert!(fs::read_dir(target.path()).unwrap().next().is_none());
+    }
+
     #[test]
     fn a_file_where_the_root_should_be_is_root_unavailable() {
         let root = TempDir::new();
@@ -1233,6 +1307,7 @@ mod tests {
             ScanError::RootUnavailable,
             ScanError::ReadFailed,
             ScanError::TooManyEntries,
+            ScanError::UnexpectedSymlink,
         ] {
             assert!(error.to_string().starts_with("vault-pm-storage-removable"));
         }

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -447,7 +447,7 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             continue;
         }
         let target_bucket_dir = target.join(&bucket_name);
-        ensure_real_directory(&target_bucket_dir)?;
+        ensure_real_bucket_directory(&target_bucket_dir)?;
 
         for object_entry in fs::read_dir(bucket_entry.path()).map_err(|_| CopyError::IoFailed)? {
             let object_entry = object_entry.map_err(|_| CopyError::IoFailed)?;
@@ -483,14 +483,19 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
     Ok(report)
 }
 
-/// Ensure `path` is a real (non-symlink) directory, creating it if absent.
+/// Ensure `path` is a real (non-symlink) directory, creating it (and any
+/// missing parents) if absent.
 ///
 /// Refuses rather than follows an existing symlink at `path`: `storage-fs`
 /// never creates one, so one being there already means something else
 /// wrote it, and blindly treating it as "the directory exists, proceed"
 /// (`fs::create_dir_all`'s own behavior, since its own re-check follows
-/// symlinks) would let a planted symlink redirect an entire bucket's worth
-/// of writes to an attacker-chosen location.
+/// symlinks) would let a planted symlink redirect an entire object root's
+/// worth of writes to an attacker-chosen location. Used only for `target`
+/// itself, a caller-supplied path this function's own retry cannot avoid
+/// re-checking non-atomically; [`ensure_real_bucket_directory`] is the
+/// atomic, race-free version used one level below it, where a plain
+/// `create_dir` suffices.
 fn ensure_real_directory(path: &Path) -> Result<(), CopyError> {
     match fs::symlink_metadata(path) {
         Ok(metadata) => {
@@ -504,6 +509,33 @@ fn ensure_real_directory(path: &Path) -> Result<(), CopyError> {
             }
         }
         Err(_) => fs::create_dir_all(path).map_err(|_| CopyError::TargetUnavailable),
+    }
+}
+
+/// Ensure `bucket_dir` (always exactly one path component below an already
+/// validated `target`) is a real directory, creating it if absent.
+///
+/// Unlike [`ensure_real_directory`], this never needs `create_dir_all`'s
+/// recursive parent creation, so it can use the atomic, race-free
+/// `fs::create_dir` instead of the check-then-`create_dir_all` pattern:
+/// `create_dir` fails with `AlreadyExists` if *anything* — a symlink
+/// included — is already at that path, without ever following it, closing
+/// the narrow window between a separate existence check and the creation
+/// call that `ensure_real_directory` cannot fully close on its own.
+fn ensure_real_bucket_directory(bucket_dir: &Path) -> Result<(), CopyError> {
+    match fs::create_dir(bucket_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(bucket_dir).map_err(|_| CopyError::IoFailed)?;
+            if metadata.file_type().is_symlink() {
+                Err(CopyError::UnexpectedSymlink)
+            } else if metadata.is_dir() {
+                Ok(())
+            } else {
+                Err(CopyError::TargetUnavailable)
+            }
+        }
+        Err(_) => Err(CopyError::TargetUnavailable),
     }
 }
 
@@ -607,10 +639,14 @@ fn remove_stale_staging_file(staging_path: &Path) -> Result<(), CopyError> {
 /// any other file this process can read) would be opened, its bytes copied
 /// into `target` under an innocuous object name, and — if `target` is
 /// itself synced or cloud-backed — silently exfiltrated. Checking
-/// `symlink_metadata` (which does not follow the link) before `File::open`
-/// (which does) closes that path; the length bound is read from the same
-/// non-following call, so a symlink to a zero-reporting special file (e.g.
-/// `/dev/zero`) cannot bypass it either.
+/// `symlink_metadata` (which does not follow the link) before opening
+/// closes that path for a symlink already present at the check; opening
+/// with `O_NOFOLLOW` on Unix (`open_no_follow`, below) additionally closes
+/// the narrower window between that check and the open itself, so a
+/// symlink planted in the instant between them is refused by the kernel
+/// rather than raced. The length bound is read from the same
+/// non-following `symlink_metadata` call, so a symlink to a
+/// zero-reporting special file (e.g. `/dev/zero`) cannot bypass it either.
 fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
     let metadata = fs::symlink_metadata(path).map_err(|_| CopyError::IoFailed)?;
     if metadata.file_type().is_symlink() {
@@ -619,7 +655,7 @@ fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
     if metadata.len() > MAX_COPY_OBJECT_BYTES {
         return Err(CopyError::ObjectTooLarge);
     }
-    let mut file = File::open(path).map_err(|_| CopyError::IoFailed)?;
+    let mut file = open_no_follow(path)?;
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
     file.read_to_end(&mut bytes)
         .map_err(|_| CopyError::IoFailed)?;
@@ -627,6 +663,36 @@ fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
         return Err(CopyError::ObjectTooLarge);
     }
     Ok(bytes)
+}
+
+/// Open `path` for reading, refusing to follow a symlink at the final path
+/// component even if one is planted there after [`read_bounded`]'s own
+/// `symlink_metadata` check has already passed.
+///
+/// On Unix this passes `O_NOFOLLOW`, which makes the kernel itself refuse
+/// atomically -- closing the check-then-open race a userspace-only check
+/// cannot. Elsewhere this is a plain open; `symlink_metadata`'s check
+/// immediately beforehand still covers the non-racing case identically on
+/// every platform.
+#[cfg(unix)]
+fn open_no_follow(path: &Path) -> Result<File, CopyError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                CopyError::UnexpectedSymlink
+            } else {
+                CopyError::IoFailed
+            }
+        })
+}
+
+#[cfg(not(unix))]
+fn open_no_follow(path: &Path) -> Result<File, CopyError> {
+    File::open(path).map_err(|_| CopyError::IoFailed)
 }
 
 #[cfg(test)]

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -1,0 +1,902 @@
+//! # `coding_adventures_vault_pm_storage_removable` — VLT-PM00 §12 / §23 item 14
+//!
+//! ## What this crate is for
+//!
+//! `VLT-PM00-local-first-password-manager.md` §12 lists `removable/synced
+//! folder` as its own backend row, right beside `filesystem`, with one note:
+//! *"warn about third-party sync conflict copies"*. The two rows share the
+//! exact same on-disk immutable object format (`storage-fs`'s
+//! `<root>/<hex namespace>/<hex key>` layout) — `removable` is not a new
+//! transport, it is the same filesystem backend used in a directory a
+//! *third-party* tool also writes to: Dropbox, OneDrive, Syncthing, a NAS
+//! client's sync agent, or a literal USB drive carried between machines and
+//! opened by more than one of them without coordination.
+//!
+//! None of those tools know vault-pm's immutable-object invariant. When two
+//! of them write the same logical file at once, or when a person edits a
+//! synced copy on a second machine, the sync tool's own conflict-resolution
+//! policy kicks in — and every mainstream one resolves a same-name collision
+//! by keeping *both* files under different names, never by overwriting
+//! silently. That is the detectable signature this crate looks for: a file
+//! sitting where only an ordinary lowercase-hex vault-pm object name belongs,
+//! spelled some other way.
+//!
+//! This crate does **not** try to out-adversary a hostile storage backend.
+//! §7.1's "malicious storage service" adversary (reorders, duplicates,
+//! corrupts, withholds, deletes, replays objects) is already covered by
+//! object-ID content addressing, AEAD, and signatures at the repository and
+//! application layers above this one. This crate's whole job is narrower and
+//! more mundane: notice the ordinary, non-adversarial mess a sync tool leaves
+//! behind, and say so plainly instead of silently ignoring it or refusing to
+//! open.
+//!
+//! ## What it does not do
+//!
+//! - No cryptography, no content interpretation. A scan only ever looks at
+//!   *names*, never at file bytes (the copy helper below is the one
+//!   exception, and even there it only ever compares bytes for equality,
+//!   never decodes them).
+//! - No raw filenames ever leave this crate's public API. A third-party sync
+//!   tool's filename is attacker-adjacent input the moment a vault is shared
+//!   with anyone else, and this codebase's own convention (see
+//!   `vault-pm-storage`'s redacted `Debug` impls) is to never echo
+//!   attacker-controlled text into a terminal, a log, or an error message.
+//!   Findings are reported as bounded counts by closed classification, never
+//!   as strings.
+//! - No opinion on which bucket an object belongs to. `storage-fs`'s
+//!   namespace/key hex encoding is structural, not semantic, so this crate
+//!   only ever checks *shape* (even-length lowercase hex), never decodes a
+//!   name back to a `BucketId`/`ObjectId`. That keeps it below
+//!   `vault-pm-storage`'s opaque-identifier boundary rather than reaching
+//!   across it.
+//!
+//! ## Two operations
+//!
+//! 1. [`scan_object_root`] — the detector. Walks one object-store root and
+//!    reports how many entries look like ordinary vault-pm objects versus how
+//!    many look like sync-tool interference, classified into
+//!    [`SyncInterferenceKind`]. Used by `storage check` and `doctor` (VLT-PM00
+//!    §23 item 14) to warn without blocking.
+//! 2. [`copy_object_tree`] — the migration helper. Copies every committed
+//!    object file from one object-store root to another, verifying every
+//!    write by reading it back, for `storage migrate` (§19.1). It scans the
+//!    source first and carries that report along rather than blocking on it,
+//!    because the source directory being "dirty" in the way this crate
+//!    detects is exactly the situation `storage migrate` (moving off a
+//!    flaky synced folder) exists to get a vault *out of*.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+/// Absolute ceiling on one copied object file, aligned with
+/// `vault-pm-storage::MAX_OBJECT_BYTES` (itself aligned with VLT-PM01's
+/// object-frame bound). Kept as this crate's own constant rather than an
+/// added dependency edge, since this crate works one layer below the opaque
+/// `VaultObjectStore` contract, on raw files.
+pub const MAX_COPY_OBJECT_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Largest number of directory entries one [`scan_object_root`] or
+/// [`copy_object_tree`] call will walk, across every bucket directory
+/// combined. Bounds the cost of pointing either function at a huge or
+/// adversarially padded directory (a removable drive is, by definition,
+/// attacker-reachable in a way a fixed local path is not).
+pub const MAX_SCANNED_ENTRIES: usize = 1_000_000;
+
+/// Where an unexpected entry was found.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EntryLocation {
+    /// Directly under the object-store root, where only bucket directories
+    /// (even-length lowercase hex names) belong.
+    TopLevel,
+    /// Inside a bucket directory, where only object files (even-length
+    /// lowercase hex names, or a `.tmp` in-flight write) belong.
+    WithinBucket,
+}
+
+/// Closed classification of one unexpected filesystem entry.
+///
+/// Every variant is inferred from *shape* alone — never from file content —
+/// and the classification itself carries no attacker-controlled text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SyncInterferenceKind {
+    /// The name matches a mainstream sync tool's same-name-collision
+    /// convention: contains "conflict" case-insensitively (Dropbox: `"...
+    /// (<device>'s conflicted copy ...)"`, OneDrive: `"...-<device>'s
+    /// conflicted copy..."`, Google Drive Desktop and most NAS clients use
+    /// the same word), or Syncthing's fixed `.sync-conflict-<timestamp>-`
+    /// infix, or a bare parenthesized duplicate-count suffix (`" (1)"`,
+    /// `" (2)"`) that Explorer/Finder/rclone use for the same purpose.
+    ConflictCopy,
+    /// A dotfile or well-known sentinel a filesystem browser or sync client
+    /// leaves behind without ever representing a vault-pm object:
+    /// `.DS_Store`, `Thumbs.db`, `desktop.ini`, `.~lock.*#` (LibreOffice),
+    /// or any other leading-dot name that is not this backend's own
+    /// `<hex>.tmp`.
+    HiddenMetadata,
+    /// A partially transferred file a sync client has not yet renamed into
+    /// place: `.crdownload`, `.part`, `.filepart`, `.download`, or a
+    /// `~`-prefixed editor swap file.
+    PartialTransfer,
+    /// Present, not `.tmp`, and matches none of the above — still worth a
+    /// person's attention, just not one this crate can name more precisely.
+    Unknown,
+}
+
+fn classify(name: &str) -> SyncInterferenceKind {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("conflict") || has_duplicate_count_suffix(&lower) {
+        return SyncInterferenceKind::ConflictCopy;
+    }
+    if lower == ".ds_store"
+        || lower == "thumbs.db"
+        || lower == "desktop.ini"
+        || (lower.starts_with(".~lock."))
+        || (name.starts_with('.') && !is_hex_tmp_name(name))
+    {
+        return SyncInterferenceKind::HiddenMetadata;
+    }
+    if lower.ends_with(".crdownload")
+        || lower.ends_with(".part")
+        || lower.ends_with(".filepart")
+        || lower.ends_with(".download")
+        || name.starts_with('~')
+    {
+        return SyncInterferenceKind::PartialTransfer;
+    }
+    SyncInterferenceKind::Unknown
+}
+
+/// Whether `name` ends with a bare parenthesized duplicate-count suffix, e.g.
+/// `"a1b2 (1)"`. Only the shape matters; the base name is not inspected.
+fn has_duplicate_count_suffix(lower: &str) -> bool {
+    let Some(open) = lower.rfind(" (") else {
+        return false;
+    };
+    let Some(close_offset) = lower[open..].find(')') else {
+        return false;
+    };
+    let close = open + close_offset;
+    if close != lower.len() - 1 {
+        return false;
+    }
+    let digits = &lower[open + 2..close];
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+/// Whether `name` is an even-length lowercase-hex string — the exact shape
+/// `storage-fs` uses for both its namespace directories and its object
+/// files.
+fn is_hex_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len().is_multiple_of(2)
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Whether `name` is `storage-fs`'s own in-flight write marker: an
+/// even-length lowercase-hex stem with a literal `.tmp` extension. These are
+/// legitimate transient state (cleaned up by the real backend's own
+/// `initialize`), never sync interference.
+fn is_hex_tmp_name(name: &str) -> bool {
+    name.strip_suffix(".tmp").is_some_and(is_hex_name)
+}
+
+/// One unexpected entry, located but never named.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InterferenceWarning {
+    /// Where the entry was found.
+    pub location: EntryLocation,
+    /// What it looks like.
+    pub kind: SyncInterferenceKind,
+}
+
+/// The result of one [`scan_object_root`] call.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScanReport {
+    /// Bucket directories that matched the expected hex shape.
+    pub bucket_directories: usize,
+    /// Object files (or legitimate `.tmp` in-flight writes) that matched the
+    /// expected hex shape.
+    pub ordinary_objects: usize,
+    /// Every entry that did not match, in scan order.
+    pub warnings: Vec<InterferenceWarning>,
+}
+
+impl ScanReport {
+    /// Whether anything worth a person's attention was found.
+    pub fn is_clean(&self) -> bool {
+        self.warnings.is_empty()
+    }
+
+    /// Count warnings of one specific kind.
+    pub fn count_of(&self, kind: SyncInterferenceKind) -> usize {
+        self.warnings
+            .iter()
+            .filter(|warning| warning.kind == kind)
+            .count()
+    }
+}
+
+/// Closed, payload-free scan failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScanError {
+    /// The root does not exist, or exists but is not a directory.
+    RootUnavailable,
+    /// A read failed partway through (permissions, I/O error, or the root
+    /// vanished mid-scan — plausible for a removable drive that is unplugged
+    /// while `storage check` runs).
+    ReadFailed,
+    /// [`MAX_SCANNED_ENTRIES`] was exceeded.
+    TooManyEntries,
+}
+
+impl std::fmt::Display for ScanError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::RootUnavailable => "vault-pm-storage-removable: root unavailable",
+            Self::ReadFailed => "vault-pm-storage-removable: read failed",
+            Self::TooManyEntries => "vault-pm-storage-removable: too many entries",
+        })
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+/// Scan one object-store root for symptoms of third-party sync interference.
+///
+/// `root` is expected to be exactly what `storage-fs::FsStorageBackend` owns:
+/// a directory containing zero or more even-length-lowercase-hex-named
+/// subdirectories, each containing zero or more even-length-lowercase-hex
+/// named files (or `<hex>.tmp` in-flight writes). Anything else, at either
+/// level, is reported as a warning and never causes this function itself to
+/// fail — a dirty directory is exactly the case the caller wants a report
+/// about, not an error blocking the report.
+pub fn scan_object_root(root: &Path) -> Result<ScanReport, ScanError> {
+    let metadata = fs::metadata(root).map_err(|_| ScanError::RootUnavailable)?;
+    if !metadata.is_dir() {
+        return Err(ScanError::RootUnavailable);
+    }
+
+    let mut report = ScanReport::default();
+    let mut scanned = 0_usize;
+    for top_entry in read_dir_sorted(root)? {
+        bump(&mut scanned)?;
+        let name = entry_name(&top_entry)?;
+        let is_dir = top_entry
+            .file_type()
+            .map_err(|_| ScanError::ReadFailed)?
+            .is_dir();
+        if is_dir && is_hex_name(&name) {
+            report.bucket_directories += 1;
+            for inner_entry in read_dir_sorted(&top_entry.path())? {
+                bump(&mut scanned)?;
+                let inner_name = entry_name(&inner_entry)?;
+                let inner_is_dir = inner_entry
+                    .file_type()
+                    .map_err(|_| ScanError::ReadFailed)?
+                    .is_dir();
+                if !inner_is_dir && (is_hex_name(&inner_name) || is_hex_tmp_name(&inner_name)) {
+                    report.ordinary_objects += 1;
+                } else {
+                    report.warnings.push(InterferenceWarning {
+                        location: EntryLocation::WithinBucket,
+                        kind: classify(&inner_name),
+                    });
+                }
+            }
+        } else {
+            report.warnings.push(InterferenceWarning {
+                location: EntryLocation::TopLevel,
+                kind: classify(&name),
+            });
+        }
+    }
+    Ok(report)
+}
+
+fn bump(scanned: &mut usize) -> Result<(), ScanError> {
+    *scanned += 1;
+    if *scanned > MAX_SCANNED_ENTRIES {
+        return Err(ScanError::TooManyEntries);
+    }
+    Ok(())
+}
+
+fn read_dir_sorted(dir: &Path) -> Result<Vec<fs::DirEntry>, ScanError> {
+    let mut entries = fs::read_dir(dir)
+        .map_err(|_| ScanError::ReadFailed)?
+        .collect::<Result<Vec<_>, io::Error>>()
+        .map_err(|_| ScanError::ReadFailed)?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    Ok(entries)
+}
+
+fn entry_name(entry: &fs::DirEntry) -> Result<String, ScanError> {
+    entry
+        .file_name()
+        .into_string()
+        .map_err(|_| ScanError::ReadFailed)
+}
+
+/// The result of one [`copy_object_tree`] call.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CopyReport {
+    /// Object files newly written to the target and verified by read-back.
+    pub copied_objects: usize,
+    /// Bytes newly written to the target.
+    pub copied_bytes: u64,
+    /// Object files already present in the target with byte-identical
+    /// content (an idempotent re-run of an interrupted migration lands here).
+    pub already_present: usize,
+    /// The source root's own interference scan, carried along rather than
+    /// blocking the copy — VLT-PM00 §23 item 14: moving off a folder this
+    /// crate flags as suspect is exactly what `storage migrate` is often
+    /// *for*.
+    pub source_warnings: ScanReport,
+}
+
+/// Closed, payload-free copy failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CopyError {
+    /// The source root does not exist, or exists but is not a directory.
+    SourceUnavailable,
+    /// The target root could not be created or is not a directory.
+    TargetUnavailable,
+    /// A read or write failed partway through.
+    IoFailed,
+    /// The target already has a file at this object's path with *different*
+    /// bytes than the source — a genuine immutability violation between two
+    /// stores that are each individually supposed to be append-only. This is
+    /// the one case `copy_object_tree` refuses to paper over.
+    Conflict,
+    /// A file exceeded [`MAX_COPY_OBJECT_BYTES`].
+    ObjectTooLarge,
+    /// [`MAX_SCANNED_ENTRIES`] was exceeded.
+    TooManyEntries,
+}
+
+impl std::fmt::Display for CopyError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::SourceUnavailable => "vault-pm-storage-removable: source unavailable",
+            Self::TargetUnavailable => "vault-pm-storage-removable: target unavailable",
+            Self::IoFailed => "vault-pm-storage-removable: I/O failed",
+            Self::Conflict => "vault-pm-storage-removable: immutability conflict",
+            Self::ObjectTooLarge => "vault-pm-storage-removable: object too large",
+            Self::TooManyEntries => "vault-pm-storage-removable: too many entries",
+        })
+    }
+}
+
+impl std::error::Error for CopyError {}
+
+/// Copy every committed object file from `source` to `target`, verifying
+/// each write by reading it back before counting it, for `storage migrate`
+/// (VLT-PM00 §19.1 steps 2-4).
+///
+/// Only entries matching the expected `<hex>/<hex>` shape are copied;
+/// `.tmp` in-flight writes are skipped (they are not committed state, by
+/// `storage-fs`'s own documented contract), and anything else is left alone
+/// in the source and simply counted in the returned scan. `target` is
+/// created if it does not already exist. An object already present in
+/// `target` with identical bytes is left untouched and counted as
+/// `already_present`, making a re-run after an interrupted migration safe;
+/// one with *different* bytes is reported as [`CopyError::Conflict`] and
+/// aborts, because that is not a migration bug this function should paper
+/// over — it means one of the two directories was mutated by something
+/// other than an immutable put.
+///
+/// This function never deletes or modifies anything under `source`.
+pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, CopyError> {
+    let source_warnings = scan_object_root(source).map_err(|error| match error {
+        ScanError::RootUnavailable => CopyError::SourceUnavailable,
+        ScanError::ReadFailed => CopyError::IoFailed,
+        ScanError::TooManyEntries => CopyError::TooManyEntries,
+    })?;
+
+    fs::create_dir_all(target).map_err(|_| CopyError::TargetUnavailable)?;
+    if !fs::metadata(target)
+        .map_err(|_| CopyError::TargetUnavailable)?
+        .is_dir()
+    {
+        return Err(CopyError::TargetUnavailable);
+    }
+
+    let mut report = CopyReport {
+        source_warnings,
+        ..CopyReport::default()
+    };
+    let mut scanned = 0_usize;
+    for bucket_entry in fs::read_dir(source).map_err(|_| CopyError::IoFailed)? {
+        let bucket_entry = bucket_entry.map_err(|_| CopyError::IoFailed)?;
+        bump_copy(&mut scanned)?;
+        let bucket_name = bucket_entry
+            .file_name()
+            .into_string()
+            .map_err(|_| CopyError::IoFailed)?;
+        if !bucket_entry
+            .file_type()
+            .map_err(|_| CopyError::IoFailed)?
+            .is_dir()
+            || !is_hex_name(&bucket_name)
+        {
+            continue;
+        }
+        let target_bucket_dir = target.join(&bucket_name);
+        fs::create_dir_all(&target_bucket_dir).map_err(|_| CopyError::TargetUnavailable)?;
+
+        for object_entry in fs::read_dir(bucket_entry.path()).map_err(|_| CopyError::IoFailed)? {
+            let object_entry = object_entry.map_err(|_| CopyError::IoFailed)?;
+            bump_copy(&mut scanned)?;
+            let object_name = object_entry
+                .file_name()
+                .into_string()
+                .map_err(|_| CopyError::IoFailed)?;
+            if object_entry
+                .file_type()
+                .map_err(|_| CopyError::IoFailed)?
+                .is_dir()
+                || !is_hex_name(&object_name)
+            {
+                continue; // `.tmp` writes and anything unexpected are skipped.
+            }
+            copy_one_object(
+                &object_entry.path(),
+                &target_bucket_dir.join(&object_name),
+                &mut report,
+            )?;
+        }
+    }
+    Ok(report)
+}
+
+fn bump_copy(scanned: &mut usize) -> Result<(), CopyError> {
+    *scanned += 1;
+    if *scanned > MAX_SCANNED_ENTRIES {
+        return Err(CopyError::TooManyEntries);
+    }
+    Ok(())
+}
+
+fn copy_one_object(
+    source_path: &Path,
+    target_path: &Path,
+    report: &mut CopyReport,
+) -> Result<(), CopyError> {
+    let source_bytes = read_bounded(source_path)?;
+
+    if let Ok(existing) = fs::metadata(target_path) {
+        if existing.is_file() {
+            let target_bytes = read_bounded(target_path)?;
+            return if target_bytes == source_bytes {
+                report.already_present += 1;
+                Ok(())
+            } else {
+                Err(CopyError::Conflict)
+            };
+        }
+        return Err(CopyError::Conflict);
+    }
+
+    // Write-tmp-then-rename, the same discipline `storage-fs` itself uses,
+    // so a crash mid-copy leaves either nothing or one fully written file at
+    // the final path, never a truncated one.
+    let mut staging_path: PathBuf = target_path.to_path_buf();
+    let staged_name = format!(
+        "{}.migrate-tmp",
+        target_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or(CopyError::IoFailed)?
+    );
+    staging_path.set_file_name(staged_name);
+    {
+        let mut staging_file = File::create(&staging_path).map_err(|_| CopyError::IoFailed)?;
+        staging_file
+            .write_all(&source_bytes)
+            .map_err(|_| CopyError::IoFailed)?;
+        staging_file.sync_all().map_err(|_| CopyError::IoFailed)?;
+    }
+    fs::rename(&staging_path, target_path).map_err(|_| CopyError::IoFailed)?;
+
+    // Read back before counting the object copied -- VLT-PM00 §19.1 step 4.
+    let verify_bytes = read_bounded(target_path)?;
+    if verify_bytes != source_bytes {
+        return Err(CopyError::IoFailed);
+    }
+    report.copied_objects += 1;
+    report.copied_bytes += verify_bytes.len() as u64;
+    Ok(())
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
+    let metadata = fs::metadata(path).map_err(|_| CopyError::IoFailed)?;
+    if metadata.len() > MAX_COPY_OBJECT_BYTES {
+        return Err(CopyError::ObjectTooLarge);
+    }
+    let mut file = File::open(path).map_err(|_| CopyError::IoFailed)?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.read_to_end(&mut bytes)
+        .map_err(|_| CopyError::IoFailed)?;
+    if bytes.len() as u64 > MAX_COPY_OBJECT_BYTES {
+        return Err(CopyError::ObjectTooLarge);
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!(
+                "vault-pm-storage-removable-test-{}-{stamp}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_object(root: &Path, bucket: &str, object: &str, bytes: &[u8]) {
+        let bucket_dir = root.join(bucket);
+        fs::create_dir_all(&bucket_dir).unwrap();
+        fs::write(bucket_dir.join(object), bytes).unwrap();
+    }
+
+    #[test]
+    fn empty_root_scans_clean() {
+        let root = TempDir::new();
+        let report = scan_object_root(root.path()).unwrap();
+        assert!(report.is_clean());
+        assert_eq!(report.bucket_directories, 0);
+        assert_eq!(report.ordinary_objects, 0);
+    }
+
+    #[test]
+    fn ordinary_objects_and_in_flight_tmp_writes_are_clean() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        write_object(root.path(), "2121", "ddeeff", b"more ciphertext");
+        fs::write(root.path().join("2121").join("112233.tmp"), b"partial").unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert!(report.is_clean());
+        assert_eq!(report.bucket_directories, 1);
+        assert_eq!(report.ordinary_objects, 3);
+    }
+
+    #[test]
+    fn dropbox_style_conflict_copy_is_detected_within_a_bucket() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(
+            root.path()
+                .join("2121")
+                .join("aabbcc (Jane's conflicted copy 2026-08-17)"),
+            b"ciphertext",
+        )
+        .unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert!(!report.is_clean());
+        assert_eq!(report.count_of(SyncInterferenceKind::ConflictCopy), 1);
+        assert_eq!(report.warnings[0].location, EntryLocation::WithinBucket);
+    }
+
+    #[test]
+    fn syncthing_style_conflict_copy_is_detected() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(
+            root.path()
+                .join("2121")
+                .join("aabbcc.sync-conflict-20260817-120000-ABCDEFG"),
+            b"ciphertext",
+        )
+        .unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.count_of(SyncInterferenceKind::ConflictCopy), 1);
+    }
+
+    #[test]
+    fn explorer_style_duplicate_count_suffix_is_detected() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc (1)", b"ciphertext");
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.count_of(SyncInterferenceKind::ConflictCopy), 1);
+    }
+
+    #[test]
+    fn os_and_client_metadata_files_are_classified_hidden() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(root.path().join("2121").join(".DS_Store"), b"").unwrap();
+        fs::write(root.path().join("2121").join("Thumbs.db"), b"").unwrap();
+        fs::write(root.path().join("2121").join("desktop.ini"), b"").unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.count_of(SyncInterferenceKind::HiddenMetadata), 3);
+    }
+
+    #[test]
+    fn partial_transfer_files_are_classified() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(
+            root.path().join("2121").join("aabbcc.crdownload"),
+            b"partial",
+        )
+        .unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.count_of(SyncInterferenceKind::PartialTransfer), 1);
+    }
+
+    #[test]
+    fn unrecognized_entries_fall_back_to_unknown() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(root.path().join("2121").join("readme.txt"), b"hi").unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.count_of(SyncInterferenceKind::Unknown), 1);
+    }
+
+    #[test]
+    fn unexpected_top_level_entry_is_flagged_at_top_level() {
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"ciphertext");
+        fs::write(root.path().join("not-hex-at-all"), b"hi").unwrap();
+        let report = scan_object_root(root.path()).unwrap();
+        assert_eq!(report.warnings.len(), 1);
+        assert_eq!(report.warnings[0].location, EntryLocation::TopLevel);
+    }
+
+    #[test]
+    fn uppercase_hex_is_not_the_expected_shape() {
+        let root = TempDir::new();
+        // vault-pm's own encoder is always lowercase; an uppercase name at
+        // either level did not come from this backend.
+        write_object(root.path(), "2121", "AABBCC", b"ciphertext");
+        let report = scan_object_root(root.path()).unwrap();
+        assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn missing_root_is_root_unavailable() {
+        let root = TempDir::new();
+        let missing = root.path().join("does-not-exist");
+        assert_eq!(scan_object_root(&missing), Err(ScanError::RootUnavailable));
+    }
+
+    #[test]
+    fn a_file_where_the_root_should_be_is_root_unavailable() {
+        let root = TempDir::new();
+        let file_path = root.path().join("not-a-directory");
+        fs::write(&file_path, b"x").unwrap();
+        assert_eq!(
+            scan_object_root(&file_path),
+            Err(ScanError::RootUnavailable)
+        );
+    }
+
+    #[test]
+    fn copy_moves_every_object_and_verifies_by_read_back() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        fs::remove_dir_all(target.path()).unwrap(); // exercise auto-create
+        write_object(source.path(), "2121", "aabbcc", b"first object");
+        write_object(source.path(), "2121", "ddeeff", b"second object");
+        write_object(
+            source.path(),
+            "3131",
+            "112233",
+            b"third object, other bucket",
+        );
+
+        let report = copy_object_tree(source.path(), target.path()).unwrap();
+        assert_eq!(report.copied_objects, 3);
+        assert_eq!(report.copied_bytes, 12 + 13 + 26);
+        assert_eq!(report.already_present, 0);
+        assert!(report.source_warnings.is_clean());
+
+        assert_eq!(
+            fs::read(target.path().join("2121").join("aabbcc")).unwrap(),
+            b"first object"
+        );
+        assert_eq!(
+            fs::read(target.path().join("3131").join("112233")).unwrap(),
+            b"third object, other bucket"
+        );
+        // The source is left untouched.
+        assert!(source.path().join("2121").join("aabbcc").exists());
+    }
+
+    #[test]
+    fn in_flight_tmp_writes_are_never_copied() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"real object");
+        fs::write(source.path().join("2121").join("ddeeff.tmp"), b"partial").unwrap();
+        let report = copy_object_tree(source.path(), target.path()).unwrap();
+        assert_eq!(report.copied_objects, 1);
+        assert!(!target.path().join("2121").join("ddeeff.tmp").exists());
+    }
+
+    #[test]
+    fn rerunning_a_migration_after_full_success_is_idempotent() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"object");
+        copy_object_tree(source.path(), target.path()).unwrap();
+        let second = copy_object_tree(source.path(), target.path()).unwrap();
+        assert_eq!(second.copied_objects, 0);
+        assert_eq!(second.already_present, 1);
+    }
+
+    #[test]
+    fn a_target_object_with_different_bytes_is_a_conflict_not_an_overwrite() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"source bytes");
+        write_object(target.path(), "2121", "aabbcc", b"DIFFERENT bytes");
+        assert_eq!(
+            copy_object_tree(source.path(), target.path()),
+            Err(CopyError::Conflict)
+        );
+        // The mismatched target object is left exactly as it was found.
+        assert_eq!(
+            fs::read(target.path().join("2121").join("aabbcc")).unwrap(),
+            b"DIFFERENT bytes"
+        );
+    }
+
+    #[test]
+    fn missing_source_is_source_unavailable() {
+        let source = TempDir::new();
+        let missing = source.path().join("nope");
+        let target = TempDir::new();
+        assert_eq!(
+            copy_object_tree(&missing, target.path()),
+            Err(CopyError::SourceUnavailable)
+        );
+    }
+
+    #[test]
+    fn source_warnings_are_carried_but_do_not_block_the_copy() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"object");
+        fs::write(
+            source.path().join("2121").join("aabbcc (conflicted copy)"),
+            b"object",
+        )
+        .unwrap();
+        let report = copy_object_tree(source.path(), target.path()).unwrap();
+        assert_eq!(report.copied_objects, 1);
+        assert!(!report.source_warnings.is_clean());
+        assert_eq!(
+            report
+                .source_warnings
+                .count_of(SyncInterferenceKind::ConflictCopy),
+            1
+        );
+    }
+
+    #[test]
+    fn oversized_object_is_rejected_without_being_copied() {
+        let source = TempDir::new();
+        let target = TempDir::new();
+        // Cheaply exceed the bound by faking metadata length is not possible
+        // portably, so this proves the *check* path via a real short read
+        // combined with a deliberately tiny override is out of scope for a
+        // unit test; instead assert the constant is what callers expect and
+        // trust the length check reads it before ever allocating.
+        assert_eq!(MAX_COPY_OBJECT_BYTES, 64 * 1024 * 1024);
+        write_object(source.path(), "2121", "aabbcc", b"small");
+        assert!(copy_object_tree(source.path(), target.path()).is_ok());
+    }
+
+    #[test]
+    fn error_display_and_debug_are_stable_and_closed() {
+        for error in [
+            ScanError::RootUnavailable,
+            ScanError::ReadFailed,
+            ScanError::TooManyEntries,
+        ] {
+            assert!(error.to_string().starts_with("vault-pm-storage-removable"));
+        }
+        for error in [
+            CopyError::SourceUnavailable,
+            CopyError::TargetUnavailable,
+            CopyError::IoFailed,
+            CopyError::Conflict,
+            CopyError::ObjectTooLarge,
+            CopyError::TooManyEntries,
+        ] {
+            assert!(error.to_string().starts_with("vault-pm-storage-removable"));
+        }
+    }
+
+    #[test]
+    fn interference_warning_and_scan_report_expose_no_names() {
+        let warning = InterferenceWarning {
+            location: EntryLocation::TopLevel,
+            kind: SyncInterferenceKind::Unknown,
+        };
+        let debug = format!("{warning:?}");
+        assert!(debug.contains("TopLevel"));
+        assert!(debug.contains("Unknown"));
+        let report = ScanReport::default();
+        assert!(report.is_clean());
+        assert_eq!(report.count_of(SyncInterferenceKind::ConflictCopy), 0);
+    }
+
+    #[test]
+    fn classify_covers_every_kind_deterministically() {
+        assert_eq!(
+            classify("a (conflicted copy)"),
+            SyncInterferenceKind::ConflictCopy
+        );
+        assert_eq!(
+            classify("a.sync-conflict-1-2"),
+            SyncInterferenceKind::ConflictCopy
+        );
+        assert_eq!(classify("a (2)"), SyncInterferenceKind::ConflictCopy);
+        assert_eq!(classify(".DS_Store"), SyncInterferenceKind::HiddenMetadata);
+        assert_eq!(classify("Thumbs.db"), SyncInterferenceKind::HiddenMetadata);
+        assert_eq!(
+            classify(".~lock.foo#"),
+            SyncInterferenceKind::HiddenMetadata
+        );
+        assert_eq!(
+            classify(".hidden-other"),
+            SyncInterferenceKind::HiddenMetadata
+        );
+        assert_eq!(
+            classify("a.crdownload"),
+            SyncInterferenceKind::PartialTransfer
+        );
+        assert_eq!(classify("~a"), SyncInterferenceKind::PartialTransfer);
+        assert_eq!(classify("readme.txt"), SyncInterferenceKind::Unknown);
+        // A bare "(1)" with no leading space is not the Explorer/rclone
+        // shape and stays Unknown rather than over-matching.
+        assert_eq!(classify("a(1)"), SyncInterferenceKind::Unknown);
+    }
+
+    #[test]
+    fn is_hex_name_and_is_hex_tmp_name_reject_malformed_shapes() {
+        assert!(is_hex_name("aabb"));
+        assert!(!is_hex_name(""));
+        assert!(!is_hex_name("aab")); // odd length
+        assert!(!is_hex_name("aabZ"));
+        assert!(!is_hex_name("AABB"));
+        assert!(is_hex_tmp_name("aabb.tmp"));
+        assert!(!is_hex_tmp_name("aabb.tmp.tmp"));
+        assert!(!is_hex_tmp_name(".tmp"));
+    }
+}

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -264,8 +264,7 @@ pub fn scan_object_root(root: &Path) -> Result<ScanReport, ScanError> {
 
     let mut report = ScanReport::default();
     let mut scanned = 0_usize;
-    for top_entry in read_dir_sorted(root)? {
-        bump(&mut scanned)?;
+    for top_entry in read_dir_sorted(root, &mut scanned)? {
         let name = entry_name(&top_entry)?;
         let is_dir = top_entry
             .file_type()
@@ -273,8 +272,7 @@ pub fn scan_object_root(root: &Path) -> Result<ScanReport, ScanError> {
             .is_dir();
         if is_dir && is_hex_name(&name) {
             report.bucket_directories += 1;
-            for inner_entry in read_dir_sorted(&top_entry.path())? {
-                bump(&mut scanned)?;
+            for inner_entry in read_dir_sorted(&top_entry.path(), &mut scanned)? {
                 let inner_name = entry_name(&inner_entry)?;
                 // A positive `is_file()` check, not a negative `!is_dir()`
                 // one: `DirEntry::file_type()` does not follow symlinks, so
@@ -316,11 +314,25 @@ fn bump(scanned: &mut usize) -> Result<(), ScanError> {
     Ok(())
 }
 
-fn read_dir_sorted(dir: &Path) -> Result<Vec<fs::DirEntry>, ScanError> {
-    let mut entries = fs::read_dir(dir)
-        .map_err(|_| ScanError::ReadFailed)?
-        .collect::<Result<Vec<_>, io::Error>>()
-        .map_err(|_| ScanError::ReadFailed)?;
+/// List and sort one directory's entries, bounding `scanned` — the running
+/// count across the *whole* scan, not just this one directory — against
+/// [`MAX_SCANNED_ENTRIES`] as each raw entry is pulled from the OS, not
+/// after they have all already been collected.
+///
+/// The distinction matters: collecting the full `fs::ReadDir` iterator into
+/// a `Vec` *before* ever consulting the bound (the previous shape of this
+/// function) would fully materialize and sort an adversarially huge
+/// directory listing in memory first and only then discover it was too
+/// large — defeating the bound's own stated purpose against exactly the
+/// "adversarially padded directory" a removable drive makes plausible
+/// (VLT-PM50 §7). `bump` now runs per entry as it is pulled, so this
+/// function never holds more than [`MAX_SCANNED_ENTRIES`] entries at once.
+fn read_dir_sorted(dir: &Path, scanned: &mut usize) -> Result<Vec<fs::DirEntry>, ScanError> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|_| ScanError::ReadFailed)? {
+        bump(scanned)?;
+        entries.push(entry.map_err(|_| ScanError::ReadFailed)?);
+    }
     entries.sort_by_key(fs::DirEntry::file_name);
     Ok(entries)
 }
@@ -447,6 +459,12 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             continue;
         }
         let target_bucket_dir = target.join(&bucket_name);
+        // Re-validates `target` itself, not only the bucket directory one
+        // level below it: a concurrent writer capable of removing and
+        // replacing `target` after its own one-time validation above could
+        // otherwise have every bucket from this point on transparently
+        // created inside whatever `target` now resolves to.
+        ensure_real_directory(target)?;
         ensure_real_bucket_directory(&target_bucket_dir)?;
 
         for object_entry in fs::read_dir(bucket_entry.path()).map_err(|_| CopyError::IoFailed)? {
@@ -473,12 +491,15 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             {
                 continue; // `.tmp` writes, symlinks, and anything else are skipped.
             }
-            // Re-verified before every object, not only once per bucket: a
-            // concurrent writer to `target` (VLT-PM50 §7's own threat model)
-            // could otherwise remove the bucket directory this loop already
-            // validated and replace it with a symlink between two writes in
-            // the same bucket, and `copy_one_object`'s own checks only ever
-            // cover the leaf object/staging path, never this parent.
+            // Re-verified before every object, not only once per bucket --
+            // and `target` along with it, for the same reason -- a
+            // concurrent writer to `target` (VLT-PM50 §7's own threat
+            // model) could otherwise remove either directory this loop
+            // already validated and replace it with a symlink between two
+            // writes in the same bucket, and `copy_one_object`'s own
+            // checks only ever cover the leaf object/staging path, never
+            // these parents.
+            ensure_real_directory(target)?;
             ensure_real_bucket_directory(&target_bucket_dir)?;
             copy_one_object(
                 &object_entry.path(),
@@ -493,16 +514,30 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
 /// Ensure `path` is a real (non-symlink) directory, creating it (and any
 /// missing parents) if absent.
 ///
-/// Parent directories are created with the ordinary recursive
-/// `fs::create_dir_all` — `path`'s parents are not this function's leaf
-/// concern and, for the one caller that has any (`target` itself), are a
-/// caller-supplied location that pre-existed the migration far more often
-/// than not. `path` itself — the exact directory every subsequent object
-/// write in this bucket (or, for `target`, the whole migration) depends
-/// on — is created through [`create_directory_component_atomically`], so a
-/// symlink planted at that exact path cannot be silently followed the way
-/// `fs::create_dir_all`'s own re-check (which follows symlinks when
-/// deciding "the directory is already there, proceed") would follow one.
+/// `path`'s own, final path component is created — or, if already present,
+/// validated — through [`create_directory_component_atomically`], so a
+/// symlink at that exact path is refused rather than followed. Everything
+/// above it is created with the ordinary recursive `fs::create_dir_all`.
+///
+/// That split is a deliberate, documented scope limit, not an oversight:
+/// `create_dir_all` transparently resolves through *any* existing symlink
+/// while walking to a missing descendant, including a legitimate one —
+/// `/tmp` and `/var` are themselves symlinks on macOS, and are exactly the
+/// kind of ancestor a caller-supplied absolute path routinely passes
+/// through. Extending the atomic, no-symlink-anywhere check to every
+/// ancestor component was tried and reverted: it correctly refuses a
+/// symlink an attacker plants as an *interior* component of `target`'s
+/// own not-yet-created path, but it identically refuses `/var` on every
+/// macOS host, which is not an attack. The residual this leaves — a
+/// symlink planted at an ancestor of `target` that does not exist yet —
+/// is narrower and lower-impact than the leaf-level attacks this module
+/// does close: it can only relocate *this migration's own* newly written
+/// ciphertext to a different physical directory the same configured
+/// `target` path would still consistently resolve through, never read an
+/// unrelated file that already exists elsewhere or overwrite one, which
+/// is what [`create_directory_component_atomically`] and [`read_bounded`]
+/// exist to prevent for the paths this function and its callers actually
+/// write into and read from.
 fn ensure_real_directory(path: &Path) -> Result<(), CopyError> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -68,7 +68,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -276,11 +276,20 @@ pub fn scan_object_root(root: &Path) -> Result<ScanReport, ScanError> {
             for inner_entry in read_dir_sorted(&top_entry.path())? {
                 bump(&mut scanned)?;
                 let inner_name = entry_name(&inner_entry)?;
-                let inner_is_dir = inner_entry
+                // A positive `is_file()` check, not a negative `!is_dir()`
+                // one: `DirEntry::file_type()` does not follow symlinks, so
+                // a symlink's type is neither "dir" nor "file". A negative
+                // check would let a symlink through as an "ordinary
+                // object" whenever its name happened to be hex-shaped --
+                // exactly the case a removable/synced folder makes
+                // plausible (VLT-PM50 §7) -- and this crate never opens an
+                // object it has classified as ordinary; `copy_object_tree`
+                // does, and must draw the identical line (below).
+                let inner_is_file = inner_entry
                     .file_type()
                     .map_err(|_| ScanError::ReadFailed)?
-                    .is_dir();
-                if !inner_is_dir && (is_hex_name(&inner_name) || is_hex_tmp_name(&inner_name)) {
+                    .is_file();
+                if inner_is_file && (is_hex_name(&inner_name) || is_hex_tmp_name(&inner_name)) {
                     report.ordinary_objects += 1;
                 } else {
                     report.warnings.push(InterferenceWarning {
@@ -358,6 +367,15 @@ pub enum CopyError {
     ObjectTooLarge,
     /// [`MAX_SCANNED_ENTRIES`] was exceeded.
     TooManyEntries,
+    /// A symlink was found exactly where this function needs a real file or
+    /// directory: a bucket directory, an object file being read, or the
+    /// exact path this function is about to create. Refused rather than
+    /// followed, because `source`/`target` are exactly the directories a
+    /// third-party sync tool or a second machine sharing removable media may
+    /// also write to (VLT-PM50 §7) -- a planted symlink there could
+    /// otherwise redirect a read to an arbitrary file this process can see,
+    /// or a write to overwrite one.
+    UnexpectedSymlink,
 }
 
 impl std::fmt::Display for CopyError {
@@ -369,6 +387,7 @@ impl std::fmt::Display for CopyError {
             Self::Conflict => "vault-pm-storage-removable: immutability conflict",
             Self::ObjectTooLarge => "vault-pm-storage-removable: object too large",
             Self::TooManyEntries => "vault-pm-storage-removable: too many entries",
+            Self::UnexpectedSymlink => "vault-pm-storage-removable: unexpected symlink",
         })
     }
 }
@@ -399,13 +418,7 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
         ScanError::TooManyEntries => CopyError::TooManyEntries,
     })?;
 
-    fs::create_dir_all(target).map_err(|_| CopyError::TargetUnavailable)?;
-    if !fs::metadata(target)
-        .map_err(|_| CopyError::TargetUnavailable)?
-        .is_dir()
-    {
-        return Err(CopyError::TargetUnavailable);
-    }
+    ensure_real_directory(target)?;
 
     let mut report = CopyReport {
         source_warnings,
@@ -419,6 +432,12 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             .file_name()
             .into_string()
             .map_err(|_| CopyError::IoFailed)?;
+        // A positive `is_dir()` requirement on the *unfollowed* link type:
+        // `DirEntry::file_type()` reports a symlink's own type, never the
+        // type of what it points to, so a symlink can be neither `is_dir()`
+        // nor `is_file()` here and is silently excluded from the walk
+        // either way -- it is still visible in `source_warnings` above,
+        // since `scan_object_root` classifies it as an unexpected entry.
         if !bucket_entry
             .file_type()
             .map_err(|_| CopyError::IoFailed)?
@@ -428,7 +447,7 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             continue;
         }
         let target_bucket_dir = target.join(&bucket_name);
-        fs::create_dir_all(&target_bucket_dir).map_err(|_| CopyError::TargetUnavailable)?;
+        ensure_real_directory(&target_bucket_dir)?;
 
         for object_entry in fs::read_dir(bucket_entry.path()).map_err(|_| CopyError::IoFailed)? {
             let object_entry = object_entry.map_err(|_| CopyError::IoFailed)?;
@@ -437,13 +456,22 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
                 .file_name()
                 .into_string()
                 .map_err(|_| CopyError::IoFailed)?;
-            if object_entry
+            // Positive `is_file()`, not `!is_dir()`: the latter would let a
+            // symlink through whenever its name happened to be hex-shaped,
+            // and `read_bounded` below follows symlinks by design (it opens
+            // whatever `File::open` resolves to) -- so a symlink must never
+            // reach it. `source`/`target` are exactly the directories a
+            // third-party sync tool or a second machine may also write to
+            // (VLT-PM50 §7); a planted `<hex-name> -> /etc/shadow` symlink
+            // must never be silently read and copied as if it were an
+            // ordinary sealed object.
+            if !object_entry
                 .file_type()
                 .map_err(|_| CopyError::IoFailed)?
-                .is_dir()
+                .is_file()
                 || !is_hex_name(&object_name)
             {
-                continue; // `.tmp` writes and anything unexpected are skipped.
+                continue; // `.tmp` writes, symlinks, and anything else are skipped.
             }
             copy_one_object(
                 &object_entry.path(),
@@ -453,6 +481,30 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
         }
     }
     Ok(report)
+}
+
+/// Ensure `path` is a real (non-symlink) directory, creating it if absent.
+///
+/// Refuses rather than follows an existing symlink at `path`: `storage-fs`
+/// never creates one, so one being there already means something else
+/// wrote it, and blindly treating it as "the directory exists, proceed"
+/// (`fs::create_dir_all`'s own behavior, since its own re-check follows
+/// symlinks) would let a planted symlink redirect an entire bucket's worth
+/// of writes to an attacker-chosen location.
+fn ensure_real_directory(path: &Path) -> Result<(), CopyError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(CopyError::UnexpectedSymlink);
+            }
+            if metadata.is_dir() {
+                Ok(())
+            } else {
+                Err(CopyError::TargetUnavailable)
+            }
+        }
+        Err(_) => fs::create_dir_all(path).map_err(|_| CopyError::TargetUnavailable),
+    }
 }
 
 fn bump_copy(scanned: &mut usize) -> Result<(), CopyError> {
@@ -470,7 +522,10 @@ fn copy_one_object(
 ) -> Result<(), CopyError> {
     let source_bytes = read_bounded(source_path)?;
 
-    if let Ok(existing) = fs::metadata(target_path) {
+    if let Ok(existing) = fs::symlink_metadata(target_path) {
+        if existing.file_type().is_symlink() {
+            return Err(CopyError::UnexpectedSymlink);
+        }
         if existing.is_file() {
             let target_bytes = read_bounded(target_path)?;
             return if target_bytes == source_bytes {
@@ -485,7 +540,11 @@ fn copy_one_object(
 
     // Write-tmp-then-rename, the same discipline `storage-fs` itself uses,
     // so a crash mid-copy leaves either nothing or one fully written file at
-    // the final path, never a truncated one.
+    // the final path, never a truncated one. The staging name is
+    // predictable (this function's own fixed convention), so the file is
+    // opened with `create_new` -- which atomically refuses to follow or
+    // replace *anything* already at that path, symlink included, rather
+    // than the TOCTOU-prone "check then create" `File::create` would be.
     let mut staging_path: PathBuf = target_path.to_path_buf();
     let staged_name = format!(
         "{}.migrate-tmp",
@@ -495,8 +554,13 @@ fn copy_one_object(
             .ok_or(CopyError::IoFailed)?
     );
     staging_path.set_file_name(staged_name);
+    remove_stale_staging_file(&staging_path)?;
     {
-        let mut staging_file = File::create(&staging_path).map_err(|_| CopyError::IoFailed)?;
+        let mut staging_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staging_path)
+            .map_err(|_| CopyError::IoFailed)?;
         staging_file
             .write_all(&source_bytes)
             .map_err(|_| CopyError::IoFailed)?;
@@ -514,8 +578,44 @@ fn copy_one_object(
     Ok(())
 }
 
+/// Remove a non-symlink leftover at the fixed staging path from an
+/// interrupted previous attempt, so a retried migration stays idempotent.
+///
+/// A symlink found here is refused, not removed: only this function's own
+/// write path ever creates a regular file at this exact predictable name,
+/// so a symlink means something else placed it, and the caller's
+/// subsequent `create_new` must be allowed to refuse it rather than have
+/// this step silently clear the way.
+fn remove_stale_staging_file(staging_path: &Path) -> Result<(), CopyError> {
+    match fs::symlink_metadata(staging_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(CopyError::UnexpectedSymlink);
+            }
+            fs::remove_file(staging_path).map_err(|_| CopyError::IoFailed)
+        }
+        Err(_) => Ok(()),
+    }
+}
+
+/// Read `path`'s bytes, refusing rather than following a symlink there.
+///
+/// `source`/`target` (VLT-PM50 §7) are exactly the directories a
+/// third-party sync tool, a second machine sharing removable media, or a
+/// mirror configuration may also write to, so this is a real trust
+/// boundary: without this check a planted `<hex-name> -> /etc/shadow` (or
+/// any other file this process can read) would be opened, its bytes copied
+/// into `target` under an innocuous object name, and — if `target` is
+/// itself synced or cloud-backed — silently exfiltrated. Checking
+/// `symlink_metadata` (which does not follow the link) before `File::open`
+/// (which does) closes that path; the length bound is read from the same
+/// non-following call, so a symlink to a zero-reporting special file (e.g.
+/// `/dev/zero`) cannot bypass it either.
 fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
-    let metadata = fs::metadata(path).map_err(|_| CopyError::IoFailed)?;
+    let metadata = fs::symlink_metadata(path).map_err(|_| CopyError::IoFailed)?;
+    if metadata.file_type().is_symlink() {
+        return Err(CopyError::UnexpectedSymlink);
+    }
     if metadata.len() > MAX_COPY_OBJECT_BYTES {
         return Err(CopyError::ObjectTooLarge);
     }
@@ -775,6 +875,144 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Symlink attacks. `source`/`target` are exactly the directories a
+    // third-party sync tool, a second machine sharing removable media, or
+    // another vault's mirror configuration may also write to (VLT-PM50
+    // §7) -- these prove a planted symlink is refused rather than
+    // followed, on both the read and the write side.
+    // -----------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_object_in_source_is_never_read_or_copied() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let target = TempDir::new();
+        let secret = source.path().join("outside-the-object-tree.secret");
+        fs::write(&secret, b"arbitrary local file contents").unwrap();
+
+        let bucket_dir = source.path().join("2121");
+        fs::create_dir_all(&bucket_dir).unwrap();
+        // A hex-shaped name, so it would pass the naming check -- only the
+        // positive `is_file()` (not `!is_dir()`) requirement excludes it.
+        symlink(&secret, bucket_dir.join("aabbcc")).unwrap();
+        write_object(source.path(), "2121", "ddeeff", b"a real object");
+
+        let report = copy_object_tree(source.path(), target.path()).unwrap();
+        // Only the real object was copied; the symlink was skipped, not
+        // followed and copied under an innocuous object name.
+        assert_eq!(report.copied_objects, 1);
+        assert!(!target.path().join("2121").join("aabbcc").exists());
+        // It is still visible in the scan, exactly like any other
+        // unexpected entry -- never silently accepted as a clean object.
+        assert!(!report.source_warnings.is_clean());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_bucket_directory_in_source_is_never_descended_into() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let target = TempDir::new();
+        let elsewhere = TempDir::new();
+        write_object(
+            elsewhere.path(),
+            "9999",
+            "aabbcc",
+            b"not part of this vault",
+        );
+        // A hex-shaped bucket-level name pointing at an unrelated directory.
+        symlink(elsewhere.path(), source.path().join("2121")).unwrap();
+        write_object(source.path(), "3131", "ddeeff", b"a real object");
+
+        let report = copy_object_tree(source.path(), target.path()).unwrap();
+        assert_eq!(report.copied_objects, 1);
+        assert!(!target.path().join("2121").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_preexisting_symlinked_bucket_directory_in_target_is_refused() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let target = TempDir::new();
+        let elsewhere = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"object bytes");
+        fs::create_dir_all(target.path()).unwrap();
+        // Planted before the migration runs: a symlink standing in for the
+        // bucket directory `copy_object_tree` is about to write into.
+        symlink(elsewhere.path(), target.path().join("2121")).unwrap();
+
+        assert_eq!(
+            copy_object_tree(source.path(), target.path()),
+            Err(CopyError::UnexpectedSymlink)
+        );
+        // Nothing was written through the planted symlink.
+        assert!(fs::read_dir(elsewhere.path()).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_preexisting_symlinked_target_object_is_refused_not_read_through() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let target = TempDir::new();
+        let secret = TempDir::new();
+        fs::write(secret.path().join("shadow"), b"root:x:0:0").unwrap();
+        write_object(source.path(), "2121", "aabbcc", b"object bytes");
+        fs::create_dir_all(target.path().join("2121")).unwrap();
+        symlink(
+            secret.path().join("shadow"),
+            target.path().join("2121").join("aabbcc"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            copy_object_tree(source.path(), target.path()),
+            Err(CopyError::UnexpectedSymlink)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_top_level_target_is_refused() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let elsewhere = TempDir::new();
+        let parent = TempDir::new();
+        let target = parent.path().join("target-link");
+        symlink(elsewhere.path(), &target).unwrap();
+        write_object(source.path(), "2121", "aabbcc", b"object bytes");
+
+        assert_eq!(
+            copy_object_tree(source.path(), &target),
+            Err(CopyError::UnexpectedSymlink)
+        );
+        assert!(fs::read_dir(elsewhere.path()).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_flags_a_symlink_even_when_its_name_is_hex_shaped() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new();
+        write_object(root.path(), "2121", "aabbcc", b"real object");
+        let target_file = root.path().join("elsewhere.txt");
+        fs::write(&target_file, b"x").unwrap();
+        symlink(&target_file, root.path().join("2121").join("ddeeff")).unwrap();
+
+        let report = scan_object_root(root.path()).unwrap();
+        assert!(!report.is_clean());
+        assert_eq!(report.ordinary_objects, 1);
+    }
+
     #[test]
     fn missing_source_is_source_unavailable() {
         let source = TempDir::new();
@@ -837,6 +1075,7 @@ mod tests {
             CopyError::Conflict,
             CopyError::ObjectTooLarge,
             CopyError::TooManyEntries,
+            CopyError::UnexpectedSymlink,
         ] {
             assert!(error.to_string().starts_with("vault-pm-storage-removable"));
         }

--- a/code/packages/rust/vault-pm-storage-removable/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage-removable/src/lib.rs
@@ -473,6 +473,13 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
             {
                 continue; // `.tmp` writes, symlinks, and anything else are skipped.
             }
+            // Re-verified before every object, not only once per bucket: a
+            // concurrent writer to `target` (VLT-PM50 §7's own threat model)
+            // could otherwise remove the bucket directory this loop already
+            // validated and replace it with a symlink between two writes in
+            // the same bucket, and `copy_one_object`'s own checks only ever
+            // cover the leaf object/staging path, never this parent.
+            ensure_real_bucket_directory(&target_bucket_dir)?;
             copy_one_object(
                 &object_entry.path(),
                 &target_bucket_dir.join(&object_name),
@@ -486,47 +493,52 @@ pub fn copy_object_tree(source: &Path, target: &Path) -> Result<CopyReport, Copy
 /// Ensure `path` is a real (non-symlink) directory, creating it (and any
 /// missing parents) if absent.
 ///
-/// Refuses rather than follows an existing symlink at `path`: `storage-fs`
-/// never creates one, so one being there already means something else
-/// wrote it, and blindly treating it as "the directory exists, proceed"
-/// (`fs::create_dir_all`'s own behavior, since its own re-check follows
-/// symlinks) would let a planted symlink redirect an entire object root's
-/// worth of writes to an attacker-chosen location. Used only for `target`
-/// itself, a caller-supplied path this function's own retry cannot avoid
-/// re-checking non-atomically; [`ensure_real_bucket_directory`] is the
-/// atomic, race-free version used one level below it, where a plain
-/// `create_dir` suffices.
+/// Parent directories are created with the ordinary recursive
+/// `fs::create_dir_all` — `path`'s parents are not this function's leaf
+/// concern and, for the one caller that has any (`target` itself), are a
+/// caller-supplied location that pre-existed the migration far more often
+/// than not. `path` itself — the exact directory every subsequent object
+/// write in this bucket (or, for `target`, the whole migration) depends
+/// on — is created through [`create_directory_component_atomically`], so a
+/// symlink planted at that exact path cannot be silently followed the way
+/// `fs::create_dir_all`'s own re-check (which follows symlinks when
+/// deciding "the directory is already there, proceed") would follow one.
 fn ensure_real_directory(path: &Path) -> Result<(), CopyError> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => {
-            if metadata.file_type().is_symlink() {
-                return Err(CopyError::UnexpectedSymlink);
-            }
-            if metadata.is_dir() {
-                Ok(())
-            } else {
-                Err(CopyError::TargetUnavailable)
-            }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|_| CopyError::TargetUnavailable)?;
         }
-        Err(_) => fs::create_dir_all(path).map_err(|_| CopyError::TargetUnavailable),
     }
+    create_directory_component_atomically(path)
 }
 
-/// Ensure `bucket_dir` (always exactly one path component below an already
-/// validated `target`) is a real directory, creating it if absent.
-///
-/// Unlike [`ensure_real_directory`], this never needs `create_dir_all`'s
-/// recursive parent creation, so it can use the atomic, race-free
-/// `fs::create_dir` instead of the check-then-`create_dir_all` pattern:
-/// `create_dir` fails with `AlreadyExists` if *anything* — a symlink
-/// included — is already at that path, without ever following it, closing
-/// the narrow window between a separate existence check and the creation
-/// call that `ensure_real_directory` cannot fully close on its own.
+/// Same contract as [`ensure_real_directory`], for a directory that is
+/// always exactly one path component below an already-validated parent
+/// (a bucket directory below `target`) and therefore never needs
+/// `create_dir_all`'s recursive parent creation at all.
 fn ensure_real_bucket_directory(bucket_dir: &Path) -> Result<(), CopyError> {
-    match fs::create_dir(bucket_dir) {
+    create_directory_component_atomically(bucket_dir)
+}
+
+/// Atomically ensure exactly one directory path component is real,
+/// creating it if absent, without ever following a symlink there.
+///
+/// `fs::create_dir` fails with `AlreadyExists` if *anything* — a symlink
+/// included — is already at `path`, without ever following it. That is
+/// the whole of what makes this atomic against a concurrent writer:
+/// unlike a separate `symlink_metadata` check followed by a later
+/// `fs::create_dir_all`/`File::open` call, there is no window between
+/// "check" and "act" for a planted symlink to land in, because the one
+/// syscall this function's success path makes *is* the check. The
+/// `AlreadyExists` branch below runs only to classify an already-real
+/// directory as success and an already-present symlink as refusal; by
+/// the time it runs, `create_dir` itself has already unconditionally
+/// refused to create through or replace whatever is there.
+fn create_directory_component_atomically(path: &Path) -> Result<(), CopyError> {
+    match fs::create_dir(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            let metadata = fs::symlink_metadata(bucket_dir).map_err(|_| CopyError::IoFailed)?;
+            let metadata = fs::symlink_metadata(path).map_err(|_| CopyError::IoFailed)?;
             if metadata.file_type().is_symlink() {
                 Err(CopyError::UnexpectedSymlink)
             } else if metadata.is_dir() {
@@ -655,9 +667,19 @@ fn read_bounded(path: &Path) -> Result<Vec<u8>, CopyError> {
     if metadata.len() > MAX_COPY_OBJECT_BYTES {
         return Err(CopyError::ObjectTooLarge);
     }
-    let mut file = open_no_follow(path)?;
+    let file = open_no_follow(path)?;
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.read_to_end(&mut bytes)
+    // Capped during the read itself, not only checked afterward: the
+    // `symlink_metadata` length above is a snapshot, and a file a
+    // concurrent writer keeps appending to for the duration of this read
+    // (again, `source`/`target` are directories such a writer can reach,
+    // VLT-PM50 §7) could otherwise grow the allocation well past
+    // `MAX_COPY_OBJECT_BYTES` before the length is ever checked again.
+    // Reading one byte past the cap, rather than exactly at it, is what
+    // lets the length check below still distinguish "exactly at the
+    // bound" from "over it".
+    file.take(MAX_COPY_OBJECT_BYTES + 1)
+        .read_to_end(&mut bytes)
         .map_err(|_| CopyError::IoFailed)?;
     if bytes.len() as u64 > MAX_COPY_OBJECT_BYTES {
         return Err(CopyError::ObjectTooLarge);
@@ -1060,6 +1082,51 @@ mod tests {
             copy_object_tree(source.path(), &target),
             Err(CopyError::UnexpectedSymlink)
         );
+        assert!(fs::read_dir(elsewhere.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn ensure_real_directory_creates_nested_missing_parents() {
+        let root = TempDir::new();
+        let source = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"object bytes");
+        let deeply_nested_target = root.path().join("a").join("b").join("c");
+
+        let report = copy_object_tree(source.path(), &deeply_nested_target).unwrap();
+        assert_eq!(report.copied_objects, 1);
+        assert!(deeply_nested_target.join("2121").join("aabbcc").exists());
+
+        // Idempotent: a second run against the now-real, multi-level-deep
+        // target neither errors nor recreates anything.
+        let second = copy_object_tree(source.path(), &deeply_nested_target).unwrap();
+        assert_eq!(second.already_present, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_bucket_directory_replaced_with_a_symlink_between_writes_is_caught() {
+        use std::os::unix::fs::symlink;
+
+        let source = TempDir::new();
+        let target = TempDir::new();
+        let elsewhere = TempDir::new();
+        write_object(source.path(), "2121", "aabbcc", b"first object");
+        copy_object_tree(source.path(), target.path()).unwrap();
+        assert!(target.path().join("2121").join("aabbcc").exists());
+
+        // Simulate a concurrent writer swapping the bucket directory for a
+        // symlink after this migration already wrote into it once -- the
+        // exact window a once-per-bucket (rather than once-per-object)
+        // directory check would miss.
+        fs::remove_dir_all(target.path().join("2121")).unwrap();
+        symlink(elsewhere.path(), target.path().join("2121")).unwrap();
+
+        write_object(source.path(), "2121", "ddeeff", b"second object");
+        assert_eq!(
+            copy_object_tree(source.path(), target.path()),
+            Err(CopyError::UnexpectedSymlink)
+        );
+        // Nothing was written through the planted symlink.
         assert!(fs::read_dir(elsewhere.path()).unwrap().next().is_none());
     }
 

--- a/code/packages/rust/vault-pm-storage/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this package are documented here.
 
+## Unreleased
+
+### Added
+
+- `ReplicaSetObjectStore<P, M>`, VLT-PM00 §11.5's mirror decorator: publishes
+  every accepted `put_immutable` to a configured set of mirror stores after
+  the primary commit succeeds, never before and never gating it (§19.2).
+  `initialize` and `put_immutable` are best-effort on each mirror; `get` falls
+  back to mirrors when the primary reports the object missing or itself
+  errors. `list`, `stat`, `delete_unreferenced`, and `changes` are
+  primary-only in this slice.
+- `ReplicaHealth`, a per-mirror attempted/succeeded/last-error snapshot
+  exposed by `replica_health()`, so a caller (`storage check`) can report a
+  degraded replica from an observed failure rather than a guess.
+- `ReplicaSetObjectStore::single`, the zero-mirror construction used wherever
+  a caller does not need replication; passes the same 24-check conformance
+  suite as the store it wraps, unmodified.
+
+### Deferred
+
+- The explicit `sync --wait` ceremony and its configurable `one`/`all`/quorum
+  durability target (§19.2) — this slice's mirror writes are unconditionally
+  best-effort and asynchronous-in-spirit-but-synchronous-in-implementation
+  (no network I/O lives in this crate; a real network-backed mirror adapter
+  would need its own timeout policy).
+- Physical-delete propagation to mirrors, left to a future replica-aware GC
+  planner (§19.4) so a mirror never loses a still-referenced object ahead of
+  every device observing the pruning checkpoint.
+
 ## [0.1.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-storage/README.md
+++ b/code/packages/rust/vault-pm-storage/README.md
@@ -18,6 +18,10 @@ ancestry, and rollback anchors.
 - a deterministic thread-safe `InMemoryObjectStore`;
 - `FaultInjectingObjectStore`, including ambiguous-after-commit, stale-list,
   duplicate-list, typed-error, and corrupt-read actions;
+- `ReplicaSetObjectStore`, VLT-PM00 §11.5's mirror decorator: one primary plus
+  zero or more best-effort mirrors, write-time propagation that never blocks
+  or fails the primary commit, mirror read fallback, and a per-mirror
+  `ReplicaHealth` snapshot (§23 item 14);
 - `run_conformance_suite`, reusable by every future adapter; and
 - the embedded language-neutral `vault-pm-storage-v1.json` fixture.
 
@@ -58,13 +62,36 @@ The suite checks the baseline contract and compares optional operation behavior
 to the adapter's own capability report. Provider-specific sandbox tests remain
 necessary for authentication, quotas, and native consistency behavior.
 
+## Mirroring
+
+```rust
+use coding_adventures_vault_pm_storage::{InMemoryObjectStore, ReplicaSetObjectStore, VaultLocator, VaultObjectStore};
+
+let replicas = ReplicaSetObjectStore::new(
+    InMemoryObjectStore::new(),   // primary
+    vec![InMemoryObjectStore::new()], // mirrors
+);
+replicas.initialize(&VaultLocator::new([1; 32]))?;
+// Every put_immutable answers from the primary alone; mirror writes happen
+// afterward and never fail the call. Inspect replicas.replica_health() for
+// per-mirror attempted/succeeded counts and the most recent error, if any.
+# Ok::<(), coding_adventures_vault_pm_storage::StoreError>(())
+```
+
+`ReplicaSetObjectStore::single(store)` is the zero-mirror construction used
+everywhere a caller does not need replication; it is behaviorally identical to
+using the wrapped store directly and passes the same conformance suite.
+
+Deferred: the explicit `sync --wait` ceremony with a configurable
+`one`/`all`/quorum durability target, and physical-delete propagation to
+mirrors (left to a future replica-aware GC planner, VLT-PM00 §19.4).
+
 ## Deliberate exclusions
 
 This package has no filesystem, network, clock, process, environment, entropy,
 or key access. The `storage-core` bridge and concrete provider adapters belong
-in separate packages. Retry, caching, metrics, replica selection, commit
-publication, merge, and garbage collection also live above or beside this
-contract.
+in separate packages. Retry, caching, metrics, commit publication, merge, and
+garbage collection also live above or beside this contract.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-storage/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage/src/lib.rs
@@ -5,12 +5,16 @@
 //! feature here. A Google Drive adapter must not need to know whether bytes are
 //! a login item, a commit, or random padding.
 //!
-//! The crate contains three things:
+//! The crate contains four things:
 //!
 //! 1. [`VaultObjectStore`], the provider-neutral contract;
-//! 2. [`InMemoryObjectStore`], the deterministic executable model; and
+//! 2. [`InMemoryObjectStore`], the deterministic executable model;
 //! 3. [`FaultInjectingObjectStore`], which makes hostile storage behavior
-//!    repeatable in repository tests.
+//!    repeatable in repository tests; and
+//! 4. [`ReplicaSetObjectStore`], VLT-PM00 §11.5's mirror decorator: it
+//!    publishes every immutable write to one primary and zero or more
+//!    best-effort mirror replicas without letting a slow or unreachable
+//!    mirror block the primary commit (§19.2).
 //!
 //! The implementation has no I/O authority. Filesystem and cloud adapters live
 //! in separate packages and run [`run_conformance_suite`] against the same
@@ -916,6 +920,222 @@ impl<S: VaultObjectStore> VaultObjectStore for FaultInjectingObjectStore<S> {
     }
 }
 
+/// Per-mirror outcome counters kept by [`ReplicaSetObjectStore`].
+///
+/// A mirror's own error type is retained rather than collapsed to a bool so a
+/// caller (`storage check`, VLT-PM00 §23 item 14) can distinguish "briefly
+/// rate-limited" from "storage was reconfigured out from under us" without
+/// the decorator inventing a second error taxonomy.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReplicaHealth {
+    /// Total mirror operations attempted since construction.
+    pub attempted: u64,
+    /// Of those, the number that returned success.
+    pub succeeded: u64,
+    /// The most recent failure, or `None` if the last attempt succeeded or
+    /// none has been made yet.
+    pub last_error: Option<StoreError>,
+}
+
+impl ReplicaHealth {
+    /// Whether the most recent attempt against this mirror failed.
+    pub const fn is_degraded(&self) -> bool {
+        self.last_error.is_some()
+    }
+
+    fn record(&mut self, result: &Result<(), StoreError>) {
+        self.attempted = self.attempted.saturating_add(1);
+        match result {
+            Ok(()) => {
+                self.succeeded = self.succeeded.saturating_add(1);
+                self.last_error = None;
+            }
+            Err(error) => self.last_error = Some(error.clone()),
+        }
+    }
+}
+
+/// VLT-PM00 §11.5's `ReplicaSetObjectStore` decorator.
+///
+/// Wraps one authoritative primary store and zero or more mirror stores that
+/// receive the same immutable bytes. Two invariants this type exists to
+/// enforce, both straight from §19.2:
+///
+/// - **a local commit succeeds independently of remote availability** — every
+///   mutating call is answered from the primary alone; mirror writes happen
+///   *after* the primary call returns, and a mirror failure is recorded, not
+///   propagated; and
+/// - **replicas receive identical ciphertext objects** — mirrors are only
+///   ever given the exact bytes the primary just accepted, never a
+///   caller-chosen alternative, so a mirror cannot silently drift from the
+///   authoritative copy this decorator itself controls.
+///
+/// With zero configured mirrors this type is a transparent pass-through to
+/// the primary — `ReplicaSetObjectStore::single` is the ordinary
+/// no-replication construction used everywhere this crate's callers do not
+/// need §19.2 behavior.
+///
+/// **Deferred** (VLT-PM00 §23 item 14): the explicit `sync --wait` ceremony
+/// with a configurable `one`/`all`/quorum durability target, and treating a
+/// change feed rather than write-time propagation as the source of replica
+/// truth. What ships here is the write-time propagation and health
+/// accounting those richer features would be built on top of.
+pub struct ReplicaSetObjectStore<P, M = P> {
+    primary: P,
+    mirrors: Vec<M>,
+    health: Mutex<Vec<ReplicaHealth>>,
+}
+
+impl<P, M> ReplicaSetObjectStore<P, M> {
+    /// Wrap a primary with no mirrors — behaviorally identical to using `P`
+    /// directly.
+    pub fn single(primary: P) -> Self {
+        Self::new(primary, Vec::new())
+    }
+
+    /// Wrap a primary with an ordered, fixed set of mirrors.
+    pub fn new(primary: P, mirrors: Vec<M>) -> Self {
+        let health = mirrors.iter().map(|_| ReplicaHealth::default()).collect();
+        Self {
+            primary,
+            mirrors,
+            health: Mutex::new(health),
+        }
+    }
+
+    /// Borrow the authoritative primary store.
+    pub const fn primary(&self) -> &P {
+        &self.primary
+    }
+
+    /// Borrow the configured mirrors in publication order.
+    pub fn mirrors(&self) -> &[M] {
+        &self.mirrors
+    }
+
+    /// Return the number of configured mirrors.
+    pub fn mirror_count(&self) -> usize {
+        self.mirrors.len()
+    }
+
+    /// Snapshot each mirror's health in the same order as [`Self::mirrors`].
+    ///
+    /// `storage check` (VLT-PM00 §23 item 14) reports a replica as degraded
+    /// exactly when `is_degraded()` is true here — a real, observed failure,
+    /// never a guess based on elapsed time.
+    pub fn replica_health(&self) -> Vec<ReplicaHealth> {
+        self.health
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    fn record(&self, index: usize, result: &Result<(), StoreError>) {
+        if let Ok(mut health) = self.health.lock() {
+            if let Some(entry) = health.get_mut(index) {
+                entry.record(result);
+            }
+        }
+    }
+}
+
+impl<P, M> Debug for ReplicaSetObjectStore<P, M> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReplicaSetObjectStore")
+            .field("mirror_count", &self.mirrors.len())
+            .finish()
+    }
+}
+
+impl<P: VaultObjectStore, M: VaultObjectStore> VaultObjectStore for ReplicaSetObjectStore<P, M> {
+    fn initialize(&self, locator: &VaultLocator) -> Result<(), StoreError> {
+        self.primary.initialize(locator)?;
+        for (index, mirror) in self.mirrors.iter().enumerate() {
+            let result = mirror.initialize(locator);
+            self.record(index, &result);
+        }
+        Ok(())
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        self.primary.capabilities()
+    }
+
+    fn get(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectBytes>, StoreError> {
+        match self.primary.get(bucket, object) {
+            Ok(Some(bytes)) => Ok(Some(bytes)),
+            Ok(None) => Ok(self.read_fallback(bucket, object)),
+            Err(primary_error) => match self.read_fallback(bucket, object) {
+                Some(bytes) => Ok(Some(bytes)),
+                None => Err(primary_error),
+            },
+        }
+    }
+
+    fn stat(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectStat>, StoreError> {
+        self.primary.stat(bucket, object)
+    }
+
+    fn put_immutable(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+        bytes: &ObjectBytes,
+    ) -> Result<PutImmutableOutcome, StoreError> {
+        let outcome = self.primary.put_immutable(bucket, object, bytes)?;
+        for (index, mirror) in self.mirrors.iter().enumerate() {
+            let result = mirror.put_immutable(bucket, object, bytes).map(|_| ());
+            self.record(index, &result);
+        }
+        Ok(outcome)
+    }
+
+    fn list(
+        &self,
+        bucket: &BucketId,
+        cursor: Option<&ListCursor>,
+        limit: usize,
+    ) -> Result<ObjectPage, StoreError> {
+        self.primary.list(bucket, cursor, limit)
+    }
+
+    fn delete_unreferenced(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<DeleteOutcome, StoreError> {
+        // Deliberately primary-only. Propagating physical delete to mirrors
+        // is deferred alongside VLT-PM00 §19.4's replica-aware GC: a mirror
+        // that independently loses a still-referenced object before every
+        // device has observed the pruning checkpoint would violate that
+        // section's own retention rule, and getting that ordering right
+        // needs the GC planner, not this decorator, to own it.
+        self.primary.delete_unreferenced(bucket, object)
+    }
+
+    fn changes(&self, cursor: Option<&ChangeCursor>) -> Result<Option<ChangePage>, StoreError> {
+        self.primary.changes(cursor)
+    }
+}
+
+impl<P: VaultObjectStore, M: VaultObjectStore> ReplicaSetObjectStore<P, M> {
+    /// Try every mirror in order after the primary reported the object
+    /// missing or unavailable. VLT-PM00 §19.2: "read fallback verifies all
+    /// bytes" — the bytes returned here still pass through the same
+    /// content-addressed and AEAD verification every other object does one
+    /// layer up, so no extra verification duty belongs in a store that is
+    /// deliberately blind to what it stores.
+    fn read_fallback(&self, bucket: &BucketId, object: &ObjectId) -> Option<ObjectBytes> {
+        for mirror in &self.mirrors {
+            if let Ok(Some(bytes)) = mirror.get(bucket, object) {
+                return Some(bytes);
+            }
+        }
+        None
+    }
+}
+
 /// Summary returned by a successful adapter conformance run.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConformanceReport {
@@ -1537,6 +1757,200 @@ mod tests {
         let typed = failed_with("provider step", StoreError::Provider);
         assert_eq!(typed.error, Some(StoreError::Provider));
         assert!(!typed.to_string().contains("Provider"));
+    }
+
+    #[test]
+    fn single_mirror_free_replica_set_is_a_transparent_passthrough() {
+        let report = run_conformance_suite(|| {
+            ReplicaSetObjectStore::<InMemoryObjectStore>::single(InMemoryObjectStore::new())
+        })
+        .unwrap();
+        assert_eq!(report.checks, 24);
+        assert!(report.capabilities.change_feed);
+    }
+
+    #[test]
+    fn mirrored_replica_set_passes_shared_conformance_reading_through_primary() {
+        let report = run_conformance_suite(|| {
+            ReplicaSetObjectStore::new(
+                InMemoryObjectStore::new(),
+                vec![InMemoryObjectStore::new(), InMemoryObjectStore::new()],
+            )
+        })
+        .unwrap();
+        assert_eq!(report.checks, 24);
+    }
+
+    #[test]
+    fn put_propagates_identical_bytes_to_every_mirror() {
+        let replicas = ReplicaSetObjectStore::new(
+            InMemoryObjectStore::new(),
+            vec![InMemoryObjectStore::new(), InMemoryObjectStore::new()],
+        );
+        let locator = VaultLocator::new([1; 32]);
+        replicas.initialize(&locator).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(b"ciphertext".to_vec()).unwrap();
+        assert_eq!(
+            replicas.put_immutable(&bucket, &object, &body).unwrap(),
+            PutImmutableOutcome::Created
+        );
+        for mirror in replicas.mirrors() {
+            assert_eq!(mirror.get(&bucket, &object).unwrap(), Some(body.clone()));
+        }
+        for health in replicas.replica_health() {
+            assert_eq!(health.attempted, 2); // one initialize, one put
+            assert_eq!(health.succeeded, 2);
+            assert!(!health.is_degraded());
+        }
+    }
+
+    #[test]
+    fn primary_commit_succeeds_and_records_degraded_health_when_a_mirror_is_unreachable() {
+        let broken_mirror = FaultInjectingObjectStore::new(InMemoryObjectStore::new());
+        broken_mirror
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::Return(StoreError::Network),
+            })
+            .unwrap();
+        let replicas = ReplicaSetObjectStore::new(InMemoryObjectStore::new(), vec![broken_mirror]);
+        let locator = VaultLocator::new([1; 32]);
+        replicas.initialize(&locator).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(b"ciphertext".to_vec()).unwrap();
+
+        // The primary commit succeeds even though the mirror is about to
+        // fail -- VLT-PM00 §19.2's "a local commit succeeds independently of
+        // remote availability".
+        assert_eq!(
+            replicas.put_immutable(&bucket, &object, &body).unwrap(),
+            PutImmutableOutcome::Created
+        );
+        let health = replicas.replica_health();
+        assert_eq!(health.len(), 1);
+        assert!(health[0].is_degraded());
+        assert_eq!(health[0].last_error, Some(StoreError::Network));
+        assert_eq!(health[0].attempted, 2);
+        assert_eq!(health[0].succeeded, 1); // the earlier initialize
+
+        // A later successful mirror write clears the degraded flag.
+        let second_object = ObjectId::new([4; 32]);
+        replicas
+            .put_immutable(&bucket, &second_object, &body)
+            .unwrap();
+        let recovered = replicas.replica_health();
+        assert!(!recovered[0].is_degraded());
+        assert_eq!(recovered[0].attempted, 3);
+        assert_eq!(recovered[0].succeeded, 2);
+    }
+
+    #[test]
+    fn get_falls_back_to_a_mirror_when_the_primary_is_missing_or_unavailable() {
+        let primary = InMemoryObjectStore::new();
+        let mirror = InMemoryObjectStore::new();
+        let locator = VaultLocator::new([1; 32]);
+        primary.initialize(&locator).unwrap();
+        mirror.initialize(&locator).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(b"mirror-only".to_vec()).unwrap();
+        // The object exists only on the mirror -- e.g. a write that reached
+        // the mirror before a primary that later lost the object entirely.
+        mirror.put_immutable(&bucket, &object, &body).unwrap();
+
+        let faulting_primary = FaultInjectingObjectStore::new(primary);
+        faulting_primary.initialize(&locator).unwrap();
+        let replicas = ReplicaSetObjectStore::new(faulting_primary, vec![mirror]);
+
+        // Ordinary miss: primary answers `None`, fallback finds the mirror copy.
+        assert_eq!(replicas.get(&bucket, &object).unwrap(), Some(body.clone()));
+
+        // Primary itself errors (e.g. a removable drive briefly unplugged):
+        // fallback still serves the mirror copy rather than surfacing the
+        // primary's error when a good answer exists.
+        replicas
+            .primary()
+            .enqueue(FaultAction {
+                operation: StoreOperation::Get,
+                effect: FaultEffect::Return(StoreError::Network),
+            })
+            .unwrap();
+        assert_eq!(replicas.get(&bucket, &object).unwrap(), Some(body));
+
+        // Neither store has this one: the primary's real error surfaces.
+        let absent = ObjectId::new([9; 32]);
+        replicas
+            .primary()
+            .enqueue(FaultAction {
+                operation: StoreOperation::Get,
+                effect: FaultEffect::Return(StoreError::Network),
+            })
+            .unwrap();
+        assert_eq!(replicas.get(&bucket, &absent), Err(StoreError::Network));
+    }
+
+    #[test]
+    fn delete_and_changes_and_stat_and_capabilities_delegate_to_primary_only() {
+        let primary = InMemoryObjectStore::new();
+        let mirror = InMemoryObjectStore::new();
+        let locator = VaultLocator::new([1; 32]);
+        let replicas = ReplicaSetObjectStore::new(primary, vec![mirror]);
+        replicas.initialize(&locator).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(vec![9]).unwrap();
+        replicas.put_immutable(&bucket, &object, &body).unwrap();
+
+        assert_eq!(replicas.capabilities(), BackendCapabilities::in_memory());
+        assert!(replicas.stat(&bucket, &object).unwrap().is_some());
+        assert!(replicas.changes(None).unwrap().is_some());
+        assert_eq!(
+            replicas.delete_unreferenced(&bucket, &object).unwrap(),
+            DeleteOutcome::Deleted
+        );
+        // The delete never reached the mirror -- deliberately deferred to a
+        // future replica-aware GC planner (VLT-PM00 §19.4).
+        assert_eq!(
+            replicas.mirrors()[0].get(&bucket, &object).unwrap(),
+            Some(body)
+        );
+    }
+
+    #[test]
+    fn health_snapshot_is_empty_for_a_mirror_free_replica_set_and_debug_is_closed() {
+        let replicas =
+            ReplicaSetObjectStore::<InMemoryObjectStore>::single(InMemoryObjectStore::new());
+        assert!(replicas.replica_health().is_empty());
+        assert_eq!(replicas.mirror_count(), 0);
+        let debug = format!("{replicas:?}");
+        assert!(debug.contains("mirror_count: 0"));
+    }
+
+    #[test]
+    fn primary_failure_still_fails_the_call_even_with_healthy_mirrors() {
+        let faulting_primary = FaultInjectingObjectStore::new(InMemoryObjectStore::new());
+        let replicas =
+            ReplicaSetObjectStore::new(faulting_primary, vec![InMemoryObjectStore::new()]);
+        replicas.initialize(&VaultLocator::new([1; 32])).unwrap();
+        replicas
+            .primary()
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::Return(StoreError::Quota),
+            })
+            .unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(vec![1]).unwrap();
+        assert_eq!(
+            replicas.put_immutable(&bucket, &object, &body),
+            Err(StoreError::Quota)
+        );
+        // The primary's own rejection means the mirror is never attempted.
+        assert_eq!(replicas.replica_health()[0].attempted, 1); // only initialize
     }
 
     #[test]

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Command surface gains `storage add|list|check|migrate`
+  (`VLT-PM50-cli-storage-migration.md`, `VLT-PM00` §23 item 14, the last item
+  of Phase 1B). Added `real_cli_storage_add_check_and_migrate_a_real_vault`
+  to `tests/local_cli_e2e.rs`: registers a new filesystem storage location
+  through the real binary, confirms `storage check` reports it unreachable
+  before it is ever materialized, migrates a real on-disk vault onto it
+  through a real pseudo-terminal passphrase prompt, confirms the item
+  created before the migration is still readable afterward, and drops a
+  real Syncthing-style `.sync-conflict-` filename into the migrated
+  location's object directory to prove `storage check` detects and reports
+  it — with the offending filename itself never appearing anywhere in the
+  report.
+
 - Command surface gains `import portable|bitwarden|csv|kdbx FILE`
   (`VLT-PM49-cli-external-import.md`), replacing the old bare
   `import FILE`. Added `real_cli_imports_bitwarden_json_and_leaks_no_secret_

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -54,7 +54,18 @@ vault-pm [--vault NAME] conflict merge api-key ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge database-credential ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge totp ITEM BASE_REVISION
 vault-pm [--vault NAME] conflict merge opaque ITEM BASE_REVISION
+vault-pm storage add filesystem|removable NAME PATH
+vault-pm storage list
+vault-pm storage check NAME
+vault-pm [--vault NAME] storage migrate SOURCE TARGET [--mirror]
 ```
+
+`storage add|list|check` take no `--vault` selector — they read or extend
+configuration itself, not one vault's contents. `storage migrate` does take
+one, because it is the verb that rewrites a vault's `local_store`/
+`remote_stores`. `gdrive`/`webdav`/`s3` still parse for `storage add` and
+always fail closed with the unsupported class before touching configuration
+— Phase 2's job, the same closed-grammar answer `import kdbx` already gets.
 
 `password generate` is the one exception to everything below: it opens no
 vault, takes no `--vault` selector, collects no passphrase, and runs on a home
@@ -195,6 +206,21 @@ anywhere under the platform roots, so the store holds ciphertext and metadata
 alike. A refusal at the export prompt writes no file at all and still leaves a
 denied row in the audit chain. And the chain names neither the attachment nor
 its bytes.
+
+## Removable storage and migration, end to end through the real executable
+
+`storage add`/`storage list` need no pseudo-terminal at all — they take no
+passphrase and touch no vault — so the drill runs them as plain child
+processes. `storage migrate` does need one: its confirmation is a real
+independent unlock of the migrated copy under the vault's real passphrase,
+proven the same way every other authenticated command's prompt is. The drill
+registers a new filesystem location, confirms `storage check` reports it
+`unreachable` before it is ever materialized (no vault opened, no prompt
+issued), migrates a real on-disk vault onto it, confirms the item created
+before the migration is still readable afterward, then drops a real
+Syncthing-style `.sync-conflict-` filename into the migrated location's
+object directory and confirms `storage check` both detects it and never
+prints the offending filename itself anywhere in its report.
 
 ## The crash/fault drill
 

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -3174,3 +3174,81 @@ fn real_cli_imports_bitwarden_json_and_leaks_no_secret_anywhere() {
     assert!(!kdbx_result.status.success());
     assert!(stdout_string(&kdbx_result).is_empty());
 }
+
+fn first_subdirectory(root: &Path) -> PathBuf {
+    fs::read_dir(root)
+        .unwrap()
+        .flatten()
+        .find(|entry| entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false))
+        .map(|entry| entry.path())
+        .expect("a migrated storage root must contain at least one bucket directory")
+}
+
+/// VLT-PM00 §23 item 14, through the real executable with a real PTY:
+/// `storage add`/`storage list` are entirely non-interactive; `storage check`
+/// reports an unreachable, not-yet-materialized location without opening any
+/// vault or prompting; `storage migrate` prompts for the vault's real
+/// passphrase (its confirmation ceremony is a real independent unlock of the
+/// migrated copy) and switches the vault onto the new location while leaving
+/// its item readable; and a real third-party sync tool's conflict-copy
+/// naming convention dropped into the migrated location's object directory
+/// is detected and reported by `storage check`, with the offending filename
+/// itself never appearing anywhere in the report.
+#[test]
+fn real_cli_storage_add_check_and_migrate_a_real_vault() {
+    let home = TestHome::new();
+    assert!(run_init_in_pty(&home).0.success());
+    let (added_item_status, _) = run_add_secure_note_in_pty(&home);
+    assert!(added_item_status.success());
+
+    let new_location = home.0.join("new-primary-storage");
+    let added = run_plain(
+        &home,
+        &[
+            "storage",
+            "add",
+            "filesystem",
+            "new",
+            new_location.to_str().expect("UTF-8 test path"),
+        ],
+    );
+    assert!(added.status.success(), "{}", stdout_string(&added));
+    let listed = run_plain(&home, &["storage", "list"]);
+    assert!(listed.status.success(), "{}", stdout_string(&listed));
+    assert!(stdout_string(&listed).contains("new\tfilesystem\t"));
+    assert!(stdout_string(&listed).contains("local\tfilesystem\t"));
+
+    let unreachable = run_plain(&home, &["storage", "check", "new"]);
+    assert!(!unreachable.status.success());
+    assert!(stdout_string(&unreachable).contains("unreachable"));
+
+    let (migrated_status, migrated_transcript) = run_unlock_in_pty(
+        &home,
+        &["storage", "migrate", "local", "new"],
+        b"Storage migrated.",
+    );
+    assert!(migrated_status.success(), "{migrated_transcript}");
+    assert_transcript_excludes_secrets(&migrated_transcript);
+
+    let (listed_after_status, listed_after_transcript) =
+        run_unlock_in_pty(&home, &["item", "list"], b"Recovery note");
+    assert!(listed_after_status.success(), "{listed_after_transcript}");
+
+    let healthy = run_plain(&home, &["storage", "check", "new"]);
+    assert!(healthy.status.success(), "{}", stdout_string(&healthy));
+    assert_eq!(stdout_string(&healthy), "Storage new: healthy\n");
+
+    let bucket_dir = first_subdirectory(&new_location);
+    fs::write(bucket_dir.join("deadbeef"), b"not a real object").unwrap();
+    fs::write(
+        bucket_dir.join("deadbeef.sync-conflict-20260819-000000-ABCDEFG"),
+        b"not a real object",
+    )
+    .unwrap();
+    let dirty = run_plain(&home, &["storage", "check", "new"]);
+    assert!(!dirty.status.success());
+    let dirty_stdout = stdout_string(&dirty);
+    assert!(dirty_stdout.contains("sync_interference_detected"));
+    assert!(dirty_stdout.contains("conflict_copy: 1"));
+    assert!(!dirty_stdout.contains("sync-conflict-20260819"));
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -903,10 +903,10 @@ vault-pm attachment remove ITEM ATTACHMENT
 vault-pm import portable|bitwarden|kdbx|csv PATH
 vault-pm export portable PATH
 
-vault-pm storage add filesystem|gdrive|webdav|s3 NAME
+vault-pm storage add filesystem|removable|gdrive|webdav|s3 NAME PATH
 vault-pm storage list
 vault-pm storage check NAME
-vault-pm storage migrate SOURCE TARGET [--mirror]
+vault-pm [--vault NAME] storage migrate SOURCE TARGET [--mirror]
 
 vault-pm sync status|pull|push|run
 vault-pm audit enable
@@ -921,8 +921,10 @@ existing vault. It is command-scoped and never rewrites `default_vault`.
 Phase 1A implements `init`, `status`, `shell`, item CRUD/list, search, history,
 portable export, audit verification, and `doctor`. `password generate`,
 `totp code`, and the attachment commands are Phase 1B daily-use conveniences
-(§23 item 11), as are the import adapters (§23 item 13).
-Cloud/storage migration commands activate in Phase 2.
+(§23 item 11), as are the import adapters (§23 item 13) and the local
+`storage add|list|check|migrate` surface for the `filesystem`/`removable`
+kinds (§23 item 14). `storage add|migrate` against `gdrive`/`webdav`/`s3`,
+and `sync status|pull|push|run`, activate in Phase 2.
 
 **Item 11 has since shipped in full.** All four of its conveniences —
 `password generate`, `totp code`, `--copy`, and the attachment commands — are
@@ -2005,7 +2007,46 @@ changelog, focused build, and downstream validation.
       and CSV ones this slice already reviews, judged too large to
       review well alongside them in one PR even though this workspace
       already has the Argon2d/AES/ChaCha20 primitives it would need.
-14. removable/synced-folder mode and mirror decorator.
+14. removable/synced-folder mode and mirror decorator. **Has shipped**, as
+      `VLT-PM50-cli-storage-migration.md` — the last item of Phase 1B.
+      `storage add filesystem|removable NAME PATH`, `storage list`,
+      `storage check NAME`, and `storage migrate SOURCE TARGET [--mirror]`
+      are all real: `removable` is a variant of `filesystem` sharing the
+      identical on-disk `storage-fs` object format, distinguished only by
+      `vault-pm-storage-removable`'s new structural detector for
+      third-party sync-tool conflict-copy naming (Dropbox/OneDrive-style
+      "conflicted copy", Syncthing's `.sync-conflict-` infix,
+      Explorer/rclone's `" (N)"` suffix), reported as bounded counts by
+      closed classification with no raw filename ever echoed anywhere.
+      `storage migrate` implements §19.1's filesystem-family slice in
+      full: `copy_object_tree` copies and read-back-verifies every
+      committed object, and the freshly collected passphrase is used to
+      independently unlock the copy over a repository factory pointed only
+      at its objects before configuration is ever touched — a wrong
+      passphrase or a corrupt copy both fail that exact step, which is
+      simultaneously step 6's independent verification and step 7's
+      "explicit confirmation," reusing the existing unlock ceremony rather
+      than inventing a second one. `--mirror` adds the target to
+      `remote_stores` instead of switching `local_store`, and every
+      repository this composition root opens now runs through the new
+      `vault-pm-storage::ReplicaSetObjectStore` decorator (§11.5) — a
+      verified no-op with zero configured mirrors, real best-effort
+      write-time propagation to one or more when a vault has them, so a
+      mirrored vault keeps replicating on every later mutation, not only
+      at migration time. Checked directly against the real code before
+      writing any of it (this campaign's now-standard practice, since the
+      reuse map's storage/crypto rows have been wrong before): none of
+      §11.5's other listed decorators (`RetryingObjectStore`,
+      `RateLimitedObjectStore`, `CachingObjectStore`,
+      `MetricsObjectStore`) exist anywhere in this workspace either, and
+      `storage migrate`/`add`/`list`/`check` had no prior partial
+      implementation to extend — the whole surface was built here. The
+      `sync --wait` ceremony with a configurable `one`/`all`/quorum
+      durability target, change-feed-based replica reconciliation
+      (`storage check`'s replica status is an explicitly-labeled
+      object-count heuristic instead), physical-delete propagation to
+      mirrors, and the cloud storage kinds are explicitly deferred to
+      Phase 2 rather than silently unimplemented.
 
 ### Phase 2 — cloud
 

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -1,0 +1,462 @@
+# VLT-PM50 — Removable/Synced-Folder Mode and the Mirror Decorator
+
+## Status
+
+Normative Phase 1B contract for VLT-PM00 §23 item 14, "removable/
+synced-folder mode and mirror decorator" — the last item of Phase 1B.
+Ships `storage add|list|check|migrate`, `StorageKind::Removable`,
+`vault-pm-storage-removable`'s conflict-copy detector and migration-copy
+helper, and `vault-pm-storage::ReplicaSetObjectStore`. §9 records what is
+explicitly deferred and why, and §10 checks Phase 1B's completion against
+the master spec.
+
+## 1. Purpose
+
+VLT-PM00 §12's backend table lists `removable/synced folder` as its own
+row, right beside `filesystem`, both Phase 1(B):
+
+| Backend | Phase | Notes |
+|---|---:|---|
+| filesystem | 1 | same immutable format as cloud |
+| removable/synced folder | 1B | warn about third-party sync conflict copies |
+
+The two rows share the exact on-disk object format
+(`coding_adventures_storage_fs`'s `<root>/<hex namespace>/<hex key>`
+layout). `removable` is not a new transport — it is the same filesystem
+backend used inside a directory a *third-party* tool also writes to:
+Dropbox, OneDrive, Syncthing, a NAS client's sync agent, or a literal USB
+drive carried between machines and opened by more than one without
+coordination. None of those tools know vault-pm's immutable-object
+invariant, and every mainstream one resolves a same-name write collision
+by keeping *both* files under different names rather than overwriting —
+that renaming convention is the detectable signature this slice looks
+for.
+
+§11.5 separately lists `ReplicaSetObjectStore` among the storage
+decorators: "publish local objects to configured remote replicas." §19.1
+already specifies `storage migrate SOURCE TARGET [--mirror]`'s seven
+steps in full, and §19.2 gives the mirroring semantic contract: replicas
+receive identical ciphertext, a local commit succeeds independently of
+remote availability, and a replica never gains plaintext. This item's job
+is to make both of those real.
+
+## 2. What already existed, checked against the real code before writing
+##    any of this
+
+Per this campaign's standing finding that the reuse map is right about
+pure-parsing reuse and wrong about crypto/storage-layer reuse, both
+claims below were verified against the actual workspace, not assumed
+from §6's/§11's table text.
+
+- **`storage migrate`/`storage add`/`storage check` were entirely
+  unimplemented.** `vault-pm-cli`'s `Command` enum had no `Storage*`
+  variant; the four verbs existed only in §14.4's documentation and in
+  the fixed `USAGE` string as absent lines. There was no partial
+  `migrate` missing only `--mirror` to build on — the whole surface
+  needed building.
+- **None of §11.5's decorators except `FaultInjectingObjectStore`
+  existed anywhere in the workspace.** `grep`ing for
+  `RetryingObjectStore`, `RateLimitedObjectStore`, `MetricsObjectStore`,
+  `ReplicaSetObjectStore`, and `CachingObjectStore` across
+  `code/packages` and `code/programs` found zero implementations —
+  every one of those names appeared only in `VLT-PM00`'s own §11.5 table
+  text. `vault-pm-storage` (VLT-PM02's storage crate) already contains
+  exactly the pattern a new decorator should follow:
+  `FaultInjectingObjectStore<S>` wraps any `S: VaultObjectStore` and
+  passes the same `run_conformance_suite` the wrapped store does. §4
+  below is `ReplicaSetObjectStore<P, M>`, built the same way, in the
+  same crate.
+- **`vault-pm-repository::RepositoryAddress::derive`** — the function
+  that turns a 32-byte key into the two `BucketId`s (`object_bucket`,
+  `announcement_bucket`) a vault's repository actually uses — takes
+  `keys.locator_key()`, i.e. **key material available only after
+  unlocking**, not the plaintext locator visible in configuration. A
+  storage-level migration tool therefore cannot legitimately enumerate
+  "which buckets does this vault use" without first authenticating,
+  which would make `storage migrate` an application-layer operation
+  wrapping a storage-layer one. §19.3 already resolves this the other
+  way for backups ("byte-for-byte encrypted object repository; safe to
+  mirror") — a storage migration works below the bucket-ID boundary,
+  on the raw content-blind directory tree, exactly like a filesystem
+  `cp -r` would. §5 below follows that precedent: `copy_object_tree`
+  copies files, not buckets, and needs no vault-pm-format or
+  vault-pm-repository dependency at all.
+- **`configured_vault` (in `vault-pm-cli`) hardcoded a vault's storage
+  location to one of exactly two paths** the composition root itself
+  creates (the default `paths.object_root()`, or a named target's
+  `paths.object_root()/targets/<locator-hex>`). That restriction
+  predates `storage add` existing — there was no way to point a vault
+  anywhere else — and had to be relaxed for this item to do anything at
+  all (§6.1).
+
+## 3. Config schema: `StorageKind::Removable`
+
+`coding_adventures_vault_pm_config::StorageKind` gains a fourth variant,
+`Removable` (`kind = "removable"` in TOML, alongside the existing
+`filesystem`/`gdrive`/`webdav`/`s3`). It is constructed, validated, and
+rendered by the exact same closed-schema machinery as `Filesystem` — no
+new required field. `StorageKind::is_local_directory()` reports `true`
+for `Filesystem` and `Removable` and `false` for the three cloud kinds,
+so every call site that needs to say "this is an ordinary local directory
+tree" (the storage-location checks below, `storage add`'s kind gate)
+names one predicate instead of enumerating two variants each time.
+
+`removable` carries no on-disk difference from `filesystem` — the same
+`coding_adventures_storage_fs::FsStorageBackend` opens either. The only
+place the distinction matters operationally is that a `removable`
+location is *expected* to occasionally show sync-tool interference in
+ordinary use, where a `filesystem` location (exclusively written by this
+product) finding the same pattern is more surprising. V1 does not encode
+that expectation anywhere machine-readable (`storage check`'s report
+shape is identical for both kinds); it exists only as the documented
+reason a person would choose `removable` over `filesystem` when running
+`storage add`.
+
+## 4. The mirror decorator: `ReplicaSetObjectStore<P, M>`
+
+Added to `coding_adventures_vault_pm_storage` (VLT-PM02's storage crate),
+next to `FaultInjectingObjectStore`, implementing the same
+`VaultObjectStore` contract:
+
+```rust
+pub struct ReplicaSetObjectStore<P, M = P> { /* primary: P, mirrors: Vec<M>, .. */ }
+
+impl<P, M> ReplicaSetObjectStore<P, M> {
+    pub fn single(primary: P) -> Self;      // zero mirrors
+    pub fn new(primary: P, mirrors: Vec<M>) -> Self;
+    pub fn replica_health(&self) -> Vec<ReplicaHealth>;
+}
+```
+
+Behavior, matching §19.2 exactly:
+
+- **`initialize`/`put_immutable`**: the primary call must succeed and its
+  result is what the caller sees. Only *after* it succeeds does each
+  mirror get the identical call, best-effort — a mirror's failure is
+  recorded in its `ReplicaHealth` (`attempted`/`succeeded`/`last_error`)
+  and never returned to the caller. This is §19.2's "a local commit
+  succeeds independently of remote availability," literally: the mirror
+  call cannot even begin until the primary one has already returned
+  success.
+- **`get`**: primary first; if the primary reports the object missing or
+  itself errors, each mirror is tried in order and the first hit is
+  returned. This is §19.2's "read fallback verifies all bytes" read the
+  way this content-blind layer can honor it: the bytes returned still
+  pass through the same content-addressed/AEAD verification one layer up
+  regardless of which store answered, so no second verification duty
+  belongs here.
+- **`list`/`stat`/`delete_unreferenced`/`changes`**: primary-only in this
+  slice (§9).
+- **`ReplicaSetObjectStore::single(store)`** (zero mirrors) is a verified
+  transparent pass-through — it passes the shared 24-check conformance
+  suite identically to the wrapped store, so every existing caller that
+  predates this item sees no behavior change.
+
+## 5. `vault-pm-storage-removable`: detection and migration copy
+
+A new crate, `code/packages/rust/vault-pm-storage-removable`
+(`coding_adventures_vault_pm_storage_removable`), owning the one piece of
+real filesystem I/O this item needs, kept out of `vault-pm-storage`
+itself (which the crate's own module documentation states has "no I/O
+authority").
+
+### 5.1 `scan_object_root(root) -> Result<ScanReport, ScanError>`
+
+Walks `root` and classifies every entry against `storage-fs`'s own
+naming shape (even-length lowercase hex; bucket directories at the top
+level, object files — or a `<hex>.tmp` in-flight write, cleaned up by the
+real backend's own `initialize` — one level down). Anything that does not
+match is a warning, classified by *name shape only* (never content) into:
+
+- `ConflictCopy` — contains `"conflict"` case-insensitively (covers
+  Dropbox's, OneDrive's, and Google Drive Desktop's `"... conflicted
+  copy ..."` wording), Syncthing's fixed `.sync-conflict-<timestamp>-`
+  infix, or Explorer/Finder/rclone's bare `" (N)"` duplicate-count
+  suffix.
+- `HiddenMetadata` — `.DS_Store`, `Thumbs.db`, `desktop.ini`, a
+  LibreOffice `.~lock.*#` file, or any other leading-dot name that is not
+  this backend's own `<hex>.tmp`.
+- `PartialTransfer` — `.crdownload`, `.part`, `.filepart`, `.download`,
+  or a `~`-prefixed editor swap file.
+- `Unknown` — present, not `.tmp`, matches none of the above.
+
+**No raw filename ever appears in `ScanReport`, an error, or any `Debug`
+output.** A third-party sync tool's filename is attacker-adjacent input
+the moment a vault is shared or synced anywhere outside one machine, and
+this codebase's established convention — `vault-pm-storage`'s own
+redacted `Debug` impls, its closed `StoreError` taxonomy carrying no
+input bytes — is to never echo attacker-controlled text into a terminal,
+log, or error. `ScanReport` exposes only bounded counts by closed
+classification (`count_of(kind)`); the CLI (§7) renders those counts and
+nothing else.
+
+This is deliberately a *structural*, non-cryptographic check. §7.1's
+"malicious storage service" adversary (reorders/duplicates/corrupts/
+withholds/deletes/replays objects) is already covered by object-ID
+content addressing, AEAD, and signatures at the repository/application
+layers above this one; reimplementing content verification here would
+duplicate that coverage while breaking `storage-fs`'s own documented
+"opaque to record content" boundary for no additional real protection.
+This crate's whole job is narrower: notice the *ordinary*, non-
+adversarial mess a sync tool leaves behind, and say so.
+
+### 5.2 `copy_object_tree(source, target) -> Result<CopyReport, CopyError>`
+
+The storage-level half of `storage migrate` (§19.1 steps 2-4). Scans
+`source` first (§5.1, carried in the report rather than blocking the
+copy — a "dirty" source directory is exactly the situation `storage
+migrate` off a flaky synced folder exists to get a vault *out of*), then
+for every hex-shaped `<bucket>/<object>` file: write-tmp-then-rename into
+`target` (the same durability discipline `storage-fs` itself uses),
+**read the written bytes back and compare them to the source bytes before
+counting the object copied** (§19.1 step 4, "reads/stat-verifies target
+objects"). An object already present in `target` with byte-identical
+content is skipped and counted separately (`already_present`), so
+re-running an interrupted migration is safe; one present with *different*
+bytes is `CopyError::Conflict` and aborts rather than silently
+overwriting — a genuine immutability violation between two stores that
+are each individually supposed to be append-only. `source` is never
+modified or deleted.
+
+## 6. CLI wiring
+
+### 6.1 `configured_vault` relaxation
+
+`configured_vault`'s storage-location check (§2) changes from "kind is
+exactly `Filesystem` and location is exactly one of two fixed paths" to
+"kind's `is_local_directory()` is true and credential_ref is `none`" —
+any registered `filesystem`/`removable` location, not just the two this
+composition root creates for itself. The cross-vault collision check
+(two different vaults must not share one exact filesystem location)
+is preserved, generalized the same way. `remote_stores` (VLT-PM07's
+existing but previously always-empty replica list field) is no longer
+rejected outright: every named remote must itself resolve to a
+local-directory-kind, no-credential storage entry, the same rule as the
+primary. A cloud primary or a cloud mirror both stay `Unsupported` —
+Phase 2's job either way.
+
+### 6.2 Every repository now opens through `ReplicaSetObjectStore`
+
+`repository_factory`/`configured_repository_factory` build
+`ReplicaSetObjectStore::single(primary)` when a vault's `remote_stores`
+is empty (the default, and every vault before this item shipped) — a
+verified no-op — or `ReplicaSetObjectStore::new(primary, mirrors)` when
+it is not. This means mirror-write propagation is not limited to the
+moment `storage migrate --mirror` runs: every subsequent authenticated
+mutation against that vault propagates to its configured mirrors too,
+through the ordinary, unmodified application/repository layers, which
+know nothing about mirroring — they see one injected `VaultObjectStore`,
+as they always have.
+
+### 6.3 Command surface
+
+```text
+vault-pm storage add filesystem|removable NAME PATH
+vault-pm storage list
+vault-pm storage check NAME
+vault-pm [--vault NAME] storage migrate SOURCE TARGET [--mirror]
+```
+
+Diverges from §14.4's original table in one place, recorded here the way
+VLT-PM47 §2.1 recorded `attachment export`'s destination becoming
+required: `storage add` takes a required `PATH`, because a storage
+location cannot be given a sensible default the way `init`'s two default
+names can. `storage add gdrive|webdav|s3 NAME` still parses — every kind
+this table has ever documented stays in the grammar — and always fails
+closed with the `unsupported` exit class before touching configuration,
+the same closed-grammar answer VLT-PM49 §8 gave `import kdbx`: Phase 2
+implements the cloud kinds.
+
+`storage add`/`storage list`/`storage check` take no `--vault` selector
+(they read or extend configuration itself, joining `init`/`vault
+create`/`password generate`'s existing reasons for refusing one).
+`storage migrate` does take one — it is the verb that rewrites a specific
+vault's `local_store`/`remote_stores` — matching `agent unlock`/`agent
+lock`'s existing precedent for a lifecycle-adjacent verb that needs a
+target.
+
+### 6.4 `storage migrate`'s confirmation step
+
+§19.1 step 7 requires config to switch "only after explicit
+confirmation." Rather than inventing a second ceremony, this slice reuses
+one that already exists and already proves the thing that matters: after
+`copy_object_tree` succeeds, `storage migrate` collects the vault's real
+passphrase and independently unlocks `TARGET` — through
+`VaultAccessV1::unlock` over a repository factory pointed *only* at
+`TARGET`'s copied objects, the exact machinery `doctor --unlock` already
+uses — and only writes configuration if that unlock succeeds. A wrong
+passphrase or a corrupted/incomplete copy both fail this exact step,
+before configuration is ever touched, which is simultaneously §19.1 step
+6 ("opens the target independently... compares... hashes," realized as
+"and the unlock either succeeds against real ciphertext or it does not")
+and step 7's confirmation — successfully unlocking `TARGET` with the real
+passphrase *is* the confirmation, the same answer every other
+authenticated command in this grammar already gives to "prove you meant
+this."
+
+Without `--mirror`: the vault's `local_store` becomes `TARGET`.
+With `--mirror`: `TARGET` is appended to `remote_stores` and
+`local_store` is unchanged — the "provider → mirrored configuration"
+case §19.1's closing sentence names. `SOURCE` is untouched either way
+(step 8's default; no `--delete-source` flag exists in this slice, §9).
+
+### 6.5 `storage check`
+
+Resolves one named storage entry. For a local-directory kind: runs
+`scan_object_root` and reports `healthy` (exit 0, no warnings),
+`sync_interference_detected` (exit 6, plus a count line per non-zero
+classification, e.g. `conflict_copy: 2`) or `unreachable` (exit 7 — the
+location does not exist yet, cannot be read, or is genuinely
+unmounted; V1 does not distinguish those three, all read as "cannot
+confirm this location is healthy right now," which is honest for a
+removable location that may simply be unplugged). For a cloud kind: exit
+8, unconditionally (Phase 2). For every vault whose `local_store` is the
+checked name, one `replica NAME: STATUS` line per configured mirror,
+where `STATUS` is `in_sync`, `behind_by_approximately_N_objects`,
+`unreachable`, or `unsupported` — a structural heuristic (an object-file
+*count* comparison between the primary's and the mirror's own directory
+scan), explicitly labeled as such and explicitly not a cryptographic
+guarantee (§9).
+
+## 7. Threat-model notes
+
+No new adversary is named for this item; VLT-PM00 §7.1's existing
+"malicious storage service" already covers what a *hostile* storage
+backend could do, and this item is about a *non-adversarial* third
+party's ordinary sync behavior (§1, §5.1). Two places in this slice cross
+a trust boundary worth naming explicitly:
+
+- **A mirror target is itself another location a third-party sync tool
+  could touch** (a removable/synced folder can be a mirror as easily as
+  it can be a primary). `ReplicaSetObjectStore` does not special-case
+  this — a mirror is read through the same `get` fallback path as any
+  other mirror, and its bytes are subject to the same upper-layer
+  content-addressed/AEAD verification as a primary's, regardless of
+  which store answered. No additional trust is extended to a mirror
+  because it is a mirror.
+- **Filenames from a third-party sync tool are parsed and compared inside
+  `scan_object_root`.** They are never interpreted as paths beyond
+  `std::fs::read_dir`'s own entry, never executed, never formatted into
+  an error, and never returned from the crate's public API (§5.1). The
+  classification function (`classify`) is a pure, total function over a
+  bounded `&str` with no filesystem access of its own.
+
+## 8. Reuse map correction
+
+VLT-PM00 §11.5's decorator list should be read as an aspirational
+interface list, not an implemented-and-available-for-reuse one — as of
+this item, `ReplicaSetObjectStore` is the second decorator
+(`FaultInjectingObjectStore` was the first) to actually exist in
+`vault-pm-storage`; `RetryingObjectStore`, `RateLimitedObjectStore`,
+`CachingObjectStore`, and `MetricsObjectStore` remain unimplemented and
+should not be assumed present by a future slice without checking again
+(§2).
+
+## 9. Explicitly deferred
+
+Following this campaign's established practice (Windows named-pipe
+support in VLT-PM48 §6, KDBX in VLT-PM49 §8) of shipping a real,
+correctly-scoped slice and documenting the rest rather than silently
+dropping it:
+
+- **`sync --wait` and its configurable `one`/`all`/quorum durability
+  target** (§19.2). What ships here is unconditional best-effort
+  write-time propagation plus per-mirror `ReplicaHealth` accounting
+  (`vault-pm-storage`) and a directory-scan-based staleness heuristic
+  (`storage check`, §6.5) — the building blocks a `sync --wait` ceremony
+  would be built on top of, not that ceremony itself.
+- **Change-feed-based replica reconciliation.** `storage check`'s replica
+  status is an object-*count* comparison between two independent
+  directory scans, not a comparison of verified commit heads or catalog
+  hashes. It is explicitly labeled a heuristic in both this document and
+  the CLI's own output.
+- **Physical-delete propagation to mirrors.** `ReplicaSetObjectStore::
+  delete_unreferenced` is primary-only; propagating deletion to mirrors
+  is left to a future replica-aware GC planner (§19.4), so a mirror never
+  loses a still-referenced object ahead of every device having observed
+  the pruning checkpoint.
+- **`storage migrate --delete-source`.** Not offered in this slice; the
+  source is always left untouched (§19.1 step 8's default), and removing
+  it is a separate, more destructive decision left to the operator's own
+  filesystem tools until a real flag is designed and reviewed.
+- **Cloud storage kinds** (`gdrive`/`webdav`/`s3`) for `storage add`,
+  `storage migrate`, and mirror targets. Phase 2's job throughout; every
+  verb in this slice fails closed with the `unsupported` exit class
+  against them rather than silently doing nothing.
+
+## 10. Phase 1B completion check
+
+VLT-PM00 has no dedicated "Phase 1B acceptance criteria" section
+analogous to §14.8's Phase 1A one — §23's Phase 1B heading is a plain
+numbered list (items 11-14) with no closing acceptance subsection. That
+absence is itself worth flagging, the same way this campaign caught and
+fixed real Phase 1A completion gaps (crash-recovery wiring, passphrase
+rotation, a spec-phase contradiction) before declaring that phase done,
+rather than trusting "every numbered item has a checkmark" as sufficient
+on its own.
+
+Checked directly against the numbered list and this document plus its
+four predecessors:
+
+| Item | Status |
+|---|---|
+| 11. password generator/TOTP/clipboard/attachments | Shipped (VLT-PM44/45/46/47) |
+| 12. local agent/IPC/auto-lock | Shipped (VLT-PM48); Windows named-pipe support explicitly deferred |
+| 13. Bitwarden/KDBX/browser CSV import | Shipped (VLT-PM49); KDBX explicitly deferred |
+| 14. removable/synced-folder mode and mirror decorator | Shipped (this document); `sync --wait`/quorum durability and cloud kinds explicitly deferred |
+
+Every item is either fully shipped or shipped with an explicit,
+documented deferral — no item is silently incomplete. §14.8's own Phase
+1A acceptance criteria (one application service/object-store adapter,
+crash-safe publication, tamper detection) still hold: this item's
+`ReplicaSetObjectStore` wraps the *same* single application-service
+composition root with zero behavior change when unconfigured (§4), and
+introduces no second mutation or publication path. Phase 1B (daily local
+use) is complete under that reading; Phase 2 (cloud) is the next
+campaign target per §23's own ordering.
+
+## 11. Acceptance gates
+
+1. `StorageKind::Removable` parses, renders, and round-trips through
+   `parse_config`/`render_config`; `is_local_directory()` is true for
+   `Filesystem`/`Removable` and false for the three cloud kinds.
+2. `ReplicaSetObjectStore::single` passes the shared 24-check
+   `run_conformance_suite` identically to the store it wraps; a
+   multi-mirror configuration passes it too, reading through the
+   primary.
+3. A primary commit succeeds and is observable even when every mirror
+   is simultaneously failing; `replica_health()` records the failure
+   without the caller ever seeing it as an error from `put_immutable`.
+4. `scan_object_root` classifies a Dropbox-style, a Syncthing-style, and
+   an Explorer/rclone-style conflict-copy filename as `ConflictCopy`; OS
+   metadata files as `HiddenMetadata`; partial-download files as
+   `PartialTransfer`; and never returns a raw filename anywhere in its
+   public API, verified by a test asserting the offending name is absent
+   from the formatted report.
+5. `copy_object_tree` copies every real object, read-back-verifies each
+   one, is idempotent on re-run, and refuses (does not overwrite) a
+   target object whose existing bytes differ from the source.
+6. `storage add filesystem|removable NAME PATH` registers a location
+   without creating it or opening a vault; a duplicate name is refused;
+   `gdrive`/`webdav`/`s3` are refused with the unsupported class without
+   any configuration change.
+7. `storage check` distinguishes an unreachable (not yet materialized)
+   location, a healthy one, and one showing sync interference, and
+   reports a configured mirror's coarse status.
+8. `storage migrate SOURCE TARGET` end to end, through a real vault:
+   copies objects, independently unlocks the copy, switches
+   `local_store`, and the item created before migration is still
+   readable afterward; the source directory is provably untouched.
+9. `storage migrate SOURCE TARGET --mirror` end to end: adds `TARGET` to
+   `remote_stores` without changing `local_store`, and an item created
+   *after* mirroring is created propagates to the mirror through the
+   ordinary authenticated write path — proving §6.2's wiring, not only
+   the one-time copy.
+10. A wrong passphrase during `storage migrate` leaves configuration
+    completely unchanged (the copy having already happened is harmless
+    and does not need to be redone on retry).
+11. A real end-to-end test drives `storage add`/`storage check`/`storage
+    migrate` through the actual `vault-pm` executable over a real
+    pseudo-terminal, including dropping a real sync-tool conflict-copy
+    filename into the migrated location and confirming `storage check`
+    reports it without ever printing the filename.

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -370,7 +370,32 @@ a trust boundary worth naming explicitly:
   `same_local_directory` now falls back to comparing `fs::canonicalize`d
   paths when the raw strings differ, closing that gap for any location
   that already exists (one that does not yet cannot collide with anything
-  in the first place).
+  in the first place). A follow-up review round asked whether two
+  *concurrent* `vault-pm` processes could each pass this check against
+  two not-yet-created aliasing locations before either creates its
+  directory; verified against `vault-pm-local-host::LocalWriterGuard`
+  that they cannot — it is one non-blocking `try_lock` per config root
+  (not per vault), acquired before configuration is even loaded and held
+  for the whole command, so a second concurrent invocation against the
+  same config root fails closed with `LocalHostError::AlreadyLocked`
+  rather than racing past this check.
+- The migration-copy read/directory-creation checks (§5.2) close the
+  *static* symlink-planting case (a symlink already present when
+  `storage migrate` runs) completely, and additionally narrow — via
+  `O_NOFOLLOW` on Unix (`open_no_follow`) and an atomic non-recursive
+  `fs::create_dir` for bucket directories (`ensure_real_bucket_
+  directory`) — the *dynamic* case (a symlink planted in the instant
+  between a `symlink_metadata` check and the following read/create call)
+  to a true kernel-enforced atomic refusal on the read path and the
+  bucket-directory path. The top-level `target` directory's own creation
+  still uses a check-then-`create_dir_all` pattern (needed for its
+  recursive parent creation), so a symlink race remains theoretically
+  possible there against a truly adversarial concurrent write to that
+  exact path component during the single instant between the check and
+  the call — assessed as acceptable given `target` is a location the
+  operator explicitly configured via `storage add`, not one discovered
+  or influenced by scanning an untrusted directory the way object names
+  are.
 
 ## 8. Reuse map correction
 

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -429,6 +429,23 @@ a trust boundary worth naming explicitly:
   or overwrite one, which is what every leaf-level check in this section
   exists to prevent for the exact paths this crate reads from and
   writes into.
+- A fifth and final review round found the one path this section had not
+  yet closed: `scan_object_root`'s and `copy_object_tree`'s own
+  `root`/`source` argument — unlike `target`, which was checked from
+  round 3 onward — was validated with `fs::metadata` (follows symlinks)
+  rather than `fs::symlink_metadata`. Confirmed exploitable before being
+  fixed: a symlinked scan root or migration source was scanned or copied
+  as whatever it actually pointed to, with `ScanReport` reporting
+  completely clean and `copy_object_tree` silently copying an
+  attacker-chosen directory's contents into `target` as if they were the
+  vault's own committed objects. This is not the same as the accepted
+  ancestor-symlink residual immediately above: `source`/`root` is
+  always the exact, already-existing, currently-configured storage
+  location — not a not-yet-created ancestor — so there is no legitimate
+  case (macOS's `/tmp`/`/var` included) where refusing it is a false
+  positive the way refusing every ancestor was. Fixed the same way
+  `target`'s leaf already was, closing the last gap this document's own
+  security section had.
 
 ## 8. Reuse map correction
 

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -401,6 +401,34 @@ a trust boundary worth naming explicitly:
   is first created, closing the analogous narrower window where a
   concurrent writer swaps an already-validated bucket directory for a
   symlink between two writes to it.
+- A fourth review round found `MAX_SCANNED_ENTRIES` (§5.1) was enforced
+  only after `scan_object_root` had already fully collected and sorted an
+  entire directory's raw entries into memory, defeating its own DoS
+  purpose against an adversarially padded directory; the bound is now
+  checked per entry as it is pulled from the OS, before collection. The
+  same round found `target` was re-validated alongside each bucket
+  directory (the fix two paragraphs above) but not before *every* object
+  write within a bucket the way the bucket directory itself already was
+  — closed the same way, by re-checking both together before each write.
+- The same round also proposed, implemented, tested, and **reverted** a
+  stricter fix: validating every path component of `target` atomically,
+  from the filesystem root down, to close the narrower case where an
+  attacker plants a symlink at an *ancestor* of `target` that does not
+  exist yet (rather than at `target`'s own final component, which was
+  already closed). That fix broke on real macOS hosts — `/tmp` and
+  `/var` are themselves symlinks to `/private/tmp`/`/private/var` and
+  are transparently, legitimately present in the ancestry of essentially
+  any absolute path a person could configure, and the stricter check
+  could not tell that apart from an attacker-planted one. `ensure_real_
+  directory` therefore keeps `fs::create_dir_all` for `target`'s
+  parents, recorded as a deliberate scope limit rather than an
+  oversight: the residual this leaves can only relocate this
+  migration's own freshly written ciphertext to a different physical
+  directory the same configured `target` path would still consistently
+  resolve through — it cannot read a file that already exists elsewhere
+  or overwrite one, which is what every leaf-level check in this section
+  exists to prevent for the exact paths this crate reads from and
+  writes into.
 
 ## 8. Reuse map correction
 

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -340,6 +340,37 @@ a trust boundary worth naming explicitly:
   an error, and never returned from the crate's public API (§5.1). The
   classification function (`classify`) is a pure, total function over a
   bounded `&str` with no filesystem access of its own.
+- **A symlink planted inside `source` or `target` is refused, never
+  followed.** Caught by this PR's own security review before merge:
+  `DirEntry::file_type()`'s *negative* `!is_dir()` check (the first draft
+  of both `scan_object_root` and `copy_object_tree`'s directory walks)
+  lets a symlink through as an "ordinary object" whenever its name
+  happens to be hex-shaped, and `read_bounded`'s `File::open` follows it —
+  so a planted `<hex-name> -> ~/.ssh/id_rsa` inside `source` would have
+  been read and copied into `target` under an innocuous object name, a
+  real data-exfiltration path when `target` is itself synced or
+  cloud-backed (exactly the situation this item's own "provider →
+  mirrored configuration" case creates). Fixed by requiring the positive
+  `is_file()` everywhere an object is treated as copyable, checking
+  `fs::symlink_metadata` (which does not follow the link) before every
+  `fs::metadata`/`File::open` call, and opening the migration copy's
+  staging file with `OpenOptions::create_new` instead of `File::create`
+  to close the TOCTOU window between checking a predictable path and
+  writing to it. Six regression tests in `vault-pm-storage-removable`
+  cover a symlinked source object, a symlinked source bucket directory,
+  and pre-existing symlinks standing in for a target bucket directory, a
+  target object, and the top-level target itself.
+- **Two different-looking storage locations resolving to one real
+  directory.** `configured_vault`'s cross-vault collision check compared
+  location strings exactly; once `storage add` allows an arbitrary path
+  (rather than one of two fixed ones this composition root creates for
+  itself), two different spellings — a relative path, a symlink, a
+  trailing separator — could resolve to the same physical directory and
+  bypass the check, letting two vaults' object stores silently interleave.
+  `same_local_directory` now falls back to comparing `fs::canonicalize`d
+  paths when the raw strings differ, closing that gap for any location
+  that already exists (one that does not yet cannot collide with anything
+  in the first place).
 
 ## 8. Reuse map correction
 

--- a/code/specs/VLT-PM50-cli-storage-migration.md
+++ b/code/specs/VLT-PM50-cli-storage-migration.md
@@ -379,23 +379,28 @@ a trust boundary worth naming explicitly:
   for the whole command, so a second concurrent invocation against the
   same config root fails closed with `LocalHostError::AlreadyLocked`
   rather than racing past this check.
-- The migration-copy read/directory-creation checks (§5.2) close the
+- The migration-copy read/directory-creation checks (§5.2) close both the
   *static* symlink-planting case (a symlink already present when
-  `storage migrate` runs) completely, and additionally narrow — via
-  `O_NOFOLLOW` on Unix (`open_no_follow`) and an atomic non-recursive
-  `fs::create_dir` for bucket directories (`ensure_real_bucket_
-  directory`) — the *dynamic* case (a symlink planted in the instant
-  between a `symlink_metadata` check and the following read/create call)
-  to a true kernel-enforced atomic refusal on the read path and the
-  bucket-directory path. The top-level `target` directory's own creation
-  still uses a check-then-`create_dir_all` pattern (needed for its
-  recursive parent creation), so a symlink race remains theoretically
-  possible there against a truly adversarial concurrent write to that
-  exact path component during the single instant between the check and
-  the call — assessed as acceptable given `target` is a location the
-  operator explicitly configured via `storage add`, not one discovered
-  or influenced by scanning an untrusted directory the way object names
-  are.
+  `storage migrate` runs) and the *dynamic* one (a symlink planted in the
+  instant between a check and a following read/create call) with true
+  kernel-enforced atomic refusals throughout: `O_NOFOLLOW` on Unix
+  (`open_no_follow`) for every read, and `create_directory_component_
+  atomically` (`fs::create_dir`'s own atomic `AlreadyExists`-if-anything-
+  is-there behavior, symlink included) for every directory creation —
+  including the top-level `target` directory itself, not only bucket
+  directories one level below it. A third review round correctly
+  rejected an earlier version of this document's own claim that leaving
+  `target`'s creation on a check-then-`create_dir_all` pattern was an
+  acceptable residual: `target` is the root the *entire* migration lives
+  under, so a race there redirects everything, not one bucket, and
+  nothing about it being an operator-configured `storage add` path
+  changes that a third party with concurrent write access to `target`'s
+  parent directory can still plant a symlink at the exact `target` path
+  in the same race window. A bucket directory is now also re-validated
+  immediately before every object write, not only once when the bucket
+  is first created, closing the analogous narrower window where a
+  concurrent writer swaps an already-validated bucket directory for a
+  symlink between two writes to it.
 
 ## 8. Reuse map correction
 


### PR DESCRIPTION
## Summary

Implements VLT-PM00 §23 item 14, **the last item of Phase 1B**: removable/synced-folder mode and the mirror decorator.

- `StorageKind::Removable` — a `filesystem`-format variant, distinguished only by expected third-party sync interference (`vault-pm-config`).
- `vault-pm-storage::ReplicaSetObjectStore<P, M>` — the §11.5 mirror decorator: primary-first writes, best-effort mirror propagation, mirror read fallback, per-mirror `ReplicaHealth`. Zero mirrors = verified no-op pass-through, so existing behavior is unchanged unless a vault configures `remote_stores`.
- New crate `vault-pm-storage-removable` — `scan_object_root` (structural, name-only detection of Dropbox/OneDrive/Syncthing/Explorer-style conflict copies, OS metadata files, partial transfers — never echoes a raw filename) and `copy_object_tree` (write-tmp-then-rename, read-back-verified migration copy).
- `vault-pm-cli`: `storage add|list|check|migrate` command surface; relaxed `configured_vault`'s storage-location check (previously hardcoded to the two paths the composition root itself created) to accept any registered `filesystem`/`removable` location; every repository now opens through `ReplicaSetObjectStore` so a `--mirror`ed vault keeps replicating on every later mutation, not just at migration time.

Full design, threat-model notes, and the Phase 1B completion check are in `code/specs/VLT-PM50-cli-storage-migration.md`.

**Deferred** (documented in VLT-PM50 §9): the `sync --wait` ceremony with a configurable `one`/`all`/quorum durability target, change-feed-based replica reconciliation, physical-delete propagation to mirrors, and the cloud storage kinds (`gdrive`/`webdav`/`s3` — Phase 2).

## Security review

Went through 5 rounds of sub-agent security review before push — each round found and closed a real issue, converging to a fully symlink-safe implementation:

1. Symlink-following in read/copy logic (arbitrary file read/exfiltration, arbitrary file overwrite).
2. The round-1 fix's own TOCTOU race window (closed with `O_NOFOLLOW` on Unix, atomic `fs::create_dir`).
3. The top-level migration target's own creation had the same race the leaf bucket-directory fix didn't cover; per-object bucket re-validation added.
4. Directory-listing DoS bound was enforced too late (after full collection); target re-validated before every write, not just once.
5. **The scan root / migration source argument itself was never checked for being a symlink** (confirmed exploitable with a standalone reproduction before the fix) — the one asymmetry left between source and target.

One proposed fix (validating every ancestor path component atomically) was implemented, caught by the test suite breaking on real macOS hosts (`/tmp`/`/var` are themselves symlinks), and correctly reverted in favor of a narrower, documented scope limit.

## Test plan

- [x] `cargo test` green for `vault-pm-config`, `vault-pm-storage` (27 tests incl. `ReplicaSetObjectStore`), `vault-pm-storage-removable` (33 tests incl. 8 symlink-attack regressions), `vault-pm-cli` (137 tests incl. 10 new storage-command tests)
- [x] `cargo build --workspace` green (one pre-existing, unrelated Windows-only crate failure on macOS, unaffected by this PR)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean on all touched/new crates
- [x] Real-process pseudo-terminal end-to-end test (`real_cli_storage_add_check_and_migrate_a_real_vault`) against the actual `vault-pm` binary: registers a location, confirms `storage check` reports it unreachable before materialization, migrates a real vault through a real passphrase prompt, confirms the pre-migration item is still readable, and confirms a real Syncthing-style conflict-copy filename is detected and never echoed
- [x] Full `vault-pm-cli-program` e2e suite (17 tests) green
- [x] Security review: 5 rounds, converged (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)