### PR TITLE
fix(html-parser): position foreign list-item end tags

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7313,10 +7313,13 @@ impl HtmlParser {
             && self.has_authored_open_html_element("li")
             && self.open_list_item_in_scope_index().is_none()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                "end tag `</li>` did not match the current foreign element",
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    "end tag `</li>` did not match the current foreign element",
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-li-end-tag",
                 "end tag `</li>` did not match a list item in scope",
@@ -33888,10 +33891,7 @@ mod tests {
             assert_eq!(
                 output.parser_diagnostics,
                 vec![
-                    ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        "end tag `</li>` did not match the current foreign element"
-                    ),
+                    generic_foreign_end_tag_mismatch(&source, "li"),
                     ParserDiagnostic::new(
                         "unexpected-li-end-tag",
                         "end tag `</li>` did not match a list item in scope"
@@ -33945,6 +33945,70 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-li-end-tag"));
+    }
+
+    #[test]
+    fn positions_list_item_foreign_end_tag_mismatches_at_token_emission() {
+        let source = "<!doctype html><!--é-->\r\n<ul><li><math><mi></li></mi></math></li></ul>";
+        let output = parse_html_with_diagnostics(source).unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                generic_foreign_end_tag_mismatch(source, "li"),
+                ParserDiagnostic::new(
+                    "unexpected-li-end-tag",
+                    "end tag `</li>` did not match a list item in scope"
+                ),
+            ]
+        );
+        assert!(source.len() > source.chars().count());
+
+        let eof_source = "<!doctype html><ul><li><svg><foreignObject></li";
+        let eof_output = parse_html_with_diagnostics(eof_source).unwrap();
+        assert!(eof_output
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-foreign-content"));
+        assert_eq!(
+            eof_output.parser_diagnostics.last(),
+            Some(&eof_with_unclosed_elements(eof_source))
+        );
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        for token in [
+            Token::StartTag {
+                name: "li".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "svg".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "foreignObject".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "li".to_string(),
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        let diagnostics = unpositioned.diagnostics();
+        let foreign = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+            .unwrap();
+        let companion = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-li-end-tag")
+            .unwrap();
+        assert_eq!(foreign.position, None);
+        assert_eq!(companion.position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach source-backed tokenizer emission positions to dedicated authored HTML `li` foreign-content mismatch diagnostics
- preserve `unexpected-li-end-tag` companions and plain token streams as unpositioned
- cover SVG/MathML integration boundaries, CRLF/non-ASCII coordinates, incomplete EOF tags, and unchanged recovery

## Validation
- `cargo test -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- focused html5lib coverage, WHATWG foreign, and processing-instruction audit tests

## Live audit
- html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing/skipped
- WPT `42160a82d609269df70fece4f63ba0815fd90d97`: 1,936 tree cases; two new unrelated missing scripted-foster rows queued for the next slice