### PR TITLE
feat(human-languages): make pass-ready gaps explicit

### DIFF
--- a/code/learning/human-languages/core/assessment-policy.json
+++ b/code/learning/human-languages/core/assessment-policy.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "maxLessonMinutes": 5,
+  "levels": ["pre-A1", "A1", "A2", "B1", "B2", "C1", "C2"],
+  "skills": ["reading", "listening", "writing", "speaking"],
+  "writingStages": [
+    {
+      "id": "observe-trace",
+      "firstRequiredAt": "pre-A1",
+      "description": "Notice the shape and direction, then trace it with a model still visible."
+    },
+    {
+      "id": "guided-copy",
+      "firstRequiredAt": "pre-A1",
+      "description": "Copy a glyph, word, or short phrase with stroke or formation cues."
+    },
+    {
+      "id": "delayed-copy",
+      "firstRequiredAt": "pre-A1",
+      "description": "Look, hide the model briefly, write, then compare and repair."
+    },
+    {
+      "id": "dictation-transcription",
+      "firstRequiredAt": "pre-A1",
+      "description": "Turn a heard or romanized item into the target writing system."
+    },
+    {
+      "id": "controlled-composition",
+      "firstRequiredAt": "A1",
+      "description": "Choose and order known language to write an original word, phrase, or sentence."
+    },
+    {
+      "id": "connected-composition",
+      "firstRequiredAt": "A2",
+      "description": "Write connected sentences for a real purpose and a named reader."
+    },
+    {
+      "id": "timed-assessment-production",
+      "firstRequiredAt": "A1",
+      "description": "Complete a level-appropriate writing task under the target assessment's timing and rubric."
+    }
+  ],
+  "passEvidence": {
+    "skillsPassIndependently": true,
+    "minimumFullMocksPerLevel": 2,
+    "requiresTimedMocks": true,
+    "requiresRubric": true,
+    "requiresAnswerKey": true,
+    "requiresHumanValidation": true
+  }
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Added - pass-ready assessment contracts and the gentle writing policy (#12207)
+
+- Add HL16 and `core/assessment-policy.json`: instructional lessons remain capped
+  at five minutes while reading, listening, writing, and speaking must each pass
+  independently. The writing strand now has seven cumulative stages, from
+  observe/trace through timed assessment production.
+- Add a strict assessment-policy and per-track contract parser. A valid
+  `<track>/assessment.json` must name an external exam or clearly labelled
+  project-defined equivalent at every level, inventory all four skills, require
+  explicit thresholds and writing stages, and provide at least two timed full
+  mocks with rubrics and answer keys. Invalid contracts fail loudly.
+- Add `assessment-contract` as the completion plan's highest-priority family.
+  The current corpus now reports 22 visible contract deficits instead of letting
+  content-coverage proxies imply exam readiness: 118 enumerable items and about
+  10,190 projected tranches at the 2026-08-20 baseline.
+- This tranche does not claim that the books are pass-ready. It makes the missing
+  pass evidence machine-visible so the writing/task/mock rewrites cannot be
+  forgotten or reported as zero.
+
 ### Changed - exam points now outrank vocabulary, and the plan finally emits them (HL-C228)
 
 - `exam-point` was a declared family that **nothing generated**. The plan has been ranking work for 22 tracks with one of its seven families permanently empty, which is why vocabulary won every time — it was not beating exam points, it was running unopposed.

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -168,21 +168,22 @@ The gate above says what is *wrong*. This says what to *do* about it, and it is 
 pure function of the same measurements rather than a list somebody maintains:
 
 ```text
-22 tracks, 0 done; 89 enumerable item(s) today, ~10,172 projected to C2
+22 tracks, 0 done; 118 enumerable item(s) today, ~10,190 projected to C2
 
-    1. [pre-A1] script-closure — chinese
-       teach 7 chinese glyph(s) the track shows but never taught
-    2. [pre-A1] script-closure — japanese
-       teach 43 japanese glyph(s) the track shows but never taught
-    3. [pre-A1] vocabulary — latin
-       teaches 23 distinct headwords at or below pre-A1, against 300
+    1. [pre-A1] assessment-contract — japanese
+       require independent four-skill passes, a writing ramp, and timed full mocks
+    2. [pre-A1] assessment-contract — chinese
+       require independent four-skill passes, a writing ramp, and timed full mocks
+    3. [pre-A1] assessment-contract — gujarati
+       require independent four-skill passes, a writing ramp, and timed full mocks
 ```
 
 Three ordering rules, all mechanical. **The floor is universal** — every pre-A1 item
 outranks every A1 item in any track, because a track that climbs while its floor is
 missing has built a cliff with upper-level lessons on top. **Family priority** then
-decides what a track's next action is: the external exam target first (you cannot
-climb a rung nobody has written down), then script closure, then vocabulary. And the
+decides what a track's next action is: the complete pass-ready assessment contract
+first, then its external/project content inventory, script closure, exam points, and
+vocabulary. And the
 queue **rotates across tracks**, furthest-behind first, so every language moves once
 before any language moves twice.
 
@@ -191,7 +192,7 @@ a flat sort produced a head of 22 consecutive research tasks and no content, and
 inventory for a rung a track has not reached was outranking the floor it is standing
 on. See `code/specs/HL15-the-completion-plan.md` §4.
 
-Four of the seven families report `null` rather than a number in the projection.
+Three of the eight families report `null` rather than a number in the projection.
 That means **not projectable** — reinforcement debt at B1 is a function of lessons
 nobody has written — which is a different fact from zero.
 

--- a/code/packages/typescript/human-language-data/src/assessment.ts
+++ b/code/packages/typescript/human-language-data/src/assessment.ts
@@ -1,0 +1,203 @@
+import { CEFR_LEVELS, levelRank, type CefrLevel } from "./levels.js";
+
+export const ASSESSMENT_SKILLS = ["reading", "listening", "writing", "speaking"] as const;
+export type AssessmentSkill = (typeof ASSESSMENT_SKILLS)[number];
+
+export interface WritingStagePolicy {
+  id: string;
+  firstRequiredAt: CefrLevel;
+  description: string;
+}
+
+export interface AssessmentPolicy {
+  version: number;
+  maxLessonMinutes: number;
+  levels: CefrLevel[];
+  skills: AssessmentSkill[];
+  writingStages: WritingStagePolicy[];
+  passEvidence: {
+    skillsPassIndependently: true;
+    minimumFullMocksPerLevel: number;
+    requiresTimedMocks: true;
+    requiresRubric: true;
+    requiresAnswerKey: true;
+    requiresHumanValidation: true;
+  };
+}
+
+export interface AssessmentContract {
+  version: number;
+  language: string;
+  levels: Array<{
+    level: CefrLevel;
+    target: {
+      name: string;
+      basis: "external" | "project-defined";
+      source: string;
+    };
+    skills: Record<AssessmentSkill, {
+      taskInventory: string[];
+      passThreshold: number;
+    }>;
+    writingStages: string[];
+    fullMocks: Array<{
+      id: string;
+      timed: boolean;
+      rubric: string;
+      answerKey: string;
+    }>;
+  }>;
+}
+
+function object(value: unknown, where: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`assessment: ${where} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function nonEmpty(value: unknown, where: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`assessment: ${where} must be a non-empty string`);
+  }
+  return value;
+}
+
+function level(value: unknown, where: string): CefrLevel {
+  const found = CEFR_LEVELS.find((candidate) => candidate === value);
+  if (!found) throw new Error(`assessment: ${where} must be one of ${CEFR_LEVELS.join(", ")}`);
+  return found;
+}
+
+function exactStrings(value: unknown, expected: readonly string[], where: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`assessment: ${where} must be a string array`);
+  }
+  if (value.length !== expected.length || expected.some((item) => !value.includes(item))) {
+    throw new Error(`assessment: ${where} must contain exactly ${expected.join(", ")}`);
+  }
+  return [...value] as string[];
+}
+
+export function parseAssessmentPolicy(value: unknown): AssessmentPolicy {
+  const raw = object(value, "policy");
+  if (raw.version !== 1) throw new Error("assessment: policy version must be 1");
+  if (raw.maxLessonMinutes !== 5) {
+    throw new Error("assessment: maxLessonMinutes must be 5; a larger value breaks the gentle-ramp contract");
+  }
+  const levels = exactStrings(raw.levels, CEFR_LEVELS, "policy.levels") as CefrLevel[];
+  const skills = exactStrings(raw.skills, ASSESSMENT_SKILLS, "policy.skills") as AssessmentSkill[];
+  if (!Array.isArray(raw.writingStages) || raw.writingStages.length === 0) {
+    throw new Error("assessment: policy.writingStages must be a non-empty array");
+  }
+  const stageIds = new Set<string>();
+  const writingStages = raw.writingStages.map((entry, index) => {
+    const stage = object(entry, `policy.writingStages[${index}]`);
+    const id = nonEmpty(stage.id, `policy.writingStages[${index}].id`);
+    if (stageIds.has(id)) throw new Error(`assessment: duplicate writing stage '${id}'`);
+    stageIds.add(id);
+    return {
+      id,
+      firstRequiredAt: level(stage.firstRequiredAt, `policy.writingStages[${index}].firstRequiredAt`),
+      description: nonEmpty(stage.description, `policy.writingStages[${index}].description`),
+    };
+  });
+  const evidence = object(raw.passEvidence, "policy.passEvidence");
+  for (const key of [
+    "skillsPassIndependently",
+    "requiresTimedMocks",
+    "requiresRubric",
+    "requiresAnswerKey",
+    "requiresHumanValidation",
+  ]) {
+    if (evidence[key] !== true) throw new Error(`assessment: policy.passEvidence.${key} must be true`);
+  }
+  if (!Number.isInteger(evidence.minimumFullMocksPerLevel) || (evidence.minimumFullMocksPerLevel as number) < 1) {
+    throw new Error("assessment: policy.passEvidence.minimumFullMocksPerLevel must be a positive integer");
+  }
+  return {
+    version: 1,
+    maxLessonMinutes: 5,
+    levels,
+    skills,
+    writingStages,
+    passEvidence: evidence as unknown as AssessmentPolicy["passEvidence"],
+  };
+}
+
+export function parseAssessmentContract(
+  value: unknown,
+  expectedLanguage: string,
+  policy: AssessmentPolicy,
+): AssessmentContract {
+  const raw = object(value, `${expectedLanguage}/assessment.json`);
+  if (raw.version !== 1) throw new Error(`assessment: ${expectedLanguage} contract version must be 1`);
+  if (raw.language !== expectedLanguage) {
+    throw new Error(`assessment: ${expectedLanguage} contract declares language '${String(raw.language)}'`);
+  }
+  if (!Array.isArray(raw.levels)) throw new Error(`assessment: ${expectedLanguage}.levels must be an array`);
+  const seen = new Set<CefrLevel>();
+  const levels = raw.levels.map((entry, index) => {
+    const item = object(entry, `${expectedLanguage}.levels[${index}]`);
+    const current = level(item.level, `${expectedLanguage}.levels[${index}].level`);
+    if (seen.has(current)) throw new Error(`assessment: ${expectedLanguage} duplicates level ${current}`);
+    seen.add(current);
+    const target = object(item.target, `${expectedLanguage}.${current}.target`);
+    if (target.basis !== "external" && target.basis !== "project-defined") {
+      throw new Error(`assessment: ${expectedLanguage}.${current}.target.basis must be external or project-defined`);
+    }
+    const basis: "external" | "project-defined" = target.basis;
+    const skills = object(item.skills, `${expectedLanguage}.${current}.skills`);
+    const parsedSkills = Object.fromEntries(ASSESSMENT_SKILLS.map((skill) => {
+      const skillRaw = object(skills[skill], `${expectedLanguage}.${current}.skills.${skill}`);
+      if (!Array.isArray(skillRaw.taskInventory) || skillRaw.taskInventory.some((task) => typeof task !== "string")) {
+        throw new Error(`assessment: ${expectedLanguage}.${current}.${skill}.taskInventory must be a string array`);
+      }
+      if (typeof skillRaw.passThreshold !== "number" || skillRaw.passThreshold <= 0 || skillRaw.passThreshold > 1) {
+        throw new Error(`assessment: ${expectedLanguage}.${current}.${skill}.passThreshold must be in (0, 1]`);
+      }
+      return [skill, { taskInventory: [...skillRaw.taskInventory], passThreshold: skillRaw.passThreshold }];
+    })) as AssessmentContract["levels"][number]["skills"];
+    if (!Array.isArray(item.writingStages) || item.writingStages.some((stage) => typeof stage !== "string")) {
+      throw new Error(`assessment: ${expectedLanguage}.${current}.writingStages must be a string array`);
+    }
+    const requiredStages = policy.writingStages
+      .filter((stage) => levelRank(stage.firstRequiredAt) <= levelRank(current))
+      .map((stage) => stage.id);
+    for (const required of requiredStages) {
+      if (!item.writingStages.includes(required)) {
+        throw new Error(`assessment: ${expectedLanguage}.${current} is missing writing stage '${required}'`);
+      }
+    }
+    if (!Array.isArray(item.fullMocks) || item.fullMocks.length < policy.passEvidence.minimumFullMocksPerLevel) {
+      throw new Error(
+        `assessment: ${expectedLanguage}.${current} needs at least ${policy.passEvidence.minimumFullMocksPerLevel} full mocks`,
+      );
+    }
+    const fullMocks = item.fullMocks.map((mock, mockIndex) => {
+      const mockRaw = object(mock, `${expectedLanguage}.${current}.fullMocks[${mockIndex}]`);
+      if (mockRaw.timed !== true) throw new Error(`assessment: ${expectedLanguage}.${current} mock must be timed`);
+      return {
+        id: nonEmpty(mockRaw.id, `${expectedLanguage}.${current}.mock.id`),
+        timed: true,
+        rubric: nonEmpty(mockRaw.rubric, `${expectedLanguage}.${current}.mock.rubric`),
+        answerKey: nonEmpty(mockRaw.answerKey, `${expectedLanguage}.${current}.mock.answerKey`),
+      };
+    });
+    return {
+      level: current,
+      target: {
+        name: nonEmpty(target.name, `${expectedLanguage}.${current}.target.name`),
+        basis,
+        source: nonEmpty(target.source, `${expectedLanguage}.${current}.target.source`),
+      },
+      skills: parsedSkills,
+      writingStages: [...item.writingStages] as string[],
+      fullMocks,
+    };
+  });
+  for (const required of policy.levels) {
+    if (!seen.has(required)) throw new Error(`assessment: ${expectedLanguage} is missing level ${required}`);
+  }
+  return { version: 1, language: expectedLanguage, levels };
+}

--- a/code/packages/typescript/human-language-data/src/completion-plan.ts
+++ b/code/packages/typescript/human-language-data/src/completion-plan.ts
@@ -11,7 +11,8 @@
 // Meanwhile every number needed to order the work is computed on every run.
 // `level-gate.ts` says which of four criteria each track fails and by how much.
 // `script-closure.ts` says exactly how many glyphs a track shows its reader and
-// never taught. `exam-inventory.ts` measures against an external published list.
+// never taught. `exam-inventory.ts` measures against the named external exam or
+// clearly labelled project-defined equivalent.
 //
 // So the queue is derived rather than typed:
 //
@@ -36,8 +37,9 @@ import { CEFR_LEVELS, levelRank } from "./levels.js";
 import { LEVEL_VOCABULARY, type LevelGateReport } from "./level-gate.js";
 import type { ScriptClosureReport } from "./script-closure.js";
 
-/** The seven families of work. Every item belongs to exactly one. */
+/** The eight families of work. Every item belongs to exactly one. */
 export type WorkKind =
+  | "assessment-contract"
   | "exam-inventory"
   | "script-closure"
   | "vocabulary"
@@ -51,7 +53,7 @@ export type WorkKind =
  *
  * The two entries worth defending:
  *
- * `exam-inventory` is 1 because until the external list exists, every other
+ * `exam-inventory` follows because until the target list exists, every other
  * number for that level is a proxy for something nobody is graded on. It is also
  * the cheapest family in the file: research and JSON, no content authoring.
  *
@@ -78,13 +80,14 @@ export type WorkKind =
  * headword count is the only measurement that exists.
  */
 export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
-  "exam-inventory": 1,
-  "script-closure": 2,
-  "exam-point": 3,
-  vocabulary: 4,
-  reinforcement: 5,
-  "atom-budget": 6,
-  "spine-nodes": 7,
+  "assessment-contract": 1,
+  "exam-inventory": 2,
+  "script-closure": 3,
+  "exam-point": 4,
+  vocabulary: 5,
+  reinforcement: 6,
+  "atom-budget": 7,
+  "spine-nodes": 8,
 });
 
 /**
@@ -97,6 +100,7 @@ export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
  * list of work items, which is the entire point of computing the queue.
  */
 export const TRANCHE_SIZE: Readonly<Record<WorkKind, number>> = Object.freeze({
+  "assessment-contract": 1,
   "exam-inventory": 1,
   "script-closure": 10,
   vocabulary: 35,
@@ -160,7 +164,7 @@ export interface CompletionPlan {
   };
 }
 
-/** A (track, level) pair that already has an external inventory on disk. */
+/** A (track, level) pair that already has a target assessment inventory on disk. */
 export interface InventoryPresence {
   language: string;
   level: CefrLevel;
@@ -177,7 +181,9 @@ export interface ExamCoverageSummary {
 export interface CompletionPlanInput {
   levelGate: LevelGateReport;
   scriptClosure: ScriptClosureReport;
-  /** Which external inventories exist. Absent ones become `exam-inventory` items. */
+  /** Tracks with a validated `<track>/assessment.json` covering the whole ladder. */
+  assessmentContracts?: readonly string[];
+  /** Which target inventories exist. Absent ones become `exam-inventory` items. */
   inventories: readonly InventoryPresence[];
   /**
    * Measured coverage for every inventory that exists.
@@ -212,7 +218,8 @@ function tranchesFor(outstanding: number, kind: WorkKind): number {
  * The lowest certifiable level at or above `from` that has no inventory yet.
  *
  * Called with the level a track is IN PROGRESS at, so a track working pre-A1 is
- * asked for its A1 inventory. That is deliberate: the target for the next rung
+ * asked for its A1 inventory. That is deliberate: the external exam or
+ * project-defined target for the next rung
  * has to be written down before the climb reaches it, or the climb is once again
  * aimed at a number this repository invented. HL-C184's Phase 0 made exactly
  * this point and it is the reason the item is ordered at the IN-PROGRESS level
@@ -243,6 +250,7 @@ export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan 
   const headSize = input.headSize ?? 25;
   const have = new Set(input.inventories.map((entry) => `${entry.language}/${entry.level}`));
   const closureByLanguage = new Map(input.scriptClosure.tracks.map((track) => [track.language, track]));
+  const contracted = new Set(input.assessmentContracts ?? []);
 
   // Items are collected PER TRACK and interleaved at the end, never pooled and
   // sorted flat. The first version of this function pooled them, and the queue it
@@ -264,6 +272,27 @@ export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan 
     }
     const mine: WorkItem[] = [];
 
+    // The assessment contract is the outer target. An exam inventory says which
+    // language points occur; it does NOT prove that reading, listening, writing
+    // and speaking are each taught, scored independently, and exercised in a
+    // timed full mock. HL16 makes that distinction explicit. Until this file
+    // exists, a track cannot honestly claim that finishing its book prepares the
+    // reader to pass, however complete its vocabulary and grammar may look.
+    if (!contracted.has(track.language)) {
+      mine.push({
+        id: `assessment-contract/${track.language}`,
+        kind: "assessment-contract",
+        language: track.language,
+        level,
+        goal:
+          `write ${track.language}/assessment.json: name an external exam or project-defined equivalent ` +
+          `at every level, then require independent reading, listening, writing and speaking passes, ` +
+          `the gentle writing stages, scored tasks, rubrics, answer keys and timed full mocks`,
+        outstanding: 1,
+        tranches: 1,
+      });
+    }
+
     // 1. The external target for the next certifiable rung, if it is not written.
     const missing = nextMissingInventory(track.language, level, ceiling, have);
     if (missing !== null) {
@@ -273,7 +302,7 @@ export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan 
         language: track.language,
         level,
         goal:
-          `write the external ${missing} exam inventory for ${track.language}; ` +
+          `write the external or project-defined ${missing} assessment inventory for ${track.language}; ` +
           `until it exists, every ${track.language} number at ${missing} is a proxy`,
         outstanding: 1,
         tranches: 1,
@@ -452,12 +481,13 @@ function interleave(byTrack: ReadonlyMap<string, readonly WorkItem[]>, gate: Lev
 /**
  * The tail, counted per family.
  *
- * Only two families can honestly be projected to the ceiling. Vocabulary can,
- * because `LEVEL_VOCABULARY` states the cumulative target at every level and the
- * corpus states what a track holds today. Inventories can, because there are
- * exactly 22 tracks times six certifiable levels and that product does not move.
+ * Five families can honestly be projected to the ceiling. Assessment contracts
+ * are exactly one per track. Vocabulary can be counted because `LEVEL_VOCABULARY`
+ * states the cumulative target at every level. Exam inventories are exactly one
+ * per track and certifiable level. Script closure counts a finite observed glyph
+ * set, and exam points are projectable over the inventories that already exist.
  *
- * The other five cannot, and are reported as `null` rather than as a number.
+ * The other three cannot, and are reported as `null` rather than as a number.
  * Reinforcement debt at B1 is a function of lessons nobody has written yet;
  * quoting a figure for it would be inventing one. `null` here means NOT
  * PROJECTABLE, which is a different fact from zero — the same distinction
@@ -476,6 +506,11 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
 
   const wanted = input.levelGate.tracks.length * CERTIFIABLE_LEVELS.filter((level) => levelRank(level) <= levelRank(ceiling)).length;
   const inventoryItems = Math.max(0, wanted - input.inventories.length);
+  const trackNames = new Set(input.levelGate.tracks.map((track) => track.language));
+  const validAssessmentContracts = new Set(
+    (input.assessmentContracts ?? []).filter((language) => trackNames.has(language)),
+  );
+  const assessmentItems = Math.max(0, input.levelGate.tracks.length - validAssessmentContracts.size);
 
   const glyphs = input.scriptClosure.tracks.reduce((sum, track) => sum + track.neverTaughtGlyphs, 0);
 
@@ -497,6 +532,13 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
   const examPointItems = written.length === 0 ? null : Math.ceil(examUncovered / TRANCHE_SIZE["exam-point"]);
 
   return [
+    {
+      kind: "assessment-contract",
+      items: assessmentItems,
+      detail:
+        `${validAssessmentContracts.size} of ${input.levelGate.tracks.length} track(s) have a validated ` +
+        `four-skill, writing-ramp and timed-mock contract`,
+    },
     {
       kind: "vocabulary",
       items: vocabularyItems,

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -8,6 +8,7 @@ export * from "./types.js";
 export * from "./constants.js";
 export * from "./cousins.js";
 export * from "./exam-inventory.js";
+export * from "./assessment.js";
 export { splitFrontmatter, type Frontmatter } from "./frontmatter.js";
 export {
   declaredStrands,

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -12,6 +12,11 @@ import {
 } from "./modality-manifest.js";
 import { buildDataset, parseLesson, type ParsedLesson } from "./parse.js";
 import type { ExamInventory } from "./exam-inventory.js";
+import {
+  parseAssessmentContract,
+  parseAssessmentPolicy,
+  type AssessmentPolicy,
+} from "./assessment.js";
 import type { LedgerLetter, LetterLedger } from "./letter-ledger.js";
 import type {
   BookChapter,
@@ -65,6 +70,33 @@ export function loadLanguageRegistry(root = defaultCurriculumRoot()): LanguageRe
   return JSON.parse(
     readFileSync(join(root, "core", "languages.json"), "utf8"),
   ) as LanguageRegistry;
+}
+
+/** HL16: the universal five-minute, four-skill and writing-ramp contract. */
+export function loadAssessmentPolicy(root = defaultCurriculumRoot()): AssessmentPolicy {
+  return parseAssessmentPolicy(
+    JSON.parse(readFileSync(join(root, "core", "assessment-policy.json"), "utf8")),
+  );
+}
+
+/**
+ * Tracks whose complete assessment contract is present and valid.
+ *
+ * Absence is backlog. Invalidity is an error: treating a malformed contract as
+ * absent would send the next contributor to create a second file while hiding
+ * the broken one already in the tree.
+ */
+export function listAssessmentContracts(root = defaultCurriculumRoot()): string[] {
+  const policy = loadAssessmentPolicy(root);
+  const registry = loadLanguageRegistry(root);
+  const out: string[] = [];
+  for (const track of registry.languages) {
+    const path = join(root, track.id, "assessment.json");
+    if (!existsSync(path)) continue;
+    parseAssessmentContract(JSON.parse(readFileSync(path, "utf8")), track.id, policy);
+    out.push(track.id);
+  }
+  return out;
 }
 
 export function loadCurriculumSpine(root = defaultCurriculumRoot()): CurriculumSpine {

--- a/code/packages/typescript/human-language-data/src/plan-cli.ts
+++ b/code/packages/typescript/human-language-data/src/plan-cli.ts
@@ -12,6 +12,7 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   defaultCurriculumRoot as defaultRoot,
+  listAssessmentContracts,
   listExamInventories,
   loadChapterPolicy,
   loadEverything,
@@ -167,6 +168,7 @@ export function runCompletionPlan(args = process.argv.slice(2)): number {
   const plan = buildCompletionPlan({
     levelGate: report.levelGate,
     scriptClosure: report.scriptClosure,
+    assessmentContracts: listAssessmentContracts(options.root),
     inventories: readable,
     examCoverage,
     unreadableInventories: unreadable.length,

--- a/code/packages/typescript/human-language-data/tests/assessment.test.ts
+++ b/code/packages/typescript/human-language-data/tests/assessment.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { loadAssessmentPolicy, listAssessmentContracts } from "../src/loader.js";
+import { parseAssessmentContract, parseAssessmentPolicy } from "../src/assessment.js";
+
+describe("assessment policy (HL16)", () => {
+  it("pins five-minute lessons, four independent skills, and the complete writing ramp", () => {
+    const policy = loadAssessmentPolicy();
+    expect(policy.maxLessonMinutes).toBe(5);
+    expect(policy.skills).toEqual(["reading", "listening", "writing", "speaking"]);
+    expect(policy.writingStages.map((stage) => stage.id)).toEqual([
+      "observe-trace",
+      "guided-copy",
+      "delayed-copy",
+      "dictation-transcription",
+      "controlled-composition",
+      "connected-composition",
+      "timed-assessment-production",
+    ]);
+    expect(policy.passEvidence).toMatchObject({
+      skillsPassIndependently: true,
+      minimumFullMocksPerLevel: 2,
+      requiresTimedMocks: true,
+      requiresRubric: true,
+      requiresAnswerKey: true,
+      requiresHumanValidation: true,
+    });
+  });
+
+  it("does not let policy drift above five minutes", () => {
+    expect(() => parseAssessmentPolicy({
+      version: 1,
+      maxLessonMinutes: 6,
+      levels: ["pre-A1", "A1", "A2", "B1", "B2", "C1", "C2"],
+      skills: ["reading", "listening", "writing", "speaking"],
+      writingStages: [],
+      passEvidence: {},
+    })).toThrow(/maxLessonMinutes must be 5/);
+  });
+
+  it("reports every current track as an authored contract deficit", () => {
+    expect(listAssessmentContracts()).toEqual([]);
+  });
+});
+
+describe("track assessment contracts", () => {
+  const policy = loadAssessmentPolicy();
+
+  it("accepts a complete seven-level contract with independent skills and full mocks", () => {
+    const skill = { taskInventory: ["tasks.json"], passThreshold: 0.6 };
+    const value = {
+      version: 1,
+      language: "alpha",
+      levels: policy.levels.map((current, levelIndex) => ({
+        level: current,
+        target: { name: `Alpha ${current}`, basis: "project-defined", source: "assessment-spec.md" },
+        skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+        writingStages: policy.writingStages
+          .filter((stage) => policy.levels.indexOf(stage.firstRequiredAt) <= levelIndex)
+          .map((stage) => stage.id),
+        fullMocks: [
+          { id: `${current}-mock-1`, timed: true, rubric: "rubric.md", answerKey: "answers-1.md" },
+          { id: `${current}-mock-2`, timed: true, rubric: "rubric.md", answerKey: "answers-2.md" },
+        ],
+      })),
+    };
+    expect(parseAssessmentContract(value, "alpha", policy).levels).toHaveLength(7);
+  });
+
+  it("requires all four independently scored skills", () => {
+    const skill = { taskInventory: [], passThreshold: 0.6 };
+    const one = {
+      version: 1,
+      language: "alpha",
+      levels: [{
+        level: "pre-A1",
+        target: { name: "Alpha checkpoint", basis: "project-defined", source: "alpha.md" },
+        skills: { listening: skill, writing: skill, speaking: skill },
+        writingStages: ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription"],
+        fullMocks: [
+          { id: "mock-1", timed: true, rubric: "rubric.md", answerKey: "answers-1.md" },
+          { id: "mock-2", timed: true, rubric: "rubric.md", answerKey: "answers-2.md" },
+        ],
+      }],
+    };
+    expect(() => parseAssessmentContract(one, "alpha", policy)).toThrow(/skills\.reading must be an object/);
+  });
+
+  it("rejects a contract that calls a project equivalent external", () => {
+    const one = {
+      version: 1,
+      language: "alpha",
+      levels: [{
+        level: "pre-A1",
+        target: { name: "Alpha checkpoint", basis: "invented", source: "alpha.md" },
+        skills: {},
+        writingStages: [],
+        fullMocks: [],
+      }],
+    };
+    expect(() => parseAssessmentContract(one, "alpha", policy)).toThrow(/external or project-defined/);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
+++ b/code/packages/typescript/human-language-data/tests/completion-plan.test.ts
@@ -74,11 +74,37 @@ function plan(input: Partial<CompletionPlanInput> & Pick<CompletionPlanInput, "l
   return buildCompletionPlan({
     scriptClosure: closure([]),
     inventories: [],
+    // Most tests below isolate the older families. A fixture contract means
+    // "assessment is not the variable under test", not that the real corpus has
+    // paid this debt.
+    assessmentContracts: input.levelGate.tracks.map((track) => track.language),
     ...input,
   });
 }
 
 describe("completion plan", () => {
+  it("puts a missing pass-ready assessment contract ahead of proxy coverage", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1", blockers: vocabularyBlocker(250) }]),
+      assessmentContracts: [],
+    });
+    expect(built.head[0]).toMatchObject({
+      id: "assessment-contract/alpha",
+      kind: "assessment-contract",
+      language: "alpha",
+    });
+    expect(built.head[0]?.goal).toContain("independent reading, listening, writing and speaking passes");
+  });
+
+  it("suppresses the assessment item only for a validated contracted track", () => {
+    const built = plan({
+      levelGate: gate([{ language: "alpha", inProgressAt: "pre-A1" }]),
+      assessmentContracts: ["alpha"],
+    });
+    expect(built.head.some((item) => item.kind === "assessment-contract")).toBe(false);
+    expect(built.projection.find((entry) => entry.kind === "assessment-contract")?.items).toBe(0);
+  });
+
   it("moves every track once before any track moves twice", () => {
     // Three tracks, each with two items. A flat sort by family would emit all
     // three script items and only then the vocabulary ones; the rotation must

--- a/code/packages/typescript/human-language-data/tests/plan-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/plan-cli.test.ts
@@ -22,12 +22,12 @@ function corpus(): string {
   return root;
 }
 
-function run(root: string): { code: number; out: string; err: string } {
+function run(root: string, headSize = 25): { code: number; out: string; err: string } {
   let out = "";
   let err = "";
   vi.spyOn(process.stdout, "write").mockImplementation((chunk) => ((out += chunk), true));
   vi.spyOn(process.stderr, "write").mockImplementation((chunk) => ((err += chunk), true));
-  const code = runCompletionPlan(["--root", root]);
+  const code = runCompletionPlan(["--root", root, "--head", String(headSize)]);
   return { code, out, err };
 }
 
@@ -40,7 +40,10 @@ function editInventory(root: string, name: string, edit: (doc: Record<string, un
 
 describe("the plan CLI", () => {
   it("leads French and German with their exam gap on a clean corpus", () => {
-    const { code, out } = run(corpus());
+    // HL16 adds one assessment-contract item per track ahead of content proxy
+    // work. Ask for the complete enumerable queue so this test continues to
+    // assert that the measured French/German exam gaps survive behind that gate.
+    const { code, out } = run(corpus(), 200);
     expect(code).toBe(0);
     expect(out).toMatch(/exam-point — french/);
     expect(out).toMatch(/exam-point — german/);

--- a/code/specs/HL15-the-completion-plan.md
+++ b/code/specs/HL15-the-completion-plan.md
@@ -58,8 +58,11 @@ fifth requirement and the ordering over all five.
 | 4 | every atom revisited at least twice | `continuity.ts` | HL09 §3.1 |
 | 5 | **every exam point covered** | `exam-inventory.ts` | the awarding body |
 | 6 | **script closure: no untaught glyph is load-bearing** | `script-closure.ts` | HL11 |
+| 7 | **a four-skill, writing-ramp and full-mock assessment contract exists** | `assessment.ts` | HL16 |
 
-Criteria 5 and 6 are the two this spec adds to the definition of done. Criterion 5
+Criteria 5 and 6 are the two this spec originally added to the definition of done.
+HL16 adds criterion 7 after the owner made the pass claim and productive writing
+requirements explicit. Criterion 5
 is the only one that comes from outside this repository, which is why it is the
 one that settles the owner's question. Criterion 6 is the one the second goal
 names.
@@ -70,13 +73,14 @@ test needs a human sitting a past paper, and that item is on the queue (§6).
 
 ## 3. The item families
 
-Seven, and every one of them is enumerable from a report the package already
+Eight, and every one of them is enumerable from a report the package already
 produces. No work item is ever authored by hand; a *finding* is, and findings go
 in `BACKLOG.md`.
 
 | kind | one item is | outstanding is counted in | tranche |
 |---|---|---|---|
-| `exam-inventory` | write the external point list for one (track, level) | inventories | 1 |
+| `assessment-contract` | write one track's external/project target, four-skill pass rule, writing ramp and full-mock contract | tracks | 1 |
+| `exam-inventory` | write the external or project-defined point list for one (track, level) | inventories | 1 |
 | `script-closure` | teach the glyphs one track shows but never taught | glyphs | 10 |
 | `vocabulary` | raise one track's headword count at one level | headwords | 35 |
 | `exam-point` | cover one named point from the inventory | points | 5 |
@@ -109,13 +113,14 @@ one track clears the floor.
 ### 4.2 Kind priority second
 
 ```
-1. exam-inventory   you cannot aim at a target you have not written down
-2. script-closure   decoding is a precondition for reading, and it ENDS
-3. exam-point       named gaps against the external list  [was 4 — see below]
-4. vocabulary       the dominant remaining mass           [was 3]
-5. reinforcement    retention — what separates a corpus claim from a learner one
-6. atom-budget      a ramp that got steeper is a regression, not a backlog item
-7. spine-nodes      functional coverage, the coarsest of the six
+1. assessment-contract the whole pass target, including productive writing
+2. exam-inventory      you cannot aim at a content target not written down
+3. script-closure      decoding is a precondition for reading, and it ENDS
+4. exam-point          named gaps against the external list
+5. vocabulary          the dominant remaining mass
+6. reinforcement       retention — what separates a corpus claim from a learner one
+7. atom-budget         a ramp that got steeper is a regression, not a backlog item
+8. spine-nodes         functional coverage, the coarsest corpus criterion
 ```
 
 **Why `exam-point` moved above `vocabulary`, and it is the one ordering here
@@ -185,6 +190,12 @@ HL-C184 already accepted that.
 **The enumeration rule is the artifact. The queue head is what you act on.**
 
 ## 6. What this plan does not measure, recorded so it is not discovered late
+
+**Update, 2026-08-20:** HL16 now owns these gaps and defines the writing ramp,
+four-skill pass contract, timed mocks, rubrics, and human-validation layers. Only
+the first generated family (`assessment-contract`) is implemented in this tranche;
+the remaining HL16 families must report as unimplemented/not measurable, never
+as zero.
 
 Carried forward from HL-C182 and HL-C184 Phase 3, unchanged:
 

--- a/code/specs/HL16-exam-ready-books-and-writing-ramp.md
+++ b/code/specs/HL16-exam-ready-books-and-writing-ramp.md
@@ -1,0 +1,289 @@
+# HL16 — Exam-ready books and the gentle writing ramp
+
+**Status:** specification, 2026-08-20
+
+**Extends:** HL09, HL10, HL11, and HL15
+
+**Durable program issue:** [#12206](https://github.com/adhithyan15/coding-adventures/issues/12206)
+
+## 1. The promise
+
+Finishing a human-language book must prepare a learner to **pass the named
+assessment**, not merely encounter material carrying the same level label. Where
+an appropriate external examination exists, its current public specification is
+the target. Where none exists, the project publishes a clearly labelled
+project-defined equivalent with the same evidence, scoring, and quality bar.
+
+This promise applies independently to reading, listening, writing, and speaking.
+A strong reading score may not compensate for an absent writing course. A corpus
+coverage report may not substitute for a scored learner performance. “Touches
+C2” and “can pass C2” are different claims forever.
+
+Every instructional lesson remains designed for **at most five minutes**. There
+is no maximum book length. If an honest gentle ramp needs 50,000 micro-lessons,
+the book has 50,000 micro-lessons.
+
+## 2. Why HL15's six criteria are necessary and insufficient
+
+HL15 measures concepts, vocabulary, atom budget, reinforcement, exam points, and
+script closure. Those are strong corpus prerequisites. They do not establish the
+shape of performance:
+
+- recognising a word does not prove the learner can retrieve and write it;
+- covering a grammar point does not prove the learner can use it under time;
+- narration does not prove listening at the target speed and acoustic variety;
+- one text activity does not reproduce a listening paper, oral interview, or
+  extended writing task;
+- an inventory says what is tested, not whether practice and scoring match the
+  actual test;
+- a perfect corpus cannot prove that a human who used only that corpus passes.
+
+The Council of Europe's CEFR Companion Volume treats written production,
+written interaction, spoken production, spoken interaction, reception, and
+mediation as distinct activities. Its overall written-production ramp moves from
+basic personal information at pre-A1, through isolated sentences at A1 and
+connected text at B1, to complex, audience-aware writing at C1/C2. The project's
+writing ramp follows that progression instead of bolting handwriting onto a
+reading course.
+
+Sources:
+
+- [CEFR Companion Volume, communicative activities and written production](https://www.coe.int/en/web/common-european-framework-reference-languages/cefr-descriptors)
+- [CEFR language-by-language Reference Level Descriptions](https://www.coe.int/en/web/common-european-framework-reference-languages/reference-level-descriptions)
+- [ALTE assessment guides and separate-skill recommendations](https://www.alte.org/Materials)
+
+## 3. The universal assessment policy
+
+`core/assessment-policy.json` is the non-negotiable project contract. It records:
+
+- the five-minute instructional ceiling;
+- the seven curriculum levels from pre-A1 through C2;
+- the four independently passing skills;
+- the ordered writing stages;
+- the minimum full-mock count;
+- required timing, rubrics, answer keys, and human validation.
+
+The data package parses this file strictly. A typo must fail loudly; it must not
+silently relax the promise.
+
+## 4. One assessment contract per track
+
+Every registered track must eventually carry `<track>/assessment.json`. Absence
+is an `assessment-contract` work item in the generated completion plan. A valid
+contract contains every level and, at each level:
+
+1. the target assessment name;
+2. `basis: external` or `basis: project-defined`;
+3. a stable source or checked-in project specification;
+4. task inventories for reading, listening, writing, and speaking;
+5. an independent pass threshold for each skill;
+6. the writing stages required at that level;
+7. at least two complete timed mocks;
+8. a rubric and answer key for every mock.
+
+“No widely-sat ladder” is no longer a terminal answer. It selects the
+project-defined path. The equivalent must be published and reviewable; it may
+not be an unnamed editorial feeling hidden in code.
+
+### 4.1 External target
+
+Use an external target only when the awarding body publishes enough information
+to reconstruct the tested construct and scoring. Preserve edition/date, source
+URLs, paper structure, timing, scoring, skill aggregation rules, permitted aids,
+and sample/past-paper provenance. If the exam omits a skill, the book must still
+teach that skill to the level descriptor, but must label the additional project
+paper rather than pretending the external exam tests it.
+
+### 4.2 Project-defined equivalent
+
+A project-defined assessment must be a close functional approximation, not an
+easier placeholder. Its specification must include:
+
+- CEFR can-do descriptors or another declared proficiency framework;
+- language-specific vocabulary, grammar, orthography, register, and genre
+  inventories grounded in grammars, corpora, and community review;
+- four separately scored papers;
+- task counts, lengths, input speeds, interlocutor protocol, and timing;
+- analytic rubrics and standard-setting rationale;
+- two public mocks plus protected validation forms;
+- an explicit pass rule that cannot hide a failed skill in an average;
+- pilot evidence, reviewer qualifications, versioning, and known limitations.
+
+The label shown to learners is “Coding Adventures <Language> <Level>
+Assessment — project-defined equivalent,” never the name of an official
+qualification the project does not award.
+
+## 5. Writing is a full strand, beginning on the first page
+
+Writing has two coupled ramps:
+
+- **formation/orthography:** make the marks legibly and conventionally;
+- **composition:** retrieve and arrange language for a reader and purpose.
+
+Roman-alphabet tracks are not exempt. A Spanish learner still needs accents,
+punctuation, spelling, paragraphing, register, and timed composition. A fluent
+Devanagari reader learning Marwadi may skip detachable formation support, but may
+not skip Marwadi spelling and composition evidence.
+
+### Stage W0 — observe and trace
+
+The model stays visible. The lesson names direction, joining, spacing, or the one
+shape contrast that matters. The learner traces once or twice. No memory claim.
+
+### Stage W1 — guided copy
+
+The model remains visible while the learner copies one glyph, word, or phrase.
+Formation cues fade one at a time. The learner compares against a concrete
+checklist rather than “looks good.”
+
+### Stage W2 — delayed copy
+
+Look, briefly hide, write, reveal, compare, repair. Delay grows from one glyph to
+one word and then one short phrase. This is the bridge from motor imitation to
+orthographic recall.
+
+### Stage W3 — dictation and transcription
+
+Write a heard item, or convert a deliberately temporary romanized cue into the
+target script. Begin with already-mastered contrasts at slow speed. Remove
+romanization before it can become the learner's primary representation.
+
+### Stage W4 — controlled composition
+
+Choose known language to make a new answer: fill a real form, label a picture,
+write personal details, order sentence pieces, then write an original sentence.
+The response is no longer copied.
+
+### Stage W5 — connected composition
+
+Write connected sentences for a named purpose and reader: message, note,
+description, narration, explanation, argument, synthesis. Planning, drafting,
+revision, cohesion, register, and proofreading each receive their own five-minute
+lessons before being combined.
+
+### Stage W6 — timed assessment production
+
+Rehearse the exact task family, length, tools, rubric, and time pressure of the
+target assessment. Timing ramps gently: untimed with a model, untimed without a
+model, generous partial timing, target timing, then full-paper timing.
+
+Every stage is cumulative. C2 does not abandon legibility and proofreading; it
+requires them while adding precision, genre control, synthesis, and speed.
+
+## 6. The five-minute lesson grammar
+
+A lesson must have one small observable outcome. Productive lessons use this
+shape:
+
+1. **Recall (30–60 seconds):** retrieve one prerequisite.
+2. **Notice (30–60 seconds):** see or hear one new contrast.
+3. **Model (up to 60 seconds):** study one worked response.
+4. **Produce (up to 120 seconds):** write or say one bounded response.
+5. **Check and repair (up to 60 seconds):** compare against an answer or rubric
+   and correct immediately.
+
+Long performances are assessments or chapter payoffs assembled from previously
+learned pieces. Their preparation remains micro-lessons. A full mock is allowed
+to take the real exam's duration because it is evidence, not an instructional
+lesson; the book must label that distinction.
+
+## 7. Passing evidence
+
+The completion claim has four layers, none substitutable for another:
+
+| layer | question | required evidence |
+|---|---|---|
+| corpus coverage | Is every needed thing taught gently and reinforced? | gates, inventories, script and writing closure |
+| task readiness | Has every exam task shape been practised and scored? | task inventory and checkpoints |
+| simulation | Can the learner pass complete assessments under authentic conditions? | two timed mocks, independent skill thresholds |
+| external validity | Does book-only study work for people? | human pilot against a real or project-defined assessment |
+
+A track-level C2 “done” flag requires all four layers at every lower level. Until
+the human layer is complete, reports must say **corpus ready** or **mock ready**,
+never **learner proven**.
+
+## 8. Generated backlog families
+
+HL15 remains the ordering engine. HL16 adds these deficit families in successive,
+testable tranches:
+
+| family | one item means | projectability |
+|---|---|---|
+| `assessment-contract` | author/repair one track's seven-level target and pass contract | exact: one per track |
+| `writing-stage` | close one track/level/stage coverage deficit | exact after manifests exist |
+| `task-shape` | add missing teaching and scored practice for one paper task | exact after inventories exist |
+| `mock-assessment` | add or repair one full timed mock and its scoring materials | exact: target count minus valid mocks |
+| `human-validation` | run or repair one pre-registered book-only learner study | not honestly projectable before recruitment |
+
+The first family is implemented with this spec. The others stay explicit here
+and in #12207 until their validators land. A prose-only future family must never
+be counted as zero.
+
+## 9. Program sequence
+
+This is a multi-day, likely multi-year corpus program. The sequence is a
+dependency order, not a promise that later phases wait for every language:
+
+### Phase A — make the target executable
+
+- land this policy and the assessment-contract queue family;
+- author one contract per track, including Marwadi;
+- date and source every external target;
+- specify project-defined equivalents where required;
+- implement validators for writing stages, task shapes, mocks, and rubrics.
+
+### Phase B — repair every book's foundation
+
+- inventory current writing instruction by track, level, and W0–W6 stage;
+- add formation and orthography micro-lessons from the first useful words;
+- add delayed recall, dictation, and controlled composition;
+- keep every lesson within the atom and five-minute budgets;
+- regenerate every standalone book from canonical lessons.
+
+### Phase C — build four-skill level ladders
+
+- author external or project language inventories for A1 through C2;
+- implement authentic reading and listening input families;
+- implement interactive and sustained speaking tasks;
+- implement functional, connected, and genre-specific writing tasks;
+- add independent scoring and remediation loops at every level.
+
+### Phase D — simulate the assessments
+
+- build at least two complete public mocks per track and level;
+- reproduce timing, sequencing, input speed, response constraints, and scoring;
+- calibrate rubrics with double-scored samples;
+- add targeted five-minute repair paths from every rubric dimension.
+
+### Phase E — establish human evidence
+
+- pre-register a book-only study protocol;
+- recruit learners with documented starting profiles;
+- require completion evidence rather than self-reported exposure;
+- administer real exams where accessible and project equivalents elsewhere;
+- report every skill score, attrition, accommodations, and confidence interval;
+- revise the book and repeat when a skill misses its pass target.
+
+### Phase F — maintain validity
+
+- recheck awarding-body specifications on a scheduled cadence;
+- version contracts and mocks when exams change;
+- require community and expert review for under-resourced languages;
+- recompute the generated queue after every merge;
+- treat newly discovered work as a new measurable family before selecting the
+  next tranche.
+
+## 10. Immediate acceptance criteria
+
+This specification's first implementation tranche is complete when:
+
+- `core/assessment-policy.json` exists and is parsed strictly;
+- its four skills, seven writing stages, five-minute ceiling, two-mock minimum,
+  rubrics, answer keys, timing, and human-validation requirements are tested;
+- malformed track contracts fail loudly;
+- every track without a valid contract receives an `assessment-contract` item;
+- that deficit appears in both the queue head and the projection;
+- HL15 no longer describes production/task-shape work as an unowned late gap.
+
+It does **not** close the program. It makes the program difficult to accidentally
+declare complete.


### PR DESCRIPTION
## Summary

- add HL16: finishing a book means independent reading, listening, writing, and speaking passes against an external exam or clearly labelled project-defined equivalent
- add a strict five-minute assessment policy with seven cumulative writing stages, from observe/trace through timed production
- validate future per-track `assessment.json` contracts, including every level, four skill thresholds, two timed full mocks, rubrics, and answer keys
- add `assessment-contract` as the generated completion plan's highest-priority family; the current corpus now exposes 22 missing contracts instead of letting coverage proxies imply pass readiness

This is the first implementation tranche for #12207 under #12206. It deliberately does not close the all-books writing rewrite (#12209) or claim that any current book is exam-ready.

## Validation

- `npm run build`
- focused assessment/completion-plan/CLI tests: 33 passed
- full package suite: 811 passed; the one contention-sensitive continuity timing assertion exceeded its 1s wall-clock threshold in the parallel run (1272ms), then passed alone in 201ms
- `npm run check:books`
- `npm run check:narration`
- `npm run check:modality`
- `npm run check:progress`
- `npm run check:figures`
- `git diff --check`

## Sources behind the policy

- Council of Europe CEFR Companion Volume/descriptors
- Council of Europe language-specific Reference Level Descriptions
- ALTE assessment guidance and separate-skill recommendations

The exact source links and the full multi-phase plan are recorded in HL16.