### PR TITLE
fix(html-parser): position table title starts

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5605,10 +5605,13 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "title" && self.current_element_is_table_structure() {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "unexpected-head-content-start-tag-in-table",
-                "head-content start tag `<title>` in a table context was foster parented",
-            ));
+            self.diagnostics.push(
+                ParserDiagnostic::new(
+                    "unexpected-head-content-start-tag-in-table",
+                    "head-content start tag `<title>` in a table context was foster parented",
+                )
+                .at_emission(self.current_token_emission_position),
+            );
             if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
             {
                 self.open_elements.push(path);
@@ -27065,6 +27068,14 @@ mod tests {
         .at_emission(Some(start_tag_position(source, "meta")))
     }
 
+    fn title_start_tag_in_table_recovery(source: &str) -> ParserDiagnostic {
+        ParserDiagnostic::new(
+            "unexpected-head-content-start-tag-in-table",
+            "head-content start tag `<title>` in a table context was foster parented",
+        )
+        .at_emission(Some(start_tag_position(source, "title")))
+    }
+
     fn generic_foreign_end_tag_mismatch(source: &str, name: &str) -> ParserDiagnostic {
         ParserDiagnostic::new(
             "unexpected-end-tag-in-foreign-content",
@@ -35261,11 +35272,12 @@ mod tests {
         assert_eq!(replacement.name, "table");
         assert_eq!(element_text_content(replacement), "X");
 
-        let title = parse_html_with_diagnostics("<!doctype html><table><title>").unwrap();
-        assert!(title
+        let hidden =
+            parse_html_with_diagnostics("<!doctype html><table><input type=hidden>").unwrap();
+        assert!(hidden
             .parser_diagnostics
             .iter()
-            .filter(|diagnostic| diagnostic.code == "unexpected-head-content-start-tag-in-table")
+            .filter(|diagnostic| diagnostic.code == "unexpected-hidden-input-start-tag-in-table")
             .all(|diagnostic| diagnostic.position.is_none()));
 
         let mut unpositioned = HtmlParser::with_fragment_context_options(
@@ -35429,10 +35441,6 @@ mod tests {
         }
 
         for (source, code) in [
-            (
-                "<!doctype html><table><title>",
-                "unexpected-head-content-start-tag-in-table",
-            ),
             (
                 "<!doctype html><table><input type=hidden>",
                 "unexpected-hidden-input-start-tag-in-table",
@@ -42082,13 +42090,7 @@ mod tests {
                     if name == "meta" {
                         diagnostic == &meta_start_tag_in_table_recovery(source)
                     } else {
-                        diagnostic
-                            == &ParserDiagnostic::new(
-                            "unexpected-head-content-start-tag-in-table",
-                            format!(
-                                "head-content start tag `<{name}>` in a table context was foster parented"
-                            ),
-                        )
+                        diagnostic == &title_start_tag_in_table_recovery(source)
                     }
                 }),
                 "source {source:?}"
@@ -42183,16 +42185,14 @@ mod tests {
         assert_eq!(table.name, "table");
         assert_eq!(element_text_content(table), "X");
 
-        let title_source = "<!doctype html><table><title>A &amp; B</title>";
-        let title = parse_html_with_diagnostics(title_source).unwrap();
-        let title_diagnostic = title
+        let hidden =
+            parse_html_with_diagnostics("<!doctype html><table><input type=hidden>").unwrap();
+        let hidden_diagnostic = hidden
             .parser_diagnostics
             .iter()
-            .find(|diagnostic| diagnostic.code == "unexpected-head-content-start-tag-in-table")
+            .find(|diagnostic| diagnostic.code == "unexpected-hidden-input-start-tag-in-table")
             .unwrap();
-        assert_eq!(title_diagnostic.position, None);
-        let title_element = find_first_element_in_nodes(&title.document.children, "title").unwrap();
-        assert_eq!(title_element.children, vec![Node::text("A & B")]);
+        assert_eq!(hidden_diagnostic.position, None);
 
         let mut unpositioned = HtmlParser::with_fragment_context_options(
             HtmlParseOptions::default(),
@@ -42202,6 +42202,141 @@ mod tests {
             name: "meta".to_string(),
             attributes: Vec::new(),
             self_closing: false,
+        });
+        assert_eq!(
+            unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.code == "unexpected-head-content-start-tag-in-table")
+                .unwrap()
+                .position,
+            None
+        );
+    }
+
+    #[test]
+    fn positions_title_start_tags_fostered_from_tables_at_token_emission() {
+        for source in [
+            "<!doctype html><table><title>A &amp; B</title>",
+            "<!doctype html><table><colgroup><title>A</title>",
+            "<!doctype html><table><tbody><title>A</title>",
+            "<!doctype html><table><thead><title>A</title>",
+            "<!doctype html><table><tfoot><title>A</title>",
+            "<!doctype html><table><tbody><tr><title>A</title>",
+            "<!doctype html><template><table><title>A</title>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| {
+                    diagnostic.code == "unexpected-head-content-start-tag-in-table"
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                diagnostics,
+                vec![&title_start_tag_in_table_recovery(source)],
+                "source {source:?}"
+            );
+        }
+
+        for context in ["table", "tbody", "thead", "tfoot", "tr"] {
+            let source = "<!--é-->\r\n<title data-name='é'>A &amp; B</title>";
+            let output =
+                parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(source.len() > source.chars().count());
+            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+                diagnostic == &title_start_tag_in_table_recovery(source)
+            }));
+            let title = find_first_element_in_nodes(&output.nodes, "title").unwrap();
+            assert_eq!(title.children, vec![Node::text("A & B")]);
+            assert_eq!(title.attribute("data-name"), Some("é"));
+        }
+
+        for (source, context) in [
+            ("<title>A</title>", "caption"),
+            ("<title>A</title>", "colgroup"),
+            ("<title>A</title>", "td"),
+            ("<title>A</title>", "th"),
+            ("<title>A</title>", "template"),
+            ("<title>A</title>", "html body"),
+        ] {
+            let output =
+                parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-head-content-start-tag-in-table"
+            }));
+        }
+
+        for source in [
+            "<!doctype html><table><caption><title>A</title>",
+            "<!doctype html><table><tbody><tr><td><title>A</title>",
+            "<!doctype html><table><tbody><tr><th><title>A</title>",
+            "<!doctype html><table><select><title>A</title>",
+            "<!doctype html><template><div><title>A</title>",
+            "<!doctype html><table><div><title>A</title>",
+            "<!doctype html><table><title",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-head-content-start-tag-in-table"
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let state_source = "<!doctype html><main><table><title id=marker>A</not-title>&amp;B</title><tbody><tr><td>X</table></main>";
+        let state = parse_html_with_diagnostics(state_source).unwrap();
+        let main = find_first_element_in_nodes(&state.document.children, "main").unwrap();
+        let title = element(&main.children[0]);
+        assert_eq!(title.name, "title");
+        assert_eq!(title.attribute("id"), Some("marker"));
+        assert_eq!(title.children, vec![Node::text("A</not-title>&B")]);
+        let table = element(&main.children[1]);
+        assert_eq!(table.name, "table");
+        assert_eq!(element_text_content(table), "X");
+
+        let malformed_close_source =
+            "<!doctype html><table><title>A</title data-name='ignored'><tbody>";
+        let malformed_close = parse_html_with_diagnostics(malformed_close_source).unwrap();
+        assert!(malformed_close.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic == &title_start_tag_in_table_recovery(malformed_close_source)
+        }));
+        let title = find_first_element_in_nodes(&malformed_close.document.children, "title")
+            .unwrap();
+        assert_eq!(title.children, vec![Node::text("A")]);
+
+        let incomplete_close_source = "<!doctype html><table><title>A &amp; B</title";
+        let incomplete_close = parse_html_with_diagnostics(incomplete_close_source).unwrap();
+        assert!(incomplete_close.parser_diagnostics.iter().any(|diagnostic| {
+            diagnostic == &title_start_tag_in_table_recovery(incomplete_close_source)
+        }));
+        let eof_diagnostic = incomplete_close
+            .parser_diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "eof-in-text-mode")
+            .unwrap();
+        assert_eq!(
+            eof_diagnostic.position,
+            Some(eof_position(incomplete_close_source))
+        );
+        let title = find_first_element_in_nodes(&incomplete_close.document.children, "title")
+            .unwrap();
+        assert_eq!(title.children, vec![Node::text("A & B</title")]);
+
+        let mut unpositioned = HtmlParser::with_fragment_context_options(
+            HtmlParseOptions::default(),
+            "table",
+        );
+        unpositioned.process_token(Token::StartTag {
+            name: "title".to_string(),
+            attributes: Vec::new(),
+            self_closing: false,
+        });
+        unpositioned.process_token(Token::Text("A &amp; B".to_string()));
+        unpositioned.process_token(Token::EndTag {
+            name: "title".to_string(),
         });
         assert_eq!(
             unpositioned


### PR DESCRIPTION
## Summary
- attach `unexpected-head-content-start-tag-in-table` for authored `title` starts to the tokenizer emission point exactly once
- preserve foster-parented RCDATA parsing, DOM/open-element state, malformed and incomplete end-tag recovery, and adjacent diagnostics
- cover document and seeded-fragment table structures, controls, CRLF/non-ASCII positions, and unpositioned plain tokens

## Validation
- `cargo test --manifest-path code/packages/rust/html-parser/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/html-lexer/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/state-machine-tokenizer/Cargo.toml -q`
- `cargo clippy --manifest-path code/packages/rust/html-parser/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path code/packages/rust/html-parser/Cargo.toml --no-deps`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 -m unittest discover -s code/packages/rust/html-parser/tests/fixtures -p "test_html_conformance_coverage_audit.py"`
- live WPT/html5lib audit: 1,936 tree cases and 6,806 tokenizer cases; zero missing signatures and zero normalized skips