### PR TITLE
fix(vault-pm): zeroize CborValue trees and reveal-escape buffers end to end

### DIFF
--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- **Fixed: `escaped_revealed_text` no longer reallocates while holding a
+  secret.** `item reveal` and `conflict reveal` (via `write_revealed_text`)
+  used to build the quote/control-escaped terminal text with
+  `Zeroizing::new(format!("{value:?}"))`. `format!`'s `String` starts empty
+  and grows via `push`/`push_str` as `Debug` escapes each character, using
+  ordinary incremental-growth reallocation: once a write would exceed
+  capacity, the buffer `memcpy`s the plaintext already written into a larger
+  allocation and frees the old one through the global allocator *without
+  scrubbing it first*. `Zeroizing` only wipes the final allocation it ends up
+  holding, so every intermediate allocation the buffer reallocated out of
+  along the way left a stale, unwiped copy of the secret in freed heap — the
+  same reallocation-leaves-a-stale-copy pattern already found and fixed in
+  `vault-pm-agent-protocol`'s `AgentRequest::encode`.
+
+  `escaped_revealed_text` now reserves capacity once, before any byte of the
+  secret is read — `2 + 6 * value.len()`, a provably sufficient upper bound
+  on Debug-escaping's worst per-input-byte expansion (a lone ASCII control
+  byte escaping to `\u{xx}`) — and writes the real, unmodified `Debug`
+  formatter's output into that buffer via `write!`, so no reallocation can
+  occur while a copy of the secret is resident. A `debug_assert_eq!` on the
+  final capacity turns "the bound stayed sufficient" into a standing
+  invariant. See VLT-PM05 §13.6 for the full design account, and
+  `escaped_revealed_text_never_reallocates_a_buffer_already_holding_a_secret`
+  for the regression test (mirrors `vault-pm-agent-protocol`'s
+  `encode_never_reallocates_a_buffer_already_holding_a_secret`).
+
 - **Added `read_external_import_source`** (`VLT-PM49-cli-external-import.md`),
   the filesystem half of `vault-pm import bitwarden`/`import csv`. Same
   exact-length-read shape as `read_attachment_source` and for the same

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -21,9 +21,12 @@
   on Debug-escaping's worst per-input-byte expansion (a lone ASCII control
   byte escaping to `\u{xx}`) — and writes the real, unmodified `Debug`
   formatter's output into that buffer via `write!`, so no reallocation can
-  occur while a copy of the secret is resident. A `debug_assert_eq!` on the
-  final capacity turns "the bound stayed sufficient" into a standing
-  invariant. See VLT-PM05 §13.6 for the full design account, and
+  occur while a copy of the secret is resident. A full `assert_eq!` (not
+  `debug_assert_eq!` — this is a cheap check on an already-slow,
+  human-attended path, and compiling it out of release builds would mean a
+  future regression reopens the leak with no signal) on the final capacity
+  turns "the bound stayed sufficient" into a standing invariant. See
+  VLT-PM05 §13.6 for the full design account, and
   `escaped_revealed_text_never_reallocates_a_buffer_already_holding_a_secret`
   for the regression test (mirrors `vault-pm-agent-protocol`'s
   `encode_never_reallocates_a_buffer_already_holding_a_secret`).

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -147,6 +147,14 @@ string escaping prevents stored control characters from becoming terminal
 commands or counterfeit output; the escaped string and Windows UTF-16 buffer
 are wipe-on-drop.
 
+The escape itself is capacity-reserved, not grown incrementally:
+`escaped_revealed_text` allocates its `Zeroizing<String>` at a provably
+sufficient upper bound before writing a single byte of the secret, so the
+buffer can never trigger `String`'s ordinary reallocate-and-free-the-old-copy
+growth while it holds plaintext — the same discipline
+`vault-pm-agent-protocol`'s `AgentRequest::encode` uses for binary framing,
+applied here to Debug-escaped text. See VLT-PM05 §13.6.
+
 Fourteen Unix tests exercise stable diagnostics, text/secret bounds, constant-time
 confirmation behavior, real OS entropy, pseudo-terminal ordinary and hidden
 input, mode restoration, oversized-line draining, non-terminal refusal,

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -6,6 +6,10 @@ use coding_adventures_csprng::fill_random;
 use coding_adventures_ct_compare::ct_eq;
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Display, Formatter};
+// Trait-only import (no bound name) so `write!`'s `.write_fmt` resolves to
+// `String`'s `core::fmt::Write` impl without colliding with `std::io::Write`,
+// already imported below for file I/O.
+use core::fmt::Write as _;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::Path;
@@ -507,8 +511,78 @@ impl ControllingTerminal {
     }
 }
 
+/// Debug-escape `value` (quote-wrapped, control/backslash/quote-escaped —
+/// exactly `format!("{value:?}")`'s output) into a buffer whose capacity is
+/// reserved once, before a single byte of `value` is read, so building the
+/// escaped text can never trigger a mid-build reallocation.
+///
+/// # Why the previous `Zeroizing::new(format!("{value:?}"))` leaked
+///
+/// `Zeroizing<String>` wipes only whatever allocation the `String` holds at
+/// drop time. `format!` starts its `String` empty and grows it, via a
+/// sequence of `push`/`push_str` calls as the `Debug` formatter escapes each
+/// character in turn, using `String`'s ordinary incremental-growth
+/// reallocation: once the next write would exceed capacity, `String`
+/// allocates a larger buffer, `memcpy`s the escaped plaintext already
+/// written into it, and frees the old allocation through the global
+/// allocator *without scrubbing it first*. Every character written before
+/// the point a reallocation happened is a secret that briefly lived in an
+/// allocation `Zeroizing` never got a handle to and therefore never wiped —
+/// stranded, unscrubbed, in freed heap. This is the same
+/// reallocation-leaves-a-stale-copy pattern already found and fixed in
+/// `AgentRequest::encode` (`vault-pm-agent-protocol`); the mechanism here is
+/// text escaping rather than binary wire framing, but the fix is the same
+/// shape: reserve the buffer's capacity up front so no reallocation can ever
+/// occur while a copy of the secret is resident in it.
+///
+/// # Why this reserves an upper bound rather than the exact final length
+///
+/// `AgentRequest::encode`'s `encoded_capacity` can compute the *exact* final
+/// size because binary framing is fixed-width fields plus a raw byte copy.
+/// Debug-escaping cannot be sized that precisely without duplicating the
+/// standard library's own (private) per-character escaping rules: `\\`,
+/// `\"`, and `\n`/`\r`/`\t` each expand to 2 output bytes, everything else
+/// either prints unchanged (1:1) or expands to a `\u{..}` escape whose width
+/// depends on the code point. Reproducing exactly which applies to which
+/// character would mean re-implementing (and keeping in sync with) `core`'s
+/// internal printable-character tables.
+///
+/// Instead this reserves a **provably sufficient** upper bound — `2 +
+/// 6 * value.len()` — and lets the real, unmodified `Debug` impl write into
+/// it. The 6-bytes-per-input-byte figure is not a guess: the widest any
+/// single input *byte* can expand to is a lone ASCII control byte in
+/// `0x10..=0x1F` or `0x7F`, which Debug-escapes to `\u{xx}` — 6 output bytes
+/// (`\`, `u`, `{`, two hex digits, `}`) — for that one input byte. Every
+/// other case expands by less per input byte: the named escapes above are 2
+/// output bytes for 1 input byte, an unescaped printable character is 1:1,
+/// and a multi-byte UTF-8 sequence's `\u{..}` escape spreads its (larger)
+/// output back out over more than one input byte, so its per-*byte* ratio is
+/// smaller still. `2` covers the surrounding quotes `Debug` always adds. Any
+/// slack this leaves unused was never written to — it never held a byte of
+/// `value` — and `Zeroizing<String>`'s drop wipes the whole capacity
+/// regardless (`coding_adventures_zeroize::Zeroize for String`), so
+/// over-reserving costs a few unused bytes, never a leak.
+///
+/// The `debug_assert_eq!` below is the same empirical check
+/// `encode_never_reallocates_a_buffer_already_holding_a_secret` makes for
+/// `AgentRequest::encode`, turned into a standing runtime invariant: if this
+/// bound is ever wrong (a future `std` Debug-escaping change, a mistaken
+/// edit here), it fails loudly in every debug/test build rather than
+/// silently reopening the leak.
 fn escaped_revealed_text(value: &str) -> Zeroizing<String> {
-    Zeroizing::new(format!("{value:?}"))
+    let capacity = 2 + value.len().saturating_mul(6);
+    let mut out = Zeroizing::new(String::with_capacity(capacity));
+    // `core::fmt::Write for String` never returns `Err` — the only error
+    // the trait can report is a formatter failure, and none of `Debug`'s
+    // machinery produces one — so this `expect` cannot fire.
+    write!(out, "{value:?}").expect("writing Debug-escaped text into a String cannot fail");
+    debug_assert_eq!(
+        out.capacity(),
+        capacity,
+        "escaped_revealed_text's upper bound was too tight and the buffer reallocated \
+         while holding secret plaintext"
+    );
+    out
 }
 
 /// Durably create one explicit portable-export destination without replacing it.
@@ -1107,6 +1181,66 @@ mod tests {
             &*escaped_revealed_text("line\n\"terminal\u{1b}"),
             "\"line\\n\\\"terminal\\u{1b}\""
         );
+    }
+
+    /// `escaped_revealed_text` never reallocates while a secret is already
+    /// resident in the buffer, across a sweep of realistic secret lengths and
+    /// character mixes.
+    ///
+    /// This is the direct, empirical form of the security-review finding
+    /// this test closes (item #21): a buffer built via `format!` starts
+    /// empty and grows via `push`/`push_str` as `Debug` escapes each
+    /// character, reallocating (and leaving the plaintext already written
+    /// behind, unscrubbed, in freed heap) for most real secret lengths.
+    /// `String::capacity()` staying exactly equal to the upfront-reserved
+    /// bound, for every case in this sweep, is what proves no such
+    /// reallocation happened — mirroring
+    /// `encode_never_reallocates_a_buffer_already_holding_a_secret` in
+    /// `vault-pm-agent-protocol`, which closed the same pattern for
+    /// `AgentRequest::encode`.
+    #[test]
+    fn escaped_revealed_text_never_reallocates_a_buffer_already_holding_a_secret() {
+        // Plain ASCII (1:1, no escaping at all) at a sweep of lengths,
+        // including the empty string.
+        for len in [0_usize, 1, 8, 32, 256, 4096] {
+            let value = "s".repeat(len);
+            let expected_capacity = 2 + value.len().saturating_mul(6);
+            let escaped = escaped_revealed_text(&value);
+            assert_eq!(
+                escaped.capacity(),
+                expected_capacity,
+                "plain ASCII, len={len}: buffer reallocated while holding secret plaintext"
+            );
+        }
+
+        // Every byte needs the widest escape form (`\u{xx}`, 6 output bytes
+        // per input byte) -- the exact case the reserved capacity is sized
+        // for, so this exercises the bound at its tightest.
+        for len in [0_usize, 1, 8, 64, 512] {
+            let value = "\u{7f}".repeat(len);
+            let expected_capacity = 2 + value.len().saturating_mul(6);
+            let escaped = escaped_revealed_text(&value);
+            assert_eq!(
+                escaped.capacity(),
+                expected_capacity,
+                "all-DEL, len={len}: buffer reallocated while holding secret plaintext"
+            );
+        }
+
+        // A realistic mixed secret: printable characters, a couple of the
+        // 2-byte named escapes, and one of the widest per-byte cases.
+        let value = format!("correct-horse-battery-staple-{}\n\"\u{1b}", "x".repeat(97));
+        let expected_capacity = 2 + value.len().saturating_mul(6);
+        let escaped = escaped_revealed_text(&value);
+        assert_eq!(
+            escaped.capacity(),
+            expected_capacity,
+            "mixed secret: buffer reallocated while holding secret plaintext"
+        );
+        // And the escaping itself still round-trips to what `format!` would
+        // have produced, so the reallocation-proof capacity discipline above
+        // didn't come at the cost of correctness.
+        assert_eq!(escaped.as_str(), format!("{value:?}"));
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -563,12 +563,18 @@ impl ControllingTerminal {
 /// regardless (`coding_adventures_zeroize::Zeroize for String`), so
 /// over-reserving costs a few unused bytes, never a leak.
 ///
-/// The `debug_assert_eq!` below is the same empirical check
+/// The `assert_eq!` below is the same empirical check
 /// `encode_never_reallocates_a_buffer_already_holding_a_secret` makes for
-/// `AgentRequest::encode`, turned into a standing runtime invariant: if this
-/// bound is ever wrong (a future `std` Debug-escaping change, a mistaken
-/// edit here), it fails loudly in every debug/test build rather than
-/// silently reopening the leak.
+/// `AgentRequest::encode`, turned into a standing runtime invariant. It is
+/// deliberately a full `assert_eq!`, not `debug_assert_eq!`: this function
+/// runs only on the already-slow, human-attended terminal-reveal path, so
+/// the cost of one integer comparison is immaterial, while compiling the
+/// check out of release builds would mean a future `std` Debug-escaping
+/// change that ever widened past 6 bytes per input byte reopens this exact
+/// leak silently, with no signal in the build that actually ships. Failing
+/// loud here — refusing the reveal rather than serving a value that may
+/// have left an unwiped copy behind — is the correct trade for a security
+/// invariant like this one.
 fn escaped_revealed_text(value: &str) -> Zeroizing<String> {
     let capacity = 2 + value.len().saturating_mul(6);
     let mut out = Zeroizing::new(String::with_capacity(capacity));
@@ -576,7 +582,7 @@ fn escaped_revealed_text(value: &str) -> Zeroizing<String> {
     // the trait can report is a formatter failure, and none of `Debug`'s
     // machinery produces one — so this `expect` cannot fire.
     write!(out, "{value:?}").expect("writing Debug-escaped text into a String cannot fail");
-    debug_assert_eq!(
+    assert_eq!(
         out.capacity(),
         capacity,
         "escaped_revealed_text's upper bound was too tight and the buffer reallocated \

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -576,7 +576,7 @@ impl ControllingTerminal {
 /// have left an unwiped copy behind — is the correct trade for a security
 /// invariant like this one.
 fn escaped_revealed_text(value: &str) -> Zeroizing<String> {
-    let capacity = 2 + value.len().saturating_mul(6);
+    let capacity = value.len().saturating_mul(6).saturating_add(2);
     let mut out = Zeroizing::new(String::with_capacity(capacity));
     // `core::fmt::Write for String` never returns `Err` — the only error
     // the trait can report is a formatter failure, and none of `Debug`'s
@@ -1210,7 +1210,7 @@ mod tests {
         // including the empty string.
         for len in [0_usize, 1, 8, 32, 256, 4096] {
             let value = "s".repeat(len);
-            let expected_capacity = 2 + value.len().saturating_mul(6);
+            let expected_capacity = value.len().saturating_mul(6).saturating_add(2);
             let escaped = escaped_revealed_text(&value);
             assert_eq!(
                 escaped.capacity(),
@@ -1224,7 +1224,7 @@ mod tests {
         // for, so this exercises the bound at its tightest.
         for len in [0_usize, 1, 8, 64, 512] {
             let value = "\u{7f}".repeat(len);
-            let expected_capacity = 2 + value.len().saturating_mul(6);
+            let expected_capacity = value.len().saturating_mul(6).saturating_add(2);
             let escaped = escaped_revealed_text(&value);
             assert_eq!(
                 escaped.capacity(),
@@ -1236,7 +1236,7 @@ mod tests {
         // A realistic mixed secret: printable characters, a couple of the
         // 2-byte named escapes, and one of the widest per-byte cases.
         let value = format!("correct-horse-battery-staple-{}\n\"\u{1b}", "x".repeat(97));
-        let expected_capacity = 2 + value.len().saturating_mul(6);
+        let expected_capacity = value.len().saturating_mul(6).saturating_add(2);
         let escaped = escaped_revealed_text(&value);
         assert_eq!(
             escaped.capacity(),

--- a/code/packages/rust/vault-records/CHANGELOG.md
+++ b/code/packages/rust/vault-records/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Caller-side `CborValue` trees are now wiped end to end.** `encode_record`
+  and `decode_record`/`decode_record_as` (via the shared `split_envelope`
+  helper) and `encode_opaque` each build an owned `CborValue` tree that, for
+  all seven record kinds, *is* somebody's plaintext — `encode_payload` clones
+  every field into fresh `CborValue::Text`/`Bytes` leaves, and the typed
+  `decode_payload`s clone fields back out of a tree the codec already fully
+  materialised. The typed records themselves already wipe on drop (`Login`
+  and its five siblings implement `Zeroize` + `Drop`), but this intermediate
+  tree did not: it dropped through ordinary, non-wiping `Vec`/`String`/
+  `CborValue` destructors, once per encode or decode.
+
+  A prior security review's proposed quick fix — wipe only `try_encode`'s
+  output buffer on its error path — was correctly rejected as incomplete:
+  the caller's own tree is built and dropped regardless of whether that
+  encode call succeeds, and `canonical-cbor` itself cannot own the fix
+  (it is deliberately zero-dependency; see CBR01's "Non-goals"). The real
+  fix is here instead: a new `zeroize_cbor_value` recursively wipes every
+  `Text`/`Bytes` leaf through any nesting of `Array`/`Map`/`Tag` (its match
+  has no wildcard arm, so a future `CborValue` variant fails to compile here
+  until the new arm is added), and a new local `SecretCborValue` wrapper —
+  `Zeroizing<CborValue>` in everything but name, since `CborValue` cannot
+  itself implement the sibling crate's `Zeroize` trait without violating
+  Rust's orphan rule — calls it from `Drop`, so the wipe runs on every exit
+  path (success, an early `?`-propagated error, or a panic unwind), not only
+  the ones a hand-placed wipe call would remember to cover. See VLT-PM05
+  §13.6 for the full design account and CBR01's "Non-goals" for why this
+  could not live inside canonical-cbor.
+
 - `decode_record`'s opaque arm no longer re-encodes the payload it has just
   decoded, which closes the most severe defect this codec had: an opaque record
   that could be **read but not read back**.

--- a/code/packages/rust/vault-records/README.md
+++ b/code/packages/rust/vault-records/README.md
@@ -149,6 +149,21 @@ Every type that carries secrets (`Login.password`, `Card.cvv`,
 `DatabaseCredential.password`) implements `Zeroize`. Higher layers
 wrap held records in `Zeroizing<T>`.
 
+That covers the typed structs. The `CborValue` tree `encode_record` builds
+and `decode_record`/`decode_record_as` decode on the way to or from those
+structs is *also* plaintext — canonical-CBOR's own `CborValue` has no
+`Zeroize` impl and, being deliberately zero-dependency (see
+[`CBR01`](../../../specs/CBR01-canonical-cbor.md)'s "Non-goals"), never will.
+This crate wipes that tree itself: `zeroize_cbor_value` recursively clears
+every `Text`/`Bytes` leaf reachable through `Array`/`Map`/`Tag` nesting (an
+exhaustive match with no wildcard arm, so a future `CborValue` variant fails
+to compile here rather than silently escaping the wipe), and the local
+`SecretCborValue` wrapper — `Zeroizing<CborValue>` in everything but name —
+calls it from `Drop`, so the wipe runs on every exit path `encode_record`,
+`decode_record`, `decode_record_as`, `split_envelope`, and `encode_opaque`
+can take, not only the success path. See VLT-PM05 §13.6 for the full design
+account of why this lives here rather than in `canonical-cbor`.
+
 Diagnostic formatting is closed and value-redacted. `Debug` for each typed
 record emits only its type name and `<redacted>`; `AnyRecord` retains only the
 variant name and the same marker. Opaque content types, opaque payload bytes,

--- a/code/packages/rust/vault-records/src/lib.rs
+++ b/code/packages/rust/vault-records/src/lib.rs
@@ -227,6 +227,127 @@ impl From<CborError> for VaultRecordError {
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// 2a. Zeroizing CborValue trees
+// ─────────────────────────────────────────────────────────────────────
+//
+// `encode_record` and `decode_record` both build an owned `CborValue`
+// tree that, for the six typed record kinds plus opaque pass-through,
+// *is* somebody's plaintext: `Login.password`, `Card.number`,
+// `TotpSeed.secret`, and friends all pass through a `CborValue::Map`
+// on the way to or from the wire. `Login` and its siblings already
+// implement `Zeroize` + `Drop` (see section 4 below) so the *typed*
+// struct wipes itself. The `CborValue` tree used to build or decode
+// it did not: `encode_payload` clones every field into a fresh
+// `CborValue::Text`/`CborValue::Bytes`, and `decode_payload` clones
+// fields back out of a `CborValue` the codec already fully
+// materialised — in both directions, an owned tree of plaintext sits
+// in a local variable that dropped through the ordinary, non-wiping
+// `Vec`/`String`/`CborValue` destructors.
+//
+// A round-trip security review once proposed patching this by wiping
+// only `try_encode`'s own output buffer on its error path. That fix
+// was correctly rejected as incomplete by construction: the same
+// plaintext also sits in the *caller's* `CborValue` tree (`envelope`
+// in `encode_record`, `payload` in `decode_record`), which the
+// encoder's error path cannot reach and which is still fully built
+// and dropped unwiped even when the encoder *succeeds*.
+//
+// The real fix has to live on the caller side, for a structural
+// reason: `CborValue` is defined in `canonical-cbor`, which is
+// deliberately zero-dependency (see CBR01 and that crate's own
+// module doc) so it stays usable from arbitrarily constrained
+// contexts, including the C/C++ reference oracles it ships alongside.
+// It cannot depend on `coding_adventures_zeroize` to provide
+// `impl Zeroize for CborValue` itself, and no third crate can supply
+// that impl either — neither the `Zeroize` trait nor the `CborValue`
+// type is local to this crate, so Rust's orphan rule forbids
+// `impl coding_adventures_zeroize::Zeroize for CborValue` from
+// showing up here. `zeroize_cbor_value` and `SecretCborValue` below
+// sidestep the rule the ordinary way: the *wrapper type* is local to
+// this crate, so its `Drop` impl needs no permission from either the
+// trait's or `CborValue`'s home crate.
+//
+// `zeroize_cbor_value`'s match has **no wildcard arm** on purpose: if
+// canonical-cbor ever grows a tenth `CborValue` variant (its own docs
+// name floats as future work), this function fails to compile until
+// the new arm is added here, rather than silently leaving a class of
+// plaintext unwiped. See the `zeroize_cbor_value_wipes_every_variant`
+// test below for the same exhaustiveness check applied at the call
+// site, and `secret_cbor_value_drop_runs_even_on_panic_unwind` for
+// proof `SecretCborValue`'s `Drop` fires on every exit path — the
+// gap the rejected error-path-only quick fix left open.
+
+/// Recursively wipe every owned `Text`/`Bytes` buffer reachable from a
+/// `CborValue` tree, through any nesting of `Array`, `Map` (both keys
+/// and values), and `Tag`.
+///
+/// `Unsigned`, `Negative`, `Bool`, and `Null` carry no owned heap
+/// buffer — a `u64`/`bool` lives inline in the enum, nothing to wipe —
+/// so those arms are no-ops kept only so the match stays exhaustive.
+fn zeroize_cbor_value(value: &mut CborValue) {
+    match value {
+        CborValue::Text(s) => s.zeroize(),
+        CborValue::Bytes(b) => b.zeroize(),
+        CborValue::Array(items) => {
+            for item in items.iter_mut() {
+                zeroize_cbor_value(item);
+            }
+        }
+        CborValue::Map(entries) => {
+            for (k, v) in entries.iter_mut() {
+                zeroize_cbor_value(k);
+                zeroize_cbor_value(v);
+            }
+        }
+        CborValue::Tag(_, inner) => zeroize_cbor_value(inner),
+        CborValue::Unsigned(_) | CborValue::Negative(_) | CborValue::Bool(_) | CborValue::Null => {}
+    }
+}
+
+/// Owns a `CborValue` tree that may hold plaintext secrets and wipes
+/// it, recursively, when the guard drops.
+///
+/// This is `Zeroizing<CborValue>` in everything but name — `CborValue`
+/// cannot itself implement the sibling crate's `Zeroize` trait (see
+/// the section comment above), so this crate provides the equivalent
+/// guarantee with a local newtype instead. `Deref` gives ordinary
+/// read access (`&secret_cbor_value` coerces to `&CborValue`) so
+/// callers pass it straight through to `expect_map`, `try_encode`,
+/// and every `VaultRecord::decode_payload` without change.
+struct SecretCborValue(CborValue);
+
+impl SecretCborValue {
+    fn new(value: CborValue) -> Self {
+        Self(value)
+    }
+}
+
+impl core::ops::Deref for SecretCborValue {
+    type Target = CborValue;
+
+    fn deref(&self) -> &CborValue {
+        &self.0
+    }
+}
+
+impl Drop for SecretCborValue {
+    fn drop(&mut self) {
+        #[cfg(test)]
+        SECRET_CBOR_VALUE_DROPS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        zeroize_cbor_value(&mut self.0);
+    }
+}
+
+/// Test-only counter proving `SecretCborValue::drop` actually ran,
+/// without reading through a pointer into memory the real `Drop` has
+/// already deallocated (which would be undefined behaviour, and this
+/// crate is `#![forbid(unsafe_code)]` besides). See
+/// `secret_cbor_value_drop_runs_even_on_panic_unwind` below.
+#[cfg(test)]
+static SECRET_CBOR_VALUE_DROPS: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
+// ─────────────────────────────────────────────────────────────────────
 // 3. Top-level encode / decode
 // ─────────────────────────────────────────────────────────────────────
 
@@ -268,10 +389,16 @@ impl From<CborError> for VaultRecordError {
 /// and returns `Err` without bytes, so a refused record can never be
 /// mistaken for a truncated-but-whole one.
 pub fn encode_record<T: VaultRecord>(rec: &T) -> Result<Vec<u8>, VaultRecordError> {
-    let envelope = CborValue::Map(vec![
+    // `envelope` holds a full plaintext clone of `rec`'s fields (see the
+    // section 2a comment above) for exactly as long as it takes
+    // `try_encode` to read it. `SecretCborValue`'s `Drop` wipes that
+    // clone whether `try_encode` succeeds or the `?` below returns
+    // early on failure — both are "the relevant caller-side scope
+    // ends," and both used to leave the clone sitting in freed heap.
+    let envelope = SecretCborValue::new(CborValue::Map(vec![
         (CborValue::text("t"), CborValue::text(T::CONTENT_TYPE)),
         (CborValue::text("d"), rec.encode_payload()),
-    ]);
+    ]));
     Ok(try_encode(&envelope)?)
 }
 
@@ -410,7 +537,7 @@ pub fn decode_record_as<T: VaultRecord>(bytes: &[u8]) -> Result<T, VaultRecordEr
 /// different inputs.
 fn split_envelope(
     bytes: &[u8],
-) -> Result<(String, CborValue, core::ops::Range<usize>), VaultRecordError> {
+) -> Result<(String, SecretCborValue, core::ops::Range<usize>), VaultRecordError> {
     // Anything that is not a two-entry map is not a record envelope. A
     // shape mismatch is `Ok(None)` from the codec and a violation of the
     // canonical profile is `Err`, and the two stay distinct here.
@@ -421,15 +548,42 @@ fn split_envelope(
         return Err(VaultRecordError::NotARecord);
     }
     let mut t: Option<String> = None;
-    let mut d: Option<(CborValue, core::ops::Range<usize>)> = None;
-    for entry in entries {
+    // Wrapped the instant the plaintext value under `"d"` is captured,
+    // not after `split_envelope` returns successfully: `d` can also be
+    // dropped un-returned, from inside this loop, if the envelope's
+    // *other* entry turns out to be malformed (`BadEnvelope` below).
+    // `Option<SecretCborValue>`'s own drop glue wipes it on that path
+    // too, which a wipe placed only at the bottom of this function,
+    // after the final `match`, would have missed.
+    let mut d: Option<(SecretCborValue, core::ops::Range<usize>)> = None;
+    for mut entry in entries {
         match entry.key {
             CborValue::Text(s) if s == "t" => match entry.value {
                 CborValue::Text(s) => t = Some(s),
-                _ => return Err(VaultRecordError::BadEnvelope),
+                mut other => {
+                    // Malformed `"t"`: whatever this decoded to is
+                    // still somebody's decrypted plaintext, just filed
+                    // under the wrong key. Wipe it before the shape
+                    // mismatch is reported.
+                    zeroize_cbor_value(&mut other);
+                    return Err(VaultRecordError::BadEnvelope);
+                }
             },
-            CborValue::Text(s) if s == "d" => d = Some((entry.value, entry.value_span)),
-            _ => return Err(VaultRecordError::BadEnvelope),
+            CborValue::Text(s) if s == "d" => {
+                d = Some((SecretCborValue::new(entry.value), entry.value_span))
+            }
+            _ => {
+                // Unrecognised key. The value under it is still
+                // decrypted plaintext (this envelope's own siblings
+                // decoded through the same call), so it gets the same
+                // wipe as every other rejected shape here — including
+                // when this is the *second* of the two entries and `d`
+                // above is already `Some`, in which case `d`'s own
+                // wrap-on-capture (see above) covers it when this
+                // function returns.
+                zeroize_cbor_value(&mut entry.value);
+                return Err(VaultRecordError::BadEnvelope);
+            }
         }
     }
     match (t, d) {
@@ -828,14 +982,19 @@ pub fn encode_opaque(
     content_type: &str,
     payload_bytes: &[u8],
 ) -> Result<Vec<u8>, VaultRecordError> {
+    // `payload_bytes` here is frequently a `Quarantined`/`Opaque`
+    // record's own plaintext (see that variant's doc comment on
+    // `AnyRecord`), so `payload` and the `envelope` it moves into get
+    // the same `SecretCborValue` wipe-on-drop treatment as
+    // `encode_record`'s tree.
     let payload = decode(payload_bytes)?;
-    let envelope = CborValue::Map(vec![
+    let envelope = SecretCborValue::new(CborValue::Map(vec![
         (
             CborValue::text("t"),
             CborValue::text(content_type.to_string()),
         ),
         (CborValue::text("d"), payload),
-    ]);
+    ]));
     Ok(try_encode(&envelope)?)
 }
 
@@ -2545,5 +2704,166 @@ mod tests {
             assert_eq!(format!("{error:?}"), expected);
             assert_eq!(format!("{error:#?}"), expected);
         }
+    }
+
+    // --- CborValue zeroization (item #9) ---
+
+    /// Every leaf of a `CborValue` tree, no matter how deeply nested
+    /// under `Array`/`Map`/`Tag`, is empty after `zeroize_cbor_value`.
+    /// The checker below has its own exhaustive match (no wildcard),
+    /// so this test is a second, independent enforcement point beyond
+    /// `zeroize_cbor_value`'s own: if canonical-cbor ever grows a new
+    /// variant, *this* match fails to compile too, not just the one in
+    /// the production code it's checking.
+    #[test]
+    fn zeroize_cbor_value_wipes_every_variant() {
+        fn assert_no_plaintext_remains(v: &CborValue) {
+            match v {
+                CborValue::Text(s) => assert!(s.is_empty(), "unwiped Text leaf: {s:?}"),
+                CborValue::Bytes(b) => assert!(b.is_empty(), "unwiped Bytes leaf: {b:?}"),
+                CborValue::Array(items) => items.iter().for_each(assert_no_plaintext_remains),
+                CborValue::Map(entries) => entries.iter().for_each(|(k, v)| {
+                    assert_no_plaintext_remains(k);
+                    assert_no_plaintext_remains(v);
+                }),
+                CborValue::Tag(_, inner) => assert_no_plaintext_remains(inner),
+                CborValue::Unsigned(_)
+                | CborValue::Negative(_)
+                | CborValue::Bool(_)
+                | CborValue::Null => {}
+            }
+        }
+
+        let mut value = CborValue::Map(vec![
+            (
+                CborValue::text("password"),
+                CborValue::text("hunter2-super-secret"),
+            ),
+            (
+                CborValue::text("totp-seed"),
+                CborValue::bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+            ),
+            (
+                CborValue::text("nested"),
+                CborValue::Array(vec![
+                    CborValue::text("nested-secret-one"),
+                    CborValue::bytes(b"nested-secret-two".to_vec()),
+                    CborValue::Tag(
+                        61,
+                        Box::new(CborValue::Map(vec![(
+                            CborValue::text("k"),
+                            CborValue::text("tagged-and-mapped-secret"),
+                        )])),
+                    ),
+                ]),
+            ),
+            (CborValue::text("count"), CborValue::Unsigned(42)),
+            (CborValue::text("delta"), CborValue::Negative(7)),
+            (CborValue::text("flag"), CborValue::Bool(true)),
+            (CborValue::text("absent"), CborValue::Null),
+        ]);
+
+        zeroize_cbor_value(&mut value);
+
+        // The map's own keys are plaintext field names, not secrets —
+        // but they went through the same recursive walk as everything
+        // else, so confirming they're wiped too proves the walk really
+        // is unconditional rather than special-casing "looks secret."
+        assert_no_plaintext_remains(&value);
+    }
+
+    #[test]
+    fn zeroize_cbor_value_on_scalars_is_a_harmless_no_op() {
+        for mut v in [
+            CborValue::Unsigned(9),
+            CborValue::Negative(3),
+            CborValue::Bool(false),
+            CborValue::Null,
+        ] {
+            let before = v.clone();
+            zeroize_cbor_value(&mut v);
+            assert_eq!(v, before);
+        }
+    }
+
+    #[test]
+    fn secret_cbor_value_derefs_for_read_access_before_drop() {
+        let secret = SecretCborValue::new(CborValue::Map(vec![(
+            CborValue::text("password"),
+            CborValue::text("still-readable"),
+        )]));
+        // `expect_map`/`try_encode`/`VaultRecord::decode_payload` all
+        // take `&CborValue`; this is the coercion `encode_record`,
+        // `encode_opaque`, and every typed decode rely on.
+        let entries = expect_map(&secret).unwrap();
+        assert_eq!(get_text(entries, "password").unwrap(), "still-readable");
+    }
+
+    /// Proves `SecretCborValue::drop` actually runs the wipe — on the
+    /// ordinary success path, on early return, *and* on panic unwind —
+    /// without reading through a pointer into memory the real `Drop`
+    /// has already deallocated (unsound, and this crate forbids
+    /// `unsafe` outright). Instead this observes the one side effect
+    /// `Drop::drop` produces that's safe to check after the fact: the
+    /// `#[cfg(test)]` counter it increments. `SECRET_CBOR_VALUE_DROPS`
+    /// is a single process-wide counter shared with every other test
+    /// that (directly or via `encode_record`/`decode_record`) drops a
+    /// `SecretCborValue` concurrently, so this only ever asserts the
+    /// counter moved *forward*, never an exact value — the one
+    /// assertion that stays true no matter what else is running.
+    #[test]
+    fn secret_cbor_value_drop_runs_even_on_panic_unwind() {
+        use core::sync::atomic::Ordering;
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        // Ordinary scope exit.
+        let before = SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed);
+        {
+            let _secret = SecretCborValue::new(CborValue::text("wiped-on-scope-exit"));
+        }
+        assert!(
+            SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed) > before,
+            "SecretCborValue::drop did not run on ordinary scope exit"
+        );
+
+        // Panic unwind mid-operation, the case the rejected
+        // error-path-only quick fix (see the section 2a comment above
+        // `zeroize_cbor_value`) would not have covered.
+        let before = SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _secret = SecretCborValue::new(CborValue::text("wiped-on-panic-unwind"));
+            panic!("simulated mid-operation failure");
+        }));
+        assert!(result.is_err(), "panic did not propagate");
+        assert!(
+            SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed) > before,
+            "SecretCborValue::drop did not run during unwind"
+        );
+    }
+
+    /// End-to-end: `encode_record` and `decode_record` each build
+    /// exactly one caller-side `SecretCborValue` around real record
+    /// plaintext, and each one drops (wiping it) by the time the
+    /// function returns.
+    #[test]
+    fn encode_and_decode_record_each_wipe_their_own_cbor_tree() {
+        use core::sync::atomic::Ordering;
+
+        let login = sample_login();
+
+        let before = SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed);
+        let bytes = encode_record(&login).unwrap();
+        assert!(
+            SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed) > before,
+            "encode_record did not wipe its envelope"
+        );
+
+        let before = SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed);
+        let decoded = decode_record(&bytes).unwrap();
+        assert!(
+            SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed) > before,
+            "decode_record did not wipe its payload"
+        );
+        assert!(matches!(decoded, AnyRecord::Login(_)));
     }
 }

--- a/code/packages/rust/vault-records/src/lib.rs
+++ b/code/packages/rust/vault-records/src/lib.rs
@@ -550,15 +550,44 @@ fn split_envelope(
     let mut t: Option<String> = None;
     // Wrapped the instant the plaintext value under `"d"` is captured,
     // not after `split_envelope` returns successfully: `d` can also be
-    // dropped un-returned, from inside this loop, if the envelope's
-    // *other* entry turns out to be malformed (`BadEnvelope` below).
-    // `Option<SecretCborValue>`'s own drop glue wipes it on that path
-    // too, which a wipe placed only at the bottom of this function,
-    // after the final `match`, would have missed.
+    // dropped un-returned if the envelope's *other* entry turns out to
+    // be malformed (`BadEnvelope` below). `Option<SecretCborValue>`'s
+    // own drop glue wipes it on that path too, which a wipe placed only
+    // at the bottom of this function, after the final `match`, would
+    // have missed.
     let mut d: Option<(SecretCborValue, core::ops::Range<usize>)> = None;
+    let mut malformed = false;
+    // This loop deliberately never `return`s early, even on a shape it
+    // is about to reject. A security review of an earlier version of
+    // this function (which *did* `return Err(...)` from inside the
+    // loop body) found that doing so leaks: `for entry in entries`
+    // desugars to `IntoIterator::into_iter(entries)`, and an early
+    // `return` abandons that iterator mid-walk. Any entry the loop
+    // hadn't reached yet is still owned by the iterator and drops
+    // through ordinary, non-wiping `Drop` when the function unwinds —
+    // bypassing every explicit `zeroize_cbor_value` call in the body
+    // entirely, for both that entry's key *and* its value. With exactly
+    // two entries this is reachable: an envelope whose first
+    // (canonically-ordered) entry has an unrecognised key bails before
+    // the second entry — which could legitimately be `"d"` — is ever
+    // inspected. So instead this loop always visits every entry,
+    // wiping or capturing each one before moving to the next, and only
+    // decides what to return *after* the loop has fully drained
+    // `entries`. `malformed` records "reject at the end" without ever
+    // walking away from an entry mid-iteration.
     for mut entry in entries {
-        match entry.key {
-            CborValue::Text(s) if s == "t" => match entry.value {
+        // Every key is read only to classify the entry, never returned
+        // to the caller (the two legal ones are the literal `"t"`/`"d"`
+        // constants), so it is always wiped immediately after — even
+        // though `"t"`/`"d"` are not secrets, this keeps the "everything
+        // this loop touches gets wiped, no exceptions" invariant simple
+        // to audit rather than special-casing "looks secret."
+        let is_t = matches!(&entry.key, CborValue::Text(s) if s == "t");
+        let is_d = matches!(&entry.key, CborValue::Text(s) if s == "d");
+        zeroize_cbor_value(&mut entry.key);
+
+        if is_t {
+            match entry.value {
                 CborValue::Text(s) => t = Some(s),
                 mut other => {
                     // Malformed `"t"`: whatever this decoded to is
@@ -566,25 +595,22 @@ fn split_envelope(
                     // under the wrong key. Wipe it before the shape
                     // mismatch is reported.
                     zeroize_cbor_value(&mut other);
-                    return Err(VaultRecordError::BadEnvelope);
+                    malformed = true;
                 }
-            },
-            CborValue::Text(s) if s == "d" => {
-                d = Some((SecretCborValue::new(entry.value), entry.value_span))
             }
-            _ => {
-                // Unrecognised key. The value under it is still
-                // decrypted plaintext (this envelope's own siblings
-                // decoded through the same call), so it gets the same
-                // wipe as every other rejected shape here — including
-                // when this is the *second* of the two entries and `d`
-                // above is already `Some`, in which case `d`'s own
-                // wrap-on-capture (see above) covers it when this
-                // function returns.
-                zeroize_cbor_value(&mut entry.value);
-                return Err(VaultRecordError::BadEnvelope);
-            }
+        } else if is_d {
+            d = Some((SecretCborValue::new(entry.value), entry.value_span));
+        } else {
+            // Unrecognised key. The value under it is still decrypted
+            // plaintext (this envelope's own siblings decoded through
+            // the same call), so it gets the same wipe as every other
+            // rejected shape here.
+            zeroize_cbor_value(&mut entry.value);
+            malformed = true;
         }
+    }
+    if malformed {
+        return Err(VaultRecordError::BadEnvelope);
     }
     match (t, d) {
         (Some(t), Some((d, span))) => Ok((t, d, span)),
@@ -2865,5 +2891,43 @@ mod tests {
             "decode_record did not wipe its payload"
         );
         assert!(matches!(decoded, AnyRecord::Login(_)));
+    }
+
+    /// Pins a security-review finding against an earlier version of
+    /// `split_envelope`: its loop used to `return Err(...)` the moment it
+    /// saw a rejected entry, which abandoned `entries`' iterator mid-walk.
+    /// Canonical key order sorts `"a"` before `"d"` (equal encoded length,
+    /// `"a"` < `"d"` bytewise), so a malformed envelope shaped `{"a": …,
+    /// "d": <secret>}` reached the unrecognised `"a"` key first and
+    /// returned before the loop ever visited the legitimate `"d"` entry —
+    /// which still held real secret plaintext. That entry was never
+    /// wrapped in `SecretCborValue` at all, so it dropped through
+    /// ordinary, non-wiping `Drop` on the way out, unwiped. The loop no
+    /// longer returns early (see its doc comment); this proves the `"d"`
+    /// entry gets wrapped and wiped regardless of what its sibling looked
+    /// like or which one the loop reached first.
+    #[test]
+    fn a_malformed_envelopes_second_entry_is_still_wiped_even_when_the_first_is_rejected() {
+        use core::sync::atomic::Ordering;
+
+        let envelope = CborValue::Map(vec![
+            (CborValue::text("a"), CborValue::Null),
+            (
+                CborValue::text("d"),
+                CborValue::text("a-secret-that-must-still-be-wiped"),
+            ),
+        ]);
+        let bytes = encode(&envelope);
+
+        let before = SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed);
+        assert!(matches!(
+            decode_record(&bytes).unwrap_err(),
+            VaultRecordError::BadEnvelope
+        ));
+        assert!(
+            SECRET_CBOR_VALUE_DROPS.load(Ordering::Relaxed) > before,
+            "the legitimate \"d\" entry, arriving after a rejected sibling, was never \
+             wrapped in SecretCborValue and so was never wiped"
+        );
     }
 }

--- a/code/specs/CBR01-canonical-cbor.md
+++ b/code/specs/CBR01-canonical-cbor.md
@@ -12,6 +12,17 @@ and audit entries. The contract is language-neutral. Rust is the first
 established implementation; C and C++ are independent emerging-lane reference
 oracles. No implementation is normative by itself.
 
+Every implementation is zero-dependency by design (the Rust crate's
+`[dependencies]` is empty; the C and C++ oracles link nothing beyond their own
+platform's libc). This is deliberate, not incidental: canonical-CBOR sits
+underneath everything else in the Vault stack — records, authentication
+material, audit entries — so any dependency it took on would become a
+transitive dependency of every one of those, and it is meant to stay usable
+from arbitrarily constrained contexts, including the from-scratch C/C++
+reference oracles it ships next to. See "Non-goals" for the one consequence
+of that rule worth naming explicitly: this crate cannot itself provide secure
+zeroization of a `CborValue` tree's owned buffers.
+
 ## Why this primitive exists
 
 Vault layers require one logical value to have exactly one byte sequence. Plain
@@ -206,7 +217,23 @@ The corpus covers:
 - streaming encode/decode;
 - CBOR diagnostic notation;
 - tag semantics;
-- cryptographic framing, schema evolution, signatures, storage, or I/O.
+- cryptographic framing, schema evolution, signatures, storage, or I/O;
+- in-memory zeroization of a decoded or caller-built `CborValue` tree. Rust's
+  `CborValue` is a plain owned-data enum — `Text(String)` and `Bytes(Vec<u8>)`
+  leaves, nested through `Array`, `Map`, and `Tag` — with ordinary,
+  non-wiping `Drop`. Providing secure wiping would mean depending on a
+  zeroization primitive, which this crate's zero-dependency design (see
+  "Overview") rules out. Callers that decode or build a `CborValue` tree from
+  secret plaintext — every typed Vault record does, since a record's
+  plaintext bytes are canonical CBOR — are responsible for wiping the tree
+  themselves once they are done reading from or writing to it. VLT-PM05
+  §13.6 documents the pattern this codebase uses (`vault-records`'
+  `zeroize_cbor_value` and `SecretCborValue`): a local wrapper type, not a
+  trait implemented on `CborValue` itself, because neither the wrapper's
+  trait nor `CborValue` is local to the same crate — Rust's orphan rule
+  forbids a third crate from implementing a foreign trait on a foreign type,
+  so no caller crate can hand `CborValue` a real `Zeroize` impl even if it
+  wanted to.
 
 ## Citations
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1450,9 +1450,13 @@ single input *byte* can expand to (a lone ASCII control byte escaping to
 `\u{xx}`) and every other case — named escapes, unescaped printable
 characters, multi-byte UTF-8 sequences — expands by less per input byte, not
 more. The real, unmodified `Debug` formatter still writes the escaped text;
-this only changes where it writes into. A `debug_assert_eq!` on the buffer's
-capacity turns "did the bound stay sufficient" into a standing invariant
-rather than a one-time check.
+this only changes where it writes into. A full `assert_eq!` on the buffer's
+capacity — not `debug_assert_eq!`; this runs only on an already-slow,
+human-attended reveal, so the cost is immaterial, and compiling the check
+out of release builds would let a future `std` Debug-escaping change widen
+past the reserved bound and reopen this exact leak with no signal in the
+build that ships — turns "did the bound stay sufficient" into a standing
+invariant enforced everywhere, not just in debug and test builds.
 
 **Tests.** `vault-records`: `zeroize_cbor_value_wipes_every_variant` builds
 one tree exercising every `CborValue` variant, nested under `Array`/`Map`/

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -1351,6 +1351,131 @@ edit_as_login`. `vault-pm-cli` pins the two rendering surfaces directly:
 `render_item_shows_a_redacted_placeholder_for_a_quarantined_record_
 instead_of_erroring`.
 
+### 13.6 CborValue trees and Debug-escaped reveals, wiped end to end
+
+§13.5 closed the zeroization gaps in `decode_live`'s own locals
+(`record_bytes`, the window around `payload`) once a decoded `AnyRecord` had
+already been produced. Two lower-severity, pre-existing gaps — logged
+separately, batched here because a round-1 security review flagged them as
+the same root pattern — sat one layer further down, in the codec plumbing
+every one of those decodes and encodes goes through, and in the CLI's own
+terminal-reveal path. Both are "build, use, then let an unwiped intermediate
+drop" defects; both are fixed by building the final, correctly-sized buffer
+up front instead.
+
+**Gap 1 — the caller-side `CborValue` tree (`vault-records`).**
+`encode_record` builds a `CborValue::Map` from `rec.encode_payload()`, which
+clones every field of a `Login`/`Card`/`TotpSeed`/`ApiKey`/
+`DatabaseCredential`/`SecureNote` into fresh `CborValue::Text`/`Bytes`
+leaves; `decode_record` and `decode_record_as` decode a `CborValue` tree that
+*is* somebody's plaintext and then clone fields back out of it into a typed
+struct. The typed structs already wipe themselves (`Login` and its five
+siblings implement `Zeroize` + `Drop`; see section 4 of `vault-records`), but
+the intermediate `CborValue` tree used to build or decode them did not —
+`envelope` in `encode_record`, `payload` in `decode_record`/
+`decode_record_as`, and the equivalent locals inside `split_envelope` and
+`encode_opaque` all dropped through ordinary, non-wiping `Vec`/`String`/
+`CborValue` destructors, once per record encode or decode, across all seven
+record kinds (six typed plus opaque pass-through).
+
+A round-1 security review's suggested quick fix — wipe only `try_encode`'s
+own output buffer on its error path — was correctly rejected as incomplete
+by construction: the plaintext clone the encoder's error path can reach was
+never the whole problem. The *caller's* tree is built and dropped
+regardless of whether the encode call inside it succeeds, and canonical-CBOR
+itself cannot be the one to fix this — see CBR01's "Non-goals": `CborValue`
+is defined in a deliberately zero-dependency crate that cannot take on a
+zeroization dependency, and no third crate can implement the sibling
+`coding_adventures_zeroize::Zeroize` trait on `CborValue` either, because
+Rust's orphan rule forbids a foreign trait on a foreign type from anywhere
+but the two crates that define them.
+
+The fix lives in `vault-records`, which already depends on
+`coding_adventures_zeroize` for the typed records' own `Drop` impls:
+
+```rust
+// coding_adventures_vault_records (vault-records/src/lib.rs)
+
+/// Recursively wipes every owned Text/Bytes buffer, through any nesting
+/// of Array, Map (keys and values), and Tag. No wildcard arm: a future
+/// CborValue variant fails this match at compile time instead of
+/// silently escaping the wipe.
+fn zeroize_cbor_value(value: &mut CborValue) { /* ... */ }
+
+/// `Zeroizing<CborValue>` in everything but name — a local wrapper
+/// (not a trait impl on CborValue) whose Drop calls zeroize_cbor_value.
+/// Derefs to &CborValue, so it drops straight into every call site that
+/// used to hold a bare CborValue.
+struct SecretCborValue(CborValue);
+```
+
+`encode_record`, `encode_opaque`, and `split_envelope` (the shared helper
+`decode_record` and `decode_record_as` both go through for the `"d"` field)
+now build their `CborValue` trees as `SecretCborValue` instead of bare
+`CborValue`. Because the wipe is a `Drop` impl rather than a call inserted at
+each known return point, it runs on every exit path — the success path, an
+early `?`-propagated error, and a panic unwind — which is the actual
+difference from the rejected quick fix: "wipe as you build" (a guard that
+cannot be forgotten because it doesn't require remembering) instead of
+"build, then hope every return path remembers to wipe." `split_envelope`
+wraps the `"d"` value the instant it is captured, before the loop that reads
+it can reach any later `BadEnvelope` return, so a malformed envelope's
+*other* entry cannot cause the already-captured secret half to leak on the
+way to reporting the error.
+
+**Gap 2 — `escaped_revealed_text` (`vault-pm-cli-host`).** `item reveal` and
+`conflict reveal` both write a secret to the controlling terminal through
+`write_revealed_text`, which quote- and control-escapes the value first via
+`escaped_revealed_text`. That function used to be
+`Zeroizing::new(format!("{value:?}"))`. `format!` builds its `String` from an
+empty start and grows it, via a sequence of `push`/`push_str` calls as
+`Debug` escapes each character, using `String`'s ordinary incremental-growth
+reallocation — which `memcpy`s whatever plaintext is already written into a
+larger allocation and frees the old one through the global allocator without
+scrubbing it first. `Zeroizing` wipes only the final allocation it ends up
+holding; every intermediate allocation the buffer grew out of along the way
+is a stale, unwiped copy of a secret sitting in freed heap. This is the same
+reallocation-leaves-a-stale-copy pattern already found and fixed in
+`AgentRequest::encode` (`vault-pm-agent-protocol`), applied to text escaping
+instead of binary wire framing.
+
+The fix is the same shape as that one: reserve the buffer's capacity once,
+before any byte of the secret is written, so no reallocation can occur while
+a copy is resident. The one difference is that Debug-escaping cannot be
+sized *exactly* the way fixed-width binary framing can, without duplicating
+`core`'s own private per-character escaping tables — so
+`escaped_revealed_text` reserves a **provably sufficient upper bound**
+instead of an exact size: `2 + 6 * value.len()`, where 6 is the most any
+single input *byte* can expand to (a lone ASCII control byte escaping to
+`\u{xx}`) and every other case — named escapes, unescaped printable
+characters, multi-byte UTF-8 sequences — expands by less per input byte, not
+more. The real, unmodified `Debug` formatter still writes the escaped text;
+this only changes where it writes into. A `debug_assert_eq!` on the buffer's
+capacity turns "did the bound stay sufficient" into a standing invariant
+rather than a one-time check.
+
+**Tests.** `vault-records`: `zeroize_cbor_value_wipes_every_variant` builds
+one tree exercising every `CborValue` variant, nested under `Array`/`Map`/
+`Tag`, and asserts every `Text`/`Bytes` leaf is empty afterward, via a
+checker with its own independent exhaustive match (no wildcard) —
+`zeroize_cbor_value_on_scalars_is_a_harmless_no_op` covers the four
+no-owned-buffer variants explicitly.
+`secret_cbor_value_drop_runs_even_on_panic_unwind` proves `SecretCborValue`'s
+`Drop` fires on ordinary scope exit and on a panic mid-operation, using a
+`#[cfg(test)]` counter rather than reading through a pointer into memory the
+real `Drop` has already deallocated — unsound, and this crate is
+`#![forbid(unsafe_code)]` besides.
+`encode_and_decode_record_each_wipe_their_own_cbor_tree` pins the same
+property at the actual call sites, not just the primitives in isolation.
+`vault-pm-cli-host`:
+`escaped_revealed_text_never_reallocates_a_buffer_already_holding_a_secret`
+mirrors `AgentRequest::encode`'s
+`encode_never_reallocates_a_buffer_already_holding_a_secret` — a sweep of
+plain-ASCII, all-widest-escape, and mixed-content secrets, each asserting
+`String::capacity()` stays exactly equal to the reserved upper bound (no
+reallocation occurred), plus one exact-output check confirming the
+capacity discipline did not change what gets written.
+
 ## 14. Required verification
 
 The Phase 1A package must include:


### PR DESCRIPTION
## Summary

Closes two batched, pre-existing, low-severity findings logged from earlier security reviews (items #9 and #21), both the same root pattern: build-then-wipe vs. wipe-as-you-build.

- **Item #9** — `encode_record`/`decode_record`/`decode_record_as`/`split_envelope`/`encode_opaque` in `vault-records` each build an owned `CborValue` tree that, for all seven record kinds (login/note/card/api-key/db-cred/totp/opaque), *is* somebody's plaintext, and dropped it through ordinary non-wiping destructors. The original review's suggested quick fix — wipe only `try_encode`'s output buffer on its error path — was correctly rejected as incomplete: the caller's own tree is built and dropped regardless of whether the encode succeeds, and `canonical-cbor` itself can't own the fix (it's deliberately zero-dependency — see CBR01's new "Non-goals" entry — and no third crate can `impl` the sibling `Zeroize` trait on the foreign `CborValue` type due to Rust's orphan rule). Fixed with a local `SecretCborValue` wrapper — `Zeroizing<CborValue>` in everything but name — whose `Drop` recursively wipes every `Text`/`Bytes` leaf via a new `zeroize_cbor_value` (an exhaustive match with no wildcard arm, so a future `CborValue` variant fails to compile here rather than silently escaping the wipe).

- **Item #21** — `escaped_revealed_text` in `vault-pm-cli-host` (used by both `item reveal` and `conflict reveal`) built its output via `Zeroizing::new(format!("{value:?}"))`. `format!`'s `String` grows via incremental reallocation as `Debug` escapes each character, leaving every intermediate allocation an unwiped copy of the secret in freed heap — the same reallocation-leaves-a-stale-copy pattern already fixed in `vault-pm-agent-protocol`'s `AgentRequest::encode`. Fixed the same way: reserve capacity once, before any secret byte is written. Debug-escaping can't be sized exactly without duplicating `core`'s private tables, so this reserves a provably sufficient upper bound (`value.len() * 6 + 2`, saturating) instead, backed by a full `assert_eq!` on the buffer's final capacity.

A round-1 security review of this PR found a real MEDIUM in the first draft of the `split_envelope` fix (its loop `return`ed early on a malformed entry, abandoning the iterator mid-walk and leaking any not-yet-visited entry through ordinary `Drop`) — restructured so the loop always visits and wipes/captures every entry before deciding pass/fail, with a new regression test pinning the exact scenario. Round 2 passed clean; one INFO nit (saturating arithmetic on the capacity bound) applied.

Specs updated: `VLT-PM05` §13.6 documents the design account for both; `CBR01` gains an explicit zero-dependency rationale and a "Non-goals" entry pointing to the caller-side pattern. Package READMEs and CHANGELOGs updated to match.

## Test plan

- [x] `cargo test` green across `canonical-cbor`, `zeroize`, `vault-records` (45 tests), `vault-pm-domain`, `vault-pm-application` (245 tests), `vault-pm-cli-host` (43 tests, including the new reallocation regression test), `vault-pm-cli` (139 tests) — 505 tests total in the affected closure
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `/security-review`: round 1 found a real MEDIUM (fixed), round 2 passed clean with one applied INFO nit

🤖 Generated with [Claude Code](https://claude.com/claude-code)