### PR TITLE
fix(html-parser): position foreign description item end tags

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7348,10 +7348,13 @@ impl HtmlParser {
                 || self.has_authored_open_html_element("dt"))
             && self.open_html_element_in_scope_index(name).is_none()
         {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-end-tag-in-foreign-content",
-                format!("end tag `</{name}>` did not match the current foreign element"),
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-end-tag-in-foreign-content",
+                    format!("end tag `</{name}>` did not match the current foreign element"),
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             self.diagnostics.push(ParserDiagnostic::new(
                 "unexpected-description-item-end-tag",
                 format!("end tag `</{name}>` did not match a description item in scope"),
@@ -34153,12 +34156,7 @@ mod tests {
                 assert_eq!(
                     output.parser_diagnostics,
                     vec![
-                        ParserDiagnostic::new(
-                            "unexpected-end-tag-in-foreign-content",
-                            format!(
-                                "end tag `</{item_name}>` did not match the current foreign element"
-                            )
-                        ),
+                        generic_foreign_end_tag_mismatch(&source, item_name),
                         ParserDiagnostic::new(
                             "unexpected-description-item-end-tag",
                             format!(
@@ -34186,12 +34184,7 @@ mod tests {
             assert_eq!(
                 output.parser_diagnostics,
                 vec![
-                    ParserDiagnostic::new(
-                        "unexpected-end-tag-in-foreign-content",
-                        format!(
-                            "end tag `</{end_name}>` did not match the current foreign element"
-                        )
-                    ),
+                    generic_foreign_end_tag_mismatch(&source, end_name),
                     ParserDiagnostic::new(
                         "unexpected-description-item-end-tag",
                         format!(
@@ -34274,6 +34267,87 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-description-item-end-tag"));
+    }
+
+    #[test]
+    fn positions_description_item_foreign_end_tag_mismatches_at_token_emission() {
+        for (item_name, end_name) in [("dd", "dt"), ("dt", "dd")] {
+            let source = format!(
+                "<!doctype html><!--é-->\r\n<dl><{item_name}><math><mi></{end_name}>X</mi></math></{item_name}></dl>"
+            );
+            let output = parse_html_with_diagnostics(&source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![
+                    generic_foreign_end_tag_mismatch(&source, end_name),
+                    ParserDiagnostic::new(
+                        "unexpected-description-item-end-tag",
+                        format!(
+                            "end tag `</{end_name}>` did not match a description item in scope"
+                        )
+                    ),
+                ],
+                "source {source:?}"
+            );
+            assert!(source.len() > source.chars().count());
+
+            let eof_source = format!(
+                "<!doctype html><dl><{item_name}><svg><foreignObject></{end_name}"
+            );
+            let eof_output = parse_html_with_diagnostics(&eof_source).unwrap();
+            assert!(eof_output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-end-tag-in-foreign-content"
+            }));
+            assert_eq!(
+                eof_output.parser_diagnostics.last(),
+                Some(&eof_with_unclosed_elements(&eof_source))
+            );
+        }
+
+        let nearer_foreign_match = parse_html_with_diagnostics(
+            "<!doctype html><dl><dd><svg><dd></dd>X</svg></dd></dl>",
+        )
+        .unwrap();
+        assert!(nearer_foreign_match
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-end-tag-in-foreign-content"));
+
+        let mut unpositioned = HtmlParser::with_body_fragment_options(HtmlParseOptions::default());
+        for token in [
+            Token::StartTag {
+                name: "dd".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "svg".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::StartTag {
+                name: "foreignObject".to_string(),
+                attributes: Vec::new(),
+                self_closing: false,
+            },
+            Token::EndTag {
+                name: "dt".to_string(),
+            },
+            Token::Eof,
+        ] {
+            unpositioned.process_token(token);
+        }
+        let diagnostics = unpositioned.diagnostics();
+        let foreign = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-end-tag-in-foreign-content")
+            .unwrap();
+        let companion = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "unexpected-description-item-end-tag")
+            .unwrap();
+        assert_eq!(foreign.position, None);
+        assert_eq!(companion.position, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- attach dedicated authored HTML `dd`/`dt` foreign-content mismatches to the tokenizer end-tag emission point
- keep description-item scope companions independently unpositioned and preserve existing DOM/recovery behavior
- cover SVG/MathML integration boundaries, opposite-name recovery, nearer foreign matches, incomplete EOF tags, CRLF/non-ASCII positions, fragments, and plain unpositioned token streams

## Validation
- `cargo test -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer`
- `cargo clippy -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -q -p coding-adventures-html-parser -p coding-adventures-html-lexer -p state-machine-tokenizer --no-deps`
- tree fixture and all focused audit integrity checks
- live WPT `e5c6f33944034560e09421e650211f5e1ccc619d`: 1,936 tree cases, zero missing
- live html5lib `224991ec10db04f056a89eed8b0bd8695fd2950e`: 6,806 tokenizer cases, zero missing, zero normalized skips