### PR TITLE
human-languages: define official French A1 task shapes

### DIFF
--- a/code/learning/human-languages/french/task-shapes/a1.json
+++ b/code/learning/human-languages/french/task-shapes/a1.json
@@ -1,0 +1,340 @@
+{
+  "version": 1,
+  "language": "french",
+  "level": "A1",
+  "target": {
+    "name": "DELF A1 tout public",
+    "basis": "external"
+  },
+  "sources": [
+    {
+      "id": "fei-a1-overview",
+      "title": "DELF tout public - niveau A1",
+      "url": "https://www.france-education-international.fr/diplome/delf-tout-public/niveau-a1?langue=fr",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "fei-a1-candidate-manual",
+      "title": "Manuel du candidat DELF A1",
+      "url": "https://www.france-education-international.fr/document/manuel-candidat-delf-a1",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "fei-a1-examples",
+      "title": "Exemples de sujets - niveau A1",
+      "url": "https://france-education-international.fr/diplome/delf-tout-public/niveau-a1/exemples-sujets?langue=fr",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "fei-a1-speaking-demo",
+      "title": "DELF A1 tout public - document candidat, production orale",
+      "url": "https://www.france-education-international.fr/document/delf-dalf-a1-tp-candidat-ind-sujet-demo",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "fei-a1-speaking-grid",
+      "title": "DELF A1 - grille d'evaluation de la production orale",
+      "url": "https://www.france-education-international.fr/document/grille-po-a1",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 80,
+    "speakingMinutes": {
+      "minimum": 5,
+      "maximum": 7
+    },
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 10,
+    "deliveryModes": [
+      "paper and in-person speaking at an approved examination centre"
+    ]
+  },
+  "passRule": {
+    "maximumPoints": 100,
+    "passPoints": 50,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.2,
+      "listening": 0.2,
+      "writing": 0.2,
+      "speaking": 0.2
+    },
+    "note": "Each skill is worth 25 points. France Education international requires at least 50/100 overall and at least 5/25 in every skill; any skill below 5 is eliminatory. The 0.2 values transcribe that 5/25 floor, not the project's eventual stronger readiness standard."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 30,
+      "parts": [
+        {
+          "id": "reading-short-instruction",
+          "promptModes": ["written text", "optional image"],
+          "promptGenres": ["short email", "invitation card", "short personal message"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": ["marking or underlining on the exam paper"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "document word count", "response length for mixed selection and short-answer items", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "reading-orient-in-space",
+          "promptModes": ["written text", "map or image when supplied"],
+          "promptGenres": ["notice", "sign", "public-place directions"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": ["marking or underlining on the exam paper"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "document word count", "response length for mixed selection and short-answer items", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "reading-orient-in-time",
+          "promptModes": ["written text", "optional image"],
+          "promptGenres": ["instruction", "advertisement", "schedule information"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": ["marking or underlining on the exam paper"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "document word count", "response length for mixed selection and short-answer items", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "reading-short-informative-article",
+          "promptModes": ["written text", "optional image"],
+          "promptGenres": ["short informative article"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": ["marking or underlining on the exam paper"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "article word count", "response length for mixed selection and short-answer items", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        }
+      ],
+      "variants": [
+        {
+          "id": "reading-published-format-1",
+          "partIds": ["reading-short-instruction", "reading-orient-in-space", "reading-orient-in-time", "reading-short-informative-article"],
+          "note": "Official receptive format 1; question counts and document lengths differ from format 2 and remain uncollapsed.",
+          "sourceIds": ["fei-a1-examples", "fei-a1-candidate-manual"]
+        },
+        {
+          "id": "reading-published-format-2",
+          "partIds": ["reading-short-instruction", "reading-orient-in-space", "reading-orient-in-time", "reading-short-informative-article"],
+          "note": "Official receptive format 2; it preserves the same source-described purpose families with different questions and lengths.",
+          "sourceIds": ["fei-a1-examples", "fei-a1-candidate-manual"]
+        }
+      ]
+    },
+    {
+      "skill": "listening",
+      "minutes": 20,
+      "parts": [
+        {
+          "id": "listening-voicemail",
+          "promptModes": ["recorded audio", "written questions", "optional images"],
+          "promptGenres": ["voicemail message"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "clip duration", "speech rate", "response length for mixed item modes", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "listening-public-announcement",
+          "promptModes": ["recorded audio", "written questions", "optional images"],
+          "promptGenres": ["public-place announcement", "radio announcement"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "clip duration", "speech rate", "response length for mixed item modes", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "listening-simple-instructions",
+          "promptModes": ["recorded audio", "written questions", "optional images"],
+          "promptGenres": ["simple everyday instructions"],
+          "responseModes": ["selected response", "short answer"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["per-format question count", "clip duration", "speech rate", "response length for mixed item modes", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "listening-mini-dialogues",
+          "promptModes": ["recorded audio", "image set"],
+          "promptGenres": ["four or five short everyday dialogues"],
+          "responseModes": ["match each dialogue to one of six images"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["whether the administered form has four or five dialogues", "clip duration", "speech rate", "response length is not applicable to image matching", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "listening-identify-objects",
+          "promptModes": ["recorded audio", "image set"],
+          "promptGenres": ["short descriptions of everyday objects"],
+          "responseModes": ["identify or match objects"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["item count", "clip duration", "speech rate", "response length is not applicable to image matching", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        }
+      ],
+      "variants": [
+        {
+          "id": "listening-four-exercise-format",
+          "partIds": ["listening-voicemail", "listening-public-announcement", "listening-simple-instructions", "listening-mini-dialogues"],
+          "note": "Four-exercise form published on the current A1 overview and described by the candidate manual.",
+          "sourceIds": ["fei-a1-overview", "fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "listening-five-exercise-format",
+          "partIds": ["listening-voicemail", "listening-public-announcement", "listening-simple-instructions", "listening-mini-dialogues", "listening-identify-objects"],
+          "note": "Five-exercise circulating form adds the officially published object-identification family.",
+          "sourceIds": ["fei-a1-candidate-manual", "fei-a1-examples"]
+        }
+      ]
+    },
+    {
+      "skill": "writing",
+      "minutes": 30,
+      "parts": [
+        {
+          "id": "writing-form",
+          "promptModes": ["written instructions", "personal-information form"],
+          "promptGenres": ["everyday form"],
+          "responseModes": ["write requested personal details into form fields"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["supply the requested information intelligibly"] },
+          "aids": { "allowed": ["pen"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["number of form fields", "scenario word count", "response length", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-overview", "fei-a1-candidate-manual", "fei-a1-examples"]
+        },
+        {
+          "id": "writing-personal-message",
+          "promptModes": ["written situation and content instructions"],
+          "promptGenres": ["postcard", "email", "short everyday personal message"],
+          "responseModes": ["continuous written message"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": { "unit": "words", "minimum": 40, "maximum": null, "approximate": false },
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": {
+            "maxRawPoints": null,
+            "criteria": ["respect the task and minimum length", "sociolinguistic appropriateness", "inform or describe", "lexicon and spelling", "morphosyntax", "cohesion"]
+          },
+          "aids": { "allowed": ["pen"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["maximum response length", "prompt word count", "replay is not applicable to written input", "part-level raw point ceiling"],
+          "sourceIds": ["fei-a1-overview", "fei-a1-candidate-manual", "fei-a1-examples"]
+        }
+      ]
+    },
+    {
+      "skill": "speaking",
+      "minutes": {
+        "minimum": 5,
+        "maximum": 7
+      },
+      "parts": [
+        {
+          "id": "speaking-directed-interview",
+          "promptModes": ["live examiner questions"],
+          "promptGenres": ["slow, reformulatable questions about self, family, preferences, and activities"],
+          "responseModes": ["live spoken answers about self"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": { "unit": "seconds", "minimum": 60, "maximum": 60, "approximate": true },
+          "interaction": "pair",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 4, "criteria": ["task fulfilment: directed interview"] },
+          "aids": { "allowed": [], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["question count", "question length", "repetition and reformulation count", "stimulus word count"],
+          "sourceIds": ["fei-a1-speaking-demo", "fei-a1-speaking-grid", "fei-a1-candidate-manual"]
+        },
+        {
+          "id": "speaking-information-exchange",
+          "promptModes": ["six drawn keyword cards", "live examiner responses"],
+          "promptGenres": ["familiar personal-information keywords"],
+          "responseModes": ["ask live questions prompted by the cards"],
+          "items": 6,
+          "stimulusLength": null,
+          "responseLength": { "unit": "seconds", "minimum": 120, "maximum": 120, "approximate": true },
+          "interaction": "pair",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 4, "criteria": ["task fulfilment: information exchange"] },
+          "aids": { "allowed": ["six exam-provided keyword cards", "ten-minute preparation shared with the role play"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["card word count", "response word count", "repetition policy", "stimulus length"] ,
+          "sourceIds": ["fei-a1-speaking-demo", "fei-a1-speaking-grid", "fei-a1-candidate-manual"]
+        },
+        {
+          "id": "speaking-simulated-dialogue",
+          "promptModes": ["two drawn role-play choices", "live examiner speech", "exam-provided product images and play money"],
+          "promptGenres": ["buying or ordering in an everyday service encounter"],
+          "responseModes": ["choose one role play", "ask for information", "state quantity", "choose and pay", "use greeting and courtesy forms"],
+          "items": 1,
+          "stimulusLength": null,
+          "responseLength": { "unit": "seconds", "minimum": 120, "maximum": 120, "approximate": true },
+          "interaction": "pair",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 4, "criteria": ["task fulfilment: simulated dialogue"] },
+          "aids": { "allowed": ["two exam-provided role-play choices", "exam-provided product images", "exam-provided play money", "ten-minute preparation shared with the information exchange"], "forbidden": ["dictionary", "phone"], "notPublished": ["other aids"] },
+          "notPublished": ["role-play prompt word count", "response word count", "repetition policy", "stimulus length"],
+          "sourceIds": ["fei-a1-speaking-demo", "fei-a1-speaking-grid", "fei-a1-candidate-manual"]
+        }
+      ]
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added - official DELF A1 four-skill target (#12237)
+
+- Inventory all four DELF A1 tout public skills from France Education
+  international's official overview, candidate manual, example formats, oral
+  candidate material and oral scoring grid.
+- Preserve the two circulating receptive forms, the published 5-7 minute oral
+  range, and the open-ended minimum 40-word writing task without inventing
+  counts, ceilings or lengths the official sources do not publish.
+- Record the real 50/100 aggregate pass mark and eliminatory 5/25 per-skill
+  floors. This defines the target; it does not claim the current French book is
+  ready for that exam.
+
 ### Changed - preserve open-ended published task lengths (#12241)
 
 - Allow a task length to carry only a minimum or only a maximum when that is all

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -104,6 +104,7 @@ import {
   loadTaskShapeInventory,
 } from "@coding-adventures/human-language-data";
 
+const frenchA1 = loadTaskShapeInventory("french", "A1");
 const germanA1 = loadTaskShapeInventory("german", "A1");
 const present = listTaskShapeInventories();
 const missing = buildTaskShapeBacklog(
@@ -112,9 +113,11 @@ const missing = buildTaskShapeBacklog(
 );
 ```
 
-The first inventory is official Goethe German A1. It is a target for later
-five-minute lesson decomposition and mocks, not a claim that the current German
-book is pass-ready.
+The first two inventories are official DELF French A1 and Goethe German A1.
+They are targets for later five-minute lesson decomposition and mocks, not claims
+that either current book is pass-ready. Alternate published DELF receptive forms,
+open-ended minimum lengths, and duration ranges remain distinct rather than being
+collapsed into invented single values.
 
 ### Source-bounded exam inventories (HL20)
 

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -3,6 +3,31 @@ import { loadLanguageRegistry, loadTaskShapeInventory, listTaskShapeInventories 
 import { buildTaskShapeBacklog, parseTaskShapeInventory } from "../src/task-shapes.js";
 
 describe("four-skill task-shape inventories (HL18)", () => {
+  it("loads the official French A1 performance target without flattening its forms", () => {
+    const inventory = loadTaskShapeInventory("french", "A1");
+    expect(inventory.target).toEqual({
+      name: "DELF A1 tout public",
+      basis: "external",
+    });
+    expect(inventory.sections.flatMap((section) => section.parts)).toHaveLength(14);
+    expect(inventory.administration.speakingMinutes).toEqual({ minimum: 5, maximum: 7 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.2, 0.2, 0.2, 0.2]);
+
+    const listening = inventory.sections.find((section) => section.skill === "listening");
+    expect(listening?.variants.map((variant) => variant.partIds.length)).toEqual([4, 5]);
+
+    const writing = inventory.sections.find((section) => section.skill === "writing");
+    expect(writing?.parts[1]?.responseLength).toEqual({
+      unit: "words",
+      minimum: 40,
+      maximum: null,
+      approximate: false,
+    });
+
+    const speaking = inventory.sections.find((section) => section.skill === "speaking");
+    expect(speaking?.parts.map((part) => part.scoring.maxRawPoints)).toEqual([4, 4, 4]);
+  });
+
   it("loads the official German A1 performance target", () => {
     const inventory = loadTaskShapeInventory("german", "A1");
     expect(inventory.target).toEqual({
@@ -25,9 +50,14 @@ describe("four-skill task-shape inventories (HL18)", () => {
     const registry = loadLanguageRegistry();
     const present = listTaskShapeInventories();
     const backlog = buildTaskShapeBacklog(registry.languages.map((track) => track.id), present);
-    expect(present).toEqual([{ language: "german", level: "A1" }]);
-    expect(backlog).toHaveLength(registry.languages.length * 6 - 1);
-    expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 1);
+    expect(present).toEqual([
+      { language: "french", level: "A1" },
+      { language: "german", level: "A1" },
+    ]);
+    expect(backlog).toHaveLength(registry.languages.length * 6 - 2);
+    expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 2);
+    expect(backlog.some((item) => item.id === "task-shape/french/A1")).toBe(false);
+    expect(backlog.some((item) => item.id === "task-shape/french/A2")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/german/A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/german/A2")).toBe(true);
   });


### PR DESCRIPTION
## Summary
- encode the official DELF A1 reading, listening, writing, and speaking task shapes from France Education international
- model bounded and open-ended task lengths without inventing false item counts
- pin the official 50/100 pass rule and 5/25 per-skill floor as the foundation for exam-ready lesson coverage
- add validator coverage for French A1 and document the new manifest

## Validation
- npm run build
- npm test -- tests/task-shapes.test.ts tests/integration.test.ts tests/gentle-ramp.test.ts tests/ramp.test.ts (55 passed)
- git diff --check origin/main...HEAD

Closes #12237