### PR TITLE
fix(html-parser): position table hidden inputs

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5641,10 +5641,13 @@ impl HtmlParser {
             if attribute_value(&attributes, "type")
                 .is_some_and(|value| value.eq_ignore_ascii_case("hidden"))
             {
-                self.diagnostics.push(ParserDiagnostic::new(
-                    "unexpected-hidden-input-start-tag-in-table",
-                    "hidden input start tag in a table context was inserted with a parse error",
-                ));
+                self.diagnostics.push(
+                    ParserDiagnostic::new(
+                        "unexpected-hidden-input-start-tag-in-table",
+                        "hidden input start tag in a table context was inserted with a parse error",
+                    )
+                    .at_emission(self.current_token_emission_position),
+                );
                 self.append_node(Node::element(name, attributes));
             } else {
                 self.diagnostics.push(ParserDiagnostic::new(
@@ -27076,6 +27079,14 @@ mod tests {
         .at_emission(Some(start_tag_position(source, "title")))
     }
 
+    fn hidden_input_start_tag_in_table_recovery(source: &str) -> ParserDiagnostic {
+        ParserDiagnostic::new(
+            "unexpected-hidden-input-start-tag-in-table",
+            "hidden input start tag in a table context was inserted with a parse error",
+        )
+        .at_emission(Some(start_tag_position(source, "input")))
+    }
+
     fn generic_foreign_end_tag_mismatch(source: &str, name: &str) -> ParserDiagnostic {
         ParserDiagnostic::new(
             "unexpected-end-tag-in-foreign-content",
@@ -35272,12 +35283,11 @@ mod tests {
         assert_eq!(replacement.name, "table");
         assert_eq!(element_text_content(replacement), "X");
 
-        let hidden =
-            parse_html_with_diagnostics("<!doctype html><table><input type=hidden>").unwrap();
-        assert!(hidden
+        let input = parse_html_with_diagnostics("<!doctype html><table><input type=text>").unwrap();
+        assert!(input
             .parser_diagnostics
             .iter()
-            .filter(|diagnostic| diagnostic.code == "unexpected-hidden-input-start-tag-in-table")
+            .filter(|diagnostic| diagnostic.code == "unexpected-input-start-tag-in-table")
             .all(|diagnostic| diagnostic.position.is_none()));
 
         let mut unpositioned = HtmlParser::with_fragment_context_options(
@@ -35442,8 +35452,8 @@ mod tests {
 
         for (source, code) in [
             (
-                "<!doctype html><table><input type=hidden>",
-                "unexpected-hidden-input-start-tag-in-table",
+                "<!doctype html><table><input type=text>",
+                "unexpected-input-start-tag-in-table",
             ),
             (
                 "<!doctype html><table><b>",
@@ -41392,11 +41402,7 @@ mod tests {
             let output = parse_html_with_diagnostics(source).unwrap();
             assert!(
                 output.parser_diagnostics.iter().any(|diagnostic| {
-                    diagnostic
-                        == &ParserDiagnostic::new(
-                            "unexpected-hidden-input-start-tag-in-table",
-                            "hidden input start tag in a table context was inserted with a parse error",
-                        )
+                    diagnostic == &hidden_input_start_tag_in_table_recovery(source)
                 }),
                 "source {source:?}"
             );
@@ -41411,6 +41417,151 @@ mod tests {
                 diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
             }));
         }
+    }
+
+    #[test]
+    fn positions_hidden_input_start_tags_in_tables_at_token_emission() {
+        for source in [
+            "<!doctype html><table><input type=hidden>",
+            "<!doctype html><table><colgroup><input type=HIDDEN>",
+            "<!doctype html><table><tbody><input type=hidden>",
+            "<!doctype html><table><thead><input type=hidden>",
+            "<!doctype html><table><tfoot><input type=hidden>",
+            "<!doctype html><table><tbody><tr><input type=hidden>",
+            "<!doctype html><template><table><input type=hidden>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            let diagnostics = output
+                .parser_diagnostics
+                .iter()
+                .filter(|diagnostic| {
+                    diagnostic.code == "unexpected-hidden-input-start-tag-in-table"
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                diagnostics,
+                vec![&hidden_input_start_tag_in_table_recovery(source)],
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><input type=HiDdEn />",
+            "<!doctype html><table><input type=hidd&#x65;n>",
+            "<!doctype html><table><input type=hidden type=text>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic == &hidden_input_start_tag_in_table_recovery(source)
+                }),
+                "source {source:?}"
+            );
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "non-void-html-element-self-closing"
+            }));
+        }
+
+        for context in ["table", "tbody", "thead", "tfoot", "tr"] {
+            let source = "<!--é-->\r\n<input type=hidden data-name='é'>";
+            let output =
+                parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(source.len() > source.chars().count());
+            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+                diagnostic == &hidden_input_start_tag_in_table_recovery(source)
+            }));
+            let input = find_first_element_in_nodes(&output.nodes, "input").unwrap();
+            assert_eq!(input.attribute("type"), Some("hidden"));
+            assert_eq!(input.attribute("data-name"), Some("é"));
+        }
+
+        for (source, context) in [
+            ("<input type=hidden>", "caption"),
+            ("<input type=hidden>", "colgroup"),
+            ("<input type=hidden>", "td"),
+            ("<input type=hidden>", "th"),
+            ("<input type=hidden>", "template"),
+            ("<input type=hidden>", "html body"),
+        ] {
+            let output =
+                parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
+            }));
+        }
+
+        for source in [
+            "<!doctype html><table><caption><input type=hidden>",
+            "<!doctype html><table><tbody><tr><td><input type=hidden>",
+            "<!doctype html><table><tbody><tr><th><input type=hidden>",
+            "<!doctype html><table><select><input type=hidden>",
+            "<!doctype html><template><div><input type=hidden>",
+            "<!doctype html><table><div><input type=hidden>",
+            "<!doctype html><table><input type=hidden",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().all(|diagnostic| {
+                    diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
+                }),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><input>",
+            "<!doctype html><table><input type=>",
+            "<!doctype html><table><input type=' hidden'>",
+            "<!doctype html><table><input type=text type=hidden>",
+            "<!doctype html><table><input type=hidden/>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
+            }));
+            let companion = output
+                .parser_diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.code == "unexpected-input-start-tag-in-table")
+                .unwrap();
+            assert_eq!(companion.position, None, "source {source:?}");
+        }
+
+        let state_source = "<!doctype html><main><table><input id=marker type=hidden><tbody><tr><td>X</table></main>";
+        let state = parse_html_with_diagnostics(state_source).unwrap();
+        let main = find_first_element_in_nodes(&state.document.children, "main").unwrap();
+        let table = element(&main.children[0]);
+        assert_eq!(table.name, "table");
+        let input = element(&table.children[0]);
+        assert_eq!(input.name, "input");
+        assert_eq!(input.attribute("id"), Some("marker"));
+        assert!(input.children.is_empty());
+        assert_eq!(element(&table.children[1]).name, "tbody");
+        assert_eq!(element_text_content(table), "X");
+
+        let mut unpositioned = HtmlParser::with_fragment_context_options(
+            HtmlParseOptions::default(),
+            "table",
+        );
+        unpositioned.process_token(Token::StartTag {
+            name: "input".to_string(),
+            attributes: vec![LexerAttribute {
+                name: "type".to_string(),
+                value: "hidden".to_string(),
+            }],
+            self_closing: false,
+        });
+        assert_eq!(
+            unpositioned
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| {
+                    diagnostic.code == "unexpected-hidden-input-start-tag-in-table"
+                })
+                .unwrap()
+                .position,
+            None
+        );
     }
 
     #[test]
@@ -42185,14 +42336,13 @@ mod tests {
         assert_eq!(table.name, "table");
         assert_eq!(element_text_content(table), "X");
 
-        let hidden =
-            parse_html_with_diagnostics("<!doctype html><table><input type=hidden>").unwrap();
-        let hidden_diagnostic = hidden
+        let input = parse_html_with_diagnostics("<!doctype html><table><input type=text>").unwrap();
+        let input_diagnostic = input
             .parser_diagnostics
             .iter()
-            .find(|diagnostic| diagnostic.code == "unexpected-hidden-input-start-tag-in-table")
+            .find(|diagnostic| diagnostic.code == "unexpected-input-start-tag-in-table")
             .unwrap();
-        assert_eq!(hidden_diagnostic.position, None);
+        assert_eq!(input_diagnostic.position, None);
 
         let mut unpositioned = HtmlParser::with_fragment_context_options(
             HtmlParseOptions::default(),


### PR DESCRIPTION
## Summary
- attach `unexpected-hidden-input-start-tag-in-table` to the authored input start tag tokenizer emission point
- preserve hidden-input table insertion and void-element state across document and seeded fragment contexts
- keep non-hidden input and adjacent table diagnostics independently unpositioned

## Validation
- full Rust HTML parser, browser-readiness, lexer, and tokenizer test matrix
- Clippy with warnings denied and rustdoc with warnings denied
- all 22 focused parser audit indexes and fixture metadata checks
- live WPT/html5lib coverage: 1,936 tree cases and 6,806 tokenizer cases, zero missing signatures and zero normalized skips