### PR TITLE
fix(cowsay): un-gate the TextContent literal so a macOS-only break cannot recur

### DIFF
--- a/code/programs/rust/cowsay/CHANGELOG.md
+++ b/code/programs/rust/cowsay/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to the Rust `cowsay` program are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- **macOS build was broken: `TextContent` was missing its `wrap` field.** The
+  Apple-only PNG rendering path (`render_cowsay_png_metal`) constructs a
+  `layout_ir::TextContent`. When `layout-ir` gained a `wrap: bool` field, every
+  other construction site in the repository was updated, but this one was not,
+  because it sits inside `#[cfg(target_vendor = "apple")]` and so does not exist
+  for the Linux or Windows compilers. The program therefore could not compile at
+  all on macOS:
+
+  ```
+  error[E0063]: missing field `wrap` in initializer of `layout_ir::TextContent`
+     --> src/main.rs:451:37
+  ```
+
+  The value is now set explicitly to `wrap: false`. That is the semantically
+  correct choice, not merely the one that compiles: cowsay emits fixed-format
+  monospace ASCII art whose speech-bubble borders and cow legs align only
+  because each line keeps exactly the spaces it was built with. `layout-to-paint`
+  implements soft wrapping as a greedy word wrapper that re-splits on
+  `split_whitespace()`, collapsing runs of interior spaces — so `wrap: true`
+  could silently re-flow the art into gibberish. Hard `\n` breaks, which are the
+  only breaks cowsay produces, are preserved either way.
+
+### Changed
+
+- **The PNG scene description is no longer hidden behind a platform gate.**
+  Building the `TextContent` and its `FontSpec` moved out of the Apple-only
+  function into two un-gated helpers, `cowsay_text_content` and `png_font`. Only
+  the *rendering* genuinely needs Metal and CoreText; *describing* the scene is
+  plain data that compiles everywhere.
+
+  This is the durable fix for the class of bug above. Previously the Ubuntu and
+  Windows CI legs reported green on a program that could not compile, and the
+  breakage surfaced only on a macOS runner long afterwards. Now all three legs
+  type-check the struct literal, so the next field added to `TextContent` fails
+  within minutes on every platform instead of rotting undetected. `dead_code` is
+  allowed on non-Apple targets — the binary really does not call these helpers
+  there — but a lint allowance does not suppress type checking, which is the
+  whole point.
+
+### Added
+
+- **First test suite for this package** (6 tests), running on Linux, Windows and
+  macOS alike. Includes an explicit regression test, `ascii_art_never_soft_wraps`,
+  which pins `wrap == false` and `max_lines == None`, plus coverage of byte-exact
+  art preservation, font selection and line height, text alignment and colour,
+  empty input, and the non-Apple `render_cowsay_png_metal` stub contract.
+
+### Notes
+
+- This package previously had no `BUILD` file, which is why the defect went
+  unnoticed: the build tool discovers packages by their `BUILD` file, so a crate
+  without one is never built and its tests never run. Adding that file is handled
+  separately by the in-flight PR #12153; this changelog entry records the
+  dependency so the two are not confused. Until that lands, cowsay's only CI
+  coverage comes from the affected-package graph of the shared `layout-ir` crate.

--- a/code/programs/rust/cowsay/src/main.rs
+++ b/code/programs/rust/cowsay/src/main.rs
@@ -1,30 +1,32 @@
 use cli_builder::types::ParserOutput;
 use cli_builder::{load_spec_from_file, Parser};
+// `layout_ir` is a pure-data crate that builds on every target, so the pieces
+// used to *describe* the PNG scene stay un-gated on purpose — see the note on
+// `cowsay_text_content` below for why that matters. Only the imports that pull
+// in Apple-only machinery (Metal, CoreText) are gated.
+use layout_ir::{color_black, font_spec, FontSpec, TextAlign, TextContent};
 // These layout/text imports are only used by the Apple-only PNG rendering path
 // below (`#[cfg(target_vendor = "apple")]`). Gate them the same way so non-Apple
 // targets (e.g. Linux CI) don't flag them as unused.
 #[cfg(target_vendor = "apple")]
-use layout_ir::{
-    color_black, color_white, font_spec, Content, PositionedNode, TextAlign, TextContent,
-    TextMeasurer,
-};
+use layout_ir::{color_white, Content, PositionedNode, TextMeasurer};
 #[cfg(target_vendor = "apple")]
 use layout_text_measure_native::NativeMeasurer;
 #[cfg(target_vendor = "apple")]
 use layout_to_paint::{layout_to_paint, LayoutToPaintOptions};
-#[cfg(target_vendor = "apple")]
-use std::collections::HashMap;
-#[cfg(target_vendor = "apple")]
-use text_native::text_interfaces::{FontMetrics, FontResolver, TextShaper};
-#[cfg(target_vendor = "apple")]
-use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 use regex::Regex;
 use serde_json::Value;
+#[cfg(target_vendor = "apple")]
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_vendor = "apple")]
+use text_native::text_interfaces::{FontMetrics, FontResolver, TextShaper};
+#[cfg(target_vendor = "apple")]
+use text_native::{NativeMetrics, NativeResolver, NativeShaper};
 
 #[derive(Debug, Default)]
 struct PaintRenderOptions {
@@ -421,12 +423,63 @@ fn random_message() -> String {
     RANDOM_MESSAGES[idx].to_string()
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// PNG scene description — deliberately NOT platform-gated
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Only the *rendering* of the PNG needs Metal and CoreText, and that part is
+// gated to Apple below. Describing the scene is plain data, so the two helpers
+// here stay un-gated even though the binary only calls them on macOS.
+//
+// That is not an accident, it is the fix for a real outage. `layout_ir` gained
+// a new `TextContent` field (`wrap`); every construction site in the repo was
+// updated except this one, because it sat inside `#[cfg(target_vendor =
+// "apple")]` and therefore did not exist for the Linux and Windows compilers.
+// The Ubuntu and Windows CI legs went green on a program that could not
+// compile at all, and the breakage only surfaced much later on a macOS runner.
+//
+// Keeping the struct literal out here means all three CI legs type-check it.
+// `dead_code` is allowed on non-Apple targets (the binary genuinely never calls
+// it there) but a lint allowance does not stop type checking: the next time a
+// field is added to `TextContent`, Ubuntu fails in minutes instead of macOS
+// failing in months.
+
+/// Monospace font for the PNG path. Menlo is chosen because cowsay's art only
+/// aligns in a fixed-width face; `line_height` is tightened from layout-ir's
+/// 1.2 default so consecutive rows of the cow touch the way a terminal's do.
+#[cfg_attr(not(target_vendor = "apple"), allow(dead_code))]
+fn png_font() -> FontSpec {
+    let mut font = font_spec("Menlo", 18.0);
+    font.line_height = 1.1;
+    font
+}
+
+/// Wrap cowsay's finished ASCII art in a `TextContent` for the layout pipeline.
+#[cfg_attr(not(target_vendor = "apple"), allow(dead_code))]
+fn cowsay_text_content(output: &str, font: FontSpec) -> TextContent {
+    TextContent {
+        value: output.to_string(),
+        font,
+        color: color_black(),
+        max_lines: None,
+        // Cowsay output is fixed-format monospace ASCII art: the speech
+        // bubble's `/ \ | _ -` borders and the cow's legs only line up
+        // because every line keeps exactly the spaces it was built with.
+        // Soft wrapping is a paragraph feature — layout-to-paint's greedy
+        // wrapper re-splits on `split_whitespace()`, which collapses runs
+        // of spaces — so enabling it here could silently re-flow the art
+        // into gibberish. Hard `\n` breaks (the only ones cowsay emits)
+        // are preserved either way, so `false` is the faithful choice.
+        wrap: false,
+        text_align: TextAlign::Start,
+    }
+}
+
 #[cfg(target_vendor = "apple")]
 fn render_cowsay_png_metal(output: &str, path: &Path) -> Result<(), String> {
-    let font_size = 18.0;
     let padding = 24.0;
-    let mut font = font_spec("Menlo", font_size);
-    font.line_height = 1.1;
+    let font = png_font();
+    let font_size = font.size;
 
     let measurer = NativeMeasurer::new();
     let lines: Vec<&str> = output.lines().collect();
@@ -448,13 +501,7 @@ fn render_cowsay_png_metal(output: &str, path: &Path) -> Result<(), String> {
         width: text_width,
         height: text_height,
         id: Some("cowsay-text".to_string()),
-        content: Some(Content::Text(TextContent {
-            value: output.to_string(),
-            font,
-            color: color_black(),
-            max_lines: None,
-            text_align: TextAlign::Start,
-        })),
+        content: Some(Content::Text(cowsay_text_content(output, font))),
         children: Vec::new(),
         ext: HashMap::new(),
     };
@@ -493,4 +540,102 @@ fn render_cowsay_png_metal(output: &str, path: &Path) -> Result<(), String> {
 #[cfg(not(target_vendor = "apple"))]
 fn render_cowsay_png_metal(_output: &str, _path: &Path) -> Result<(), String> {
     Err("paint-metal PNG rendering requires an Apple target".to_string())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These run on Linux, Windows and macOS alike. That is the point: the bug they
+// guard against was a `TextContent` field that only the macOS compiler ever
+// saw. Anything asserted here is asserted by all three CI legs.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The cow, rendered. Note the deliberate runs of interior spaces — this
+    /// is the exact shape that soft wrapping would destroy.
+    const SAMPLE_ART: &str = concat!(
+        " _____\n",
+        "< moo >\n",
+        " -----\n",
+        "        \\   ^__^\n",
+        "         \\  (oo)\\_______\n",
+        "            (__)\\       )\\/\\\n",
+        "                ||----w |\n",
+        "                ||     ||\n",
+    );
+
+    #[test]
+    fn png_font_is_monospace_and_tightly_leaded() {
+        let font = png_font();
+        // Menlo is fixed-width; a proportional face would break every column
+        // of the art regardless of what the wrapper does.
+        assert_eq!(font.family, "Menlo");
+        assert_eq!(font.size, 18.0);
+        // Tighter than layout-ir's 1.2 default, so rows of the cow meet.
+        assert_eq!(font.line_height, 1.1);
+    }
+
+    /// Regression test for the macOS-only build break.
+    ///
+    /// `layout_ir::TextContent` grew a `wrap` field. Every construction site
+    /// in the repo was updated except cowsay's, which lived behind
+    /// `#[cfg(target_vendor = "apple")]` and so was invisible to the Linux and
+    /// Windows compilers — the failure surfaced only on a macOS runner, long
+    /// after the change that caused it.
+    ///
+    /// Beyond re-asserting the value, the mere existence of this test forces
+    /// the struct literal to be compiled on every platform.
+    #[test]
+    fn ascii_art_never_soft_wraps() {
+        let content = cowsay_text_content(SAMPLE_ART, png_font());
+        // Soft wrapping re-splits on `split_whitespace()`, collapsing the runs
+        // of spaces that hold the cow together. Cowsay has already decided
+        // where its line breaks go; the layout engine must not second-guess.
+        assert!(!content.wrap, "cowsay ASCII art must never soft-wrap");
+        // `max_lines` truncates once wrapping is on; unlimited is the only
+        // correct answer for art whose height is fixed by its own newlines.
+        assert_eq!(content.max_lines, None);
+    }
+
+    #[test]
+    fn text_content_preserves_the_art_byte_for_byte() {
+        let content = cowsay_text_content(SAMPLE_ART, png_font());
+        // Nothing between cowsay and the layout engine may trim, re-indent or
+        // re-flow the art: the value handed over is the value produced.
+        assert_eq!(content.value, SAMPLE_ART);
+        assert!(content.value.contains("        \\   ^__^"));
+        assert_eq!(content.value.lines().count(), 8);
+    }
+
+    #[test]
+    fn text_is_left_aligned_and_black() {
+        let content = cowsay_text_content(SAMPLE_ART, png_font());
+        // Centring or justifying pre-formatted art would shift whole rows
+        // relative to each other.
+        assert_eq!(content.text_align, TextAlign::Start);
+        assert_eq!(content.color, color_black());
+        assert_eq!(content.font, png_font());
+    }
+
+    #[test]
+    fn empty_output_still_produces_valid_content() {
+        let content = cowsay_text_content("", png_font());
+        assert_eq!(content.value, "");
+        assert!(!content.wrap);
+    }
+
+    #[test]
+    fn non_apple_targets_report_png_rendering_as_unsupported() {
+        // The stub and the real implementation must agree on their signature;
+        // this pins the non-Apple contract so the two cannot drift apart.
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            let err = render_cowsay_png_metal("moo", Path::new("out.png"))
+                .expect_err("PNG rendering cannot work without Metal");
+            assert!(err.contains("Apple target"), "unexpected message: {err}");
+        }
+    }
 }

--- a/lessons.md
+++ b/lessons.md
@@ -3643,3 +3643,67 @@ in review.
    ordinary unlock, and audit the E2E test itself when a PTY-based test
    hangs at a `read_until` for a prompt — a hang there just as often means
    "the prompt legitimately stopped happening" as "the process is stuck."
+
+## A struct literal inside a platform `cfg` gate is invisible to the other platforms' compilers (cowsay, PR #12168)
+
+`rust/programs/cowsay` failed only on `build (macos-latest)` with
+
+```
+error[E0063]: missing field `wrap` in initializer of `layout_ir::TextContent`
+```
+
+`layout-ir` had gained a `wrap: bool` field on `TextContent`. Every other
+construction site in the repo was updated at the time; the one that was missed
+sat inside `#[cfg(target_vendor = "apple")] fn render_cowsay_png_metal`.
+
+The generalisable point is that this is **not** the usual cross-platform bug.
+It has nothing to do with path separators, line endings, locale, filesystem
+case-sensitivity, `/tmp` vs `$TMPDIR`, terminal width, or Unicode — the list
+you reach for when a job is red on one OS only. Those all describe code that
+*runs* differently. Here the code did not *exist* for two of the three
+compilers, so no amount of correctness on Linux or Windows could say anything
+about it. When a **compile** error (rather than a test failure) is
+platform-specific, suspect a `cfg` gate before suspecting behaviour. The clue
+was in the timing: `FAILED 12.2s` means it compiled and stopped, not that a
+long build ran or a test executed.
+
+Three consequences worth internalising:
+
+1. **Grepping for construction sites is necessary but not sufficient — grep
+   for gated ones specifically.** The existing lesson "grep every consumer for
+   record construction, not just pattern matches" (Haskell section) assumes
+   your compiler will show you the consumers. It will not show you the ones
+   behind a `cfg` for a platform you are not building. After changing a shared
+   struct, run `grep -rn "cfg(target_" --include=*.rs` across the consumers you
+   found and check each gated site against the target it is gated to.
+
+2. **Prefer un-gating the data from the platform code.** The durable fix was
+   not filling in the field, it was moving the struct literal out of the gated
+   function into an un-gated helper — `layout_ir` is pure data, and only the
+   *rendering* needed Metal/CoreText. All three legs then type-check the
+   literal, so the next field addition fails on Ubuntu in minutes instead of on
+   macOS in months. Gate the code that genuinely cannot compile elsewhere, and
+   no more than that. `#[cfg_attr(not(target_vendor = "apple"),
+   allow(dead_code))]` handles the resulting dead-code warning — and note that
+   a lint allowance does **not** suppress type checking, which is exactly why
+   this works.
+
+3. **You can verify an Apple-gated path from Windows or Linux.** `cargo check`
+   type-checks without linking, so `rustup target add aarch64-apple-darwin`
+   followed by `cargo check --all-targets --target aarch64-apple-darwin`
+   compiles the gated body with no Mac involved. This works whenever no
+   dependency has a `build.rs` driving the `cc` crate. Do the same for
+   `cargo clippy --target <t> --all-targets -- -D warnings`, once per target.
+
+   **Always pair it with a control run.** Restore the pre-fix file
+   (`git checkout origin/main -- <path>`, having first copied your version to
+   the scratchpad — `git stash` is unsafe in these shared worktrees) and
+   confirm the cross-check reproduces CI's exact error at the exact line, then
+   restore your version. A check that cannot fail proves nothing; the control
+   is what turns a clean run into evidence.
+
+Finally, the reason it rotted at all: cowsay had **no `BUILD` file**, so the
+build tool never discovered it and no CI leg ever compiled it. A `cfg`-gated
+literal inside an unwatched package is doubly invisible. Before concluding "CI
+is green, so this package is fine", confirm the package is actually in the
+build graph — `ls <pkg>/BUILD`.


### PR DESCRIPTION
> **Status: blocked on #12153 — do not merge first.**
>
> While this was being written, #12153 pushed commit `82cb240f77` which fixes the
> same compile error. That PR should land first; this one then rebases down to the
> part it does not cover. Auto-merge is deliberately off so this small PR cannot
> jump ahead of a 67-crate PR and force it to re-conflict and re-run a 2-hour CI.

## The failure

`build (macos-latest)` reported `rust/programs/cowsay  FAILED  12.2s`, green on ubuntu and windows. The job log's `--- FAILED: rust/programs/cowsay ---` block shows it is a **compile error**, not a test failure:

```
error[E0063]: missing field `wrap` in initializer of `layout_ir::TextContent`
   --> src/main.rs:451:37
    |
451 |         content: Some(Content::Text(TextContent {
    |                                     ^^^^^^^^^^^ missing `wrap`

error: could not compile `cowsay` (bin "cowsay" test) due to 1 previous error
error: could not compile `cowsay` (bin "cowsay") due to 1 previous error
```

## Why it was macOS-only

Nothing to do with paths, line endings, locale, terminal width or Unicode — the usual cross-platform suspects. The construction site sits inside `#[cfg(target_vendor = "apple")] fn render_cowsay_png_metal`, the Metal/CoreText PNG rendering path. **For the Linux and Windows compilers that code does not exist**, so they cannot notice a missing field.

`layout-ir` added `wrap: bool` to `TextContent` in #10345. Every other construction site was updated — `html-to-layout`, `document-ast-to-layout`, `diagram-to-paint`, `layout-block`, `layout-to-paint` all carry `wrap:` today. Only the Apple-gated one was missed, and no CI leg could see it.

It stayed hidden because cowsay has no `BUILD` file, so the build tool never built it at all. This is pre-existing breakage on `main`; the full-repo rebuild only made an already-broken program visible.

## Overlap with #12153, and what is left

#12153 sets `wrap: false` with the same reasoning, so on the value itself we independently agree — reassuring, since that is the semantic question. Two things it does not do, which are what this PR is really for:

**1. The literal is still inside the platform gate.** #12153 fills in today's missing field but leaves the struct literal where only the macOS compiler can see it. The next field added to `TextContent` breaks macOS again, exactly the same way, and again invisibly.

This PR moves the scene *description* out of the gate into `png_font()` and `cowsay_text_content()`. Only *rendering* needs Metal and CoreText; describing is plain data. All three CI legs then type-check the literal, so the next field addition fails on Ubuntu in minutes rather than on macOS in months. `dead_code` is allowed on non-Apple targets — the binary genuinely never calls them there — but a lint allowance does not suppress type checking, which is the whole point.

**2. There are no tests.** This adds the package's first suite (6 tests, all three platforms): `ascii_art_never_soft_wraps` pins `wrap == false` and `max_lines == None`, plus byte-exact art preservation, font metrics, alignment and colour, empty input, and the non-Apple stub contract. Nothing was deleted, skipped or `#[cfg]`-ed out.

On why `false` is right and not merely compilable: cowsay emits fixed-format monospace ASCII art whose bubble borders and cow legs align only because each line keeps exactly the spaces it was built with. `layout-to-paint`'s soft wrapper is greedy and re-splits on `split_whitespace()`, collapsing runs of interior spaces, so `wrap: true` could silently re-flow the art into gibberish. Hard `\n` breaks — the only ones cowsay produces — are preserved either way.

## Verification without a Mac

Developed on Windows with no macOS runner available, so the Apple-gated path was verified by cross-compiling to the real target (`cargo check` type-checks without linking):

| Target | `cargo check --all-targets` | `cargo clippy --all-targets -- -D warnings` |
|---|---|---|
| `aarch64-apple-darwin` | clean | clean |
| `x86_64-unknown-linux-gnu` | clean | clean |
| `x86_64-pc-windows-msvc` | clean | clean |

`cargo test --no-fail-fast` on the Windows host: 6 passed, 0 failed.

A **control run** confirms the check can actually fail: reverting `main.rs` to `origin/main` and re-running the darwin check reproduces CI's error exactly — same code, same line, same message.

```
error[E0063]: missing field `wrap` in initializer of `TextContent`
   --> src\main.rs:451:37
```

**Note on CI's limits here:** because cowsay still has no `BUILD` file on `main`, the build tool cannot discover it, so this PR's own macOS leg does not compile cowsay and a green tick on it proves nothing about this fix. Real CI coverage begins when #12153's `BUILD` lands. Until then the cross-compile above, with its control, is the evidence.

## Plan

1. #12153 merges.
2. This branch rebases onto it: the `wrap: false` line and the changelog entry become theirs, and this PR reduces to the un-gating plus the tests.
3. CI re-runs with the `BUILD` file present, so the macOS leg genuinely exercises cowsay.
4. Re-enable auto-merge.

## Notes

- Does not touch `BUILD` — that is #12153's.
- Sibling cases found the same way: `x86-simulator` (#12164, merged) and `chief-of-staff-hardware-key-approval` (#12165).
- Security review passed with no findings. It flagged a **pre-existing, out-of-scope** path traversal in `load_cow`'s `--cowfile` handling, filed as #12169 rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
