### PR TITLE
fix(vault-pm): derive MAX_CATALOG_ENTRIES from MAX_ENCODED_SIZE (VLT-PM05 §13.4)

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,74 @@
 
 All notable changes to this package are documented here.
 
+## [0.67.0] - 2026-08-19
+
+### Fixed
+
+- **`MAX_CATALOG_ENTRIES` is now derived from `MAX_ENCODED_SIZE`, not an
+  eyeballed `100,000`** (VLT-PM05 §13.4), closing a MEDIUM pre-existing bug
+  where an ordinary vault — no hostile peer needed — froze every mutation
+  including `item delete` once its catalog crossed roughly nineteen thousand
+  items, well inside the old, fictional 100,000-entry admission ceiling.
+
+  - The old bound described what `validate_catalog` admitted, not what
+    `CatalogV1::encode` could carry: canonical-CBOR's 1 MiB `MAX_ENCODED_SIZE`
+    refused to re-emit a catalog long before entry count reached 100,000, so
+    the number the catalog advertised was never the number it could hold.
+    Because catalog entries are never removed — a deleted item becomes a
+    tombstone *entry*, the same size on the wire, not a smaller one — a vault
+    that crossed the real ceiling had no recourse from inside the product at
+    all: every later mutation that had to re-encode the full catalog failed
+    the same way, forever.
+
+  - `CATALOG_ENTRY_BYTES` (55, the exact cost of one item id plus one
+    candidate revision id in canonical CBOR) and `CATALOG_FRAME_OVERHEAD_BYTES`
+    are now `const`s pinned against the real encoder, and
+    `MAX_ENCODABLE_CATALOG_ENTRIES = (MAX_ENCODED_SIZE - overhead) /
+    CATALOG_ENTRY_BYTES = 19,064` is a *proven* ceiling: no encode of a
+    `CatalogV1`, on this device or any other honouring the wire format, can
+    ever exceed it.
+
+  - Admission and decode now use two different bounds, deliberately.
+    `validate_catalog` (and therefore every local mutation that builds a new
+    catalog) applies the tight, margined `MAX_CATALOG_ENTRIES = 19,064 -
+    1,000 = 18,064`, refusing the item that would make the catalog
+    unencodable *before* that catalog is ever built. `CatalogV1::decode` and
+    `materialize_current_catalog`'s cross-head merge instead apply the
+    looser, unmargined `MAX_ENCODABLE_CATALOG_ENTRIES`, so a catalog this
+    device's past self (or any honest peer) could have legitimately produced
+    under the old admission check stays openable, while a catalog no honest
+    encoder could ever have produced — a peer hand-crafting bytes past its
+    own claimed framing budget — is still refused. Applying the tight bound
+    uniformly would have repeated, at the catalog level, the open-denies-the-
+    whole-vault mistake VLT-PM05 §13.3 already corrected once for individual
+    records.
+
+  - `CatalogV1::decode` no longer routes through `CatalogV1::new` for its
+    final construction, because that would silently re-apply the tight
+    admission bound after the intentionally looser decode-time check. The
+    per-record encode is factored into `encode_catalog_entries`, reused by
+    both `CatalogV1::encode` and the tests that construct catalog bytes past
+    the admission ceiling to model an honest-but-looser peer.
+
+  - Tests: `codec.rs` pins the byte-cost derivation and both bounds directly
+    against the real encoder — cheap, exact, no crypto needed. `open.rs`
+    reproduces the bug end to end against a real, unlocked vault:
+    `a_synced_catalog_at_the_proven_ceiling_opens` and
+    `a_synced_catalog_past_the_proven_ceiling_denies_open` bracket 19,064
+    exactly through `open_active_vault` against a peer-authored catalog
+    delivered the way a real sync would (many small publications, since one
+    commit cannot itself carry more than `MAX_ADDED_OBJECTS` new objects);
+    `a_catalog_at_the_admission_ceiling_can_still_be_deleted_from` reproduces
+    the named symptom directly — a real `delete_current_item` call succeeds
+    on a catalog sitting at this device's own admission ceiling.
+
+  - `MAX_CATALOG_ENTRIES` dropped from a nominal 100,000 to 18,064. No
+    honestly-produced catalog could ever have exceeded roughly 19,064 entries
+    regardless of that nominal figure, so this is not a new restriction on
+    anything that could actually have existed — it is the admission ceiling
+    catching up to the encode ceiling that was always the real one.
+
 ## [0.66.0] - 2026-08-18
 
 ### Added

--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -70,6 +70,28 @@ All notable changes to this package are documented here.
     anything that could actually have existed — it is the admission ceiling
     catching up to the encode ceiling that was always the real one.
 
+  - **Caught in security review before merge:** applying the tight
+    `MAX_CATALOG_ENTRIES` unconditionally to *every* catalog rebuild —
+    including a delete, edit, or restore that does not add an entry —
+    reopened this exact bug at a narrower band: a catalog synced from a
+    peer, or grown under this device's own pre-fix admission policy, with an
+    entry count anywhere in `(MAX_CATALOG_ENTRIES,
+    MAX_ENCODABLE_CATALOG_ENTRIES]` would decode and open fine, then fail
+    *every* subsequent mutation — delete included — because rebuilding that
+    same, unchanged entry count still ran into the tight admission ceiling.
+    `CatalogV1::new_for_mutation` fixes this: it only applies the tight
+    ceiling when a mutation's entry count actually grows past what it
+    already was, and the looser, proven `MAX_ENCODABLE_CATALOG_ENTRIES`
+    otherwise. `CatalogV1::encode` no longer re-runs `validate_catalog`
+    either, for the same reason — that re-check does not know whether the
+    catalog was built as new growth or as a non-growing mutation, and
+    applying the tight bound there unconditionally would undo
+    `new_for_mutation`'s fix at the encode step. Regression tests:
+    `mutation_of_an_above_admission_catalog_succeeds_when_it_does_not_grow`
+    (`codec.rs`) and `a_catalog_above_the_admission_ceiling_can_still_be_
+    deleted_from` (`open.rs`, a real `delete_current_item` call against a
+    real synced vault whose catalog already exceeds the admission ceiling).
+
 ## [0.66.0] - 2026-08-18
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -504,9 +504,14 @@ vault that reached the real ceiling could never shrink back under it from
 inside the product — every later mutation that had to re-encode the full
 catalog failed the same way, permanently, delete included. `MAX_CATALOG_ENTRIES`
 is now *derived* from `MAX_ENCODED_SIZE` — the exact per-entry byte cost (55
-bytes) plus a safety margin — so admission refuses the entry that would make
+bytes) plus a safety margin — so admission refuses the item that would make
 the catalog unencodable before that catalog is ever built, rather than
-discovering the failure on the next re-encode. See VLT-PM05 section 13.4.
+discovering the failure on the next re-encode. Only genuine growth is held to
+that tighter bound, though: `CatalogV1::new_for_mutation` checks a non-growing
+mutation (an edit, a delete, a restore) against the looser, proven
+`MAX_ENCODABLE_CATALOG_ENTRIES` instead, so a catalog already sitting above
+the admission ceiling — synced from a peer, say — stays editable and
+deletable-from, not merely openable. See VLT-PM05 section 13.4.
 
 The remaining ones — a first-party record, the revision framing around it, and
 the re-encode of entries imported from someone else's artifact — are reachable

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -488,14 +488,25 @@ encode" as a reachable outcome and reports `BoundExceeded`, never a panic — a
 process abort would discard in-flight state and, because the offending value
 persists, would repeat on every later command against the same vault.
 
-Three of these need no hostile input at all:
+Two of these need no hostile input at all:
 
-- the **catalog** is re-encoded by every mutation, and its own validation admits
-  100,000 entries — far past the codec ceiling;
 - a **portable export** of a vault holding a couple of large entries produces a
   snapshot over 1 MiB;
 - **local state** carries the publication journal, which admits thousands of
   prepared objects.
+
+The **catalog** used to be a third: it is re-encoded by every mutation, and its
+own admission check used to allow 100,000 entries — a number the codec
+ceiling could never actually carry, since an ordinary vault crossed it
+somewhere around nineteen thousand items. Because catalog entries are never
+removed (a deleted item becomes a tombstone *entry*, not a smaller one), a
+vault that reached the real ceiling could never shrink back under it from
+inside the product — every later mutation that had to re-encode the full
+catalog failed the same way, permanently, delete included. `MAX_CATALOG_ENTRIES`
+is now *derived* from `MAX_ENCODED_SIZE` — the exact per-entry byte cost (55
+bytes) plus a safety margin — so admission refuses the entry that would make
+the catalog unencodable before that catalog is ever built, rather than
+discovering the failure on the next re-encode. See VLT-PM05 section 13.4.
 
 The remaining ones — a first-party record, the revision framing around it, and
 the re-encode of entries imported from someone else's artifact — are reachable
@@ -522,9 +533,11 @@ a *size* violated this was `decode_record`'s opaque arm, which re-encoded the
 payload it had just decoded; it no longer does.
 
 The invariant is about size, and about materialisation. Open still fails closed
-on corrupt frames, broken pins, failed signatures, and a catalog past
-`MAX_CATALOG_ENTRIES` — and a revision that does not decode at all still denies
-it, which a peer-authored first-party record with a schema-invalid payload can
+on corrupt frames, broken pins, failed signatures, and a catalog past the
+proven, decode-time `MAX_ENCODABLE_CATALOG_ENTRIES` ceiling (deliberately
+looser than the admission-time `MAX_CATALOG_ENTRIES` above — see VLT-PM05
+section 13.4) — and a revision that does not decode at all still denies it,
+which a peer-authored first-party record with a schema-invalid payload can
 still cause. That residual is pre-existing and tracked; it needs a decision
 about what a partly-unreadable item looks like to every ceremony, not a local
 fix. See VLT-PM05 section 13.3 and VLT02 *Decoding never re-encodes*.

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -2,7 +2,9 @@ use crate::{
     ApplicationError, ObjectKind, ATTACHMENT_CHUNK_BYTES, ATTACHMENT_DEK_BYTES,
     MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_CHUNKS, MAX_ATTACHMENT_NAME_BYTES,
 };
-use coding_adventures_canonical_cbor::{decode, encode, try_encode, CborError, CborValue};
+use coding_adventures_canonical_cbor::{
+    decode, encode, try_encode, CborError, CborValue, MAX_ENCODED_SIZE,
+};
 use coding_adventures_vault_attachments::{BlobId, EncryptedChunk};
 use coding_adventures_vault_pm_audit::SignedAuditEventV1;
 use coding_adventures_vault_pm_domain::{
@@ -24,8 +26,112 @@ const VERSION: u64 = 1;
 const LIVE_STATE: u64 = 1;
 const TOMBSTONE_STATE: u64 = 2;
 pub(crate) const MAX_PLAINTEXT_BYTES: usize = 16 * 1024 * 1024;
-pub(crate) const MAX_CATALOG_ENTRIES: usize = 100_000;
 pub(crate) const MAX_CANDIDATES_PER_ITEM: usize = 16;
+
+// ─────────────────────────────────────────────────────────────────────
+// Catalog entry bounds — derived from MAX_ENCODED_SIZE, not eyeballed
+// ─────────────────────────────────────────────────────────────────────
+//
+// This used to be one flat, round `100_000` used for admission, decode,
+// and cross-head merging alike. `100_000` was never reachable: canonical-
+// CBOR's own 1 MiB `MAX_ENCODED_SIZE` (this crate's *inner* bound, see
+// `CatalogV1::encode`'s doc comment and VLT-PM05 §13.1) refuses to emit a
+// catalog anywhere near that many entries. An ordinary vault crossed the
+// real ceiling somewhere below twenty thousand items, and because catalog
+// entries are never removed — a deleted item becomes a tombstone *entry*,
+// not a smaller one — nothing this product does from inside a session
+// could ever bring an over-ceiling catalog back under it. Every mutation
+// that had to re-encode the catalog, delete included, failed the same way
+// forever. See VLT-PM05 §13.2 for the full account.
+//
+// The fix is two numbers, not one, because "can we still open a catalog
+// bigger than what we would create" and "how big a catalog are we willing
+// to keep growing" are different questions with different backward-
+// compatibility answers:
+
+/// Exact byte cost of one catalog entry with exactly one candidate
+/// revision: `{1: bytes(item_id), 2: [bytes(revision_id)]}`.
+///
+/// `ItemId` is a fixed 16-byte value and `RevisionId` a fixed 32-byte
+/// value, and canonical-CBOR's header for a definite-length byte string
+/// is fully determined by its length, never its content — so this is not
+/// an estimate, it is an exact count:
+///
+/// ```text
+///   entry map header (2 pairs, < 24)              1
+///   key 1 (unsigned < 24)                          1
+///   item id   bytes header (len 16, < 24)          1
+///             item id bytes                       16
+///   key 2 (unsigned < 24)                          1
+///   candidates  array header (1 elem, < 24)        1
+///     revision id  bytes header (len 32, >= 24)    2
+///                  revision id bytes               32
+///                                                ----
+///                                                  55
+/// ```
+///
+/// One candidate is the cheapest an entry can be — a second candidate
+/// (a conflict) adds 34 more bytes, never fewer — so this is a lower
+/// bound on real per-entry cost and therefore an *upper* bound on how
+/// many entries any valid catalog can hold. Pinned against the real
+/// encoder by `catalog_entry_byte_cost_is_exact` below.
+const CATALOG_ENTRY_BYTES: usize = 55;
+
+/// Conservative upper bound on the bytes *outside* the per-entry cost:
+/// the outer map's three fields (version, kind, entries array) plus the
+/// entries array's own length header, which grows from 1 byte
+/// (< 24 elements) to 2 (< 256), 3 (< 65,536), or 5 (< 2^32) as the
+/// catalog grows. 16 bytes covers all of that with room to spare in the
+/// size range this bound actually operates in (tens of thousands of
+/// entries, a 3-byte array header) without needing a separate case for
+/// the exact crossover point.
+const CATALOG_FRAME_OVERHEAD_BYTES: usize = 16;
+
+/// The real ceiling: the largest entry count *any* valid encode of a
+/// `CatalogV1` can reach, on this device or any other honouring the same
+/// wire format. Because `CATALOG_ENTRY_BYTES` is the cheapest an entry
+/// can ever be, no catalog — however its entries are distributed between
+/// single-candidate and conflicted — can exceed this many entries and
+/// still fit inside `MAX_ENCODED_SIZE`. That makes it safe to use as a
+/// decode-time bound with zero backward-compatibility cost: nothing
+/// honestly produced by this wire format, past or present, can be turned
+/// away by it. Only a peer that does not honour `MAX_ENCODED_SIZE` at all
+/// — hand-crafting bytes rather than running this encoder — can ever
+/// author a catalog object this large.
+pub(crate) const MAX_ENCODABLE_CATALOG_ENTRIES: usize =
+    (MAX_ENCODED_SIZE - CATALOG_FRAME_OVERHEAD_BYTES) / CATALOG_ENTRY_BYTES;
+
+/// Entries of headroom subtracted from [`MAX_ENCODABLE_CATALOG_ENTRIES`]
+/// to get the admission-time ceiling below. Two things eat into the exact
+/// ceiling without changing entry *count*: items that have gone through
+/// conflict resolution carry more than one candidate revision (34 extra
+/// bytes each), and this margin needs to absorb that without a per-entry
+/// accounting. 1,000 entries of margin is 55,000 bytes of slack — room
+/// for on the order of a thousand simultaneously-conflicted items, far
+/// past what concurrent editing of a personal vault produces in
+/// practice. A vault that legitimately exceeds even that is the
+/// pre-existing, tracked residual VLT-PM05 §13.2 names for the
+/// conflicted-item case, not a new one this change introduces.
+const CATALOG_ADMISSION_SAFETY_MARGIN: usize = 1_000;
+
+/// The admission-time ceiling this device applies to catalogs it
+/// constructs itself: [`MAX_ENCODABLE_CATALOG_ENTRIES`] minus
+/// [`CATALOG_ADMISSION_SAFETY_MARGIN`]. Used by `validate_catalog`, and
+/// therefore by every local mutation that builds a new `CatalogV1` —
+/// `item add`, `item delete`, `item edit`, the authored conflict merges,
+/// and portable import. Reaching this ceiling refuses the *next* item
+/// admitted, with `BoundExceeded`, before the catalog is ever built —
+/// which is the actual fix: the old code let admission run all the way
+/// to a fictional `100_000` and only discovered the real ceiling on
+/// re-encode, by which point every entry already admitted was
+/// permanently stuck in an unencodable catalog. A catalog that stays
+/// under this ceiling can always be edited, deleted from, and
+/// re-encoded — the escape hatch VLT-PM05 §13.2 already relies on for
+/// oversized individual records now also holds for the catalog as a
+/// whole, because admission never lets the catalog reach a size that
+/// escape hatch can't recover from.
+pub(crate) const MAX_CATALOG_ENTRIES: usize =
+    MAX_ENCODABLE_CATALOG_ENTRIES - CATALOG_ADMISSION_SAFETY_MARGIN;
 
 /// Owner-private authority and device seeds persisted only as encrypted state.
 #[derive(PartialEq, Eq)]
@@ -162,57 +268,60 @@ impl CatalogV1 {
     ///
     /// # Why this encode is checked
     ///
-    /// `validate_catalog` admits up to `MAX_CATALOG_ENTRIES` (100,000)
-    /// items, and each entry costs roughly sixty bytes once the item id
-    /// and its candidate revision ids are encoded. A full catalog is
-    /// therefore several megabytes — comfortably past canonical-CBOR's
-    /// 1 MiB `MAX_ENCODED_SIZE`, which this crate's own 16 MiB plaintext
-    /// gate does not bound (VLT-PM05 section 13.1).
+    /// `validate_catalog` admits up to `MAX_CATALOG_ENTRIES` entries, which
+    /// is derived (see the constant's own doc comment) to stay under
+    /// canonical-CBOR's 1 MiB `MAX_ENCODED_SIZE` — the *inner* bound this
+    /// crate's own 16 MiB plaintext gate does not itself enforce (VLT-PM05
+    /// §13.1). Because admission already refuses the entry that would have
+    /// pushed a catalog past what can be re-encoded, this call is not
+    /// expected to fail on entry count: `self.entries` can only have been
+    /// built through [`CatalogV1::new`] or [`CatalogV1::empty`], both of
+    /// which already ran `validate_catalog`.
     ///
-    /// Unlike the record encodes, this one needs no hostile peer: an
-    /// ordinary vault crosses the codec's ceiling somewhere below twenty
-    /// thousand items, and the catalog is re-encoded by every mutation.
-    /// So the bound this function's own validation advertises is not the
-    /// binding one, and the encode reports `BoundExceeded` rather than
-    /// aborting the process.
+    /// It re-validates and re-checks anyway, for the same reason the record
+    /// encodes keep `check_plaintext_bound` after their own inner checks
+    /// (§13.1): a conflicted item can carry more than one candidate
+    /// revision, and enough conflicted entries at once can still exhaust
+    /// `MAX_CATALOG_ENTRIES`'s safety margin even though entry *count*
+    /// stayed under the admission ceiling. That residual is narrow — it
+    /// needs on the order of a thousand simultaneously-conflicted items —
+    /// and reports `BoundExceeded` the same as every other re-encode this
+    /// layer performs, rather than aborting the process.
     pub fn encode(&self) -> Result<Vec<u8>, ApplicationError> {
         validate_catalog(&self.entries)?;
-        let entries = self
-            .entries
-            .iter()
-            .map(|(item, candidates)| {
-                CborValue::Map(vec![
-                    field(1, bytes(item.as_bytes())),
-                    field(
-                        2,
-                        CborValue::Array(
-                            candidates
-                                .iter()
-                                .map(|candidate| bytes(candidate.as_bytes()))
-                                .collect(),
-                        ),
-                    ),
-                ])
-            })
-            .collect();
-        let encoded = try_encode(&CborValue::Map(vec![
-            field(1, CborValue::Unsigned(VERSION)),
-            field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
-            field(3, CborValue::Array(entries)),
-        ]))
-        .map_err(map_encode_error)?;
-        check_plaintext_bound(&encoded)?;
-        Ok(encoded)
+        encode_catalog_entries(&self.entries)
     }
 
     /// Strictly decode one closed canonical V1 catalog.
+    ///
+    /// # Why this uses the looser of the two entry bounds
+    ///
+    /// This checks entry count against [`MAX_ENCODABLE_CATALOG_ENTRIES`],
+    /// not the tighter admission-time [`MAX_CATALOG_ENTRIES`]. The two
+    /// differ by design: [`MAX_ENCODABLE_CATALOG_ENTRIES`] is a *proven*
+    /// ceiling — with one candidate per entry, the cheapest an entry can
+    /// ever encode to, no valid `CatalogV1::encode` output from any device
+    /// honouring this wire format can exceed it — so rejecting past it
+    /// costs nothing for any honestly-produced catalog, old client or new.
+    /// Using the tighter, margined `MAX_CATALOG_ENTRIES` here instead would
+    /// repeat the mistake VLT-PM05 §13.3 already corrected once for
+    /// individual records: this decode runs on the open path (through
+    /// `materialize_current_catalog`), and a hard reject there does not
+    /// refuse one mutation, it denies the whole vault. A catalog a past
+    /// version of this device (or any honest peer) legitimately produced
+    /// between the two bounds must stay openable even though this device
+    /// would no longer *admit* growing a catalog that large; only a
+    /// catalog no honest encoder could ever have produced — because it
+    /// exceeds the proven ceiling — is rejected here, which is exactly the
+    /// case of a peer installing a catalog this device could never itself
+    /// re-encode.
     pub fn decode(encoded: &[u8]) -> Result<Self, ApplicationError> {
         check_plaintext_bound(encoded)?;
         let mut fields = closed_fields(encoded, &[1, 2, 3])?;
         check_version(take_uint(&mut fields, 1)?)?;
         check_kind(take_uint(&mut fields, 2)?, ObjectKind::Catalog)?;
         let encoded_entries = take_array(&mut fields, 3)?;
-        if encoded_entries.len() > MAX_CATALOG_ENTRIES {
+        if encoded_entries.len() > MAX_ENCODABLE_CATALOG_ENTRIES {
             return Err(ApplicationError::BoundExceeded);
         }
         let mut entries = BTreeMap::new();
@@ -238,8 +347,51 @@ impl CatalogV1 {
             }
             entries.insert(item, candidates);
         }
-        Self::new(entries)
+        // Not `Self::new`: that runs `validate_catalog`, which applies the
+        // *admission* ceiling. The structural checks above (sorted, unique,
+        // non-empty, within `MAX_CANDIDATES_PER_ITEM`) are exactly what
+        // `validate_catalog` would otherwise re-check per entry; the only
+        // thing it would add is the tighter entry-count bound this function
+        // deliberately does not apply. See the decode doc comment above.
+        Ok(Self { entries })
     }
+}
+
+/// Encode `entries` into the exact closed canonical V1 catalog body,
+/// without checking entry count against either bound.
+///
+/// Factored out of [`CatalogV1::encode`] so tests can construct catalog
+/// bytes past the admission ceiling — modelling a peer whose own
+/// validation is looser than this device's — without reaching into the
+/// wire format by hand.
+pub(crate) fn encode_catalog_entries(
+    entries: &BTreeMap<ItemId, Vec<RevisionId>>,
+) -> Result<Vec<u8>, ApplicationError> {
+    let encoded_entries = entries
+        .iter()
+        .map(|(item, candidates)| {
+            CborValue::Map(vec![
+                field(1, bytes(item.as_bytes())),
+                field(
+                    2,
+                    CborValue::Array(
+                        candidates
+                            .iter()
+                            .map(|candidate| bytes(candidate.as_bytes()))
+                            .collect(),
+                    ),
+                ),
+            ])
+        })
+        .collect();
+    let encoded = try_encode(&CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
+        field(3, CborValue::Array(encoded_entries)),
+    ]))
+    .map_err(map_encode_error)?;
+    check_plaintext_bound(&encoded)?;
+    Ok(encoded)
 }
 
 impl Debug for CatalogV1 {
@@ -1198,6 +1350,11 @@ fn encode_any_record(record: &AnyRecord) -> Result<Vec<u8>, ApplicationError> {
     }
 }
 
+/// Admission-time validation for a catalog this device is about to build
+/// or publish. Applies the tight, margined [`MAX_CATALOG_ENTRIES`] — not
+/// the looser [`MAX_ENCODABLE_CATALOG_ENTRIES`] `CatalogV1::decode` uses —
+/// because this runs on the write path, where refusing the *next* item is
+/// the correct, cheap failure, unlike decode's open-path hard reject.
 fn validate_catalog(entries: &BTreeMap<ItemId, Vec<RevisionId>>) -> Result<(), ApplicationError> {
     if entries.len() > MAX_CATALOG_ENTRIES {
         return Err(ApplicationError::BoundExceeded);
@@ -1593,33 +1750,184 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn oversized_catalog_is_reported_rather_than_aborting_the_process() {
-        // The catalog's own validation admits 100,000 entries, but the
-        // encoder beneath it stops at 1 MiB, so the advertised bound is
-        // not the binding one. No hostile input is involved here: this is
-        // an ordinary vault that grew, and the catalog is re-encoded on
-        // every mutation.
+    /// Build `count` distinct, sorted, single-candidate catalog entries.
+    fn many_single_candidate_entries(count: usize) -> BTreeMap<ItemId, Vec<RevisionId>> {
         let mut entries = BTreeMap::new();
-        for index in 0..30_000_u32 {
+        for index in 0..count {
+            let index = u64::try_from(index).unwrap();
             let mut id = [0_u8; 16];
-            id[..4].copy_from_slice(&index.to_be_bytes());
+            id[..8].copy_from_slice(&index.to_be_bytes());
             entries.insert(ItemId::new(id), vec![RevisionId::new([1; 32])]);
         }
-        let catalog = CatalogV1::new(entries).unwrap();
-        assert_eq!(catalog.encode(), Err(ApplicationError::BoundExceeded));
+        entries
+    }
+
+    /// One CBOR definite-length header: major type `major`, argument `len`,
+    /// smallest form. Independent of `try_encode` so tests can author bytes
+    /// no honest use of this crate's own encoder could ever produce --
+    /// modelling a peer whose encoder does not share `MAX_ENCODED_SIZE`.
+    fn raw_cbor_header(major: u8, len: usize) -> Vec<u8> {
+        let major = major << 5;
+        if len <= 23 {
+            vec![major | len as u8]
+        } else if len <= 0xFF {
+            vec![major | 24, len as u8]
+        } else if len <= 0xFFFF {
+            let mut out = vec![major | 25];
+            out.extend_from_slice(&(len as u16).to_be_bytes());
+            out
+        } else {
+            let mut out = vec![major | 26];
+            out.extend_from_slice(&(len as u32).to_be_bytes());
+            out
+        }
+    }
+
+    /// Hand-assemble `count` catalog entries directly onto the wire,
+    /// bypassing `try_encode` (and therefore `MAX_ENCODED_SIZE`) entirely.
+    /// This is what a peer whose own encoder has a larger — or absent —
+    /// framing budget would produce: valid canonical CBOR this device's own
+    /// encoder could never have written.
+    fn raw_catalog_bytes(count: usize) -> Vec<u8> {
+        let mut out = vec![0xa3, 0x01, 0x01, 0x02, 0x02, 0x03];
+        out.extend(raw_cbor_header(4, count));
+        for index in 0..count {
+            let index = u64::try_from(index).unwrap();
+            let mut item_id = [0_u8; 16];
+            item_id[..8].copy_from_slice(&index.to_be_bytes());
+            out.extend([0xa2, 0x01]);
+            out.extend(raw_cbor_header(2, 16));
+            out.extend_from_slice(&item_id);
+            out.extend([0x02, 0x81]);
+            out.extend(raw_cbor_header(2, 32));
+            out.extend_from_slice(&[1_u8; 32]);
+        }
+        out
+    }
+
+    #[test]
+    fn catalog_entry_byte_cost_is_exact() {
+        // `CATALOG_ENTRY_BYTES` is asserted, not measured, in the constant's
+        // own doc comment. Pin it against the real encoder so a change to
+        // `ItemId`/`RevisionId` width, or to the CBOR profile, fails this
+        // test instead of silently invalidating every bound derived from it.
+        let empty = encode_catalog_entries(&BTreeMap::new()).unwrap();
+        let one = encode_catalog_entries(&many_single_candidate_entries(1)).unwrap();
+        assert_eq!(one.len() - empty.len(), CATALOG_ENTRY_BYTES);
+
+        // The hand-assembled wire form used by the tests below must be
+        // byte-for-byte what the real encoder produces, or the "peer" bytes
+        // those tests build would not be modelling this wire format at all.
+        assert_eq!(raw_catalog_bytes(0), empty);
+        assert_eq!(raw_catalog_bytes(1), one);
+        assert_eq!(
+            raw_catalog_bytes(500),
+            encode_catalog_entries(&many_single_candidate_entries(500)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn max_encodable_catalog_entries_is_a_proven_ceiling() {
+        // No valid encode of any catalog, from this device or any other
+        // honouring MAX_ENCODED_SIZE, can exceed this many entries: one
+        // candidate per entry is the cheapest an entry can be, so this is
+        // the theoretical maximum, not an estimate. Proven two ways: the
+        // real encoder accepts exactly this many single-candidate entries
+        // and refuses one more (going through `encode_catalog_entries`,
+        // which -- unlike `CatalogV1::encode` -- does not apply the
+        // tighter admission ceiling, so this measures the wire format's
+        // limit and nothing about this device's own policy).
+        let at_ceiling = many_single_candidate_entries(MAX_ENCODABLE_CATALOG_ENTRIES);
+        let encoded = encode_catalog_entries(&at_ceiling).unwrap();
+        assert!(encoded.len() <= coding_adventures_canonical_cbor::MAX_ENCODED_SIZE);
+
+        let one_more = many_single_candidate_entries(MAX_ENCODABLE_CATALOG_ENTRIES + 1);
+        assert_eq!(
+            encode_catalog_entries(&one_more),
+            Err(ApplicationError::BoundExceeded),
+        );
+    }
+
+    #[test]
+    fn admission_refuses_growth_before_the_catalog_is_ever_unencodable() {
+        // Before this fix, `validate_catalog` admitted up to a flat,
+        // eyeballed 100,000 entries -- a number the encoder beneath it
+        // could never actually reach. Admission now refuses the entry that
+        // would make the catalog unencodable, before that catalog is ever
+        // built, rather than discovering the failure on the next re-encode.
+        let at_ceiling = many_single_candidate_entries(MAX_CATALOG_ENTRIES);
+        let catalog = CatalogV1::new(at_ceiling).unwrap();
+        let encoded = catalog.encode().unwrap();
+        assert_eq!(CatalogV1::decode(&encoded).unwrap(), catalog);
+
+        let one_more = many_single_candidate_entries(MAX_CATALOG_ENTRIES + 1);
+        assert_eq!(
+            CatalogV1::new(one_more),
+            Err(ApplicationError::BoundExceeded),
+            "admission must reject the (MAX_CATALOG_ENTRIES + 1)-th item \
+             itself, not merely fail later on encode",
+        );
 
         // A catalog that does fit still encodes and round trips, so the
         // check has not simply closed the door on every large vault.
-        let mut small = BTreeMap::new();
-        for index in 0..1_000_u32 {
-            let mut id = [0_u8; 16];
-            id[..4].copy_from_slice(&index.to_be_bytes());
-            small.insert(ItemId::new(id), vec![RevisionId::new([1; 32])]);
-        }
+        let small = many_single_candidate_entries(1_000);
         let catalog = CatalogV1::new(small).unwrap();
         let encoded = catalog.encode().unwrap();
         assert_eq!(CatalogV1::decode(&encoded).unwrap(), catalog);
+    }
+
+    #[test]
+    fn decode_stays_open_to_a_legacy_or_peer_catalog_admission_would_now_refuse() {
+        // Between the two bounds -- admission's MAX_CATALOG_ENTRIES and the
+        // proven MAX_ENCODABLE_CATALOG_ENTRIES ceiling -- is exactly the
+        // band a fully honest encoder (this device before this fix shipped,
+        // or any other device honouring the same wire format) could
+        // legitimately have produced, but this device would no longer admit
+        // building itself. Decode must still accept it: denying it would
+        // turn "this device won't grow the catalog further" into "this
+        // device can no longer open its own history," which is the failure
+        // VLT-PM05 section 13.3 already ruled out once for individual
+        // records.
+        const BETWEEN: usize = MAX_CATALOG_ENTRIES + 500;
+        const _: () = assert!(MAX_CATALOG_ENTRIES < MAX_ENCODABLE_CATALOG_ENTRIES);
+        const _: () = assert!(BETWEEN < MAX_ENCODABLE_CATALOG_ENTRIES);
+        let between = BETWEEN;
+
+        let entries = many_single_candidate_entries(between);
+        // This device would no longer admit constructing it fresh...
+        assert_eq!(
+            CatalogV1::new(entries.clone()),
+            Err(ApplicationError::BoundExceeded),
+        );
+        // ...but it decodes and opens, because a past version of this
+        // device (or any honest peer) could have produced these exact
+        // bytes through this exact encoder.
+        let encoded = encode_catalog_entries(&entries).unwrap();
+        let decoded = CatalogV1::decode(&encoded).unwrap();
+        assert_eq!(decoded.entries(), &entries);
+    }
+
+    #[test]
+    fn decode_rejects_a_catalog_no_honest_encoder_could_have_produced() {
+        // Past MAX_ENCODABLE_CATALOG_ENTRIES, no device honouring
+        // MAX_ENCODED_SIZE -- old or new -- could ever have written these
+        // bytes, so rejecting them costs no legitimate peer or legacy vault
+        // anything. This is the decode-time half of the fix: a peer whose
+        // own framing budget is looser than this wire format's cannot hand
+        // this device a catalog it can decode but never again re-encode.
+        let too_many = MAX_ENCODABLE_CATALOG_ENTRIES + 1;
+        let peer_bytes = raw_catalog_bytes(too_many);
+        assert!(peer_bytes.len() <= MAX_PLAINTEXT_BYTES);
+        assert_eq!(
+            CatalogV1::decode(&peer_bytes),
+            Err(ApplicationError::BoundExceeded),
+        );
+
+        // The control: one entry under the same ceiling, built the same
+        // hand-assembled way, must still decode -- so the rejection above
+        // is about count, not about how the bytes were authored.
+        let at_ceiling = raw_catalog_bytes(MAX_ENCODABLE_CATALOG_ENTRIES);
+        assert!(CatalogV1::decode(&at_ceiling).is_ok());
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -246,9 +246,69 @@ pub struct CatalogV1 {
 }
 
 impl CatalogV1 {
-    /// Validate and construct a canonical catalog snapshot.
+    /// Validate and construct a canonical catalog snapshot from scratch.
+    ///
+    /// Every entry here is new growth — this is what portable import and
+    /// tests use, where there is no "previous" catalog to compare against —
+    /// so the whole entry count is checked against the tight, margined
+    /// [`MAX_CATALOG_ENTRIES`]. An ordinary item mutation, which carries
+    /// forward every entry that already existed and touches at most one,
+    /// should use [`CatalogV1::new_for_mutation`] instead: that constructor
+    /// is what keeps a catalog already sitting above the admission ceiling
+    /// editable and deletable-from rather than merely openable. See that
+    /// constructor's doc comment, and VLT-PM05 §13.4, for why the two must
+    /// differ.
     pub fn new(entries: BTreeMap<ItemId, Vec<RevisionId>>) -> Result<Self, ApplicationError> {
         validate_catalog(&entries)?;
+        Ok(Self { entries })
+    }
+
+    /// Validate and construct a catalog for one ordinary item mutation,
+    /// given the entry count immediately before it.
+    ///
+    /// # Why this is not just `CatalogV1::new`
+    ///
+    /// `validate_catalog` (used by [`CatalogV1::new`]) rejects any entry
+    /// count over the tight, margined [`MAX_CATALOG_ENTRIES`] — correct
+    /// for admitting *new growth*, wrong for a mutation that does not grow
+    /// the catalog at all. A single item mutation carries forward every
+    /// entry `current_items` already had and touches exactly one: entry
+    /// count after the mutation is `previous_entry_count` unchanged (edit,
+    /// delete, restore, or conflict-resolution of an item that already had
+    /// a catalog entry) or `previous_entry_count + 1` (a brand-new item,
+    /// the only case that is genuinely new growth).
+    ///
+    /// Applying the tight bound unconditionally — as an earlier version of
+    /// this fix did — reopened the exact bug VLT-PM05 §13.4 exists to
+    /// close, just at a narrower band: a catalog synced from a peer, or
+    /// grown under this device's own pre-fix admission policy, with an
+    /// entry count anywhere in `(MAX_CATALOG_ENTRIES,
+    /// MAX_ENCODABLE_CATALOG_ENTRIES]` would decode and open (§13.4's
+    /// decode-time bound is the looser, proven ceiling) but then fail
+    /// *every* subsequent mutation — including delete, the escape hatch —
+    /// because rebuilding that same, unchanged entry count through
+    /// `validate_catalog` always exceeded the tighter admission ceiling,
+    /// regardless of whether the mutation added anything.
+    ///
+    /// So the ceiling this function applies depends on whether the
+    /// mutation is growing the catalog: [`MAX_CATALOG_ENTRIES`] only if
+    /// `entries.len() > previous_entry_count`, otherwise the looser
+    /// [`MAX_ENCODABLE_CATALOG_ENTRIES`] — the same proven ceiling decode
+    /// already trusts, so a catalog decode accepted can always still be
+    /// edited, deleted from, and restored, not merely opened.
+    pub(crate) fn new_for_mutation(
+        entries: BTreeMap<ItemId, Vec<RevisionId>>,
+        previous_entry_count: usize,
+    ) -> Result<Self, ApplicationError> {
+        let ceiling = if entries.len() > previous_entry_count {
+            MAX_CATALOG_ENTRIES
+        } else {
+            MAX_ENCODABLE_CATALOG_ENTRIES
+        };
+        if entries.len() > ceiling {
+            return Err(ApplicationError::BoundExceeded);
+        }
+        validate_catalog_structure(&entries)?;
         Ok(Self { entries })
     }
 
@@ -266,29 +326,36 @@ impl CatalogV1 {
 
     /// Encode the exact closed canonical V1 application object.
     ///
-    /// # Why this encode is checked
+    /// # Why this does not re-run `validate_catalog`
     ///
-    /// `validate_catalog` admits up to `MAX_CATALOG_ENTRIES` entries, which
-    /// is derived (see the constant's own doc comment) to stay under
-    /// canonical-CBOR's 1 MiB `MAX_ENCODED_SIZE` — the *inner* bound this
-    /// crate's own 16 MiB plaintext gate does not itself enforce (VLT-PM05
-    /// §13.1). Because admission already refuses the entry that would have
-    /// pushed a catalog past what can be re-encoded, this call is not
-    /// expected to fail on entry count: `self.entries` can only have been
-    /// built through [`CatalogV1::new`] or [`CatalogV1::empty`], both of
-    /// which already ran `validate_catalog`.
+    /// An earlier version of this method called `validate_catalog(&self.
+    /// entries)` here, applying the tight, margined `MAX_CATALOG_ENTRIES`
+    /// unconditionally before encoding. That was wrong for exactly the
+    /// catalogs [`CatalogV1::new_for_mutation`] exists to allow: a catalog
+    /// already sitting above the admission ceiling — synced from a peer,
+    /// or grown under this device's own pre-fix admission policy — whose
+    /// entry count does not increase (an edit, a delete, a restore) is
+    /// legitimately constructed by `new_for_mutation` against the looser,
+    /// proven [`MAX_ENCODABLE_CATALOG_ENTRIES`], and re-checking it here
+    /// against the tighter bound would refuse to encode a catalog that
+    /// constructor had already correctly accepted — reopening, at the
+    /// encode step, the exact bug VLT-PM05 §13.4 exists to close. See that
+    /// constructor's doc comment for the full account.
     ///
-    /// It re-validates and re-checks anyway, for the same reason the record
-    /// encodes keep `check_plaintext_bound` after their own inner checks
-    /// (§13.1): a conflicted item can carry more than one candidate
-    /// revision, and enough conflicted entries at once can still exhaust
-    /// `MAX_CATALOG_ENTRIES`'s safety margin even though entry *count*
-    /// stayed under the admission ceiling. That residual is narrow — it
-    /// needs on the order of a thousand simultaneously-conflicted items —
-    /// and reports `BoundExceeded` the same as every other re-encode this
-    /// layer performs, rather than aborting the process.
+    /// `self.entries` was already validated by whichever constructor built
+    /// this value ([`CatalogV1::new`], [`CatalogV1::new_for_mutation`], or
+    /// [`CatalogV1::empty`]), each against the ceiling appropriate to how
+    /// it was built. This encode's own job is only to confirm the *bytes*
+    /// still fit `MAX_ENCODED_SIZE` — the inner bound this crate's own
+    /// 16 MiB plaintext gate does not itself enforce (VLT-PM05 §13.1) —
+    /// which `encode_catalog_entries` checks unconditionally regardless of
+    /// entry count. That inner check is what actually can still fail here:
+    /// a conflicted item carries more than one candidate revision, and
+    /// enough conflicted entries at once can exhaust a margin no entry-
+    /// count ceiling accounts for. It reports `BoundExceeded` the same as
+    /// every other re-encode this layer performs, rather than aborting the
+    /// process.
     pub fn encode(&self) -> Result<Vec<u8>, ApplicationError> {
-        validate_catalog(&self.entries)?;
         encode_catalog_entries(&self.entries)
     }
 
@@ -1350,15 +1417,26 @@ fn encode_any_record(record: &AnyRecord) -> Result<Vec<u8>, ApplicationError> {
     }
 }
 
-/// Admission-time validation for a catalog this device is about to build
-/// or publish. Applies the tight, margined [`MAX_CATALOG_ENTRIES`] — not
-/// the looser [`MAX_ENCODABLE_CATALOG_ENTRIES`] `CatalogV1::decode` uses —
-/// because this runs on the write path, where refusing the *next* item is
-/// the correct, cheap failure, unlike decode's open-path hard reject.
+/// Admission-time validation for a catalog built entirely from scratch —
+/// used by [`CatalogV1::new`]. Applies the tight, margined
+/// [`MAX_CATALOG_ENTRIES`] to the *whole* entry count, which is correct
+/// exactly when every entry is new growth (portable import, tests) and
+/// wrong for an ordinary item mutation that carries forward entries that
+/// already existed — see [`CatalogV1::new_for_mutation`] for that case.
 fn validate_catalog(entries: &BTreeMap<ItemId, Vec<RevisionId>>) -> Result<(), ApplicationError> {
     if entries.len() > MAX_CATALOG_ENTRIES {
         return Err(ApplicationError::BoundExceeded);
     }
+    validate_catalog_structure(entries)
+}
+
+/// Structural checks shared by every catalog construction path, regardless
+/// of which entry-count ceiling applies: every item's candidate list is
+/// non-empty, within [`MAX_CANDIDATES_PER_ITEM`], and sorted with no
+/// duplicates.
+fn validate_catalog_structure(
+    entries: &BTreeMap<ItemId, Vec<RevisionId>>,
+) -> Result<(), ApplicationError> {
     for candidates in entries.values() {
         if candidates.is_empty() || candidates.len() > MAX_CANDIDATES_PER_ITEM {
             return Err(ApplicationError::InvalidInput);
@@ -1905,6 +1983,55 @@ mod tests {
         let encoded = encode_catalog_entries(&entries).unwrap();
         let decoded = CatalogV1::decode(&encoded).unwrap();
         assert_eq!(decoded.entries(), &entries);
+    }
+
+    #[test]
+    fn mutation_of_an_above_admission_catalog_succeeds_when_it_does_not_grow() {
+        // A first version of this fix applied the tight MAX_CATALOG_ENTRIES
+        // ceiling unconditionally to every catalog rebuild, admission and
+        // mutation alike. That reopened the exact bug this fix exists to
+        // close, just at a narrower band: a catalog synced from a peer, or
+        // grown under this device's own pre-fix admission policy, with an
+        // entry count anywhere in (MAX_CATALOG_ENTRIES,
+        // MAX_ENCODABLE_CATALOG_ENTRIES] would decode and open (decode uses
+        // the looser ceiling) but then fail *every* subsequent mutation --
+        // including delete -- because rebuilding that same, unchanged entry
+        // count through the tight bound always failed, regardless of
+        // whether the mutation added anything. `new_for_mutation` is the
+        // fix: it only applies the tight ceiling when entry count actually
+        // grows past what it already was.
+        const ABOVE_ADMISSION: usize = MAX_CATALOG_ENTRIES + 500;
+        const _: () = assert!(ABOVE_ADMISSION < MAX_ENCODABLE_CATALOG_ENTRIES);
+
+        let entries = many_single_candidate_entries(ABOVE_ADMISSION);
+
+        // Same entry count as "before" (an edit, delete, or restore of an
+        // item that already had a catalog entry): allowed, because nothing
+        // grew, even though the count is already past MAX_CATALOG_ENTRIES.
+        let catalog = CatalogV1::new_for_mutation(entries.clone(), ABOVE_ADMISSION).unwrap();
+        // And it must actually re-encode -- this is the failure mode the
+        // bug exhibited: admission accepting a catalog that then can't be
+        // turned back into bytes.
+        let encoded = catalog.encode().unwrap();
+        assert_eq!(CatalogV1::decode(&encoded).unwrap(), catalog);
+
+        // One MORE entry than "before" (a brand-new item): this is genuine
+        // growth, so the tight admission ceiling still applies and refuses
+        // it, exactly as it should.
+        let mut grown = entries.clone();
+        grown.insert(ItemId::new([0xff; 16]), vec![RevisionId::new([1; 32])]);
+        assert_eq!(
+            CatalogV1::new_for_mutation(grown, ABOVE_ADMISSION),
+            Err(ApplicationError::BoundExceeded),
+        );
+
+        // Fewer entries than "before" is never growth either, so it is
+        // allowed on the same terms as the unchanged case, all the way up
+        // to the proven ceiling.
+        let mut shrunk = entries;
+        shrunk.remove(shrunk.keys().next().copied().as_ref().unwrap());
+        let catalog = CatalogV1::new_for_mutation(shrunk, ABOVE_ADMISSION).unwrap();
+        assert!(catalog.encode().is_ok());
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -1554,6 +1554,7 @@ fn prepare_item_publication_with_objects(
         .map_err(|_| ApplicationError::InternalInvariant)?;
     let revision_id = RevisionId::new(*revision_object_id.as_bytes());
 
+    let previous_entry_count = current_items.len();
     let mut catalog_entries = BTreeMap::new();
     for (existing_item_id, candidates) in current_items {
         let mut revision_ids = candidates
@@ -1565,7 +1566,18 @@ fn prepare_item_publication_with_objects(
         catalog_entries.insert(*existing_item_id, revision_ids);
     }
     catalog_entries.insert(item_id, vec![revision_id]);
-    let catalog_plaintext = Zeroizing::new(CatalogV1::new(catalog_entries)?.encode()?);
+    // `new_for_mutation`, not `CatalogV1::new`: this rebuild carries
+    // forward every entry `current_items` already had and touches exactly
+    // one, so it is only genuine growth when `item_id` was not already a
+    // key -- and only genuine growth should be capped by the tight
+    // admission ceiling. See VLT-PM05 §13.4 and that constructor's doc
+    // comment: applying the tight bound unconditionally here would refuse
+    // an ordinary edit or delete on a catalog that is already open but
+    // sits above the admission ceiling, reopening the bug this fix exists
+    // to close.
+    let catalog_plaintext = Zeroizing::new(
+        CatalogV1::new_for_mutation(catalog_entries, previous_entry_count)?.encode()?,
+    );
     let catalog_frame = seal_object(
         keys,
         ObjectKind::Catalog,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -16438,11 +16438,6 @@ mod tests {
         out
     }
 
-    /// Seal `item_count` distinct, tiny, peer-authored opaque item
-    /// revisions and return their frames alongside the sorted
-    /// `(item_id, revision_id)` pairs a catalog entry list needs. Entry
-    /// count is exactly the caller's choice, independent of any bound this
-    /// device's own admission path applies.
     /// Publish a peer-authored catalog that ends up carrying `item_count`
     /// distinct items, then adopt its final head locally.
     ///

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -16630,6 +16630,67 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_catalog_above_the_admission_ceiling_can_still_be_deleted_from() {
+        // A sharper reproduction than the test above: this vault is synced
+        // from a peer whose catalog *already* exceeds this device's own
+        // admission ceiling -- squarely in the band (MAX_CATALOG_ENTRIES,
+        // MAX_ENCODABLE_CATALOG_ENTRIES] that a fully honest peer (or this
+        // device's own pre-fix past self) could legitimately have produced.
+        // An earlier version of this fix opened such a vault fine but then
+        // refused every subsequent mutation, including delete, because
+        // rebuilding the catalog's unchanged entry count still ran through
+        // the tight admission ceiling regardless of whether anything grew
+        // -- the exact bug this fix exists to close, just relocated to a
+        // higher threshold instead of eliminated. `delete_current_item`
+        // succeeding here is the actual fix: a mutation that does not grow
+        // the catalog is never blocked by how large the catalog already is.
+        const ABOVE_ADMISSION: usize = MAX_CATALOG_ENTRIES + 500;
+        const _: () = assert!(ABOVE_ADMISSION < MAX_ENCODABLE_CATALOG_ENTRIES);
+
+        let (locator, local, bootstrap, factory) = initialized();
+        publish_peer_catalog_with_item_count(
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+            ABOVE_ADMISSION,
+        );
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(session.current_catalog.items.len(), ABOVE_ADMISSION);
+        let item_id = ItemId::new([0; 16]);
+        session
+            .delete_current_item(item_id, 900, 901, delete_item_randomness(0x5f), &local)
+            .unwrap();
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(session.current_catalog.items.len(), ABOVE_ADMISSION);
+        let candidates = &session.current_catalog.items[&item_id];
+        assert_eq!(candidates.len(), 1);
+        assert!(matches!(candidates[0].state(), ItemState::Tombstone(_)));
+
+        // A second delete on a different item, to be sure the first one
+        // wasn't a fluke of exactly matching some boundary -- the catalog
+        // stays exactly the same size delete after delete, and each one
+        // must keep succeeding.
+        // Item index 1's id, matching `publish_peer_catalog_with_item_count`'s
+        // scheme: the counter's big-endian bytes in the first 8 bytes, the
+        // rest zero.
+        let second_item_id = ItemId::new([0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+        session
+            .delete_current_item(
+                second_item_id,
+                902,
+                903,
+                delete_item_randomness(0x60),
+                &local,
+            )
+            .unwrap();
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(session.current_catalog.items.len(), ABOVE_ADMISSION);
+    }
+
     // ---------------------------------------------------------------------
     // VLT-PM43 — passphrase rotation
     // ---------------------------------------------------------------------

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -30,7 +30,10 @@ use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::codec::{MAX_CANDIDATES_PER_ITEM, MAX_CATALOG_ENTRIES};
+use crate::codec::MAX_CANDIDATES_PER_ITEM;
+#[cfg(test)]
+use crate::codec::MAX_CATALOG_ENTRIES;
+use crate::codec::MAX_ENCODABLE_CATALOG_ENTRIES;
 
 /// Default maximum number of historical revisions returned for one item.
 pub const DEFAULT_ITEM_HISTORY_LIMIT: usize = 100;
@@ -4181,6 +4184,25 @@ pub fn open_active_vault(
     })
 }
 
+/// Merge every reachable head's catalog into the one current view.
+///
+/// # Why the merge cap is `MAX_ENCODABLE_CATALOG_ENTRIES`, not `MAX_CATALOG_ENTRIES`
+///
+/// Each catalog object decoded here already passed `CatalogV1::decode`'s own
+/// bound at the same value (VLT-PM05 §13.2's derivation), so a single head
+/// can never contribute more than that many distinct items. This loop's own
+/// check exists for the case of *several* unreconciled concurrent heads
+/// whose entries only partly overlap: the union across heads can in
+/// principle exceed what any one of them could encode alone. Using the
+/// proven, unmargined ceiling here (rather than the tighter admission bound)
+/// keeps that union check from denying `open_active_vault` over a size any
+/// honest set of heads could legitimately reach — VLT-PM05 §13.3 already
+/// established that open must not fail closed over size where a narrower,
+/// correctly-calibrated bound suffices. A merged view that does exceed even
+/// this proven ceiling cannot have come from any device honouring this wire
+/// format, so denying open here is deliberate: VLT-PM05 §13.3 names exactly
+/// this case — "a catalog with more entries than `MAX_CATALOG_ENTRIES`" —
+/// as one of the things open should still fail closed on.
 fn materialize_current_catalog(
     keys: &V1Keys,
     repository: &dyn ApplicationRepository,
@@ -4207,7 +4229,9 @@ fn materialize_current_catalog(
         let catalog = CatalogV1::decode(&catalog_plaintext)?;
 
         for (item_id, revision_ids) in catalog.entries() {
-            if !materialized.contains_key(item_id) && materialized.len() == MAX_CATALOG_ENTRIES {
+            if !materialized.contains_key(item_id)
+                && materialized.len() == MAX_ENCODABLE_CATALOG_ENTRIES
+            {
                 return Err(ApplicationError::IntegrityFailure);
             }
             let candidates = materialized.entry(*item_id).or_default();
@@ -16371,6 +16395,244 @@ mod tests {
         let candidates = &session.current_catalog.items[&item_id];
         assert_eq!(candidates.len(), 1);
         assert!(matches!(candidates[0].state(), ItemState::Tombstone(_)));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A synced peer's oversized *catalog* -- the item count crossed, not
+    // any one record's size (VLT-PM05 §13.2's admission/decode fix)
+    //
+    // Mirrors the opaque-record class above one level up: instead of one
+    // poisoned record, the catalog object itself carries more entries
+    // than this device's own (now-tighter) admission ceiling would ever
+    // build, delivered the way a sync delivers it. The two tests bracket
+    // `MAX_ENCODABLE_CATALOG_ENTRIES` exactly: at the ceiling, no honest
+    // encoder could have produced more, so it must still open even though
+    // this device would refuse to grow a catalog that large itself; one
+    // entry past it, no honest encoder -- old or new -- could have
+    // produced it at all, so `materialize_current_catalog` denies open,
+    // which VLT-PM05 §13.3 names as one of the cases open should still
+    // fail closed on.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// One CBOR definite-length header in the smallest form, independent of
+    /// this crate's own encoder -- see [`cbor_header`] above, reused here at
+    /// the catalog level.
+    fn raw_catalog_bytes_for(entries: &[(ItemId, RevisionId)]) -> Vec<u8> {
+        let mut out = vec![
+            0xa3,
+            0x01,
+            0x01,
+            0x02,
+            ObjectKind::Catalog.code() as u8,
+            0x03,
+        ];
+        out.extend(cbor_header(4, entries.len()));
+        for (item_id, revision_id) in entries {
+            out.extend([0xa2, 0x01]);
+            out.extend(cbor_header(2, 16));
+            out.extend_from_slice(item_id.as_bytes());
+            out.extend([0x02, 0x81]);
+            out.extend(cbor_header(2, 32));
+            out.extend_from_slice(revision_id.as_bytes());
+        }
+        out
+    }
+
+    /// Seal `item_count` distinct, tiny, peer-authored opaque item
+    /// revisions and return their frames alongside the sorted
+    /// `(item_id, revision_id)` pairs a catalog entry list needs. Entry
+    /// count is exactly the caller's choice, independent of any bound this
+    /// device's own admission path applies.
+    /// Publish a peer-authored catalog that ends up carrying `item_count`
+    /// distinct items, then adopt its final head locally.
+    ///
+    /// One commit cannot carry more than `MAX_ADDED_OBJECTS` (4,096) new
+    /// objects -- VLT-PM format's own bound on one publication, unrelated
+    /// to the catalog-entry bound this fix derives -- so a catalog this
+    /// size cannot be delivered as a single implausible mega-sync. It is
+    /// delivered the way a catalog this size actually comes to exist:
+    /// many small publications, each adding a batch of new items and a
+    /// fresh cumulative catalog snapshot, exactly the shape ordinary
+    /// incremental growth already takes. This is not a simplification for
+    /// the test's sake -- it is what "an ordinary vault that grew" (the
+    /// bug's own framing, VLT-PM05 §13.2) looks like at the object-store
+    /// level.
+    fn publish_peer_catalog_with_item_count(
+        locator: BootstrapLocator,
+        local: &MemoryLocalStateStore,
+        bootstrap: &MemoryBootstrapStore,
+        factory: &V1ApplicationRepositoryFactory<InMemoryObjectStore>,
+        item_count: usize,
+    ) {
+        const BATCH_SIZE: usize = 4_000;
+        let mut accumulated: BTreeMap<ItemId, RevisionId> = BTreeMap::new();
+        let mut next_index = 0_usize;
+        while next_index < item_count {
+            let batch_end = (next_index + BATCH_SIZE).min(item_count);
+
+            let exact_active = local.0.lock().unwrap().clone().unwrap();
+            let LocalVaultStateV1::Active(active) =
+                LocalVaultStateV1::decode(&exact_active).unwrap()
+            else {
+                panic!("fixture must be active")
+            };
+            let fixture = generation_zero_bytes();
+            let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+            let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+
+            let mut frames = Vec::with_capacity(batch_end - next_index);
+            for index in next_index..batch_end {
+                let counter = u64::try_from(index).unwrap();
+                let mut item_id_bytes = [0_u8; 16];
+                item_id_bytes[..8].copy_from_slice(&counter.to_be_bytes());
+                let item_id = ItemId::new(item_id_bytes);
+
+                let mut dek = [0xd0_u8; 32];
+                dek[..8].copy_from_slice(&counter.to_be_bytes());
+                let mut wrap_nonce = [0xd1_u8; 24];
+                wrap_nonce[..8].copy_from_slice(&counter.to_be_bytes());
+                let mut payload_nonce = [0xd2_u8; 24];
+                payload_nonce[..8].copy_from_slice(&counter.to_be_bytes());
+
+                let frame = seal_object(
+                    &keys,
+                    ObjectKind::ItemRevision,
+                    &peer_opaque_revision_plaintext(item_id, 8),
+                    &ObjectRandomness::new(dek, wrap_nonce, payload_nonce),
+                )
+                .unwrap();
+                let revision_id = RevisionId::new(*frame.id().unwrap().as_bytes());
+                accumulated.insert(item_id, revision_id);
+                frames.push(frame);
+            }
+
+            let entries: Vec<(ItemId, RevisionId)> =
+                accumulated.iter().map(|(id, rev)| (*id, *rev)).collect();
+            let catalog_plaintext = raw_catalog_bytes_for(&entries);
+            let batch_counter = u64::try_from(next_index).unwrap();
+            let mut catalog_dek = [0xd4_u8; 32];
+            catalog_dek[..8].copy_from_slice(&batch_counter.to_be_bytes());
+            let mut catalog_wrap_nonce = [0xd5_u8; 24];
+            catalog_wrap_nonce[..8].copy_from_slice(&batch_counter.to_be_bytes());
+            let mut catalog_payload_nonce = [0xd6_u8; 24];
+            catalog_payload_nonce[..8].copy_from_slice(&batch_counter.to_be_bytes());
+            let catalog_frame = seal_object(
+                &keys,
+                ObjectKind::Catalog,
+                &catalog_plaintext,
+                &ObjectRandomness::new(catalog_dek, catalog_wrap_nonce, catalog_payload_nonce),
+            )
+            .unwrap();
+            let publication = publication_for_catalog(&active, frames, catalog_frame);
+            peer_publishes(locator, local, bootstrap, factory, publication);
+
+            next_index = batch_end;
+        }
+    }
+
+    #[test]
+    fn a_synced_catalog_at_the_proven_ceiling_opens() {
+        let (locator, local, bootstrap, factory) = initialized();
+        publish_peer_catalog_with_item_count(
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+            MAX_ENCODABLE_CATALOG_ENTRIES,
+        );
+
+        // No honest encoder -- this device's own included -- could have
+        // produced one entry more, so this is the largest catalog any
+        // peer could legitimately have handed over. It still opens, even
+        // though this device's own tighter admission ceiling would refuse
+        // to grow a catalog to this size itself.
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(
+            session.current_catalog.items.len(),
+            MAX_ENCODABLE_CATALOG_ENTRIES
+        );
+    }
+
+    #[test]
+    fn a_synced_catalog_past_the_proven_ceiling_denies_open() {
+        let (locator, local, bootstrap, factory) = initialized();
+        publish_peer_catalog_with_item_count(
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+            MAX_ENCODABLE_CATALOG_ENTRIES + 1,
+        );
+
+        // Past the proven ceiling, no device honouring MAX_ENCODED_SIZE --
+        // old or new -- could ever have written these bytes, and
+        // `CatalogV1::decode` refuses them with `BoundExceeded` before
+        // `materialize_current_catalog`'s own cross-head merge check is
+        // ever reached (that check exists for a different case: several
+        // *individually* in-bounds heads whose union exceeds the ceiling).
+        // Denying open here is deliberate either way: VLT-PM05 §13.3 names
+        // exactly this case, a catalog with more entries than the derived
+        // bound, as one of the things open should still fail closed on,
+        // distinct from the individual-record-size case that section fixed
+        // to never deny open.
+        let result = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        );
+        assert_eq!(result.map(|_| ()), Err(ApplicationError::BoundExceeded));
+    }
+
+    #[test]
+    fn a_catalog_at_the_admission_ceiling_can_still_be_deleted_from() {
+        // The bug this fix closes, reproduced directly. Before it, a
+        // catalog that reached the real (undocumented, far lower than the
+        // advertised 100,000) encode ceiling could never again be
+        // re-encoded by *any* mutation -- delete included, because a
+        // deleted item becomes a tombstone *entry*, not a smaller one. An
+        // ordinary vault that grew this large had no recourse from inside
+        // the product at all. Now that admission keeps this device's own
+        // catalogs under a ceiling that always survives re-encode, delete
+        // -- the escape hatch VLT-PM05 §13.2 already relies on for
+        // oversized individual records -- keeps working even once the
+        // catalog is as large as this device will ever grow one itself,
+        // and admission correctly refuses to grow it further.
+        let (locator, local, bootstrap, factory) = initialized();
+        publish_peer_catalog_with_item_count(
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+            MAX_CATALOG_ENTRIES,
+        );
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(session.current_catalog.items.len(), MAX_CATALOG_ENTRIES);
+        let item_id = ItemId::new([0; 16]);
+        session
+            .delete_current_item(item_id, 900, 901, delete_item_randomness(0x5e), &local)
+            .unwrap();
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(session.current_catalog.items.len(), MAX_CATALOG_ENTRIES);
+        let candidates = &session.current_catalog.items[&item_id];
+        assert_eq!(candidates.len(), 1);
+        assert!(matches!(candidates[0].state(), ItemState::Tombstone(_)));
+
+        // The other half of the same bug: admission still correctly
+        // refuses to grow this catalog past the ceiling it is already at
+        // -- deleting one item did not "make room," because catalog
+        // entries are never removed.
+        let randomness = add_item_randomness(0x5f);
+        let document = new_login_document(randomness.item_id(), "One too many", "x");
+        assert_eq!(
+            session
+                .add_item(document, 902, randomness, &local)
+                .map(|_| ()),
+            Err(ApplicationError::BoundExceeded),
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -435,10 +435,13 @@ CatalogV1 {
 }
 ```
 
-V1 permits 100,000 entries and at most 16 current candidates per item. Every
-candidate frame must decrypt as `ItemRevisionV1` with the same item ID. Empty
-candidate sets, duplicate item IDs, wrong-kind frames, dangling references, and
-candidate amplification are corruption.
+V1 permits at most 16 current candidates per item. Entry count is bounded by
+two different numbers depending on which side of the wire is asking — see
+§13.4 for the derivation and why decode and admission deliberately disagree —
+rather than one flat, round figure. Every candidate frame must decrypt as
+`ItemRevisionV1` with the same item ID. Empty candidate sets, duplicate item
+IDs, wrong-kind frames, dangling references, and candidate amplification are
+corruption.
 
 Catalogs are immutable snapshots. Phase 1A rewrites one encrypted catalog frame
 per mutation. A later tree format may optimize this without changing domain or
@@ -682,8 +685,8 @@ After authentication, the opener strictly decodes the closed snapshot, checks
 the exact candidate count and domain-separated hash, and verifies the embedded
 bootstrap's authority public key and self-signature. Candidate entries must be
 strictly increasing by source item/revision identity, unique, bounded to
-100,000 items and 16 candidates per item, canonically decode as item revisions,
-and reproduce the entry's item identity. Every intermediate plaintext CBOR
+`MAX_CATALOG_ENTRIES` items (§13.4) and 16 candidates per item, canonically
+decode as item revisions, and reproduce the entry's item identity. Every intermediate plaintext CBOR
 tree, passphrase, derived key, ciphertext copy, bootstrap, encoded revision,
 and hash preimage is wiped on every return path.
 
@@ -740,7 +743,8 @@ Additional V1 bounds are checked before allocation:
 |---|---:|
 | local state bytes | 32 MiB |
 | prepared/pending publication objects | 4,096 |
-| catalog entries | 100,000 |
+| catalog entries admitted by this device (`MAX_CATALOG_ENTRIES`) | 18,064 |
+| catalog entries this device will still decode (`MAX_ENCODABLE_CATALOG_ENTRIES`) | 19,064 |
 | candidates per item | 16 |
 | application plaintext object | 16 MiB |
 | search query | 256 bytes |
@@ -918,7 +922,10 @@ correct.
 
 It is about *materialisation*, not about the whole open. Open still fails
 closed on the things it should: a corrupt frame, a broken pin, a failed
-signature, a catalog with more entries than `MAX_CATALOG_ENTRIES`.
+signature, a catalog with more entries than the decode-time ceiling
+(`MAX_ENCODABLE_CATALOG_ENTRIES` as of §13.4 — this bound was named
+`MAX_CATALOG_ENTRIES` and set to a flat, unreachable `100,000` when this
+section was written).
 
 And it is about *size*, not about every per-item failure. A revision that
 does not decode still denies open, and one case of that is reachable from
@@ -977,6 +984,144 @@ was declined. The third could not be answered that way, because on the
 open path a closed error *is* the loss. Fixing it meant removing the
 failure rather than reporting it — which was available, because the
 re-encode was never needed in the first place.
+
+### 13.4 The catalog's own entry ceiling was fictional
+
+§13.1 gave every record encode a `BoundExceeded` outcome instead of an abort,
+including `CatalogV1::encode` itself. That fix assumed the catalog's own
+admission check — `entries.len() > MAX_CATALOG_ENTRIES`, with
+`MAX_CATALOG_ENTRIES` a flat, round `100,000` — was merely the *looser* of
+two bounds, the same relationship the plaintext gate has to the encoder's
+ceiling everywhere else in this layer. It was not. `100,000` was never
+reachable: `CatalogV1::encode`'s own comment already said so — "an ordinary
+vault crosses the codec's ceiling somewhere below twenty thousand items" —
+but the number the catalog *admitted* was never brought down to match the
+number it could actually carry.
+
+**Why this one has no delete escape hatch.** §13.2 names deletion as the
+recourse for an oversized individual record: a tombstone revision carries
+only the item id and a timestamp, so it never re-triggers the record encode
+that failed. That recourse does not exist for an oversized *catalog*, because
+catalog entries are not removed by deletion — an item's tombstone is still a
+catalog entry, the same size on the wire as the live entry it replaced. A
+catalog that has reached the real ceiling stays at that size forever. Every
+subsequent mutation that has to re-encode the full catalog — `item add`,
+`item edit`, `item delete`, every authored conflict merge, and `export` —
+fails the same way, permanently, with no operation left inside the product
+that shrinks the catalog back under the ceiling. An ordinary vault that grew
+past roughly nineteen thousand items had no recourse at all, and needed no
+hostile peer to get there.
+
+**The derivation.** `CatalogV1::encode`'s wire shape for one entry with one
+candidate is exactly:
+
+```text
+  entry map header (2 pairs, < 24)              1
+  key 1 (unsigned < 24)                          1
+  item id   bytes header (len 16, < 24)          1
+            item id bytes                       16
+  key 2 (unsigned < 24)                          1
+  candidates  array header (1 elem, < 24)        1
+    revision id  bytes header (len 32, >= 24)    2
+                 revision id bytes               32
+                                                ----
+                                                 55
+```
+
+`ItemId` and `RevisionId` are fixed-width byte strings, and canonical-CBOR's
+header for a definite-length byte string depends only on its length, never
+its content, so 55 bytes is exact, not an estimate — and it is the *cheapest*
+an entry can encode to: a second candidate (a conflict) costs 34 more bytes,
+never fewer. With a 16-byte conservative allowance for the frame around the
+entries array (the outer map's three fields plus the entries array's own
+length header), the largest entry count any encode of a `CatalogV1` can ever
+reach is:
+
+```text
+MAX_ENCODABLE_CATALOG_ENTRIES = (MAX_ENCODED_SIZE - 16) / 55 = 19,064
+```
+
+No catalog produced by any device honouring `MAX_ENCODED_SIZE` — this one,
+past or present, or any other implementation of this wire format — can ever
+exceed 19,064 entries. That makes it a *proven* ceiling rather than a policy
+choice, which is what lets it be used as a decode-time bound with zero
+backward-compatibility cost (below).
+
+Admission then subtracts a safety margin of 1,000 entries — 55,000 bytes of
+slack, enough to absorb on the order of a thousand simultaneously-conflicted
+items (each extra candidate costs 34 bytes, not a full entry) without a
+per-entry accounting — arriving at:
+
+```text
+MAX_CATALOG_ENTRIES = MAX_ENCODABLE_CATALOG_ENTRIES - 1,000 = 18,064
+```
+
+**Two bounds, not one, and why they must differ.** The fix is not "lower
+`MAX_CATALOG_ENTRIES` to the real number." A single tightened bound applied
+uniformly would repeat, at the catalog level, the exact mistake §13.3
+corrected for individual records: a hard reject on the *open* path over
+*size*, which does not refuse one mutation, it denies the whole vault. A
+catalog between the two bounds is not hypothetical residue — under the old
+`100,000`-entry admission check, this device's own past self could
+legitimately have grown a catalog anywhere up to the *real* 19,064-entry
+ceiling before this fix shipped, and any other device honouring the same
+wire format could have too. That catalog must stay openable.
+
+So admission and decode use different bounds, on purpose:
+
+- **Admission** (`validate_catalog`, and therefore `CatalogV1::new` and every
+  local mutation that builds a new catalog — `item add`, `item delete`,
+  `item edit`, the authored conflict merges, and portable import) uses the
+  tight, margined `MAX_CATALOG_ENTRIES` (18,064). Reaching it refuses the
+  *next* item with `BoundExceeded`, before that catalog is ever built, which
+  is the actual fix: the failure moves from re-encode time to admission
+  time, and a catalog admission has already bounded can always still be
+  edited, deleted from, and re-encoded — the freeze this section opened
+  with cannot recur, because admission never lets the catalog reach a size
+  that re-encode can't recover from.
+- **Decode** (`CatalogV1::decode`) uses the looser, unmargined
+  `MAX_ENCODABLE_CATALOG_ENTRIES` (19,064) — the proven ceiling, not this
+  device's own admission policy. This runs on the open path, through
+  `materialize_current_catalog`, so a hard reject here denies the whole
+  vault rather than one mutation; using the proven ceiling means the only
+  catalogs it ever rejects are ones no honest encoder, old or new, could
+  ever have produced. A catalog this device would no longer *admit*
+  building fresh — because it exceeds 18,064 — still opens, because it
+  might be exactly what a past version of this device, or any honest peer,
+  legitimately wrote. Only past 19,064 is a catalog certainly the product
+  of a peer whose own encoder does not honour `MAX_ENCODED_SIZE` — hand-
+  crafting wire bytes rather than running a compliant encoder — and that is
+  the case this closes: a peer cannot install a catalog this device could
+  decode but never again re-encode.
+
+`materialize_current_catalog`'s own cross-head merge check (reachable when
+several unreconciled concurrent heads each individually decode within bounds
+but their union does not) uses the same proven ceiling as decode, for the
+same reason. A merged view that does exceed it cannot have come from any
+device honouring this wire format, so denying open there remains one of the
+cases open should still fail closed on — §13.3 already named exactly this,
+"a catalog with more entries than `MAX_CATALOG_ENTRIES`," as the accepted
+exception to the invariant it otherwise established.
+
+**Tests.** `codec.rs` pins the derivation directly against the real encoder:
+`catalog_entry_byte_cost_is_exact` measures the 55-byte cost;
+`max_encodable_catalog_entries_is_a_proven_ceiling` shows the encoder accepts
+exactly 19,064 single-candidate entries and refuses one more, from any
+caller, not only this device's own admission path;
+`admission_refuses_growth_before_the_catalog_is_ever_unencodable` shows
+admission refuses the 18,065th entry itself, rather than building a catalog
+that fails later on encode; `decode_stays_open_to_a_legacy_or_peer_catalog_
+admission_would_now_refuse` and `decode_rejects_a_catalog_no_honest_encoder_
+could_have_produced` cover the two decode-time halves. `open.rs` reproduces
+the bug end to end against a real, unlocked vault: `a_synced_catalog_at_the_
+proven_ceiling_opens` and `a_synced_catalog_past_the_proven_ceiling_denies_
+open` bracket 19,064 exactly, through `open_active_vault` against a
+peer-authored catalog delivered the way a real sync would deliver one (many
+small publications, since one commit cannot itself carry more than
+`MAX_ADDED_OBJECTS` new objects); `a_catalog_at_the_admission_ceiling_can_
+still_be_deleted_from` reproduces the named symptom directly — a real
+`delete_current_item` call succeeds on a catalog sitting at this device's own
+admission ceiling, and a subsequent `add_item` is correctly refused.
 
 ## 14. Required verification
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1069,30 +1069,56 @@ wire format could have too. That catalog must stay openable.
 
 So admission and decode use different bounds, on purpose:
 
-- **Admission** (`validate_catalog`, and therefore `CatalogV1::new` and every
-  local mutation that builds a new catalog — `item add`, `item delete`,
-  `item edit`, the authored conflict merges, and portable import) uses the
-  tight, margined `MAX_CATALOG_ENTRIES` (18,064). Reaching it refuses the
-  *next* item with `BoundExceeded`, before that catalog is ever built, which
-  is the actual fix: the failure moves from re-encode time to admission
-  time, and a catalog admission has already bounded stays editable, can
-  always be deleted from, and always re-encodes — the freeze this section
-  opened with cannot recur, because admission never lets the catalog reach
-  a size that re-encode can't recover from.
-- **Decode** (`CatalogV1::decode`) uses the looser, unmargined
-  `MAX_ENCODABLE_CATALOG_ENTRIES` (19,064) — the proven ceiling, not this
-  device's own admission policy. This runs on the open path, through
-  `materialize_current_catalog`, so a hard reject here denies the whole
-  vault rather than one mutation; using the proven ceiling means the only
-  catalogs it ever rejects are ones no honest encoder, old or new, could
-  ever have produced. A catalog this device would no longer *admit*
-  building fresh — because it exceeds 18,064 — still opens, because it
-  might be exactly what a past version of this device, or any honest peer,
-  legitimately wrote. Only past 19,064 is a catalog certainly the product
-  of a peer whose own encoder does not honour `MAX_ENCODED_SIZE` — hand-
-  crafting wire bytes rather than running a compliant encoder — and that is
-  the case this closes: a peer cannot install a catalog this device could
-  decode but never again re-encode.
+- **Admission of new growth** (`validate_catalog`, used by `CatalogV1::new`
+  — portable import, and any construction with no "previous" catalog to
+  compare against) applies the tight, margined `MAX_CATALOG_ENTRIES`
+  (18,064) to the whole entry count. Reaching it refuses the *next* item
+  with `BoundExceeded`, before that catalog is ever built.
+- **Ordinary item mutation** (`CatalogV1::new_for_mutation`, used by every
+  local mutation that touches one item — `item add`, `item delete`, `item
+  edit`, restore, and the authored conflict merges) is more careful,
+  because it does not build a catalog from scratch: it carries forward
+  every entry the vault already had and touches exactly one, so the
+  resulting entry count is either unchanged (an edit, delete, restore, or
+  conflict-resolution of an item that already had a catalog entry) or one
+  more than before (a genuinely new item — the only case that is actual
+  growth). Only the growth case is checked against the tight
+  `MAX_CATALOG_ENTRIES`; a mutation that does not grow the catalog is
+  checked against the looser, proven `MAX_ENCODABLE_CATALOG_ENTRIES`
+  instead. `CatalogV1::encode` does not independently re-apply either
+  bound — it trusts whichever constructor built its `self.entries` already
+  chose the right one, and confirms only that the actual bytes still fit
+  `MAX_ENCODED_SIZE`.
+
+  This split was caught in security review, not designed in from the
+  start: an earlier version of this fix applied the tight ceiling to
+  *every* catalog rebuild uniformly, admission and mutation alike. That
+  reopened this section's own bug at a narrower band — a catalog synced
+  from a peer, or grown under this device's own pre-fix admission policy,
+  with an entry count anywhere in `(MAX_CATALOG_ENTRIES,
+  MAX_ENCODABLE_CATALOG_ENTRIES]` decoded and opened fine (decode already
+  used the looser bound) but then failed *every* subsequent mutation,
+  delete included, because rebuilding that same, unchanged entry count
+  still ran into the tight bound regardless of whether the mutation added
+  anything. The lesson generalises: an admission ceiling on total entry
+  count is only correct for constructions where every entry is new growth.
+  Anywhere a mutation carries forward entries that already existed,
+  admission has to ask whether *this* mutation grows the catalog, not
+  merely how big the catalog already is.
+- **Decode** (`CatalogV1::decode`) uses the same looser, unmargined
+  `MAX_ENCODABLE_CATALOG_ENTRIES` (19,064) as a non-growing mutation — the
+  proven ceiling, not this device's own admission policy. This runs on the
+  open path, through `materialize_current_catalog`, so a hard reject here
+  denies the whole vault rather than one mutation; using the proven ceiling
+  means the only catalogs it ever rejects are ones no honest encoder, old
+  or new, could ever have produced. A catalog this device would no longer
+  *admit* building fresh — because it exceeds 18,064 — still opens, because
+  it might be exactly what a past version of this device, or any honest
+  peer, legitimately wrote. Only past 19,064 is a catalog certainly the
+  product of a peer whose own encoder does not honour `MAX_ENCODED_SIZE` —
+  hand-crafting wire bytes rather than running a compliant encoder — and
+  that is the case this closes: a peer cannot install a catalog this
+  device could decode but never again re-encode.
 
 `materialize_current_catalog`'s own cross-head merge check (reachable when
 several unreconciled concurrent heads each individually decode within bounds
@@ -1122,6 +1148,13 @@ small publications, since one commit cannot itself carry more than
 still_be_deleted_from` reproduces the named symptom directly — a real
 `delete_current_item` call succeeds on a catalog sitting at this device's own
 admission ceiling, and a subsequent `add_item` is correctly refused.
+`mutation_of_an_above_admission_catalog_succeeds_when_it_does_not_grow`
+(`codec.rs`) and `a_catalog_above_the_admission_ceiling_can_still_be_deleted_
+from` (`open.rs`) pin the growth-vs-non-growth correction above directly:
+the latter opens a real, peer-synced vault whose catalog already exceeds the
+admission ceiling and performs two real `delete_current_item` calls against
+it, which is exactly the scenario security review found broken in the first
+version of this fix.
 
 ## 14. Required verification
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1075,10 +1075,10 @@ So admission and decode use different bounds, on purpose:
   tight, margined `MAX_CATALOG_ENTRIES` (18,064). Reaching it refuses the
   *next* item with `BoundExceeded`, before that catalog is ever built, which
   is the actual fix: the failure moves from re-encode time to admission
-  time, and a catalog admission has already bounded can always still be
-  edited, deleted from, and re-encoded — the freeze this section opened
-  with cannot recur, because admission never lets the catalog reach a size
-  that re-encode can't recover from.
+  time, and a catalog admission has already bounded stays editable, can
+  always be deleted from, and always re-encodes — the freeze this section
+  opened with cannot recur, because admission never lets the catalog reach
+  a size that re-encode can't recover from.
 - **Decode** (`CatalogV1::decode`) uses the looser, unmargined
   `MAX_ENCODABLE_CATALOG_ENTRIES` (19,064) — the proven ceiling, not this
   device's own admission policy. This runs on the open path, through


### PR DESCRIPTION
## Summary

- Fixes a MEDIUM pre-existing bug: an ordinary vault — no hostile peer needed — froze every mutation including `item delete` once its catalog crossed roughly nineteen thousand items, well inside the old, fictional 100,000-entry admission ceiling. `MAX_CATALOG_ENTRIES` is now *derived* from `MAX_ENCODED_SIZE` (the real 1 MiB CBOR encode ceiling), not eyeballed.
- Introduces two deliberately different bounds: `MAX_CATALOG_ENTRIES` (18,064, tight/margined, gates genuinely new growth at admission time) and `MAX_ENCODABLE_CATALOG_ENTRIES` (19,064, the proven wire-format ceiling, used at decode/open time and for non-growing mutations) — so a catalog a past version of this device (or any honest peer) legitimately produced under the old looser check stays openable *and* editable, without repeating the open-denies-the-whole-vault mistake VLT-PM05 §13.3 already fixed once for individual records.
- A first version of this fix applied the tight bound unconditionally to every catalog rebuild (including non-growing mutations like delete), which security review caught as reopening the exact same bug at a narrower band. `CatalogV1::new_for_mutation` fixes that: it only applies the tight ceiling when a mutation's entry count is genuine growth (a brand-new item), and the looser proven ceiling otherwise.

## Test plan

- [x] `codec.rs` unit tests pin the byte-cost derivation and both bounds directly against the real encoder (`catalog_entry_byte_cost_is_exact`, `max_encodable_catalog_entries_is_a_proven_ceiling`, `admission_refuses_growth_before_the_catalog_is_ever_unencodable`, `decode_stays_open_to_a_legacy_or_peer_catalog_admission_would_now_refuse`, `decode_rejects_a_catalog_no_honest_encoder_could_have_produced`, `mutation_of_an_above_admission_catalog_succeeds_when_it_does_not_grow`)
- [x] `open.rs` reproduces the bug end to end against a real, unlocked vault (`a_synced_catalog_at_the_proven_ceiling_opens`, `a_synced_catalog_past_the_proven_ceiling_denies_open`, `a_catalog_at_the_admission_ceiling_can_still_be_deleted_from`, `a_catalog_above_the_admission_ceiling_can_still_be_deleted_from`)
- [x] `cargo build --workspace` (vault-pm crates; unrelated pre-existing `paint-vm-direct2d` Windows-only failure on macOS, not touched by this PR)
- [x] `cargo test --lib` in `vault-pm-application` — 241 passed
- [x] `cargo test -p coding_adventures_vault_pm_cli -p coding_adventures_vault_pm_application_storage_core` — 137 passed
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] `/security-review` — 2 rounds; round 1 found a real HIGH-severity regression of the same bug class (fixed via `new_for_mutation`), round 2 passed clean
- [x] VLT-PM05 §6.2, §11, §13 (bounds table), and new §13.4 updated; package README/CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)