### PR TITLE
fix(vault-pm): quarantine schema-mismatched peer records instead of denying open (VLT-PM05 §13.5)

### DIFF
--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1414,6 +1414,19 @@ fn encode_any_record(record: &AnyRecord) -> Result<Vec<u8>, ApplicationError> {
             content_type,
             payload_bytes,
         } => encode_opaque(content_type, payload_bytes).map_err(map_record_encode_error),
+        // A quarantined record's `payload_bytes` are the inner payload's own
+        // already-canonical CBOR bytes (VLT-PM05 §13.3's decode-time fix —
+        // see `decode_record`'s doc comment in vault-records), the exact
+        // same shape `Opaque` carries. Re-wrapping them with `encode_opaque`
+        // forwards the record faithfully on write paths that walk every
+        // live candidate (`export`, `history restore`, conflict merges):
+        // still unreadable, still round-trips byte-for-byte, never silently
+        // repaired or dropped.
+        AnyRecord::Quarantined {
+            content_type,
+            payload_bytes,
+            reason: _,
+        } => encode_opaque(content_type, payload_bytes).map_err(map_record_encode_error),
     }
 }
 

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1214,7 +1214,18 @@ fn decode_live(value: CborValue) -> Result<ItemDocument, ApplicationError> {
         None => BTreeMap::new(),
         Some(value) => decode_attachment_manifest_references(value)?,
     };
-    let record_bytes = take_bytes(&mut fields, 8)?;
+    // `record_bytes` is the record's own still-encoded plaintext -- a
+    // Login's password, a Card's PAN and CVV, a TotpSeed's secret, and so
+    // on, depending on content type -- so it is wrapped the same way every
+    // other secret-bearing decode buffer in this module is (`Zeroizing`,
+    // e.g. `take_secret_fixed` below). Without it, `record_bytes` would
+    // drop unwiped on every exit: the error path if `decode_record` fails
+    // (a malformed envelope can still carry a genuine secret payload in a
+    // well-formed `"d"` field), and, with a strictly larger exposure
+    // window, the ordinary success path -- `record_bytes` is not read again
+    // after this line, so nothing else would ever wipe it before it goes
+    // out of scope at the end of this function.
+    let record_bytes = Zeroizing::new(take_bytes(&mut fields, 8)?);
     let payload = decode_record(&record_bytes).map_err(|_| ApplicationError::IntegrityFailure)?;
     ItemDocument::new(
         id,

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1186,8 +1186,25 @@ fn decode_live(value: CborValue) -> Result<ItemDocument, ApplicationError> {
             .remove(&7)
             .ok_or(ApplicationError::IntegrityFailure)?,
     )?;
-    let record_bytes = take_bytes(&mut fields, 8)?;
-    let payload = decode_record(&record_bytes).map_err(|_| ApplicationError::IntegrityFailure)?;
+    // Fields 9 and 10 (attachments, attachment manifests) are decoded before
+    // field 8 (the record) on purpose, even though the wire order is 8, 9,
+    // 10 -- `fields` is already a key-indexed map at this point, so nothing
+    // about the wire's byte order depends on the order these two `remove`
+    // calls happen in. What *does* depend on it: `decode_record` can return
+    // `AnyRecord::Quarantined`, whose `payload_bytes` may carry a peer's
+    // genuine secret-bearing plaintext (VLT-PM05 §13.5 -- a schema-
+    // mismatched `Login` still has a real title/username sitting in its raw
+    // bytes). `AnyRecord` has no `Drop` of its own (typed variants each
+    // implement `Drop` themselves; `Quarantined` and `Opaque` do not, by
+    // design -- see the NOTE above `AnyRecord`'s `Zeroize` impl in
+    // vault-records), so a `payload` bound to a local variable is wiped only
+    // when something explicitly zeroizes it. `ItemDocument` does that for
+    // us the moment `payload` is moved inside it (its own `Drop` calls
+    // `self.zeroize()`), but only from that point on -- any fallible step
+    // between binding `payload` and constructing the `ItemDocument` is a
+    // window where an early `?` return would drop an unzeroized secret.
+    // Decoding fields 9 and 10 first, before field 8, empties that window:
+    // once `payload` exists, the very next statement is `ItemDocument::new`.
     let attachments = decode_observed(
         fields
             .remove(&9)
@@ -1197,6 +1214,8 @@ fn decode_live(value: CborValue) -> Result<ItemDocument, ApplicationError> {
         None => BTreeMap::new(),
         Some(value) => decode_attachment_manifest_references(value)?,
     };
+    let record_bytes = take_bytes(&mut fields, 8)?;
+    let payload = decode_record(&record_bytes).map_err(|_| ApplicationError::IntegrityFailure)?;
     ItemDocument::new(
         id,
         schema,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -4661,7 +4661,8 @@ mod tests {
         VaultObjectStore,
     };
     use coding_adventures_vault_records::{
-        AnyRecord, Login, SecureNote, TotpSeed, LOGIN_V1, SECURE_NOTE_V1, TOTP_SEED_V1,
+        encode_record, AnyRecord, Login, SecureNote, TotpSeed, LOGIN_V1, SECURE_NOTE_V1,
+        TOTP_SEED_V1,
     };
     use coding_adventures_zeroize::Zeroize;
     use std::sync::{
@@ -16395,6 +16396,269 @@ mod tests {
         let candidates = &session.current_catalog.items[&item_id];
         assert_eq!(candidates.len(), 1);
         assert!(matches!(candidates[0].state(), ItemState::Tombstone(_)));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A synced peer's *schema-mismatched* record -- not oversized, just
+    // malformed relative to its declared content type (VLT-PM05 §13.3's
+    // adjacent, previously-unrepaired residual)
+    //
+    // The bug this closes is the same shape as the oversized-opaque one
+    // above but reached through a different door and with no "return the
+    // original bytes" escape hatch available: the payload here decoded
+    // through the strict canonical CBOR decoder (so the bytes are legal
+    // CBOR and could be returned verbatim) but does not satisfy the
+    // schema its declared content type names -- a `Login` missing its
+    // `password` field. There is no typed `Login` value to hand back, so
+    // the repair is `AnyRecord::Quarantined` instead of a re-encode fix.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Canonical CBOR bytes for a `vault/login/v1` record whose payload
+    /// is missing the required `password` field -- otherwise well-formed
+    /// (valid CBOR, a `{t,d}` envelope, `d` a map with `title`,
+    /// `username`, and an empty `urls` array).
+    ///
+    /// This is the same defect as vault-records'
+    /// `login_missing_password_is_schema_mismatch` fixture, reproduced
+    /// here (rather than imported) because it has to be embedded inside
+    /// a full sealed item revision, which vault-records has no notion of.
+    fn schema_mismatched_login_record_bytes() -> Vec<u8> {
+        let envelope = CborValue::Map(vec![
+            (CborValue::text("t"), CborValue::text(LOGIN_V1.to_string())),
+            (
+                CborValue::text("d"),
+                CborValue::Map(vec![
+                    (
+                        CborValue::text("title"),
+                        CborValue::text("Peer Login".to_string()),
+                    ),
+                    (
+                        CborValue::text("username"),
+                        CborValue::text("mallory".to_string()),
+                    ),
+                    (CborValue::text("urls"), CborValue::Array(vec![])),
+                ]),
+            ),
+        ]);
+        encode_cbor(&envelope)
+    }
+
+    /// The revision plaintext a peer seals for one live `Login` item whose
+    /// payload is schema-mismatched (missing `password`).
+    ///
+    /// Same technique as [`peer_opaque_revision_plaintext`]: encode the
+    /// revision with a placeholder record through the product's own
+    /// encoder (so field framing, timestamps, and the observed sets are
+    /// exactly what this product would write), then splice out the
+    /// placeholder record's bytes for the schema-mismatched ones. Unlike
+    /// the oversized-opaque fixture there is no size pressure here -- the
+    /// swap is small-for-small -- but the splice is still required
+    /// because there is no way to *construct* a `Login` Rust value with a
+    /// missing field; only hand-built wire bytes can carry that defect.
+    fn peer_schema_mismatched_login_revision_plaintext(item_id: ItemId) -> Vec<u8> {
+        let placeholder_login = Login {
+            title: "placeholder".to_string(),
+            username: "placeholder".to_string(),
+            password: "placeholder".to_string(),
+            urls: vec![],
+            notes: None,
+        };
+        let document = ItemDocument::new(
+            item_id,
+            ContentType::new(LOGIN_V1).unwrap(),
+            700,
+            700,
+            LwwRegister::new(false, 700, OperationId::new([0xe0; 32])),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            AnyRecord::Login(placeholder_login),
+            ObservedSet::new(),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let candidate = ItemCandidate::new(
+            RevisionId::new([0; 32]),
+            [],
+            ItemState::Live(Box::new(document)),
+        )
+        .unwrap();
+        let plaintext =
+            encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap();
+
+        let placeholder_record = encode_record(&Login {
+            title: "placeholder".to_string(),
+            username: "placeholder".to_string(),
+            password: "placeholder".to_string(),
+            urls: vec![],
+            notes: None,
+        })
+        .unwrap();
+        let broken_record = schema_mismatched_login_record_bytes();
+        let mut placeholder_field = cbor_header(2, placeholder_record.len());
+        placeholder_field.extend_from_slice(&placeholder_record);
+        let mut broken_field = cbor_header(2, broken_record.len());
+        broken_field.extend_from_slice(&broken_record);
+        splice_only_occurrence(&plaintext, &placeholder_field, &broken_field)
+    }
+
+    /// A peer commit carrying one live `Login` item whose payload is
+    /// schema-mismatched.
+    fn peer_schema_mismatched_login_publication(
+        active: &ActiveStateV1,
+        item_id: ItemId,
+    ) -> (PublicationJournalV1, RevisionId) {
+        let fixture = generation_zero_bytes();
+        let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+        let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let frame = seal_object(
+            &keys,
+            ObjectKind::ItemRevision,
+            &peer_schema_mismatched_login_revision_plaintext(item_id),
+            &ObjectRandomness::new([0xd1; 32], [0xd2; 24], [0xd3; 24]),
+        )
+        .unwrap();
+        let revision_id = RevisionId::new(*frame.id().unwrap().as_bytes());
+        let catalog = CatalogV1::new(BTreeMap::from([(item_id, vec![revision_id])])).unwrap();
+        let catalog_frame = seal_object(
+            &keys,
+            ObjectKind::Catalog,
+            &catalog.encode().unwrap(),
+            &ObjectRandomness::new([0xd4; 32], [0xd5; 24], [0xd6; 24]),
+        )
+        .unwrap();
+        (
+            publication_for_catalog(active, vec![frame], catalog_frame),
+            revision_id,
+        )
+    }
+
+    /// Sync one peer-authored schema-mismatched `Login` item into a fresh
+    /// vault and return everything needed to reopen it.
+    #[allow(clippy::type_complexity)]
+    fn vault_with_synced_schema_mismatched_login_item() -> (
+        BootstrapLocator,
+        MemoryLocalStateStore,
+        MemoryBootstrapStore,
+        V1ApplicationRepositoryFactory<InMemoryObjectStore>,
+        ItemId,
+        RevisionId,
+    ) {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x5e; 16]);
+        let (publication, revision_id) = peer_schema_mismatched_login_publication(&active, item_id);
+        peer_publishes(locator, &local, &bootstrap, &factory, publication);
+        (locator, local, bootstrap, factory, item_id, revision_id)
+    }
+
+    #[test]
+    fn a_synced_schema_mismatched_login_record_leaves_the_vault_openable() {
+        // The reachability proof. Before the fix in this test's history,
+        // `decode_record`'s `Login` arm propagated `SchemaMismatch`,
+        // `decode_live` mapped it to `IntegrityFailure` (see
+        // VLT-PM05 §13.3's residual paragraph), and that denied
+        // `open_active_vault` for the whole vault -- exactly the blast
+        // radius of the oversized-opaque bug, reached without ever
+        // crossing a size ceiling.
+        let (locator, local, bootstrap, factory, item_id, revision_id) =
+            vault_with_synced_schema_mismatched_login_item();
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        let candidates = &session.current_catalog.items[&item_id];
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].revision_id(), revision_id);
+
+        let ItemState::Live(document) = candidates[0].state() else {
+            panic!("the synced candidate must be live")
+        };
+        let AnyRecord::Quarantined {
+            content_type,
+            reason,
+            ..
+        } = document.payload()
+        else {
+            panic!("a schema-mismatched Login must decode as Quarantined")
+        };
+        assert_eq!(content_type, LOGIN_V1);
+        assert!(reason.contains("password"));
+    }
+
+    #[test]
+    fn a_synced_schema_mismatched_login_item_is_visible_in_the_redacted_list() {
+        // The item must not just fail to deny open -- it has to actually
+        // show up where an operator would look for it, or the fix
+        // degrades to "the vault opens but the item silently vanishes,"
+        // which trades one failure mode for a quieter one.
+        let (locator, local, bootstrap, factory, item_id, _) =
+            vault_with_synced_schema_mismatched_login_item();
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        let views = session.list_items().unwrap();
+        let view = views
+            .iter()
+            .find(|view| view.item_id == item_id)
+            .expect("the quarantined item must still appear in the item list");
+        let RedactedRecordView::Quarantined {
+            content_type,
+            reason,
+            ..
+        } = &view.record
+        else {
+            panic!("expected Quarantined, got {:?}", view.record)
+        };
+        assert_eq!(content_type.as_str(), LOGIN_V1);
+        assert!(reason.contains("password"));
+    }
+
+    #[test]
+    fn a_synced_schema_mismatched_login_item_can_be_deleted() {
+        // The escape hatch this section restores, on the same terms as
+        // the oversized-opaque case: deletion writes a tombstone, which
+        // carries only the item id and a timestamp and never touches the
+        // unreadable payload, so it works even though nothing can repair
+        // or even fully interpret the record itself.
+        let (locator, local, bootstrap, factory, item_id, _) =
+            vault_with_synced_schema_mismatched_login_item();
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        session
+            .delete_current_item(item_id, 701, 702, delete_item_randomness(0x5e), &local)
+            .unwrap();
+
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        let candidates = &session.current_catalog.items[&item_id];
+        assert_eq!(candidates.len(), 1);
+        assert!(matches!(candidates[0].state(), ItemState::Tombstone(_)));
+    }
+
+    #[test]
+    fn a_synced_schema_mismatched_login_item_denies_edit_as_login() {
+        // Editing requires decoding the current record as the type being
+        // edited (`login_edit_precondition`'s `let AnyRecord::Login(_) =
+        // current.payload() else { .. }`). Before quarantine existed, an
+        // item whose `schema()` field said `vault/login/v1` was
+        // guaranteed to decode as `AnyRecord::Login` -- that was a true
+        // invariant, which is why the *defensive* copy of this same
+        // check inside `replacement_login_document` reports
+        // `InternalInvariant` on failure. Quarantine breaks that
+        // invariant for the first time: `schema()` can now say
+        // `vault/login/v1` while `payload()` is `Quarantined`. This test
+        // pins that the *first* gate a real `item edit` call reaches
+        // (`login_edit_precondition`) already treats "any variant other
+        // than Login" uniformly regardless of *why* -- Opaque or
+        // Quarantined both take the same `else` branch -- so the ordinary
+        // edit ceremony reports `Unsupported`, a normal declined-command
+        // outcome, and never reaches the inner defensive check at all.
+        let (locator, local, bootstrap, factory, item_id, _) =
+            vault_with_synced_schema_mismatched_login_item();
+        let session = active_session(locator, &local, &bootstrap, &factory);
+        assert_eq!(
+            session.prepare_login_edit(item_id).err(),
+            Some(ApplicationError::Unsupported)
+        );
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/code/packages/rust/vault-pm-application/src/search.rs
+++ b/code/packages/rust/vault-pm-application/src/search.rs
@@ -187,7 +187,8 @@ impl SearchEntryV1 {
             RedactedRecordView::SecureNote { .. }
             | RedactedRecordView::Card { .. }
             | RedactedRecordView::TotpSeed { .. }
-            | RedactedRecordView::Opaque { .. } => {}
+            | RedactedRecordView::Opaque { .. }
+            | RedactedRecordView::Quarantined { .. } => {}
         }
         for tag in document.tags().values() {
             push_normalized(&mut normalized_text, tag);
@@ -209,7 +210,7 @@ fn display_title(record: &RedactedRecordView) -> Option<&str> {
         RedactedRecordView::TotpSeed { label, .. }
         | RedactedRecordView::ApiKey { label, .. }
         | RedactedRecordView::DatabaseCredential { label, .. } => Some(label),
-        RedactedRecordView::Opaque { .. } => None,
+        RedactedRecordView::Opaque { .. } | RedactedRecordView::Quarantined { .. } => None,
     }
 }
 
@@ -321,6 +322,7 @@ mod tests {
             AnyRecord::ApiKey(_) => API_KEY_V1,
             AnyRecord::DatabaseCredential(_) => DATABASE_CREDENTIAL_V1,
             AnyRecord::Opaque { content_type, .. } => content_type,
+            AnyRecord::Quarantined { content_type, .. } => content_type,
         };
         let document = ItemDocument::new(
             item_id,

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -4873,7 +4873,14 @@ fn record_title(record: &RedactedRecordView) -> &str {
         RedactedRecordView::TotpSeed { label, .. }
         | RedactedRecordView::ApiKey { label, .. }
         | RedactedRecordView::DatabaseCredential { label, .. } => label,
-        RedactedRecordView::Opaque { content_type, .. } => content_type.as_str(),
+        // Neither an opaque nor a quarantined record has a title field to
+        // show, so both fall back to their (always-present) declared
+        // content type — `item list` still names the item instead of
+        // showing a blank column, which matters most for `Quarantined`:
+        // it is the one signal in the list that this item exists and is
+        // broken, rather than the item silently vanishing from the list.
+        RedactedRecordView::Opaque { content_type, .. }
+        | RedactedRecordView::Quarantined { content_type, .. } => content_type.as_str(),
     }
 }
 
@@ -5018,6 +5025,20 @@ fn render_item(item: RedactedItemView) -> Result<CliOutput, CliFailure> {
                 None => output.push_str("none"),
             }
             output.push_str("\nPassword: <redacted>\n");
+        }
+        // Unlike `Opaque` (an ordinary content type this build simply
+        // doesn't have a renderer for, and therefore declines with
+        // `Unsupported`), a quarantined item's declared type IS
+        // recognised — its payload just doesn't parse as that type's
+        // schema. There is no per-field detail to show, so `item show`
+        // succeeds with a placeholder instead of erroring: an operator
+        // asking to see item X should learn that X exists and is broken,
+        // not receive an error that reads the same as "this command
+        // doesn't support that kind of item yet."
+        RedactedRecordView::Quarantined { reason, .. } => {
+            output.push_str("Content: could not be read (");
+            output.push_str(reason);
+            output.push_str(")\n");
         }
         _ => return Err(CliFailure::Unsupported),
     }
@@ -6455,11 +6476,74 @@ mod tests {
     use coding_adventures_vault_pm_application::{
         prepare_generation_zero, GenerationZeroRandomness, GENERATION_ZERO_RANDOM_BYTES,
     };
+    use coding_adventures_vault_pm_domain::RedactedSecret;
     use std::collections::VecDeque;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::Mutex;
+
+    // ─────────────────────────────────────────────────────────────────
+    // `record_title` / `render_item` rendering for a quarantined record
+    // (VLT-PM05 §13.3's schema-mismatch fix). Unlike the rest of this
+    // module's tests, these drive the two rendering functions directly
+    // rather than through a full CLI command, because producing a
+    // genuinely quarantined item requires peer-injecting a schema-broken
+    // record past this product's own encoder -- exercised end-to-end in
+    // `vault-pm-application`'s `open::tests` module, where the fixture
+    // machinery for that already lives. These tests instead pin what
+    // `item list` and `item show` do with the `RedactedRecordView` that
+    // layer hands back, independent of how it was produced.
+    fn quarantined_login_view() -> RedactedRecordView {
+        RedactedRecordView::Quarantined {
+            content_type: ContentType::new(LOGIN_V1).unwrap(),
+            payload_bytes: 42,
+            reason: "Login.password missing",
+            payload: RedactedSecret,
+        }
+    }
+
+    #[test]
+    fn record_title_falls_back_to_content_type_for_a_quarantined_record() {
+        // Mirrors `Opaque`'s existing fallback: neither has a title field,
+        // so both use the one thing they do have -- the declared content
+        // type -- rather than leaving the `item list` title column blank.
+        assert_eq!(record_title(&quarantined_login_view()), LOGIN_V1);
+    }
+
+    #[test]
+    fn render_item_shows_a_redacted_placeholder_for_a_quarantined_record_instead_of_erroring() {
+        // Unlike `Opaque` (an ordinary content type this build has no
+        // renderer for, and therefore declines with `Unsupported`), a
+        // quarantined item's declared type IS recognised -- decode just
+        // couldn't materialise it. `item show` must still succeed, with a
+        // placeholder that says the item exists and is broken, not an
+        // error that reads the same as "unsupported item kind."
+        let item = RedactedItemView {
+            item_id: ItemId::new([0x11; 16]),
+            schema: ContentType::new(LOGIN_V1).unwrap(),
+            record: quarantined_login_view(),
+            favorite: false,
+            collection_count: 0,
+            tag_count: 0,
+            attachment_count: 0,
+            updated_at_ms: 900,
+        };
+        let output = render_item(item).unwrap();
+        let text = output.stdout();
+        assert!(
+            text.contains("could not be read"),
+            "expected a could-not-be-read placeholder, got: {text}"
+        );
+        assert!(
+            text.contains("Login.password missing"),
+            "expected the decode reason surfaced, got: {text}"
+        );
+        // The placeholder must never claim to be showing real field
+        // values -- there are none to show.
+        assert!(!text.contains("Username:"));
+        assert!(!text.contains("Password:"));
+    }
 
     static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 

--- a/code/packages/rust/vault-pm-domain/src/lib.rs
+++ b/code/packages/rust/vault-pm-domain/src/lib.rs
@@ -744,6 +744,7 @@ fn record_content_type(record: &AnyRecord) -> &str {
         AnyRecord::ApiKey(_) => API_KEY_V1,
         AnyRecord::DatabaseCredential(_) => DATABASE_CREDENTIAL_V1,
         AnyRecord::Opaque { content_type, .. } => content_type,
+        AnyRecord::Quarantined { content_type, .. } => content_type,
     }
 }
 
@@ -1203,6 +1204,23 @@ pub enum RedactedRecordView {
         /// Payload omission marker.
         payload: RedactedSecret,
     },
+    /// A record whose declared content type this crate recognises, but
+    /// whose payload does not decode as that type's schema — a peer
+    /// authored (by bug or by malice) a first-party-tagged record this
+    /// client cannot materialise. See `AnyRecord::Quarantined`.
+    Quarantined {
+        /// The declared (but unreadable) content type.
+        content_type: ContentType,
+        /// Canonical payload byte count.
+        payload_bytes: usize,
+        /// Static, non-sensitive description of what failed to decode,
+        /// e.g. `"Login.password missing"`. Safe to surface as-is: this
+        /// is always one of a fixed set of literals this crate's own
+        /// typed decoders define, never input-derived text.
+        reason: &'static str,
+        /// Payload omission marker.
+        payload: RedactedSecret,
+    },
 }
 
 impl RedactedRecordView {
@@ -1272,6 +1290,16 @@ impl RedactedRecordView {
                 payload_bytes: payload_bytes.len(),
                 payload: RedactedSecret,
             },
+            AnyRecord::Quarantined {
+                content_type,
+                payload_bytes,
+                reason,
+            } => Self::Quarantined {
+                content_type: ContentType::new(content_type.clone())?,
+                payload_bytes: payload_bytes.len(),
+                reason,
+                payload: RedactedSecret,
+            },
         })
     }
 
@@ -1285,6 +1313,7 @@ impl RedactedRecordView {
             Self::ApiKey { .. } => VaultRecordKind::ApiKey,
             Self::DatabaseCredential { .. } => VaultRecordKind::DatabaseCredential,
             Self::Opaque { .. } => VaultRecordKind::Opaque,
+            Self::Quarantined { .. } => VaultRecordKind::Quarantined,
         }
     }
 }
@@ -1313,6 +1342,16 @@ impl core::fmt::Debug for RedactedRecordView {
                 .debug_struct("Opaque")
                 .field("content_type", &"<redacted>")
                 .field("payload_bytes", payload_bytes)
+                .finish(),
+            Self::Quarantined {
+                payload_bytes,
+                reason,
+                ..
+            } => f
+                .debug_struct("Quarantined")
+                .field("content_type", &"<redacted>")
+                .field("payload_bytes", payload_bytes)
+                .field("reason", reason)
                 .finish(),
         }
     }
@@ -1383,6 +1422,7 @@ impl Zeroize for RedactedRecordView {
                 username.zeroize();
             }
             Self::Opaque { content_type, .. } => content_type.0.zeroize(),
+            Self::Quarantined { content_type, .. } => content_type.0.zeroize(),
         }
     }
 }

--- a/code/packages/rust/vault-records/src/lib.rs
+++ b/code/packages/rust/vault-records/src/lib.rs
@@ -279,16 +279,69 @@ pub fn encode_record<T: VaultRecord>(rec: &T) -> Result<Vec<u8>, VaultRecordErro
 /// pattern-matches on the content type. Unknown types are returned
 /// as `AnyRecord::Opaque` so old clients do not crash on records
 /// produced by newer ones.
+///
+/// # Why a schema mismatch on a *known* content type does not fail
+///
+/// A payload tagged with a first-party content type (e.g.
+/// `vault/login/v1`) but missing a required field, or carrying a
+/// field of the wrong shape, used to make this function return
+/// `Err(SchemaMismatch)`. That looks like the correct behaviour in
+/// isolation — the bytes genuinely are not a `Login` — but one layer
+/// up it repeats the exact defect this function's opaque arm was
+/// fixed for (see the comment below): `decode_record` runs during
+/// vault *open*, and the caller (`decode_live` in the application
+/// layer) mapped every decode error, `SchemaMismatch` included, to
+/// `IntegrityFailure`. One peer authoring a `Login` with a missing
+/// `password` field denied the whole vault, not just that one item —
+/// the identical blast radius as the oversized-opaque bug, reached
+/// through a different door.
+///
+/// Unlike the oversized-opaque case, there is no "return the original
+/// bytes as the same type" escape hatch here: the payload cannot be
+/// materialised as a `Login` at all, by definition. What *is* available
+/// is the same technique the opaque arm already uses — the payload's
+/// own already-validated CBOR bytes, sliced rather than re-encoded —
+/// just attached to a new [`AnyRecord::Quarantined`] variant instead of
+/// a typed struct. The record is still identifiable (its declared
+/// content type is retained) and still round-trips losslessly (its
+/// bytes are retained verbatim); it just cannot be interpreted as the
+/// schema it claims. That is enough for the vault to open, for the item
+/// to be listed, and for it to be deleted — the same floor `Opaque`
+/// already stands on.
+///
+/// Only [`VaultRecordError::SchemaMismatch`] is treated this way. Any
+/// other error from a typed decoder still fails `decode_record` outright,
+/// because `VaultRecord::decode_payload` is documented to return
+/// `SchemaMismatch` and nothing else — this is a defensive branch, not a
+/// currently-reachable one, kept so a future decoder that starts
+/// returning some other error is not silently swallowed into quarantine.
 pub fn decode_record(bytes: &[u8]) -> Result<AnyRecord, VaultRecordError> {
     let (content_type, payload, payload_span) = split_envelope(bytes)?;
+    // Decode a known first-party type, quarantining a schema mismatch
+    // instead of propagating it. See the function doc comment above.
+    macro_rules! typed_or_quarantine {
+        ($ctor:expr) => {
+            match $ctor(&payload) {
+                Ok(record) => record,
+                Err(VaultRecordError::SchemaMismatch { what }) => {
+                    return Ok(AnyRecord::Quarantined {
+                        content_type,
+                        payload_bytes: bytes[payload_span].to_vec(),
+                        reason: what,
+                    })
+                }
+                Err(other) => return Err(other),
+            }
+        };
+    }
     Ok(match content_type.as_str() {
-        LOGIN_V1 => AnyRecord::Login(Login::decode_payload(&payload)?),
-        SECURE_NOTE_V1 => AnyRecord::SecureNote(SecureNote::decode_payload(&payload)?),
-        CARD_V1 => AnyRecord::Card(Card::decode_payload(&payload)?),
-        TOTP_SEED_V1 => AnyRecord::TotpSeed(TotpSeed::decode_payload(&payload)?),
-        API_KEY_V1 => AnyRecord::ApiKey(ApiKey::decode_payload(&payload)?),
+        LOGIN_V1 => AnyRecord::Login(typed_or_quarantine!(Login::decode_payload)),
+        SECURE_NOTE_V1 => AnyRecord::SecureNote(typed_or_quarantine!(SecureNote::decode_payload)),
+        CARD_V1 => AnyRecord::Card(typed_or_quarantine!(Card::decode_payload)),
+        TOTP_SEED_V1 => AnyRecord::TotpSeed(typed_or_quarantine!(TotpSeed::decode_payload)),
+        API_KEY_V1 => AnyRecord::ApiKey(typed_or_quarantine!(ApiKey::decode_payload)),
         DATABASE_CREDENTIAL_V1 => {
-            AnyRecord::DatabaseCredential(DatabaseCredential::decode_payload(&payload)?)
+            AnyRecord::DatabaseCredential(typed_or_quarantine!(DatabaseCredential::decode_payload))
         }
         // Unknown / app-specific / future-version: hand back the
         // payload's own bytes and return as opaque.
@@ -385,8 +438,10 @@ fn split_envelope(
     }
 }
 
-/// One of the known record types, or an opaque pass-through for
-/// content types this crate doesn't recognise.
+/// One of the known record types, an opaque pass-through for content
+/// types this crate doesn't recognise, or a quarantined record whose
+/// declared type it recognises but whose payload doesn't parse as
+/// that type's schema.
 #[derive(Clone, PartialEq, Eq)]
 pub enum AnyRecord {
     /// `vault/login/v1`
@@ -411,6 +466,42 @@ pub enum AnyRecord {
         /// The canonical-CBOR-encoded payload bytes.
         payload_bytes: Vec<u8>,
     },
+    /// A first-party content type (`vault/login/v1` and friends) whose
+    /// payload does not decode as that type's schema — a required field
+    /// missing, or present with the wrong shape.
+    ///
+    /// This differs from `Opaque` in *why* the type could not be
+    /// materialised: `Opaque` means "this crate doesn't recognise the
+    /// content type at all," which is an ordinary forward-compatibility
+    /// case (an older client seeing a newer peer's record). `Quarantined`
+    /// means "this crate recognises the content type and the payload is
+    /// still wrong," which only happens if a peer authored a malformed
+    /// record — by bug or by malice. The two get the same downstream
+    /// treatment (visible in `item list`, redacted in `item show`,
+    /// deletable, inert in search) because a caller's remedy is the same
+    /// either way — it cannot repair the record, only remove it — but
+    /// they are kept as distinct variants because *why* a record is
+    /// unreadable is worth preserving for diagnostics, and conflating
+    /// the two would make "how many records has this vault received
+    /// that this client cannot even parse against its own claimed type"
+    /// unanswerable.
+    Quarantined {
+        /// The content_type string from the wire (one of this crate's
+        /// own `*_V1` constants — otherwise decoding would have taken
+        /// the `Opaque` arm instead).
+        content_type: String,
+        /// The payload's own canonical-CBOR bytes, sliced rather than
+        /// re-encoded for the same reason `Opaque`'s are: the bytes came
+        /// from the strict canonical decoder, so they already are the
+        /// one legal spelling of that value, and slicing a
+        /// parser-measured range cannot fail on input that decoded.
+        payload_bytes: Vec<u8>,
+        /// Static description of what went wrong, e.g.
+        /// `"Login.password missing"`. Never attacker-controlled text —
+        /// it is always one of a fixed set of literals defined by this
+        /// crate's own typed decoders.
+        reason: &'static str,
+    },
 }
 
 impl core::fmt::Debug for AnyRecord {
@@ -423,6 +514,7 @@ impl core::fmt::Debug for AnyRecord {
             Self::ApiKey(_) => "AnyRecord::ApiKey(<redacted>)",
             Self::DatabaseCredential(_) => "AnyRecord::DatabaseCredential(<redacted>)",
             Self::Opaque { .. } => "AnyRecord::Opaque(<redacted>)",
+            Self::Quarantined { .. } => "AnyRecord::Quarantined(<redacted>)",
         };
         f.write_str(variant)
     }
@@ -445,10 +537,19 @@ pub enum VaultRecordKind {
     DatabaseCredential,
     /// Unknown, app-specific, or future-version content type.
     Opaque,
+    /// A first-party content type whose payload failed schema decode.
+    Quarantined,
 }
 
 impl VaultRecordKind {
     /// Static content type for first-party records.
+    ///
+    /// Returns `None` for `Quarantined` even though the record's *wire*
+    /// content type is one of this crate's own `*_V1` constants — this
+    /// method returns a `&'static str` and a quarantined record's content
+    /// type is only known at runtime (it is read straight off `AnyRecord`,
+    /// same as `Opaque`'s). Use `AnyRecord`'s own content-type accessor
+    /// (in the application layer) when the dynamic string is needed.
     pub fn content_type(self) -> Option<&'static str> {
         match self {
             Self::Login => Some(LOGIN_V1),
@@ -457,11 +558,16 @@ impl VaultRecordKind {
             Self::TotpSeed => Some(TOTP_SEED_V1),
             Self::ApiKey => Some(API_KEY_V1),
             Self::DatabaseCredential => Some(DATABASE_CREDENTIAL_V1),
-            Self::Opaque => None,
+            Self::Opaque | Self::Quarantined => None,
         }
     }
 
     /// True for first-party records understood by this crate.
+    ///
+    /// `Quarantined` is `false` here even though its wire content type
+    /// names a first-party schema: this predicate means "successfully
+    /// decoded as one of the six typed schemas," and a quarantined
+    /// record by definition did not.
     pub fn is_first_party(self) -> bool {
         self.content_type().is_some()
     }
@@ -495,9 +601,11 @@ pub struct VaultRecordSummary {
     pub has_expiry: bool,
     /// Whether the record carries a lease reference.
     pub has_lease: bool,
-    /// Length of an opaque record's content type. Zero for first-party records.
+    /// Length of an opaque or quarantined record's content type. Zero for
+    /// records decoded as one of the six typed schemas.
     pub opaque_content_type_len: usize,
-    /// Canonical-CBOR payload byte length for opaque records. Zero for first-party records.
+    /// Canonical-CBOR payload byte length for opaque or quarantined
+    /// records. Zero for records decoded as one of the six typed schemas.
     pub opaque_payload_bytes: usize,
 }
 
@@ -526,6 +634,12 @@ impl VaultRecordSummary {
     pub fn is_opaque(&self) -> bool {
         self.kind == VaultRecordKind::Opaque
     }
+
+    /// True when the record's declared type is known but its payload
+    /// failed schema decode.
+    pub fn is_quarantined(&self) -> bool {
+        self.kind == VaultRecordKind::Quarantined
+    }
 }
 
 impl AnyRecord {
@@ -539,6 +653,7 @@ impl AnyRecord {
             Self::ApiKey(_) => VaultRecordKind::ApiKey,
             Self::DatabaseCredential(_) => VaultRecordKind::DatabaseCredential,
             Self::Opaque { .. } => VaultRecordKind::Opaque,
+            Self::Quarantined { .. } => VaultRecordKind::Quarantined,
         }
     }
 
@@ -620,6 +735,20 @@ impl AnyRecord {
                 opaque_content_type_len: content_type.len(),
                 opaque_payload_bytes: payload_bytes.len(),
             },
+            Self::Quarantined {
+                content_type,
+                payload_bytes,
+                reason: _,
+            } => VaultRecordSummary {
+                kind: VaultRecordKind::Quarantined,
+                secret_field_count: 0,
+                optional_field_count: 0,
+                list_item_count: 0,
+                has_expiry: false,
+                has_lease: false,
+                opaque_content_type_len: content_type.len(),
+                opaque_payload_bytes: payload_bytes.len(),
+            },
         }
     }
 }
@@ -637,6 +766,19 @@ impl Zeroize for AnyRecord {
                 content_type,
                 payload_bytes,
             } => {
+                content_type.zeroize();
+                payload_bytes.zeroize();
+            }
+            AnyRecord::Quarantined {
+                content_type,
+                payload_bytes,
+                reason: _,
+            } => {
+                // `reason` is a `&'static str` literal owned by this
+                // crate's own source, never attacker-controlled, so
+                // there is nothing to wipe there. `content_type` and
+                // `payload_bytes` came off the wire and get the same
+                // treatment as `Opaque`'s.
                 content_type.zeroize();
                 payload_bytes.zeroize();
             }
@@ -658,6 +800,19 @@ impl Zeroize for AnyRecord {
 // future-version content type), the caller should call
 // `.zeroize()` explicitly via the `Zeroize` trait impl above
 // before letting the value drop.
+//
+// `AnyRecord::Quarantined { content_type, payload_bytes, reason }`
+// gets the same non-`Drop` treatment for the same structural reason
+// (no typed struct to hold a per-type `Drop`), but unlike `Opaque` its
+// bytes usually ARE known to be sensitive: the declared content type
+// names one of this crate's own secret-bearing schemas (a `Login`
+// missing its `password` field, say, still has a *username* sitting in
+// `payload_bytes`). Callers that materialise a `Quarantined` record —
+// today, only `decode_record`'s typed-dispatch arms — should treat its
+// `payload_bytes` as sensitive by default and hold it the same way they
+// would hold the typed record it failed to become (e.g. wrapped in
+// `Zeroizing<_>`), rather than assuming safety the way `Opaque`'s
+// genuinely-unknown-type bytes get to.
 
 /// Re-encode an [`AnyRecord::Opaque`] back to its full
 /// envelope-wrapped canonical CBOR bytes. Useful for forwarding a
@@ -2117,6 +2272,133 @@ mod tests {
         let bytes = encode_record(&t).unwrap();
         let err = decode_record_as::<TotpSeed>(&bytes).unwrap_err();
         assert!(matches!(err, VaultRecordError::SchemaMismatch { .. }));
+    }
+
+    // --- Schema mismatch through `decode_record` is quarantined, not denied ---
+    //
+    // The three tests above prove `decode_record_as::<T>` — a caller asking
+    // for one specific type — still fails closed on schema mismatch. These
+    // prove `decode_record` — the general decoder `decode_live` in the
+    // application layer calls at vault-open time — does not: it must
+    // materialise something rather than propagate the error, because
+    // propagating it here is exactly the bug this quarantine variant
+    // exists to close (see the `decode_record` doc comment).
+
+    #[test]
+    fn login_missing_password_via_decode_record_is_quarantined_not_denied() {
+        // Same malformed bytes as `login_missing_password_is_schema_mismatch`,
+        // but through the general decoder instead of the type-specific one.
+        let envelope = CborValue::Map(vec![
+            (CborValue::text("t"), CborValue::text(LOGIN_V1.to_string())),
+            (
+                CborValue::text("d"),
+                CborValue::Map(vec![
+                    (CborValue::text("title"), CborValue::text("x".to_string())),
+                    (
+                        CborValue::text("username"),
+                        CborValue::text("y".to_string()),
+                    ),
+                    (CborValue::text("urls"), CborValue::Array(vec![])),
+                ]),
+            ),
+        ]);
+        let bytes = encode(&envelope);
+
+        let any = decode_record(&bytes).expect(
+            "a schema-mismatched but well-formed-envelope record must still decode \
+             (as Quarantined), never deny the whole decode",
+        );
+        match any {
+            AnyRecord::Quarantined {
+                content_type,
+                payload_bytes,
+                reason,
+            } => {
+                assert_eq!(content_type, LOGIN_V1);
+                assert!(reason.contains("password"));
+                // The quarantined bytes are exactly the inner "d" payload's
+                // own canonical CBOR — the same slice-not-re-encode contract
+                // the Opaque arm already gives.
+                let payload = decode(&payload_bytes).unwrap();
+                if let CborValue::Map(entries) = payload {
+                    assert_eq!(entries.len(), 3);
+                } else {
+                    panic!("expected map");
+                }
+            }
+            other => panic!("expected Quarantined, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn card_with_invalid_month_via_decode_record_is_quarantined() {
+        let mut c = sample_card();
+        c.expiry_month = 13;
+        let bytes = encode_record(&c).unwrap();
+        let any = decode_record(&bytes).unwrap();
+        match any {
+            AnyRecord::Quarantined {
+                content_type,
+                reason,
+                ..
+            } => {
+                assert_eq!(content_type, CARD_V1);
+                assert!(reason.contains("month"));
+            }
+            other => panic!("expected Quarantined, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn quarantined_record_kind_and_summary_are_distinct_from_opaque() {
+        let mut t = sample_totp();
+        t.digits = 100;
+        let bytes = encode_record(&t).unwrap();
+        let any = decode_record(&bytes).unwrap();
+
+        assert_eq!(any.kind(), VaultRecordKind::Quarantined);
+        assert_ne!(any.kind(), VaultRecordKind::Opaque);
+        assert!(!any.kind().is_first_party());
+
+        let summary = any.summary();
+        assert_eq!(summary.kind, VaultRecordKind::Quarantined);
+        assert!(summary.is_quarantined());
+        assert!(!summary.is_opaque());
+        assert!(!summary.is_first_party());
+        assert_eq!(summary.opaque_content_type_len, TOTP_SEED_V1.len());
+        assert!(summary.opaque_payload_bytes > 0);
+    }
+
+    #[test]
+    fn quarantined_record_debug_is_value_redacted() {
+        let mut c = sample_card();
+        c.expiry_month = 13;
+        let bytes = encode_record(&c).unwrap();
+        let any = decode_record(&bytes).unwrap();
+        assert_eq!(format!("{any:?}"), "AnyRecord::Quarantined(<redacted>)");
+    }
+
+    #[test]
+    fn a_malformed_envelope_still_denies_decode_record_entirely() {
+        // Quarantine only widens the *schema-mismatch* case. A record whose
+        // envelope itself is broken (not a {t,d} map, "t" the wrong type,
+        // etc.) is not something any content type can be attributed to, and
+        // must still fail outright rather than being silently accepted as
+        // some fabricated quarantine record.
+        let not_a_record = encode(&CborValue::Array(vec![CborValue::Unsigned(1)]));
+        assert!(matches!(
+            decode_record(&not_a_record),
+            Err(VaultRecordError::NotARecord)
+        ));
+
+        let bad_envelope = CborValue::Map(vec![
+            (CborValue::text("t"), CborValue::Unsigned(1)),
+            (CborValue::text("d"), CborValue::Map(vec![])),
+        ]);
+        assert!(matches!(
+            decode_record(&encode(&bad_envelope)),
+            Err(VaultRecordError::BadEnvelope)
+        ));
     }
 
     // --- Envelope rejection ---

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1300,6 +1300,19 @@ depends on which order the `remove` calls happen in, and reordering closes
 the window: the statement immediately after `payload` is bound is
 `ItemDocument::new`, with no fallible step between them.
 
+A second round of review found the identical gap one line earlier, on
+`record_bytes` — the record's still-encoded plaintext that `decode_record`
+reads `payload` from. It is not `Quarantined`-specific (every content type
+carries genuine secret plaintext in this buffer) and was not introduced by
+this fix, but it sits inside the exact function this fix already touches
+and the same threat model applies: a malformed `{t,d}` envelope around a
+genuinely secret `"d"` payload makes `decode_record` itself fail, dropping
+`record_bytes` unwiped, and — a strictly larger window than the one above —
+`record_bytes` is read only once and otherwise sits unwiped for the rest of
+every successful decode too. `record_bytes` is now wrapped in `Zeroizing`,
+matching the convention this module already applies to every other
+secret-bearing decode buffer (e.g. `take_secret_fixed`).
+
 **One new gap this closes in passing.** Before this fix, an item's
 `schema()` field (the revision's own declared content type, checked for
 agreement with `record_content_type(&payload)` by `ItemDocument::validate`)

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -933,14 +933,14 @@ the same threat model: a peer authoring a first-party record whose
 payload does not match the schema its content type names — a `Login`
 missing a required field — yields `SchemaMismatch`, which
 `decode_live` maps to `IntegrityFailure`, which travels the same path
-shown above. That residual is pre-existing, is unchanged by this change,
-and is deliberately not repaired here. The size failure could be *removed*
-because the re-encode was never needed; a payload that does not match its
-schema has to be represented somehow instead, which means deciding what a
+shown above. That residual was pre-existing when this section was
+written and was left deliberately unrepaired here, because unlike the
+size failure it could not be *removed* the same way — a payload that does
+not match its schema has to be represented somehow instead of an
+already-typed value handed back verbatim, which means deciding what a
 partly-unreadable item looks like to search, list, show, conflict
-resolution, export, and restore — a design question, not a local fix. It
-is tracked as follow-on work against this section, alongside the two
-repairs named in §13.2.
+resolution, export, and restore. **This one is now fixed too; §13.5
+states the repair.**
 
 Also newly reachable, and fixed here rather than deferred: `encode_any_record`'s
 opaque arm folded every `encode_opaque` failure into `IntegrityFailure`.
@@ -1155,6 +1155,163 @@ the latter opens a real, peer-synced vault whose catalog already exceeds the
 admission ceiling and performs two real `delete_current_item` calls against
 it, which is exactly the scenario security review found broken in the first
 version of this fix.
+
+### 13.5 A schema-mismatched payload has no bytes to hand back
+
+§13.3 named this residual and left it deliberately unrepaired: a peer
+authoring a first-party record whose payload does not match the schema its
+content type names — a `Login` missing its `password` field is the running
+example — decodes into `SchemaMismatch`, which `decode_live` mapped to
+`IntegrityFailure`, which travels the same `decode_record → decode_
+item_revision → read_candidate → materialize_current_catalog →
+open_active_vault` chain the oversized-opaque bug did. One synced record
+denied the whole vault, the identical blast radius, reached without ever
+crossing a size ceiling.
+
+**Confirmed reachable, not assumed.** Before writing any fix, this was
+proven with a real reproduction rather than trusted from the code reading
+above: `a_synced_schema_mismatched_login_record_leaves_the_vault_openable`
+(`open.rs`) synthesises a peer-authored `Login` revision whose payload is
+valid canonical CBOR — decodable, and legal to hold under
+`MAX_PLAINTEXT_BYTES` — but missing `password`, delivers it through the
+shared object store the way a real sync would, and opens the vault.
+Temporarily reverting only the repair below (keeping everything else, so
+the test still compiles) reproduces the exact failure: `active_session`
+panics on `Err(IntegrityFailure)` from `open_active_vault`. The fix in this
+section is what turns that panic back into a normal open.
+
+**Why this is not §13.3's fix again.** §13.3's oversized-opaque payload
+decoded successfully — the failure was purely in a needless re-encode on
+the way out, so the repair was "hand back the bytes that already decoded
+correctly, don't re-encode them." A schema-mismatched payload never
+decodes as its declared type at all: there is no `Login` value to hand
+back, because none was ever constructed. "Return the original bytes"
+therefore cannot mean "return the original *typed value*" here; it can
+only mean "return the original *record's raw bytes*, unintepreted" — which
+is exactly the shape `AnyRecord::Opaque` already uses for a different
+reason (a content type this crate doesn't recognise at all). The repair
+reuses that shape under a new variant rather than folding into `Opaque`
+itself, because *why* a record is unreadable is worth keeping distinct from
+*whether* it is:
+
+```rust
+// coding_adventures_vault_records::AnyRecord (vault-records/src/lib.rs)
+Quarantined {
+    content_type: String,   // one of this crate's own *_V1 constants
+    payload_bytes: Vec<u8>, // the payload's own canonical-CBOR bytes
+    reason: &'static str,   // e.g. "Login.password missing" — never
+                             // attacker-controlled, always a literal
+                             // from this crate's own typed decoders
+},
+```
+
+`Opaque` means "this crate doesn't recognise the content type" — an
+ordinary forward-compatibility case, no different in kind from an older
+client seeing a newer peer's record. `Quarantined` means "this crate
+recognises the content type and the payload is still wrong" — which only
+happens if a peer authored a malformed record, by bug or by malice. The two
+get identical downstream treatment (below) because a caller's remedy is the
+same either way: it cannot repair the record, only remove it. They stay
+distinct variants because *why* a record is unreadable is a fact worth
+preserving — collapsing them would make "how many records has this vault
+received that this client cannot even parse against the type they
+themselves claim" permanently unanswerable, which matters for anyone
+auditing a vault for peer misbehaviour after the fact.
+
+`decode_record`'s six typed-dispatch arms now catch `SchemaMismatch`
+specifically and quarantine instead of propagating; every other
+`VaultRecordError` variant (a broken `{t,d}` envelope, `t` the wrong CBOR
+type, and so on) still denies decode outright, because those describe a
+record no content type can be attributed to — quarantine needs a content
+type to quarantine *under*. `decode_record_as::<T>`, used only when a
+caller specifically requires one exact type, is untouched and still
+returns `SchemaMismatch` directly; only the general decoder `decode_live`
+calls at open time changed behaviour.
+
+**What each affected surface does with a quarantined item**, mirroring the
+precedent §13.3 and §13.2 already set for the oversized-opaque case:
+
+- **Open.** `open_active_vault` no longer fails. The item materialises into
+  the current catalog as any other item would.
+- **`item list`.** The item appears. `RedactedRecordView` gained a matching
+  `Quarantined { content_type, payload_bytes, reason, payload:
+  RedactedSecret }` variant (`vault-pm-domain`), and the CLI's title
+  fallback (`record_title`) uses the declared content type as the display
+  title — the same fallback `Opaque` already uses, since neither has a
+  title field. A quarantined item silently missing from `item list` would
+  trade one failure mode (vault won't open) for a quieter one (item exists,
+  operator never learns it does).
+- **`item show`.** Unlike `Opaque` — an ordinary content type this build
+  simply has no renderer for, which `item show` declines with
+  `Unsupported` — a quarantined item's declared type *is* recognised; only
+  its payload failed to parse. `item show` therefore succeeds with a
+  redacted placeholder (`Content: could not be read (<reason>)`) instead of
+  erroring, because an `Unsupported` error reads the same as "this command
+  doesn't handle that item kind," which is the wrong message for "this item
+  is broken."
+- **Search.** Indexed the same as `Opaque`: no title text contributed (there
+  is none to index), tags still index normally. A quarantined item can be
+  found by tag but not by guessing at its unreadable content.
+- **Conflict resolution.** `conflict choose` (`resolve_item_conflict`) never
+  matches on `AnyRecord` at all — it operates on whichever candidate's
+  revision id is selected without decoding its payload — so it is
+  unaffected by construction. The six typed `conflict merge <type>`
+  ceremonies each gate on a `let AnyRecord::<Type>(_) = base.payload() else
+  { return Err(Unsupported) }` precondition (`login_conflict_merge_
+  precondition` and its five siblings) that already treated every non-
+  matching variant uniformly; `Quarantined` falls into that same `else`
+  branch as `Opaque` always has, so `conflict merge login` against a
+  quarantined base already returned `Unsupported` with no code change.
+  `a_synced_schema_mismatched_login_item_denies_edit_as_login` pins the
+  identically-shaped `item edit` precondition (`login_edit_precondition`)
+  directly, since editing and conflict-merging share this exact pattern.
+- **Deletion.** Unaffected, by the same structural argument as §13.2 and
+  §13.3: a tombstone revision carries only the item id and a timestamp, so
+  `delete_current_item` never reaches `encode_any_record` and never touches
+  the unreadable bytes.
+- **`export` / `history restore` / conflict merges that re-encode.**
+  `encode_any_record` gained a `Quarantined` arm that forwards through
+  `encode_opaque(content_type, payload_bytes)` — the identical call the
+  `Opaque` arm already makes. The record round-trips byte for byte: still
+  unreadable, never silently repaired, never dropped.
+
+**One new gap this closes in passing.** Before this fix, an item's
+`schema()` field (the revision's own declared content type, checked for
+agreement with `record_content_type(&payload)` by `ItemDocument::validate`)
+matching a first-party constant was a true guarantee that `payload()`
+decoded as that type — `AnyRecord::Login(_)` could not fail to match if
+`schema() == LOGIN_V1`. That is exactly why the defensive re-check inside
+`replacement_login_document` (and its five siblings) reports
+`InternalInvariant` on mismatch: reaching it meant this crate's own code
+had a bug, never that a peer did. Quarantine breaks that guarantee for the
+first time — `schema()` can now say `vault/login/v1` while `payload()` is
+`Quarantined` — but only *before* the first real precondition gate
+(`login_edit_precondition` and siblings), which every ordinary `item edit`
+and `conflict merge` call path reaches first and which already reports the
+ordinary `Unsupported` outcome instead. The inner defensive checks remain
+correctly unreachable through any call this product's own commands can
+make; nothing needed to change there.
+
+**Tests.** `vault-records` pins the decode primitive directly:
+`login_missing_password_via_decode_record_is_quarantined_not_denied` and
+`card_with_invalid_month_via_decode_record_is_quarantined` show
+`decode_record` quarantines instead of failing, while
+`login_missing_password_is_schema_mismatch` (unchanged) confirms
+`decode_record_as::<T>` still fails closed for a caller that wants one
+exact type; `quarantined_record_kind_and_summary_are_distinct_from_opaque`
+and `quarantined_record_debug_is_value_redacted` cover the new
+`VaultRecordKind` and redaction surfaces; `a_malformed_envelope_still_
+denies_decode_record_entirely` confirms envelope-level corruption (not
+attributable to any content type) still fails outright. `open.rs`
+reproduces the bug end to end and pins the fix against a real, peer-synced
+vault: `a_synced_schema_mismatched_login_record_leaves_the_vault_openable`
+(the reachability proof — see above), `a_synced_schema_mismatched_login_
+item_is_visible_in_the_redacted_list`, `a_synced_schema_mismatched_login_
+item_can_be_deleted`, and `a_synced_schema_mismatched_login_item_denies_
+edit_as_login`. `vault-pm-cli` pins the two rendering surfaces directly:
+`record_title_falls_back_to_content_type_for_a_quarantined_record` and
+`render_item_shows_a_redacted_placeholder_for_a_quarantined_record_
+instead_of_erroring`.
 
 ## 14. Required verification
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1275,6 +1275,31 @@ precedent §13.3 and §13.2 already set for the oversized-opaque case:
   `Opaque` arm already makes. The record round-trips byte for byte: still
   unreadable, never silently repaired, never dropped.
 
+**A zeroization window, found and closed during security review.** Unlike
+`Opaque` — genuinely unknown content, not assumed sensitive — a
+`Quarantined` record's declared type names one of this crate's own
+secret-bearing schemas, so its `payload_bytes` usually *are* real plaintext
+(the vault-records doc comment on the variant states this explicitly).
+`AnyRecord` has no `Drop` impl of its own (typed variants each wipe
+themselves; `Opaque` and `Quarantined` do not, by design — see the
+`AnyRecord`/`Zeroize` NOTE in vault-records), so a `payload` value bound to
+a bare local variable is wiped only by something that explicitly zeroizes
+it. `ItemDocument` does that the moment `payload` is moved inside it, since
+its own `Drop` zeroizes on any later failure — but only from that point
+on. `decode_live`'s original field order (1–8, then 9, then 10) left a
+window: `payload` was bound by decoding field 8, and two more fallible
+decodes (fields 9 and 10) ran *after* it and *before* `ItemDocument::new`
+consumed it. A peer-authored revision fully controls all three fields in
+one sealed object, so a schema-mismatched record paired with a malformed
+attachments or manifest field would return early through `?` with
+`payload` still a bare local — dropped by ordinary (non-zeroizing) Rust
+drop semantics, leaking its plaintext into freed heap memory. `decode_live`
+now decodes fields 9 and 10 before field 8; `fields` is already a
+key-indexed map by that point; so nothing about the wire's byte order
+depends on which order the `remove` calls happen in, and reordering closes
+the window: the statement immediately after `payload` is bound is
+`ItemDocument::new`, with no fallible step between them.
+
 **One new gap this closes in passing.** Before this fix, an item's
 `schema()` field (the revision's own declared content type, checked for
 agreement with `record_content_type(&payload)` by `ItemDocument::validate`)


### PR DESCRIPTION
## Summary

Closes the residual named in VLT-PM05 §13.3: a peer-authored first-party record whose payload doesn't match the schema its declared `content_type` names (e.g. a `Login` missing its `password` field) decoded to `VaultRecordError::SchemaMismatch`, which `decode_live` mapped to `IntegrityFailure`, denying **the whole vault open** — the same blast radius item #10 (PR #11958) fixed for oversized opaque records, reached through a different door.

**Reachability was confirmed with a real reproduction**, not assumed from the spec's prose: `a_synced_schema_mismatched_login_record_leaves_the_vault_openable` (open.rs) synthesizes a peer-authored schema-mismatched `Login` revision, delivers it through the shared object store the way a real sync would, and opens the vault. Temporarily reverting only the fix reproduces the exact panic on `Err(IntegrityFailure)`.

Unlike #10 (fixable by returning the original already-decoded bytes instead of re-encoding), this record never decodes into any valid typed value at all, so there's no "return the original bytes" escape hatch at that level. The fix adds a new `AnyRecord::Quarantined { content_type, payload_bytes, reason }` variant (vault-records) alongside the existing `Opaque` variant, reusing the same "slice the already-validated payload bytes, never re-encode" technique that fixed #10.

## What changed

- `decode_record`'s six typed dispatch arms now catch `SchemaMismatch` specifically and quarantine instead of propagating; every other decode error still fails closed. `decode_record_as::<T>` (used when a caller wants one exact type) is unaffected.
- Quarantined records get the same downstream treatment `Opaque` records already have: the vault opens, the item is visible in `item list` (falling back to its declared content type as the display title), `item show` renders a redacted "could not be read" placeholder instead of erroring, search indexes tags but no title text, `encode_any_record` forwards the bytes verbatim for export/history-restore/conflict-merge, and deletion works unconditionally (a tombstone never touches the payload).
- `conflict choose` is unaffected by construction (payload-agnostic). The six typed edit/conflict-merge preconditions already treated any non-matching `AnyRecord` variant uniformly via `let-else`, so `Quarantined` falls into the same `Unsupported` branch `Opaque` always has — pinned by a dedicated test rather than left as an inference.

## Security review (3 rounds, 2 real findings fixed)

- **Round 1 (MEDIUM):** `decode_live` bound a `Quarantined` payload (which can carry a peer's genuine secret plaintext, since its declared type is a first-party secret-bearing schema) to a bare local variable across two more fallible decode steps before it reached a zeroize-on-drop `ItemDocument`. Fixed by reordering those steps.
- **Round 2 (MEDIUM):** a sibling gap on `record_bytes` one line above — never wiped on either the error or success path, for every record type, not just quarantined ones. Fixed by wrapping in `Zeroizing`.
- **Round 3:** passed clean.

## Test plan

- [x] `vault-records`: quarantine primitive tested directly (`login_missing_password_via_decode_record_is_quarantined_not_denied`, `card_with_invalid_month_via_decode_record_is_quarantined`, kind/summary/debug coverage, envelope-corruption still fails closed)
- [x] `vault-pm-application`: end-to-end reachability + fix proof against a real peer-synced vault (open, list visibility, deletion, edit-precondition denial)
- [x] `vault-pm-cli`: `item list` title fallback and `item show` placeholder rendering
- [x] 476 tests pass across affected crates (`vault-records`, `vault-pm-domain`, `vault-pm-application`, `vault-pm-application-storage-core`, `vault-pm-audit`, `vault-pm-cli`)
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean on all affected crates
- [x] Spec updated: VLT-PM05-application.md §13.3 points at new §13.5, which documents the reachability proof, fix design, and both security-review fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)