### PR TITLE
fix(x86-simulator): add __twig_gc_write_barrier host shim

### DIFF
--- a/code/packages/rust/x86-simulator/CHANGELOG.md
+++ b/code/packages/rust/x86-simulator/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog — x86-simulator
 
+## 0.7.7 — 2026-08-19 — host shim for `__twig_gc_write_barrier`
+
+Fixes a **latent** breakage: three LANG-FULL matrix cells
+(`basic_array_runs_on_x86_sim`, `algol_static_array_runs_on_x86_sim`,
+`algol_for_loop_array_runs_on_x86_sim`) failed with
+
+```
+UnresolvedExternal("__twig_gc_write_barrier")
+```
+
+When the precise-GC track (AOT00-T8 follow-up) taught `x86_64-backend` to emit a
+generational write barrier after every `field_store` / `array_set`, this
+simulator's `host_call` dispatch table was not extended to match — so every
+program performing a heap store trapped. Nothing in a recent PR caused it; this
+crate's BUILD simply is not re-run by main's diff-based CI unless a change lands
+in its dependency cone, so the break sat on main silently until an unrelated
+near-full-repo rebuild surfaced it.
+
+**The shim is a genuine no-op, not a stub.** `__twig_gc_write_barrier(parent,
+child)` exists to add `parent` to a remembered set so a later *minor* collection
+does not free a young object reachable only from an old one. This simulator's
+`Memory::alloc` is a monotonic bump allocator — nothing is ever freed, swept,
+promoted, or relocated, and there is only one generation because there is no
+collector — so the remembered set has no reader and doing nothing is
+semantically exact. `src/lib.rs` carries the full reasoning inline so the arm is
+not mistaken for unfinished work.
+
+Three new unit tests, all of which fail against the pre-fix dispatch table where
+applicable: the symbol resolves to a clean `ret` rather than trapping; the shim
+is *silent* (moves neither the heap bump cursor nor stdout, and never
+dereferences either operand); and an unknown symbol still fails closed, so the
+fix did not widen the table into a catch-all.
+
+Scope: `x86-simulator` is the only crate in the repo with a host-runtime symbol
+dispatch table (it is the sole `fn host_call` / `Trap::UnresolvedExternal` site),
+so no sibling simulator shares this gap. `aarch64-backend` emits the same
+barrier, but has no simulator executing its output.
+
 ## 0.7.6 — 2026-06-23 — int ⇄ real conversions (LANG-FULL E8 PR-6b)
 
 Decode + execute the three SSE conversion opcodes, so the simulator can RUN

--- a/code/packages/rust/x86-simulator/Cargo.toml
+++ b/code/packages/rust/x86-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86-simulator"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 description = "x86/x86-64 runtime simulator — decode + execute machine code, and run the x86_64-backend's emitted code locally (host-arch-independent)"
 

--- a/code/packages/rust/x86-simulator/README.md
+++ b/code/packages/rust/x86-simulator/README.md
@@ -52,8 +52,10 @@ The harness lays the function bytes into a flat sandboxed address space, patches
 internal `call` relocations, resolves the **`_twig_globals` data symbol** (a
 zeroed 512-slot region between the code and heap — the `PcRel32` `lea` to it is
 patched the same way the real linker would), routes external calls
-(`__twig_alloc_bytes` via a bump heap, `putchar` / `print_i64` via captured I/O)
-to host shims, sets up a stack with a return sentinel, and runs from the entry —
+(`__twig_alloc_bytes` via a bump heap, `putchar` / `print_i64` via captured I/O,
+and `__twig_gc_write_barrier` as a no-op — the bump heap never collects, so there
+is no remembered set to notify) to host shims, sets up a stack with a return
+sentinel, and runs from the entry —
 returning `rax & 0xFF` as the exit code (the same convention as `run_native` /
 `run_wasm`). With `_twig_globals` support, programs that use **module globals**
 (LANG-FULL E6 captured scalars, O3 Oct `static`, AL6 ALGOL `own`) run locally.

--- a/code/packages/rust/x86-simulator/src/lib.rs
+++ b/code/packages/rust/x86-simulator/src/lib.rs
@@ -156,6 +156,42 @@ impl Simulator {
                 let v = self.state.get(Reg::Rdi) as i64;
                 self.stdout.extend(v.to_string().into_bytes());
             }
+            // `void __twig_gc_write_barrier(i64 parent, i64 child)` — deliberately
+            // a **no-op here**, and that is a real implementation, not a stub.
+            //
+            // On a real target this is the *generational* write barrier
+            // (`gc-core-capi`'s `__gc_write_barrier`): when the mutator stores a
+            // reference `child` into a field of an already-**old** object
+            // `parent`, the collector must remember `parent`, because a later
+            // *minor* collection only traces the young generation and would
+            // otherwise never discover that an old object now points at a young
+            // one — and would free a live object. The barrier's whole job is to
+            // add `parent` to that remembered set. `child` is never dereferenced.
+            //
+            // None of that machinery exists in this simulator. `Memory::alloc`
+            // (the `__twig_alloc_bytes` shim above) is a **monotonic bump
+            // allocator**: `heap_next` only ever moves forward, nothing is ever
+            // freed, swept, promoted, or relocated, and there is exactly one
+            // generation because there is no collector at all. With no minor
+            // collection to run, a remembered set has no reader, so recording
+            // into one would be pure bookkeeping no observable behaviour depends
+            // on. Doing nothing is therefore *semantically exact*, not an
+            // approximation — a simulated program cannot distinguish this from a
+            // real barrier, since the only way to observe a missed barrier is to
+            // watch the collector reclaim a live object, and this heap never
+            // reclaims anything.
+            //
+            // Consequently we read both arguments purely to document the System V
+            // signature the `x86_64-backend` emits against — `parent` in RDI,
+            // `child` in RSI (see `array_set`/`field_store`, which reload both
+            // fresh from their stack slots into `abi.arg_regs()[0..2]` right
+            // before the `call`). Being `void`, it leaves RAX alone, exactly like
+            // the `__twig_print_i64` shim above: SysV treats RAX as
+            // caller-clobbered, so a caller may not rely on its value either way.
+            "__twig_gc_write_barrier" => {
+                let _parent = self.state.get(Reg::Rdi);
+                let _child = self.state.get(Reg::Rsi);
+            }
             other => return Err(Trap::UnresolvedExternal(other.to_string())),
         }
         Ok(())
@@ -181,5 +217,72 @@ mod tests {
             .build("main")
             .expect("entry exists");
         assert_eq!(sim.run().unwrap(), 42, "the simulator runs real x86_64 codegen → 42");
+    }
+
+    // The shape `x86_64-backend` emits after every `field_store` / `array_set`:
+    // a `call rel32` to the GC write barrier (relocated at offset 1), then `ret`.
+    // `E8 00000000` is the un-patched call; the harness records offset 1 as an
+    // external relocation, so `Flow::Call` routes it through `host_call`.
+    const BARRIER_CALL_FN: &[u8] = &[0xE8, 0x00, 0x00, 0x00, 0x00, 0xC3];
+
+    /// Regression guard for the gap that made three LANG-FULL matrix cells
+    /// (`basic_array`, `algol_static_array`, `algol_for_loop_array`) trap with
+    /// `UnresolvedExternal("__twig_gc_write_barrier")`: once the precise-GC track
+    /// taught the backend to emit a write barrier on heap stores, every array /
+    /// field store in the matrix reached a symbol this dispatch table did not
+    /// know. Any program doing a heap store now routes through here, so a
+    /// regression would break far more than one test — this asserts the symbol
+    /// resolves at all, independent of any particular frontend.
+    #[test]
+    fn gc_write_barrier_resolves_instead_of_trapping() {
+        let relocs = [harness::Reloc { patch_offset: 1, symbol: "__twig_gc_write_barrier".into() }];
+        let mut sim = harness::MachineCodeHarness::new()
+            .function("main", BARRIER_CALL_FN, &relocs)
+            .build("main")
+            .expect("entry exists");
+        assert_eq!(
+            sim.run(),
+            Ok(0),
+            "a call to __twig_gc_write_barrier must run to a clean ret, not trap as an unresolved external",
+        );
+    }
+
+    /// The barrier must be a *silent* no-op, not merely a resolved symbol: it may
+    /// not allocate, and it may not emit output. This pins the two observable
+    /// channels a wrong implementation would disturb — an accidental `alloc`
+    /// would move the bump cursor (corrupting every later heap address the guest
+    /// computed), and an accidental write would corrupt captured stdout.
+    #[test]
+    fn gc_write_barrier_is_a_silent_no_op() {
+        let mut sim = harness::MachineCodeHarness::new()
+            .function("main", MIN_FN, &[])
+            .build("main")
+            .expect("entry exists");
+        // Non-zero, deliberately bogus arguments: the barrier never dereferences
+        // either operand, so even a wild `child` must be harmless.
+        sim.state.set(Reg::Rdi, 0x4141_4141);
+        sim.state.set(Reg::Rsi, 0x4242_4242);
+        // `alloc(0)` is an idempotent probe of the bump cursor: it reserves
+        // nothing and returns the current (aligned) `heap_next`.
+        let heap_before = sim.mem.alloc(0).expect("heap probe");
+        sim.host_call("__twig_gc_write_barrier").expect("the barrier shim resolves");
+        let heap_after = sim.mem.alloc(0).expect("heap probe");
+        assert_eq!(heap_before, heap_after, "the barrier must not allocate — the heap cursor may not move");
+        assert!(sim.stdout.is_empty(), "the barrier must not write to stdout");
+    }
+
+    /// The fix must not have widened the dispatch table into a catch-all: an
+    /// unknown symbol still has to fail closed.
+    #[test]
+    fn an_unknown_external_still_traps() {
+        let mut sim = harness::MachineCodeHarness::new()
+            .function("main", MIN_FN, &[])
+            .build("main")
+            .expect("entry exists");
+        assert_eq!(
+            sim.host_call("__twig_not_a_real_symbol"),
+            Err(Trap::UnresolvedExternal("__twig_not_a_real_symbol".to_string())),
+            "unknown externals must still trap, not silently no-op",
+        );
     }
 }

--- a/lessons.md
+++ b/lessons.md
@@ -1264,6 +1264,41 @@ arms passed and masked the gap on the inline-runtime backends.
   frontend, so class patterns never reach `case_eq`. Backends with no
   Range/Regexp value type implement it as plain structural equality.
 
+## The same open-ended-dispatch trap applies to native RUNTIME SYMBOLS, not just SIR builtins
+
+Same shape as the `case_eq` lesson above, one layer down. When the precise-GC
+track taught `x86_64-backend` to emit `call __twig_gc_write_barrier` after every
+`field_store` / `array_set`, `x86-simulator`'s `Simulator::host_call` dispatch
+table was not extended to match — its floor is
+`Trap::UnresolvedExternal(...)`, so **every** matrix program doing a heap store
+trapped. Three LANG-FULL cells sat red on main until an unrelated near-full-repo
+rebuild surfaced them (PR #12164).
+
+**Why it stayed hidden for so long**: `x86-simulator`'s BUILD only re-runs when a
+diff touches its dependency cone, and the backend crates that emit the symbol
+(`x86_64-backend`, `aarch64-backend`) have **no BUILD file at all** — so neither
+the emitter's own relocation-assertion tests nor the consumer's execution tests
+ran when the emitter changed. A green CI on the PR that added the barrier proved
+nothing about either side.
+
+**Lessons:**
+- When a backend starts emitting a NEW external runtime symbol, grep every
+  *consumer* of that symbol — simulators, runtime shims, linker stubs — before
+  assuming it resolves. The emitter-side test (assert the relocation exists) and
+  the consumer-side test (assert the symbol resolves) are different tests, and
+  passing the first tells you nothing about the second.
+- `x86-simulator` is currently the repo's only host-runtime dispatch table (the
+  sole `fn host_call` / `Trap::UnresolvedExternal` site) — so it is the one place
+  to update, but also the one place with no sibling to cross-check against.
+- A **no-op** is sometimes the correct implementation of a runtime hook, not a
+  stub: the simulator's bump allocator never collects, so a generational write
+  barrier has no remembered set to notify. Say *why* in a comment, or the next
+  reader will "finish" it.
+- Barrier/GC regression tests are notoriously **vacuous** (see the aarch64 and
+  `iir-to-llvm` entries elsewhere in this file — both passed with the barrier
+  deleted). Always prove a new guard is load-bearing by temporarily reverting the
+  fix and confirming the test goes red.
+
 Discovered: 2026-07-02, while adding trailing-`case` implicit return; a `case`
 program printed correctly on Python but panicked on Go/Rust/JS.
 


### PR DESCRIPTION
## The bug

Three LANG-FULL matrix cells in `code/packages/rust/x86-simulator/tests/lang_matrix_x86.rs` fail on `main`:

- `basic_array_runs_on_x86_sim`
- `algol_static_array_runs_on_x86_sim`
- `algol_for_loop_array_runs_on_x86_sim`

All three identically:

```
x86_64 machine code should run to a clean ret: UnresolvedExternal("__twig_gc_write_barrier")
```

## Root cause

When the precise-GC track (AOT00-T8 follow-up) taught `x86_64-backend` to emit a generational write barrier after every `field_store` / `array_set`, this simulator's `Simulator::host_call` dispatch table was not extended to match. It knew `__twig_alloc_bytes`, `putchar`/`getchar`, and the `print_i64` aliases, and nothing else — so every program performing a heap store fell through to the unknown-symbol arm and trapped.

**This is not caused by any recent PR.** `x86-simulator`'s BUILD is only re-run when a diff touches its dependency cone, so the break sat on `main` silently until an unrelated near-full-repo rebuild surfaced it.

## The fix

`__twig_gc_write_barrier(parent, child)` — signature confirmed against the canonical implementation in `gc-core-capi/src/twig_compat.rs` — takes two `i64` args and returns nothing. Under System V: `parent` in RDI, `child` in RSI, no result in RAX.

The shim is a **genuine no-op, and that is a real implementation, not a stub.** The barrier exists to add `parent` to a remembered set so a later *minor* collection does not free a young object reachable only from an old one. `Memory::alloc` in this simulator is a monotonic bump allocator — nothing is ever freed, swept, promoted, or relocated, and there is exactly one generation because there is no collector at all. With no minor collection to run, the remembered set has no reader, so doing nothing is *semantically exact* rather than an approximation: the only way to observe a missed barrier is to watch the collector reclaim a live object, and this heap never reclaims anything.

`src/lib.rs` carries that reasoning inline (per the repo's literate-programming standard) so a future reader does not mistake the arm for unfinished work.

## Tests

Three new unit tests:

- `gc_write_barrier_resolves_instead_of_trapping` — assembles the exact shape the backend emits (`call rel32` to the barrier, then `ret`) and asserts it runs to a clean ret.
- `gc_write_barrier_is_a_silent_no_op` — passes deliberately bogus non-zero args and asserts the shim moves neither the heap bump cursor nor stdout.
- `an_unknown_external_still_traps` — guards the fail-closed property, so the fix did not widen the table into a catch-all.

Per `lessons.md` (the vacuous-pass trap at ~line 2711/2796, where a write-barrier test passed both with and without the barrier), the guards were **verified load-bearing**: temporarily renaming the dispatch arm turns both barrier tests red alongside the three original matrix cells.

## Sibling backends

`x86-simulator` is the repo's **only** crate with a host-runtime symbol dispatch table — it is the sole `fn host_call` / `Trap::UnresolvedExternal` site in `code/packages/rust`. No sibling simulator shares this gap. `aarch64-backend` emits the same barrier, but there is no simulator executing its output, and `arm-simulator` has no external-symbol resolution at all.

## Verification

- `cargo test -p x86-simulator --no-fail-fast` — 66 tests, 0 failed. `lang_matrix_x86` goes 24 passed/3 failed → **27 passed/0 failed**; lib unit tests 30 → 33.
- `cargo clippy --all-targets -- -D warnings` — clean, zero warnings.
- `/security-review` — passed on the first round, no findings.

CHANGELOG updated and version bumped 0.7.6 → 0.7.7; README's host-shim list updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
