### PR TITLE
Add bounded Matter operational discovery

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1014,6 +1014,7 @@ members = [
     "smart-home-homekit-discovery-integration",
     "smart-home-ipp-printer-discovery-integration",
     "smart-home-ipp-scanner-discovery-integration",
+    "smart-home-matter-operational-discovery-integration",
     "smart-home-thread-border-agent-discovery-integration",
     "smart-home-enphase-envoy-integration",
     "smart-home-airgradient-local-integration",

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ## Unreleased
 
+- Add a first-party bounded Matter `_matter._tcp` operational discovery entry
+  while keeping commissionable discovery, fabric credentials, secure sessions,
+  Interaction Model traffic, and control out of scope.
 - Record AirGradient's exact-consent, readback-verified credential-free MQTT
   broker and coupled custom HTTPS-domain controls.
 - Add the reusable data-governance primitive family and require it for

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -44928,6 +44928,7 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         ipp_printer_entry(),
         ipp_scanner_entry(),
         thread_border_agent_entry(),
+        matter_operational_discovery_entry(),
         protocol_entry(
             "matter",
             "Matter",
@@ -49265,6 +49266,54 @@ fn thread_border_agent_entry() -> IntegrationCatalogEntry {
         label: "Thread Border Router white paper".to_string(),
         url: "https://www.threadgroup.org/Portals/0/documents/support/ThreadBorderRouterWhitePaper_07192022_4001_1.pdf".to_string(),
         external_id: None,
+    });
+    entry
+}
+
+fn matter_operational_discovery_entry() -> IntegrationCatalogEntry {
+    let mut entry = base_entry(
+        "matter_operational_discovery",
+        "Matter Operational Discovery",
+        "Bounded DNS-SD discovery for commissioned Matter nodes on the local infrastructure link.",
+        IntegrationCategory::ProtocolStandard,
+        ConnectivityClass::LocalPolling,
+        ImplementationStatus::FirstPartyRuntime,
+        1,
+        "matter",
+    )
+    .with_protocols(vec![ProtocolFamily::Matter])
+    .with_capabilities(&["smart_home.read"])
+    .with_entities(&[])
+    .with_discovery(&[DiscoveryMechanism::Mdns])
+    .with_auth(&[AuthMode::None])
+    .with_notes(&[
+        "The first-party runtime supports only authorized bounded _matter._tcp operational identity, endpoint, MRP, TCP-capability, and ICD discovery.",
+        "Commissionable discovery, fabric credentials, PASE, CASE, certificate validation, secure sessions, Interaction Model traffic, and control remain out of scope.",
+    ]);
+    entry.required_primitives = vec![
+        PrimitiveFamily::DiscoveryIndex,
+        PrimitiveFamily::Mdns,
+        PrimitiveFamily::NormalizedModel,
+        PrimitiveFamily::CapabilityPolicy,
+        PrimitiveFamily::Supervision,
+        PrimitiveFamily::TestSimulator,
+    ];
+    entry.source_refs.push(SourceReference {
+        label: "Matter DNS-SD service naming".to_string(),
+        url: "https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/ServiceNaming.h".to_string(),
+        external_id: Some("_matter._tcp".to_string()),
+    });
+    entry.source_refs.push(SourceReference {
+        label: "Matter operational instance-name parsing".to_string(),
+        url: "https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/ServiceNaming.cpp".to_string(),
+        external_id: Some("ExtractIdFromInstanceName".to_string()),
+    });
+    entry.source_refs.push(SourceReference {
+        label: "Matter DNS-SD TXT field bounds".to_string(),
+        url:
+            "https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/TxtFields.h"
+                .to_string(),
+        external_id: Some("CommonTxtKey".to_string()),
     });
     entry
 }
@@ -82346,6 +82395,47 @@ mod tests {
             PrimitiveFamily::VaultLease,
         ] {
             assert!(!thread.required_primitives.contains(&primitive));
+        }
+    }
+
+    #[test]
+    fn matter_operational_entry_exposes_bounded_mdns_discovery_only_runtime() {
+        let catalog = first_party_catalog();
+        let matter = find_entry(
+            &catalog,
+            &IntegrationId::trusted("matter_operational_discovery"),
+        )
+        .unwrap();
+        assert_eq!(
+            matter.implementation_status,
+            ImplementationStatus::FirstPartyRuntime
+        );
+        assert_eq!(matter.connectivity, ConnectivityClass::LocalPolling);
+        assert_eq!(matter.auth_modes, vec![AuthMode::None]);
+        assert_eq!(matter.supported_protocols, vec![ProtocolFamily::Matter]);
+        assert_eq!(
+            matter.required_capabilities,
+            vec![CapabilityId::trusted("smart_home.read")]
+        );
+        assert!(matter.target_entity_kinds.is_empty());
+        for primitive in [
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::Mdns,
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+            PrimitiveFamily::TestSimulator,
+        ] {
+            assert!(matter.required_primitives.contains(&primitive));
+        }
+        for primitive in [
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::MatterCommissioning,
+            PrimitiveFamily::CertificatePairing,
+            PrimitiveFamily::Tcp,
+            PrimitiveFamily::VaultLease,
+        ] {
+            assert!(!matter.required_primitives.contains(&primitive));
         }
     }
 

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/BUILD
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-matter-operational-discovery-integration -- --nocapture

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add authorized, bounded `_matter._tcp.local` operational discovery with
+  strict compressed-fabric-id, node-id, endpoint, MRP, TCP-support, and ICD
+  checks.
+- Normalize verified commissioned-node candidates into D23 without browsing
+  commissionable services, accepting fabric credentials, opening a secure
+  session, reading attributes, subscribing, or exposing control.

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "smart-home-matter-operational-discovery-integration"
+version = "0.1.0"
+edition = "2021"
+description = "Authorized bounded Matter operational DNS-SD discovery for Smart Home"
+license = "MIT"
+
+[dependencies]
+serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+
+[[bin]]
+name = "smart-home-matter-operational-discovery-integration"
+path = "src/main.rs"

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/README.md
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/README.md
@@ -1,0 +1,25 @@
+# smart-home-matter-operational-discovery-integration
+
+This package discovers commissioned Matter nodes through the official
+`_matter._tcp.local` operational DNS-SD service. It reuses the production Smart
+Home mDNS scanner, strictly validates the compressed fabric id and node id in
+the service instance, validates resolved endpoints, and normalizes optional
+MRP, TCP-support, and intermittently-connected-device TXT data into verified
+D23 discovery candidates after authorization.
+
+Discovery does not browse the commissionable `_matterc._udp` service, open the
+advertised endpoint, or accept fabric credentials. It performs no PASE, CASE,
+certificate validation, fabric membership check, Interaction Model read,
+subscription, command, or control. Those operations require separate supervised
+commissioning, secret-custody, secure-session, and operation-policy owners.
+
+Official references:
+
+- <https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/ServiceNaming.h>
+- <https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/ServiceNaming.cpp>
+- <https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/TxtFields.h>
+- <https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/Types.h>
+
+```sh
+cargo run -p smart-home-matter-operational-discovery-integration -- discover
+```

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/src/lib.rs
@@ -1,0 +1,760 @@
+//! Authorized bounded Matter operational DNS-SD discovery for D23.
+
+#![forbid(unsafe_code)]
+
+use smart_home_core::{AgentId, BridgeTransport, IntegrationId, ProtocolFamily, SmartHomeTool};
+use smart_home_discovery::{
+    run_mdns_ipv4_scan, DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource,
+    DiscoveryUpsert, MdnsAdvertisement, MdnsScanOptions, MdnsScanResult, PairingRequirement,
+};
+use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::Duration;
+
+pub const VERSION: &str = "0.1.0";
+pub const INTEGRATION_ID: &str = "matter_operational_discovery";
+pub const MDNS_SERVICE_TYPE: &str = "_matter._tcp.local";
+pub const MAX_RESPONSES: usize = 64;
+const MAX_HOST_BYTES: usize = 253;
+const MAX_MRP_INTERVAL_MS: u64 = 3_600_000;
+const TCP_CLIENT_FLAG: u8 = 1 << 1;
+const TCP_SERVER_FLAG: u8 = 1 << 2;
+const SUPPORTED_TCP_FLAGS: u8 = TCP_CLIENT_FLAG | TCP_SERVER_FLAG;
+
+#[derive(Debug)]
+pub enum MatterOperationalDiscoveryError {
+    Validation(String),
+    Discovery(DiscoveryError),
+    Runtime(RuntimeError),
+}
+
+impl fmt::Display for MatterOperationalDiscoveryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(message) => {
+                write!(formatter, "invalid Matter operational discovery: {message}")
+            }
+            Self::Discovery(error) => error.fmt(formatter),
+            Self::Runtime(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for MatterOperationalDiscoveryError {}
+
+impl From<DiscoveryError> for MatterOperationalDiscoveryError {
+    fn from(error: DiscoveryError) -> Self {
+        Self::Discovery(error)
+    }
+}
+
+impl From<RuntimeError> for MatterOperationalDiscoveryError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatterOperationalDiscoveryConfig {
+    pub timeout: Duration,
+    pub maximum_responses: usize,
+    pub record_ttl: Duration,
+}
+
+impl Default for MatterOperationalDiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(2),
+            maximum_responses: 32,
+            record_ttl: Duration::from_secs(300),
+        }
+    }
+}
+
+impl MatterOperationalDiscoveryConfig {
+    pub fn validate(&self) -> Result<(), MatterOperationalDiscoveryError> {
+        if self.timeout.is_zero() {
+            return Err(MatterOperationalDiscoveryError::Validation(
+                "timeout must be non-zero".to_string(),
+            ));
+        }
+        if !(1..=MAX_RESPONSES).contains(&self.maximum_responses) {
+            return Err(MatterOperationalDiscoveryError::Validation(format!(
+                "maximum responses must be between 1 and {MAX_RESPONSES}"
+            )));
+        }
+        if self.record_ttl.is_zero() {
+            return Err(MatterOperationalDiscoveryError::Validation(
+                "record TTL must be non-zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn scan_options(&self, discovered_at_ms: u64) -> Result<MdnsScanOptions, DiscoveryError> {
+        Ok(
+            MdnsScanOptions::new(MDNS_SERVICE_TYPE, discovered_at_ms, self.timeout)?
+                .with_max_responses(self.maximum_responses),
+        )
+    }
+}
+
+pub trait MatterOperationalMdnsTransport {
+    fn scan(
+        &mut self,
+        options: MdnsScanOptions,
+    ) -> Result<MdnsScanResult, MatterOperationalDiscoveryError>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UdpMatterOperationalMdnsTransport;
+
+impl MatterOperationalMdnsTransport for UdpMatterOperationalMdnsTransport {
+    fn scan(
+        &mut self,
+        options: MdnsScanOptions,
+    ) -> Result<MdnsScanResult, MatterOperationalDiscoveryError> {
+        Ok(run_mdns_ipv4_scan(options)?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatterOperationalDiscoveryReport {
+    pub records: Vec<DiscoveryRecord>,
+    pub failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MatterOperationalRuntimeCommitSummary {
+    pub inserted: usize,
+    pub replaced: usize,
+    pub ignored: usize,
+    pub failures: usize,
+}
+
+pub fn discover<T: MatterOperationalMdnsTransport>(
+    config: &MatterOperationalDiscoveryConfig,
+    transport: &mut T,
+    discovered_at_ms: u64,
+) -> Result<MatterOperationalDiscoveryReport, MatterOperationalDiscoveryError> {
+    config.validate()?;
+    let result = transport.scan(config.scan_options(discovered_at_ms)?)?;
+    if normalized_service_type(&result.service_type) != normalized_service_type(MDNS_SERVICE_TYPE) {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "scanner returned unexpected service type `{}`",
+            result.service_type
+        )));
+    }
+
+    let advertisement_count = result.advertisements.len();
+    let mut failures = result
+        .failures
+        .into_iter()
+        .map(|failure| match failure.source {
+            Some(source) => format!("invalid mDNS reply from {source}: {}", failure.message),
+            None => format!("invalid mDNS reply: {}", failure.message),
+        })
+        .collect::<Vec<_>>();
+    if advertisement_count > config.maximum_responses {
+        failures.push(format!(
+            "discarded {} Matter operational advertisements beyond the configured result limit",
+            advertisement_count - config.maximum_responses
+        ));
+    }
+    let ttl_ms = u64::try_from(config.record_ttl.as_millis()).unwrap_or(u64::MAX);
+    let expires_at_ms = discovered_at_ms.saturating_add(ttl_ms);
+    let mut records = BTreeMap::<String, DiscoveryRecord>::new();
+
+    for advertisement in result
+        .advertisements
+        .into_iter()
+        .take(config.maximum_responses)
+    {
+        match discovery_record(&advertisement, expires_at_ms) {
+            Ok(record) => match records.get(&record.native_bridge_id) {
+                Some(existing) if existing.address != record.address => failures.push(format!(
+                    "Matter node {} advertises conflicting endpoints `{}` and `{}`",
+                    record.native_bridge_id,
+                    existing.address.as_deref().unwrap_or(""),
+                    record.address.as_deref().unwrap_or("")
+                )),
+                Some(_) => {}
+                None => {
+                    records.insert(record.native_bridge_id.clone(), record);
+                }
+            },
+            Err(error) => failures.push(format!(
+                "invalid Matter operational advertisement `{}`: {error}",
+                advertisement.instance_name
+            )),
+        }
+    }
+
+    Ok(MatterOperationalDiscoveryReport {
+        records: records.into_values().collect(),
+        failures,
+    })
+}
+
+pub fn discover_into_runtime<T: MatterOperationalMdnsTransport>(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    config: &MatterOperationalDiscoveryConfig,
+    transport: &mut T,
+    now_ms: u64,
+) -> Result<MatterOperationalRuntimeCommitSummary, MatterOperationalDiscoveryError> {
+    let tool = SmartHomeTool::Discover;
+    let decision = runtime.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+    if !decision.missing_capabilities.is_empty() {
+        return Err(MatterOperationalDiscoveryError::Runtime(
+            RuntimeError::UnauthorizedTool {
+                principal_id,
+                tool,
+                missing_capabilities: decision.missing_capabilities,
+            },
+        ));
+    }
+
+    let report = discover(config, transport, now_ms)?;
+    let mut summary = MatterOperationalRuntimeCommitSummary {
+        failures: report.failures.len(),
+        ..MatterOperationalRuntimeCommitSummary::default()
+    };
+    for record in report.records {
+        match runtime.record_discovery(record)? {
+            DiscoveryUpsert::Inserted => summary.inserted += 1,
+            DiscoveryUpsert::Replaced(_) => summary.replaced += 1,
+            DiscoveryUpsert::Ignored(_) => summary.ignored += 1,
+        }
+    }
+    Ok(summary)
+}
+
+pub fn discovery_record(
+    advertisement: &MdnsAdvertisement,
+    expires_at_ms: u64,
+) -> Result<DiscoveryRecord, MatterOperationalDiscoveryError> {
+    if normalized_service_type(&advertisement.service_type)
+        != normalized_service_type(MDNS_SERVICE_TYPE)
+    {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "unexpected mDNS service type `{}`",
+            advertisement.service_type
+        )));
+    }
+    if advertisement.port == 0 {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "operational TCP port must be non-zero".to_string(),
+        ));
+    }
+    if advertisement.addresses.is_empty() {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "operational advertisement must resolve at least one IP address".to_string(),
+        ));
+    }
+    validate_host_name(&advertisement.host_name)?;
+
+    let (compressed_fabric_id, node_id) = parse_operational_instance(&advertisement.instance_name)?;
+    let idle_interval = optional_decimal(advertisement, "SII", 7, MAX_MRP_INTERVAL_MS, true)?;
+    let active_interval = optional_decimal(advertisement, "SAI", 7, MAX_MRP_INTERVAL_MS, true)?;
+    let active_threshold = optional_decimal(advertisement, "SAT", 5, u16::MAX.into(), false)?;
+    let tcp_flags =
+        optional_decimal(advertisement, "T", 1, u8::MAX.into(), true)?.unwrap_or(0) as u8;
+    if tcp_flags & !SUPPORTED_TCP_FLAGS != 0 {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "T contains reserved or unsupported TCP capability flags".to_string(),
+        ));
+    }
+    let icd = optional_boolean(advertisement, "ICD")?.unwrap_or(false);
+    let native_id = format!(
+        "fabric-{}-node-{}",
+        compressed_fabric_id.to_ascii_lowercase(),
+        node_id.to_ascii_lowercase()
+    );
+
+    let mut record = DiscoveryRecord::new(
+        IntegrationId::trusted(INTEGRATION_ID),
+        ProtocolFamily::Matter,
+        native_id,
+        DiscoverySource::Mdns,
+        BridgeTransport::LanTcp,
+        advertisement.discovered_at_ms,
+    )?
+    .with_display_name(advertisement.instance_name.to_ascii_uppercase())
+    .with_address(advertisement.endpoint_with_scheme("tcp"))
+    .with_confidence(DiscoveryConfidence::Verified)
+    .with_pairing_requirement(PairingRequirement::Credentials)
+    .with_expires_at_ms(expires_at_ms)
+    .with_metadata("smart_home.discovery.service_type", MDNS_SERVICE_TYPE)
+    .with_metadata("matter.compressed_fabric_id", &compressed_fabric_id)
+    .with_metadata("matter.node_id", &node_id)
+    .with_metadata(
+        "matter.tcp_client_supported",
+        (tcp_flags & TCP_CLIENT_FLAG != 0).to_string(),
+    )
+    .with_metadata(
+        "matter.tcp_server_supported",
+        (tcp_flags & TCP_SERVER_FLAG != 0).to_string(),
+    )
+    .with_metadata("matter.icd", icd.to_string());
+
+    for (key, value) in [
+        ("matter.mrp_idle_interval_ms", idle_interval),
+        ("matter.mrp_active_interval_ms", active_interval),
+        ("matter.mrp_active_threshold_ms", active_threshold),
+    ] {
+        if let Some(value) = value {
+            record = record.with_metadata(key, value.to_string());
+        }
+    }
+    Ok(record)
+}
+
+fn parse_operational_instance(
+    value: &str,
+) -> Result<(String, String), MatterOperationalDiscoveryError> {
+    if value.len() != 33 || value.as_bytes().get(16) != Some(&b'-') {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "instance must be 16 hexadecimal fabric-id digits, a hyphen, and 16 node-id digits"
+                .to_string(),
+        ));
+    }
+    let fabric = &value[..16];
+    let node = &value[17..];
+    if !fabric.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || !node.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "instance fabric id and node id must be hexadecimal".to_string(),
+        ));
+    }
+    Ok((fabric.to_ascii_uppercase(), node.to_ascii_uppercase()))
+}
+
+fn validate_host_name(value: &str) -> Result<(), MatterOperationalDiscoveryError> {
+    if value.is_empty()
+        || value.len() > MAX_HOST_BYTES
+        || value.chars().any(char::is_control)
+        || !value
+            .trim_end_matches('.')
+            .to_ascii_lowercase()
+            .ends_with(".local")
+    {
+        return Err(MatterOperationalDiscoveryError::Validation(
+            "host name must be bounded local DNS text without control characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn optional_txt<'a>(
+    advertisement: &'a MdnsAdvertisement,
+    key: &str,
+) -> Result<Option<&'a str>, MatterOperationalDiscoveryError> {
+    let mut matches = advertisement
+        .txt
+        .iter()
+        .filter(|entry| entry.key.eq_ignore_ascii_case(key));
+    let value = matches.next().map(|entry| entry.value.as_str());
+    if matches.next().is_some() {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "duplicate case-insensitive {key} TXT record"
+        )));
+    }
+    if value == Some("") {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "{key} TXT record must not be empty"
+        )));
+    }
+    Ok(value)
+}
+
+fn optional_decimal(
+    advertisement: &MdnsAdvertisement,
+    key: &str,
+    maximum_length: usize,
+    maximum: u64,
+    allow_zero: bool,
+) -> Result<Option<u64>, MatterOperationalDiscoveryError> {
+    optional_txt(advertisement, key)?
+        .map(|value| parse_decimal(value, key, maximum_length, maximum, allow_zero))
+        .transpose()
+}
+
+fn parse_decimal(
+    value: &str,
+    field: &str,
+    maximum_length: usize,
+    maximum: u64,
+    allow_zero: bool,
+) -> Result<u64, MatterOperationalDiscoveryError> {
+    if value.len() > maximum_length
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+        || (value.len() > 1 && value.starts_with('0'))
+    {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "{field} must be a canonical bounded unsigned decimal integer"
+        )));
+    }
+    let parsed = value.parse::<u64>().map_err(|_| {
+        MatterOperationalDiscoveryError::Validation(format!(
+            "{field} is outside its unsigned range"
+        ))
+    })?;
+    if parsed > maximum || (!allow_zero && parsed == 0) {
+        return Err(MatterOperationalDiscoveryError::Validation(format!(
+            "{field} is outside its permitted range"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn optional_boolean(
+    advertisement: &MdnsAdvertisement,
+    key: &str,
+) -> Result<Option<bool>, MatterOperationalDiscoveryError> {
+    optional_txt(advertisement, key)?
+        .map(|value| match value {
+            "0" => Ok(false),
+            "1" => Ok(true),
+            _ => Err(MatterOperationalDiscoveryError::Validation(format!(
+                "{key} must be 0 or 1"
+            ))),
+        })
+        .transpose()
+}
+
+fn normalized_service_type(value: &str) -> &str {
+    value.trim_end_matches('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use smart_home_discovery::{MdnsResponsePacket, MdnsScanFailure};
+    use std::net::UdpSocket;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    const INSTANCE: &str = "0123456789ABCDEF-1122334455667788";
+
+    #[derive(Debug)]
+    struct FakeTransport {
+        calls: Arc<AtomicUsize>,
+        result: MdnsScanResult,
+    }
+
+    impl MatterOperationalMdnsTransport for FakeTransport {
+        fn scan(
+            &mut self,
+            options: MdnsScanOptions,
+        ) -> Result<MdnsScanResult, MatterOperationalDiscoveryError> {
+            assert_eq!(options.service_type, MDNS_SERVICE_TYPE);
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.result.clone())
+        }
+    }
+
+    fn advertisement(address: &str, instance: &str) -> MdnsAdvertisement {
+        MdnsAdvertisement::new(
+            MDNS_SERVICE_TYPE,
+            instance,
+            "matter-node.local",
+            5540,
+            1_000,
+        )
+        .unwrap()
+        .with_address(address)
+        .unwrap()
+        .with_txt("SII", "5000")
+        .unwrap()
+        .with_txt("SAI", "300")
+        .unwrap()
+        .with_txt("SAT", "4000")
+        .unwrap()
+        .with_txt("T", "6")
+        .unwrap()
+        .with_txt("ICD", "1")
+        .unwrap()
+    }
+
+    fn scan_result(advertisements: Vec<MdnsAdvertisement>) -> MdnsScanResult {
+        MdnsScanResult {
+            service_type: MDNS_SERVICE_TYPE.to_string(),
+            discovered_at_ms: 1_000,
+            datagram_count: advertisements.len(),
+            advertisements,
+            failures: Vec::new(),
+        }
+    }
+
+    fn grant(runtime: &mut SmartHomeRuntime, principal: &AgentId) {
+        let _ = runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant:matter-operational-discovery-test"),
+                principal.clone(),
+                PrivilegeTier::LowRisk,
+                "test",
+                0,
+            )
+            .with_expiry(20_000),
+        );
+    }
+
+    #[test]
+    fn validates_scan_bounds() {
+        let mut config = MatterOperationalDiscoveryConfig {
+            timeout: Duration::ZERO,
+            ..MatterOperationalDiscoveryConfig::default()
+        };
+        assert!(config.validate().is_err());
+        config.timeout = Duration::from_secs(1);
+        config.maximum_responses = 0;
+        assert!(config.validate().is_err());
+        config.maximum_responses = MAX_RESPONSES + 1;
+        assert!(config.validate().is_err());
+        config.maximum_responses = 1;
+        config.record_ttl = Duration::ZERO;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn normalizes_operational_identity_and_common_txt() {
+        let record = discovery_record(&advertisement("192.0.2.80", INSTANCE), 9_000).unwrap();
+        assert_eq!(
+            record.native_bridge_id,
+            "fabric-0123456789abcdef-node-1122334455667788"
+        );
+        assert_eq!(record.address.as_deref(), Some("tcp://192.0.2.80:5540"));
+        assert_eq!(record.confidence, DiscoveryConfidence::Verified);
+        assert_eq!(record.pairing_requirement, PairingRequirement::Credentials);
+        assert_eq!(record.expires_at_ms, Some(9_000));
+        for (key, value) in [
+            ("matter.compressed_fabric_id", "0123456789ABCDEF"),
+            ("matter.node_id", "1122334455667788"),
+            ("matter.mrp_idle_interval_ms", "5000"),
+            ("matter.mrp_active_interval_ms", "300"),
+            ("matter.mrp_active_threshold_ms", "4000"),
+            ("matter.tcp_client_supported", "true"),
+            ("matter.tcp_server_supported", "true"),
+            ("matter.icd", "true"),
+        ] {
+            assert!(record
+                .metadata
+                .iter()
+                .any(|item| item.key == key && item.value == value));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_operational_contract() {
+        assert!(discovery_record(&advertisement("192.0.2.80", "bad-instance"), 1).is_err());
+
+        let mut leading_zero = advertisement("192.0.2.80", INSTANCE);
+        leading_zero.txt.retain(|entry| entry.key != "SII");
+        leading_zero = leading_zero.with_txt("SII", "05000").unwrap();
+        assert!(discovery_record(&leading_zero, 1).is_err());
+
+        let mut invalid_flags = advertisement("192.0.2.80", INSTANCE);
+        invalid_flags.txt.retain(|entry| entry.key != "T");
+        invalid_flags = invalid_flags.with_txt("T", "1").unwrap();
+        assert!(discovery_record(&invalid_flags, 1).is_err());
+
+        let mut duplicate_case = advertisement("192.0.2.80", INSTANCE);
+        duplicate_case = duplicate_case.with_txt("sii", "6000").unwrap();
+        assert!(discovery_record(&duplicate_case, 1).is_err());
+
+        let mut unresolved = advertisement("192.0.2.80", INSTANCE);
+        unresolved.addresses.clear();
+        assert!(discovery_record(&unresolved, 1).is_err());
+    }
+
+    #[test]
+    fn deduplicates_identity_preserves_failures_and_caps_results() {
+        let mut result = scan_result(vec![
+            advertisement("192.0.2.80", INSTANCE),
+            advertisement("192.0.2.81", &INSTANCE.to_ascii_lowercase()),
+            advertisement("192.0.2.82", "FEDCBA9876543210-8877665544332211"),
+        ]);
+        result.failures.push(MdnsScanFailure {
+            source: Some("192.0.2.99:5353".to_string()),
+            message: "truncated DNS packet".to_string(),
+        });
+        let mut transport = FakeTransport {
+            calls: Arc::new(AtomicUsize::new(0)),
+            result,
+        };
+        let report = discover(
+            &MatterOperationalDiscoveryConfig {
+                maximum_responses: 2,
+                ..MatterOperationalDiscoveryConfig::default()
+            },
+            &mut transport,
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(report.records.len(), 1);
+        assert_eq!(
+            report.records[0].address.as_deref(),
+            Some("tcp://192.0.2.80:5540")
+        );
+        assert_eq!(report.failures.len(), 3);
+    }
+
+    #[test]
+    fn denies_before_transport_io() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut transport = FakeTransport {
+            calls: calls.clone(),
+            result: scan_result(Vec::new()),
+        };
+        let result = discover_into_runtime(
+            &mut SmartHomeRuntime::new(),
+            AgentId::trusted("agent:denied"),
+            &MatterOperationalDiscoveryConfig::default(),
+            &mut transport,
+            1_000,
+        );
+        assert!(matches!(
+            result,
+            Err(MatterOperationalDiscoveryError::Runtime(
+                RuntimeError::UnauthorizedTool { .. }
+            ))
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn live_loopback_packet_is_parsed_and_committed() {
+        struct LoopbackTransport;
+        impl MatterOperationalMdnsTransport for LoopbackTransport {
+            fn scan(
+                &mut self,
+                options: MdnsScanOptions,
+            ) -> Result<MdnsScanResult, MatterOperationalDiscoveryError> {
+                let receiver = UdpSocket::bind("127.0.0.1:0").unwrap();
+                receiver
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .unwrap();
+                let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+                sender
+                    .send_to(
+                        &matter_mdns_response_packet(),
+                        receiver.local_addr().unwrap(),
+                    )
+                    .unwrap();
+                let mut bytes = [0u8; 1500];
+                let (length, source) = receiver.recv_from(&mut bytes).unwrap();
+                Ok(MdnsScanResult::from_packets(
+                    options.service_type,
+                    options.discovered_at_ms,
+                    [MdnsResponsePacket::new(bytes[..length].to_vec())
+                        .with_source(source.to_string())],
+                )?)
+            }
+        }
+
+        let principal = AgentId::trusted("agent:matter-operational-discovery");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        let summary = discover_into_runtime(
+            &mut runtime,
+            principal,
+            &MatterOperationalDiscoveryConfig::default(),
+            &mut LoopbackTransport,
+            2_000,
+        )
+        .unwrap();
+        assert_eq!(summary.inserted, 1);
+        assert!(runtime
+            .registry()
+            .bridge(&smart_home_core::BridgeId::trusted(
+                "matter_operational_discovery.bridge.fabric-0123456789abcdef-node-1122334455667788"
+            ))
+            .is_some());
+    }
+
+    fn matter_mdns_response_packet() -> Vec<u8> {
+        let mut packet = Vec::new();
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 0x8400);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 1);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 3);
+
+        let instance = format!("{INSTANCE}.{MDNS_SERVICE_TYPE}");
+        encode_name(MDNS_SERVICE_TYPE, &mut packet);
+        push_record_header(&mut packet, 12);
+        let ptr_length = reserve_length(&mut packet);
+        encode_name(&instance, &mut packet);
+        fill_length(&mut packet, ptr_length);
+
+        encode_name(&instance, &mut packet);
+        push_record_header(&mut packet, 33);
+        let srv_length = reserve_length(&mut packet);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 5540);
+        encode_name("matter-node.local", &mut packet);
+        fill_length(&mut packet, srv_length);
+
+        encode_name(&instance, &mut packet);
+        push_record_header(&mut packet, 16);
+        let txt_length = reserve_length(&mut packet);
+        for (key, value) in [
+            ("SII", "5000"),
+            ("SAI", "300"),
+            ("SAT", "4000"),
+            ("T", "6"),
+            ("ICD", "1"),
+        ] {
+            push_txt(&mut packet, key, value);
+        }
+        fill_length(&mut packet, txt_length);
+
+        encode_name("matter-node.local", &mut packet);
+        push_record_header(&mut packet, 1);
+        let address_length = reserve_length(&mut packet);
+        packet.extend_from_slice(&[127, 0, 0, 1]);
+        fill_length(&mut packet, address_length);
+        packet
+    }
+
+    fn encode_name(name: &str, packet: &mut Vec<u8>) {
+        for label in name.trim_end_matches('.').split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0);
+    }
+
+    fn push_record_header(packet: &mut Vec<u8>, record_type: u16) {
+        push_u16(packet, record_type);
+        push_u16(packet, 1);
+        packet.extend_from_slice(&120u32.to_be_bytes());
+    }
+
+    fn reserve_length(packet: &mut Vec<u8>) -> usize {
+        let offset = packet.len();
+        push_u16(packet, 0);
+        offset
+    }
+
+    fn fill_length(packet: &mut [u8], offset: usize) {
+        let length = packet.len() - offset - 2;
+        packet[offset..offset + 2].copy_from_slice(&(length as u16).to_be_bytes());
+    }
+
+    fn push_txt(packet: &mut Vec<u8>, key: &str, value: &str) {
+        let entry = format!("{key}={value}");
+        packet.push(entry.len() as u8);
+        packet.extend_from_slice(entry.as_bytes());
+    }
+
+    fn push_u16(packet: &mut Vec<u8>, value: u16) {
+        packet.extend_from_slice(&value.to_be_bytes());
+    }
+}

--- a/code/packages/rust/smart-home-matter-operational-discovery-integration/src/main.rs
+++ b/code/packages/rust/smart-home-matter-operational-discovery-integration/src/main.rs
@@ -1,0 +1,48 @@
+use serde_json::json;
+use smart_home_matter_operational_discovery_integration::{
+    discover, MatterOperationalDiscoveryConfig, UdpMatterOperationalMdnsTransport,
+};
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("smart-home-matter-operational-discovery-integration: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments = env::args().skip(1).collect::<Vec<_>>();
+    if arguments.as_slice() != ["discover"] {
+        return Err(
+            "usage: smart-home-matter-operational-discovery-integration discover".to_string(),
+        );
+    }
+    let report = discover(
+        &MatterOperationalDiscoveryConfig::default(),
+        &mut UdpMatterOperationalMdnsTransport,
+        0,
+    )
+    .map_err(|error| error.to_string())?;
+    println!(
+        "{}",
+        json!({
+            "nodes": report.records.iter().map(|record| json!({
+                "native_bridge_id": record.native_bridge_id,
+                "display_name": record.display_name,
+                "address": record.address,
+                "pairing_requirement": record.pairing_requirement.as_str(),
+                "metadata": record.metadata.iter().map(|item| json!({
+                    "key": item.key,
+                    "value": item.value,
+                })).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+            "failures": report.failures,
+        })
+    );
+    Ok(())
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -2696,6 +2696,38 @@ radio transport, or a MeshCoP session:
 This broadens Thread infrastructure visibility while preserving the existing
 block on a production Thread network host and commissioning stack.
 
+## Current Matter Operational DNS-SD Discovery Breadth Slice
+
+The next breadth slice adds standards-based visibility into commissioned Matter
+nodes without claiming ownership of fabric credentials, secure sessions, or
+the Interaction Model:
+
+- `smart-home-matter-operational-discovery-integration` browses the Matter
+  `_matter._tcp.local` operational service through the shared production mDNS
+  scanner and strictly validates the 16-hex-digit compressed fabric id and
+  16-hex-digit node id encoded in each instance name, the resolved local host,
+  address, and non-zero endpoint port.
+- Optional common Matter TXT fields are parsed with the official canonical
+  decimal and range rules: MRP idle and active retry intervals, active
+  threshold, supported TCP client/server roles, and intermittently connected
+  device status. Case-insensitive duplicate fields, reserved TCP flags, and
+  malformed values remain isolated partial failures.
+- Fabric and node identity provide deterministic D23 candidate identity.
+  First observations win while conflicting endpoints and over-limit
+  advertisements are reported without discarding valid peers.
+- D23 discovery authorization runs before socket I/O. One browse accepts at
+  most 64 replies, uses a bounded timeout and record TTL, preserves parser
+  failures, and records only public DNS-SD facts.
+- The runtime does not browse `_matterc._udp` commissionable nodes, accept
+  fabric credentials, validate fabric membership, or open the advertised
+  endpoint. PASE, CASE, certificate validation, secure-session lifetime,
+  Interaction Model reads, subscriptions, commands, and control require
+  separately supervised commissioning, secret-custody, session, transport,
+  and operation-policy owners.
+
+This broadens Matter fabric visibility while preserving the existing block on
+a production commissioning and secure-session host.
+
 The protocol- and vendor-specific backlog below remains valid after these
 breadth steps:
 

--- a/code/specs/D23A-smart-home-integration-catalog.md
+++ b/code/specs/D23A-smart-home-integration-catalog.md
@@ -608,6 +608,7 @@ These should be implemented before most vendor-specific adapters:
 | `smart-home-ipp-printer-discovery-integration` | bounded `_ipp._tcp` mDNS printer UUID, resource path, authentication, TLS, model, location, document-format, color, duplex, and endpoint discovery with D23 candidate projection |
 | `smart-home-ipp-scanner-discovery-integration` | bounded `_scan._sub._ipp._tcp` mDNS scanner UUID, scan resource, authentication, TLS, model, location, document-format, feeder, transparency-adaptor, push-destination-scheme, and endpoint discovery with D23 candidate projection |
 | `smart-home-thread-border-agent-discovery-integration` | bounded `_meshcop._udp` mDNS Border Agent identity, Thread version, state bitmap, network, topology, vendor, and endpoint discovery with binary TXT preservation and D23 candidate projection |
+| `smart-home-matter-operational-discovery-integration` | bounded `_matter._tcp` DNS-SD commissioned-node fabric identity, node identity, endpoint, MRP, TCP-capability, and ICD discovery with D23 candidate projection |
 | `coap-protocol` and `smart-home-coap-integration` | bounded Confirmable GET framing and authorized read-only local CoAP scalar telemetry with strict text/JSON decoding |
 | `snmp-protocol` and `smart-home-snmp-integration` | strict bounded SNMPv2c GET framing and authorized read-only local OID telemetry with ephemeral shared-secret handling |
 | `nut-protocol` and `smart-home-nut-ups-integration` | strict bounded RFC 9271 `LIST VAR` framing and authorized anonymous read-only local UPS/PDU telemetry |


### PR DESCRIPTION
## Summary

- add authorized bounded `_matter._tcp.local` operational DNS-SD discovery through the shared production mDNS scanner and D23 runtime
- strictly normalize compressed fabric id, node id, resolved endpoint, MRP intervals, TCP roles, and ICD status with stable first-observation deduplication and partial-failure preservation
- register an honest discovery-only first-party catalog entry and update D23A plus the D18-D23 completion inventory

## Boundary

This opens no Matter endpoint and accepts no fabric credential. Commissionable `_matterc._udp` discovery, PASE, CASE, certificate validation, fabric membership checks, secure-session lifetime, Interaction Model reads, subscriptions, commands, public endpoints, and long-lived sockets remain out of scope.

## Validation

- 6 package tests, including live UDP loopback and deny-before-I/O
- 348 integration catalog tests
- strict Clippy for both changed Rust packages
- warning-free rustdoc for the new package
- new-package formatting and diff checks
- both package BUILD gates
- serialized affected build with 1,362 packages discovered, all 189 affected packages built, and 1,173 skipped

The successful affected build included the sparse worktree cross-language worker and complete fixture prerequisites. It passed before the final normal rebase over unrelated human-language and HTML-parser commits; focused tests, all catalog tests, strict Clippy, warning-free rustdoc, formatting, and diff checks passed on exact head `aa45b83c96367f6a3b53afa3fdf0b0fbbf66bedf`.
