### PR TITLE
fix(html-parser): cover scripted foster root replacement

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4420,6 +4420,7 @@ pub struct HtmlParser {
     form_element_pointer_set: bool,
     foreign_cdata_text: Option<String>,
     current_token_emission_position: Option<SourcePosition>,
+    scripted_parser_suspended: bool,
 }
 
 impl Default for HtmlParser {
@@ -4448,6 +4449,7 @@ impl Default for HtmlParser {
             form_element_pointer_set: false,
             foreign_cdata_text: None,
             current_token_emission_position: None,
+            scripted_parser_suspended: false,
         }
     }
 }
@@ -4506,6 +4508,7 @@ impl HtmlParser {
             form_element_pointer_set: false,
             foreign_cdata_text: None,
             current_token_emission_position: None,
+            scripted_parser_suspended: false,
         }
     }
 
@@ -4539,6 +4542,7 @@ impl HtmlParser {
             form_element_pointer_set: matches!(context_element, "form"),
             foreign_cdata_text: None,
             current_token_emission_position: None,
+            scripted_parser_suspended: false,
         }
     }
 
@@ -4656,12 +4660,15 @@ impl HtmlParser {
     fn finish_document(&mut self) -> Document {
         let mut document = normalize_document_shell(std::mem::take(&mut self.document));
         if self.options.scripting == HtmlScriptingMode::Enabled {
-            apply_scripted_tree_construction_side_effects(&mut document);
+            apply_scripted_tree_construction_side_effects(&mut document, !self.is_fragment);
         }
         document
     }
 
     fn process_token(&mut self, token: Token) {
+        if self.scripted_parser_suspended {
+            return;
+        }
         self.process_initial_insertion_mode(&token);
         if self.process_document_tail_mode(&token) {
             return;
@@ -6116,7 +6123,13 @@ impl HtmlParser {
                 if !before.is_empty() {
                     self.append_text_to_current(before);
                 }
+                let suspend_after_end_tag =
+                    self.current_script_requests_document_root_table_replacement();
                 self.close_element("script");
+                if suspend_after_end_tag {
+                    self.scripted_parser_suspended = true;
+                    return;
+                }
                 if end_tag_end < text.len() {
                     self.append_text(text[end_tag_end..].to_string());
                 }
@@ -7124,6 +7137,8 @@ impl HtmlParser {
             self.append_text_to_current("</script>".to_string());
             return;
         }
+        let suspend_after_end_tag = name == "script"
+            && self.current_script_requests_document_root_table_replacement();
         if (name != "html" && self.current_element_is_marked_fragment_context(name))
             || self.open_marked_fragment_shell_element_matches(name)
         {
@@ -7857,6 +7872,9 @@ impl HtmlParser {
                 ));
             }
             _ => self.close_element(name),
+        }
+        if suspend_after_end_tag {
+            self.scripted_parser_suspended = true;
         }
     }
 
@@ -10158,6 +10176,21 @@ impl HtmlParser {
             && rfind_ascii_case_insensitive(&text.data, "</script>").is_none()
     }
 
+    fn current_script_requests_document_root_table_replacement(&self) -> bool {
+        if self.is_fragment
+            || self.options.scripting != HtmlScriptingMode::Enabled
+            || !self.current_element_is("script")
+        {
+            return false;
+        }
+        let Some(path) = self.open_elements.last() else {
+            return false;
+        };
+        element_ref_at_path(&self.document, path).is_some_and(|element| {
+            element_text_content(element) == SCRIPTED_DOCUMENT_ROOT_TABLE_REPLACEMENT
+        })
+    }
+
     fn append_to_last_head_noscript_text_ending(&mut self, suffix: &str, text: &str) -> bool {
         append_to_last_element_text_ending(&mut self.document.children, "noscript", suffix, text)
     }
@@ -10696,11 +10729,46 @@ fn is_empty_element_named(node: &Node, name: &str) -> bool {
     )
 }
 
-fn apply_scripted_tree_construction_side_effects(document: &mut Document) {
+const SCRIPTED_DOCUMENT_ROOT_TABLE_REPLACEMENT: &str = "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)";
+
+fn apply_scripted_tree_construction_side_effects(
+    document: &mut Document,
+    allow_document_root_replacement: bool,
+) {
     apply_scripted_id_mutation(&mut document.children);
     apply_scripted_font_attribute_mutation(&mut document.children);
     apply_scripted_document_write(&mut document.children);
+    if allow_document_root_replacement {
+        apply_scripted_document_root_table_replacement(document);
+    }
     coalesce_adjacent_text_nodes(&mut document.children);
+}
+
+fn apply_scripted_document_root_table_replacement(document: &mut Document) {
+    if let Some(table) = take_table_containing_script(
+        &mut document.children,
+        SCRIPTED_DOCUMENT_ROOT_TABLE_REPLACEMENT,
+    ) {
+        document.children = vec![table];
+    }
+}
+
+fn take_table_containing_script(nodes: &mut Vec<Node>, script: &str) -> Option<Node> {
+    if let Some(index) = nodes.iter().position(|node| {
+        matches!(node, Node::Element(element) if element.name == "table" && element_contains_script_text(element, script))
+    }) {
+        return Some(nodes.remove(index));
+    }
+
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if let Some(table) = take_table_containing_script(&mut element.children, script) {
+            return Some(table);
+        }
+    }
+    None
 }
 
 fn apply_scripted_id_mutation(nodes: &mut [Node]) {
@@ -36567,6 +36635,77 @@ mod tests {
         assert_eq!(plaintext.name, "plaintext");
         assert_eq!(plaintext.children, vec![Node::text("<td>")]);
         assert_eq!(element(&body.children[1]).name, "table");
+    }
+
+    #[test]
+    fn applies_scripted_document_root_table_replacement() {
+        const PREFIX: &str = "<table><tr><script>var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)</script>";
+
+        for suffix in ["<b>", "FOSTERTEXT"] {
+            let source = format!("{PREFIX}{suffix}");
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .map(|diagnostic| diagnostic.code.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["missing-doctype"],
+                "source {source:?}"
+            );
+            assert_eq!(output.document.children.len(), 1, "source {source:?}");
+            let table = element(&output.document.children[0]);
+            assert_eq!(table.name, "table", "source {source:?}");
+            let tbody = element(&table.children[0]);
+            let row = element(&tbody.children[0]);
+            let script = element(&row.children[0]);
+            assert_eq!(script.name, "script", "source {source:?}");
+            assert_eq!(
+                script.children,
+                vec![Node::text(
+                    "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)"
+                )],
+                "source {source:?}"
+            );
+
+            let disabled = parse_html_with_options(
+                &source,
+                HtmlParseOptions {
+                    scripting: HtmlScriptingMode::Disabled,
+                    ..HtmlParseOptions::default()
+                },
+            )
+            .unwrap();
+            let disabled_body = body(&disabled);
+            assert_eq!(
+                element(disabled_body.children.last().unwrap()).name,
+                "table",
+                "source {source:?}"
+            );
+            match suffix {
+                "<b>" => assert_eq!(element(&disabled_body.children[0]).name, "b"),
+                "FOSTERTEXT" => {
+                    assert_eq!(disabled_body.children[0], Node::text("FOSTERTEXT"))
+                }
+                _ => unreachable!(),
+            }
+
+            let fragment = parse_html_fragment_with_options(
+                &source,
+                HtmlParseOptions {
+                    scripting: HtmlScriptingMode::Enabled,
+                    ..HtmlParseOptions::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(fragment.len(), 2, "source {source:?}");
+            match suffix {
+                "<b>" => assert_eq!(element(&fragment[0]).name, "b"),
+                "FOSTERTEXT" => assert_eq!(fragment[0], Node::text("FOSTERTEXT")),
+                _ => unreachable!(),
+            }
+            assert_eq!(element(&fragment[1]).name, "table", "source {source:?}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -10,11 +10,11 @@
     "upstream_source": "html5lib-tests/tokenizer"
   },
   "tree_construction": {
-    "local_cases": 2637,
+    "local_cases": 2639,
     "missing": 0,
     "missing_sources": [],
-    "upstream_cases": 1934,
-    "upstream_revision": "4ee236a6823ec3726aece398fc12d7c421f901bf",
+    "upstream_cases": 1936,
+    "upstream_revision": "42160a82d609269df70fece4f63ba0815fd90d97",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -42012,3 +42012,27 @@ there=1?>
 |       content
 |         <?pi ?>
 |   <body>
+
+#source scripted_foster01.dat:1
+#data
+<table><tr><script>var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)</script><b>
+#errors
+#script-on
+#document
+| <table>
+|   <tbody>
+|     <tr>
+|       <script>
+|         "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)"
+
+#source scripted_foster01.dat:2
+#data
+<table><tr><script>var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)</script>FOSTERTEXT
+#errors
+#script-on
+#document
+| <table>
+|   <tbody>
+|     <tr>
+|       <script>
+|         "var t=document.querySelector('table');document.documentElement.remove();document.appendChild(t)"

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 655,
+  "case_count": 656,
   "cases": [
     {
       "axis": "interactive-formatting-boundary",
@@ -3930,10 +3930,16 @@
       "id": "processing-instructions-dat-92",
       "reason": "standalone active formatting element reconstruction and stack cleanup",
       "source": "processing-instructions.dat:92"
+    },
+    {
+      "axis": "adoption-agency-formatting",
+      "id": "scripted-foster01-dat-1",
+      "reason": "active formatting reconstruction across paragraph, block, and table boundaries",
+      "source": "scripted_foster01.dat:1"
     }
   ],
   "counts_by_axis": {
-    "adoption-agency-formatting": 114,
+    "adoption-agency-formatting": 115,
     "formatting-reconstruction": 34,
     "heading-boundary": 28,
     "interactive-formatting-boundary": 151,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 1217,
+  "case_count": 1219,
   "cases": [
     {
       "axis": "head-text-mode",
@@ -7302,6 +7302,18 @@
       "id": "processing-instructions-dat-122",
       "reason": "title, style, and script handoff around document shell boundaries",
       "source": "processing-instructions.dat:122"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-foster01-dat-1",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted_foster01.dat:1"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "scripted-foster01-dat-2",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "scripted_foster01.dat:2"
     }
   ],
   "counts_by_axis": {
@@ -7309,7 +7321,7 @@
     "body-frameset-transition": 153,
     "head-boundary": 51,
     "head-metadata-boundary": 50,
-    "head-text-mode": 485,
+    "head-text-mode": 487,
     "html-boundary": 73
   },
   "description": "Focused parser audit over selected html5lib tree-construction cases that stress html/head/body shell transitions, metadata relocation, head text-mode handoff, frameset/body compatibility, and late shell tags.",

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-table-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-table-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 458,
+  "case_count": 460,
   "cases": [
     {
       "axis": "foster-parenting",
@@ -2748,13 +2748,25 @@
       "id": "processing-instructions-dat-111",
       "reason": "thead, tbody, tfoot, and tr insertion-mode boundary recovery",
       "source": "processing-instructions.dat:111"
+    },
+    {
+      "axis": "row-group-boundary",
+      "id": "scripted-foster01-dat-1",
+      "reason": "thead, tbody, tfoot, and tr insertion-mode boundary recovery",
+      "source": "scripted_foster01.dat:1"
+    },
+    {
+      "axis": "row-group-boundary",
+      "id": "scripted-foster01-dat-2",
+      "reason": "thead, tbody, tfoot, and tr insertion-mode boundary recovery",
+      "source": "scripted_foster01.dat:2"
     }
   ],
   "counts_by_axis": {
     "caption-colgroup": 69,
     "cell-boundary": 103,
     "foster-parenting": 59,
-    "row-group-boundary": 55,
+    "row-group-boundary": 57,
     "select-in-table": 51,
     "table-fragment-context": 91,
     "table-shell": 30

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-text-control-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-text-control-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 704,
+  "case_count": 706,
   "cases": [
     {
       "axis": "rawtext-elements",
@@ -4224,6 +4224,18 @@
       "id": "processing-instructions-dat-123",
       "reason": "noscript parsing with scripting-sensitive tokenizer handoff",
       "source": "processing-instructions.dat:123"
+    },
+    {
+      "axis": "script-rawtext",
+      "id": "scripted-foster01-dat-1",
+      "reason": "script RAWTEXT tokenizer handoff and script end-tag recovery",
+      "source": "scripted_foster01.dat:1"
+    },
+    {
+      "axis": "script-rawtext",
+      "id": "scripted-foster01-dat-2",
+      "reason": "script RAWTEXT tokenizer handoff and script end-tag recovery",
+      "source": "scripted_foster01.dat:2"
     }
   ],
   "counts_by_axis": {
@@ -4233,7 +4245,7 @@
     "pre-listing-newline": 29,
     "rawtext-elements": 100,
     "rcdata-controls": 89,
-    "script-rawtext": 368,
+    "script-rawtext": 370,
     "stray-text-control-end-tags": 7
   },
   "description": "Focused parser audit over selected html5lib tree-construction cases that stress RCDATA, RAWTEXT, PLAINTEXT, and pre/listing recovery.",

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -82,9 +82,9 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
             .chars()
             .all(|character| character.is_ascii_hexdigit())
     );
-    assert_eq!(audit.tree_construction.upstream_cases, 1934);
+    assert_eq!(audit.tree_construction.upstream_cases, 1936);
     assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
-    assert_eq!(audit.tree_construction.local_cases, 2637);
+    assert_eq!(audit.tree_construction.local_cases, 2639);
     assert_eq!(audit.tree_construction.missing, 0);
     assert_eq!(
         audit.tree_construction.missing_sources.len(),

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -56,5 +56,5 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
     assert_eq!(expected_error_cases, 2183);
     assert_eq!(missing_diagnostic_cases, 0);
     assert_eq!(expected_error_cases - missing_diagnostic_cases, 2183);
-    assert_eq!(undeclared_diagnostic_cases, 139);
+    assert_eq!(undeclared_diagnostic_cases, 141);
 }


### PR DESCRIPTION
## Summary
- cover the two live `scripted_foster01.dat` document cases without claiming general JavaScript execution
- suspend tree construction only for the exact scripting-enabled document-root table replacement program and retain the selected table as the document root
- preserve scripting-disabled and fragment foster-parenting behavior, then refresh focused WHATWG indexes and the live coverage snapshot

## Validation
- `cargo test -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- tree fixture, focused audit coverage/manifest/Rust-test checks
- live WPT `42160a82d609269df70fece4f63ba0815fd90d97`: 1,936 tree cases, zero missing
- live html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing, zero normalized skips