### PR TITLE
feat(jvm-zip): add portable raw RFC 1951 support

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 12283,
   "last_inventory": {
     "revision": "d6baf53b3ef32353fc8e4fcd9b8087349aad788e",
     "schema_version": 3,
@@ -3774,12 +3774,17 @@
     {
       "id": "zip-raw-rfc1951-jvm-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in the JVM lanes",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/jvm-zip-raw-rfc1951",
-      "pr_number": null,
+      "pr_number": 12283,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/12283",
+      "opened_at": "2026-08-20T14:52:55Z",
       "selection_revision": "993c78f1d65304f696cce4aeb765de40ac2f34cf",
       "selection_notes": "Selected only after .NET ZIP PR #12271 completed all 29 checks and auto-merged cleanly, the collision-checked schema-3 inventory was regenerated at exact main with unchanged topology and counts, and a fresh ownership audit found no active PR for any remaining ZIP parity surface. This Java/Kotlin pair is the sole remaining child of the ZIP raw-codec umbrella; completing it unlocks umbrella closure and fourteen dependent PNG parity slots. Both packages are pure in-memory codecs with local LZSS composite-build dependencies and explicit empty capabilities. The ancient no-PR cross-lane ZIP branch remains stale residue and will not be reused or cherry-picked; implementation is isolated on this fresh branch from merge main.",
+      "implementation_revision": "d66707e8e3dd94e9ece5b22461b58f9cc84b6056",
+      "validation_notes": "Java and Kotlin each consume all 34 neutral RFC 1951/CRC-32 cases and expose ZIP-owned raw deflate, counted caller-capped inflate, CRC-32, and the closed 14-code payload-blind failure taxonomy. Both decoders accept stored, fixed, dynamic, multi-block, foreign full-window, and historical-wrapper streams; enforce exact compressed-byte and declared-output consumption; reject suffix cavities, malformed canonical tables, invalid back-references, and ZIP size mismatches; map raw failures into IOException; and preflight Central Directory sizes against the caller's aggregate budget before decoding. The obsolete fixed-only decoder paths are removed. Under JDK 21.0.12 and Gradle 8.11.1, clean warning-failing package builds pass 17 Java tests at 93.12% line coverage and 31 Kotlin tests at 94.10% line coverage, both 80% JaCoCo gates, and both literal Windows BUILD front doors. The neutral fixture and capability suites pass 16 tests plus 719 subtests. Go build-tool tests, vet, and binary build pass; fresh diff-aware plans validate each lane and build only LZSS plus ZIP. The exact-main schema-3 parity gate reports 15 lanes, 1,367 identities, 4,551 slots, zero collisions, and zero unknown buckets; the 393-item state is unique, dependency-complete, acyclic, and has exactly this item active. Production authority and credential scans are clean, Jackson remains test-only, explicit empty capabilities remain accurate, final security review found no blocker, and git diff --check passes.",
+      "publication_notes": "Ready-for-review PR #12283 opened from fully validated implementation revision d66707e8e3 after clean rebases onto exact main d6baf53b3e. GitHub reports the branch mergeable with no conflict. CI and CodeQL checks are queued, so the loop is monitor-only and auto-merge remains disabled until every required check reaches an acceptable terminal conclusion.",
       "notes": "Portable Java and Kotlin child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 12271,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "6694384516b8bd2d2b7696daf2604fa5d0118d8f",
+    "revision": "d6baf53b3ef32353fc8e4fcd9b8087349aad788e",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1367,
@@ -3681,7 +3681,7 @@
     {
       "id": "zip-raw-rfc1951-dotnet-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in the .NET lanes",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
       "branch": "codex/dotnet-zip-raw-rfc1951",
       "pr_number": 12271,
@@ -3691,7 +3691,10 @@
       "selection_notes": "Selected only after external auto-merge completed Haskell ZIP PR #12234 and the collision-checked schema-3 inventory was regenerated at exact main with no topology or count change: 15 established lanes, 1,366 implementation identities, 4,550 established slots, 174 high-consensus packages with 271 gaps, 904 singletons with 12,656 gaps, 714 Rust singletons, zero collisions, and zero unknown buckets. The .NET C#/F# pair is the lowest-risk remaining dependency-ready ZIP child: both packages are pure in-memory codecs with local LZSS project references, explicit empty capabilities, real cross-platform dotnet test front doors, and the installed .NET 9.0.315 toolchain. It advances two lanes and leaves only the JVM pair before the ZIP umbrella and fourteen PNG slots can close. No open PR overlaps the target packages, state, roadmap, CMP09, or neutral fixture; the ancient no-PR cross-lane ZIP branch remains unowned residue and will not be reused or cherry-picked.",
       "implementation_revision": "fe37c45b438cb82664420f5ed5981e6b61ac343f",
       "validation_notes": "The C# and F# implementations consume all 34 neutral RFC 1951/CRC-32 cases, decode stored/fixed/dynamic/multi-block streams, expose counted caller-capped raw APIs with the closed 14-code payload-blind taxonomy, independently verify raw deflate with Python zlib, accept a foreign full-window stream, enforce exact ZIP payload and declared-size boundaries, map raw failures back into the historical InvalidDataException container contract, and apply the 256 MiB per-entry and aggregate ceilings. The superseded fixed-only decoders were removed so each lane has one canonical codec path. Under .NET 9.0.315 the exact Windows BUILD commands pass 30 C# tests at 91.84% line/77.89% branch coverage and 21 F# tests at 91.64% line/73.43% branch coverage; strict builds are warning-free, both 0.2.0 packages build, and both complete dependency graphs report no vulnerable packages. Fresh uncached Go build-tool plans validate and build C# LZSS/ZIP (2 of 199) and F# LZSS/ZIP (2 of 198); build-tool tests, vet, and binary build pass. The neutral fixture and capability suites pass 16 tests plus 719 subtests. The exact-main schema-3 parity gate reports 15 lanes, 1,367 identities, 4,551 slots, zero collisions, and zero unknown buckets; the 393-item state is unique, dependency-complete, acyclic, and has exactly this item in progress. Production authority and credential scans are clean, capability profiles remain explicitly empty, the Windows wrappers are repeatable and safely quote checkout-derived environment paths, and git diff --check passes.",
-      "publication_notes": "Ready-for-review PR #12271 opened from fully validated branch head 8ec90fa8ca after a clean rebase onto exact main 6694384516. GitHub reports the branch mergeable with no conflict; CI and CodeQL checks are queued, so the loop is monitor-only and auto-merge remains disabled until every required check reaches an acceptable terminal conclusion.",
+      "publication_notes": "Ready-for-review PR #12271 opened from fully validated branch head 8ec90fa8ca after a clean rebase onto exact main 6694384516. GitHub reported the branch mergeable with no conflict. The final reviewed head b3c4eac6b8020717fd8be985b933a5f2815efc27 completed all 29 reported checks with 23 successes and six expected skips; after every job became terminal and acceptable and GitHub still reported a clean merge, the loop enabled squash auto-merge. GitHub merged the PR without manual merge authority as 993c78f1d65304f696cce4aeb765de40ac2f34cf at 2026-08-20T14:10:41Z.",
+      "final_review_revision": "b3c4eac6b8020717fd8be985b933a5f2815efc27",
+      "merged_at": "2026-08-20T14:10:41Z",
+      "merge_revision": "993c78f1d65304f696cce4aeb765de40ac2f34cf",
       "notes": "Portable C# and F# child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {
@@ -3771,10 +3774,12 @@
     {
       "id": "zip-raw-rfc1951-jvm-lane-parity",
       "title": "Expose ZIP raw RFC 1951 conformance in the JVM lanes",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/jvm-zip-raw-rfc1951",
       "pr_number": null,
+      "selection_revision": "993c78f1d65304f696cce4aeb765de40ac2f34cf",
+      "selection_notes": "Selected only after .NET ZIP PR #12271 completed all 29 checks and auto-merged cleanly, the collision-checked schema-3 inventory was regenerated at exact main with unchanged topology and counts, and a fresh ownership audit found no active PR for any remaining ZIP parity surface. This Java/Kotlin pair is the sole remaining child of the ZIP raw-codec umbrella; completing it unlocks umbrella closure and fourteen dependent PNG parity slots. Both packages are pure in-memory codecs with local LZSS composite-build dependencies and explicit empty capabilities. The ancient no-PR cross-lane ZIP branch remains stale residue and will not be reused or cherry-picked; implementation is isolated on this fresh branch from merge main.",
       "notes": "Portable Java and Kotlin child of the ZIP raw-codec completion umbrella. Consume CMP09 and every closed zip-raw-rfc1951-v1 case, expose the ZIP-owned raw primitives without duplicating DEFLATE, preserve pure in-memory operation, and add explicit empty capability metadata."
     },
     {

--- a/code/packages/java/zip/CHANGELOG.md
+++ b/code/packages/java/zip/CHANGELOG.md
@@ -3,7 +3,31 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] — 2026-08-03
+## [Unreleased] — 2026-08-20
+
+### Added
+
+- Added the CMP09 portable raw RFC 1951 surface: `rawDeflate`, `rawInflate`,
+  `rawInflateCounted`, incremental `crc32`, exact consumed-byte reporting, a
+  caller-lowerable 256 MiB ceiling, and the closed 14-code payload-blind error
+  taxonomy.
+- Added all 34 language-neutral fixture cases, JDK raw-codec interoperability,
+  a foreign full-window stream, and strict ZIP boundary/aggregate-budget tests.
+
+### Changed
+
+- Method-8 ZIP reads now accept dynamic Huffman streams, reject trailing
+  compressed bytes and declared-size mismatches, and map typed raw failures to
+  the established `IOException` container contract.
+- Removed the superseded stored/fixed-only decoder so Java ZIP has one
+  canonical raw codec path. Package version is now 0.2.0.
+
+### Security
+
+- Replaced the boxed `List<Byte>` decoder output with a primitive, bounded
+  growable buffer that checks the caller limit before every append or
+  back-reference copy. One-shot unzip also enforces a configurable 256 MiB
+  aggregate output budget.
 
 ### Fixed
 

--- a/code/packages/java/zip/README.md
+++ b/code/packages/java/zip/README.md
@@ -46,7 +46,9 @@ The dual-header design supports two workflows:
 
 ```java
 import com.codingadventures.zip.Zip;
+import com.codingadventures.zip.RawRfc1951;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 // ── Write ──────────────────────────────────────────────────────────────────
@@ -71,6 +73,29 @@ byte[] zipped = Zip.zip(List.of(
 List<Zip.ZipEntry> entries = Zip.unzip(zipped);
 ```
 
+### Raw RFC 1951 and CRC-32
+
+ZIP owns the raw DEFLATE stream carried by method-8 entries. The public raw
+surface is also the canonical codec for sibling zlib, gzip, and PNG wrappers:
+
+```java
+byte[] encoded = RawRfc1951.rawDeflate(data);
+RawRfc1951.InflateResult decoded =
+    RawRfc1951.rawInflateCounted(encoded, 8 * 1024 * 1024);
+assert decoded.bytesConsumed() == encoded.length;
+assert Arrays.equals(data, decoded.output());
+
+long checksum = RawRfc1951.crc32(firstChunk);
+checksum = RawRfc1951.crc32(secondChunk, checksum);
+```
+
+`rawInflate` and `rawInflateCounted` accept stored, fixed-Huffman, and
+dynamic-Huffman blocks, multi-block streams, overlapping copies, and the full
+32 KiB distance window. The caller may lower the output ceiling; 256 MiB is
+both the default and hard maximum. Failures use the closed 14-code
+`RawInflateException` taxonomy from CMP09, and messages never include payload
+bytes, offsets, paths, counts, or partial output.
+
 ## Design decisions
 
 ### DEFLATE via LZSS
@@ -91,6 +116,10 @@ callers to pre-analyse their data.
 
 - **CRC-32 verification** on every read — corrupt data raises `IOException`.
 - **256 MB decompression limit** — guards against decompression bombs.
+- **Exact method-8 boundaries** — counted inflate must consume the complete
+  compressed payload and produce exactly the Central Directory size.
+- **256 MB aggregate unzip limit** — one-shot extraction also caps the sum of
+  all entry outputs; callers may lower it with `Zip.unzip(data, maxTotalBytes)`.
 - **LEN/NLEN validation** on stored DEFLATE blocks.
 - **Encryption rejection** — encrypted entries (GP flag bit 0) raise
   `IOException` rather than producing garbage.
@@ -108,6 +137,9 @@ gradle test
 Requires Java 21 and Gradle (or the Gradle wrapper from the parent repo).
 The `lzss` package is resolved via a Gradle composite build (`includeBuild`),
 so no separate install step is needed.
+
+The Gradle `check` task enforces JaCoCo line coverage above 80%. CRC-32 is an
+accidental-corruption checksum, not authentication or cryptographic integrity.
 
 ## Dependencies
 

--- a/code/packages/java/zip/build.gradle.kts
+++ b/code/packages/java/zip/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.codingadventures"
-version = "0.1.0"
+version = "0.2.0"
 
 repositories {
     mavenCentral()
@@ -21,6 +21,7 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     api("com.codingadventures:lzss")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/code/packages/java/zip/required_capabilities.json
+++ b/code/packages/java/zip/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "java/zip",
   "capabilities": [],
-  "justification": "Pure in-memory Java ZIP archive format implementation and tests."
+  "justification": "Pure in-memory Java ZIP, raw RFC 1951, and CRC-32 byte transforms; fixture reads and JDK interoperability oracles are test-only."
 }

--- a/code/packages/java/zip/src/main/java/com/codingadventures/zip/RawRfc1951.java
+++ b/code/packages/java/zip/src/main/java/com/codingadventures/zip/RawRfc1951.java
@@ -1,0 +1,359 @@
+package com.codingadventures.zip;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ZIP-owned raw RFC 1951 and CRC-32 primitives.
+ *
+ * <p>The API deliberately says {@code raw}: these streams contain no ZIP,
+ * zlib, or gzip framing. Production is a pure in-memory byte transform and
+ * owns no filesystem, process, network, environment, clock, entropy, FFI, or
+ * credential authority.</p>
+ */
+public final class RawRfc1951 {
+    /** Default and hard output ceiling: 256 MiB. */
+    public static final int MAX_OUTPUT = 256 * 1024 * 1024;
+
+    /** Complete payload-blind failure taxonomy, in fixture order. */
+    public static final List<String> ERROR_CODES = List.of(
+        "invalid-output-limit",
+        "unexpected-eof",
+        "reserved-block-type",
+        "stored-length-mismatch",
+        "huffman-oversubscribed",
+        "incomplete-code-length-tree",
+        "incomplete-literal-length-tree",
+        "incomplete-distance-tree",
+        "repeat-without-previous",
+        "repeat-overrun",
+        "invalid-literal-length-symbol",
+        "reserved-distance-symbol",
+        "invalid-back-reference",
+        "output-limit-exceeded"
+    );
+
+    private RawRfc1951() {}
+
+    /** A stable raw-inflate failure whose message contains only its code. */
+    public static final class RawInflateException extends IOException {
+        private final String code;
+
+        RawInflateException(String code) {
+            super(code);
+            this.code = code;
+        }
+
+        /** Return the stable portable failure identifier. */
+        public String code() {
+            return code;
+        }
+    }
+
+    /**
+     * Decoded bytes and the exact compressed byte count reached.
+     * The output array is newly allocated and owned by the caller.
+     */
+    public record InflateResult(byte[] output, int bytesConsumed) {}
+
+    /** Compress bytes as raw RFC 1951 without ZIP, zlib, or gzip framing. */
+    public static byte[] rawDeflate(byte[] data) throws IOException {
+        if (data == null) throw new NullPointerException("data");
+        return Zip.DeflateCompressor.compress(data);
+    }
+
+    /** Inflate raw RFC 1951 with the default 256 MiB ceiling. */
+    public static byte[] rawInflate(byte[] data) throws RawInflateException {
+        return rawInflate(data, MAX_OUTPUT);
+    }
+
+    /** Inflate raw RFC 1951 with a caller-lowerable output ceiling. */
+    public static byte[] rawInflate(byte[] data, int maxOutput) throws RawInflateException {
+        return rawInflateCounted(data, maxOutput).output();
+    }
+
+    /** Inflate and report the exact final compressed input byte reached. */
+    public static InflateResult rawInflateCounted(byte[] data, int maxOutput)
+            throws RawInflateException {
+        if (data == null) throw new NullPointerException("data");
+        return Inflater.inflate(data, maxOutput);
+    }
+
+    /** Compute incremental ZIP CRC-32, passing the previous result as initial. */
+    public static long crc32(byte[] data, long initial) {
+        if (data == null) throw new NullPointerException("data");
+        return Zip.Crc32.compute(data, initial) & 0xffffffffL;
+    }
+
+    /** Compute ZIP CRC-32 from the standard zero initial value. */
+    public static long crc32(byte[] data) {
+        return crc32(data, 0L);
+    }
+
+    private static final class Inflater {
+        private enum Completeness { CODE_LENGTH, LITERAL_LENGTH, DISTANCE }
+
+        private record Tables(HuffmanTable literalLength, HuffmanTable distance) {}
+
+        private static final class HuffmanTable {
+            private final Map<Integer, Integer>[] codesByLength;
+            private final int maximumLength;
+
+            HuffmanTable(Map<Integer, Integer>[] codesByLength, int maximumLength) {
+                this.codesByLength = codesByLength;
+                this.maximumLength = maximumLength;
+            }
+
+            int decode(Zip.BitReader reader) throws RawInflateException {
+                if (maximumLength == 0) fail("unexpected-eof");
+                int code = 0;
+                for (int length = 1; length <= maximumLength; length++) {
+                    int bit = reader.readLsb(1);
+                    if (bit < 0) fail("unexpected-eof");
+                    code = (code << 1) | bit;
+                    Integer symbol = codesByLength[length].get(code);
+                    if (symbol != null) return symbol;
+                }
+                return failResult("unexpected-eof");
+            }
+        }
+
+        private static final class OutputBuffer {
+            private final int maximum;
+            private byte[] data;
+            private int size;
+
+            OutputBuffer(int maximum) {
+                this.maximum = maximum;
+                this.data = new byte[Math.min(maximum, 8192)];
+            }
+
+            int size() {
+                return size;
+            }
+
+            void add(int value) throws RawInflateException {
+                ensure(1);
+                data[size++] = (byte) value;
+            }
+
+            void copy(int distance, int length) throws RawInflateException {
+                if (distance <= 0 || distance > size) fail("invalid-back-reference");
+                ensure(length);
+                for (int index = 0; index < length; index++) {
+                    data[size] = data[size - distance];
+                    size++;
+                }
+            }
+
+            void ensure(int additional) throws RawInflateException {
+                if (additional > maximum - size) fail("output-limit-exceeded");
+                int required = size + additional;
+                if (required <= data.length) return;
+                int doubled = data.length == 0 ? 1 : data.length * 2;
+                data = Arrays.copyOf(data, Math.min(maximum, Math.max(required, doubled)));
+            }
+
+            byte[] toArray() {
+                return Arrays.copyOf(data, size);
+            }
+        }
+
+        static InflateResult inflate(byte[] data, int maximumOutput)
+                throws RawInflateException {
+            if (maximumOutput < 0 || maximumOutput > MAX_OUTPUT) fail("invalid-output-limit");
+            Zip.BitReader reader = new Zip.BitReader(data);
+            OutputBuffer output = new OutputBuffer(maximumOutput);
+
+            while (true) {
+                int finalBlock = reader.readLsb(1);
+                int type = reader.readLsb(2);
+                if (finalBlock < 0 || type < 0) fail("unexpected-eof");
+                switch (type) {
+                    case 0 -> readStored(reader, output);
+                    case 1 -> {
+                        Tables tables = fixedTables();
+                        decodeCompressed(reader, output, tables.literalLength(), tables.distance());
+                    }
+                    case 2 -> {
+                        Tables tables = readDynamicTables(reader);
+                        decodeCompressed(reader, output, tables.literalLength(), tables.distance());
+                    }
+                    default -> fail("reserved-block-type");
+                }
+                if (finalBlock == 1) return new InflateResult(output.toArray(), reader.position());
+            }
+        }
+
+        private static void readStored(Zip.BitReader reader, OutputBuffer output)
+                throws RawInflateException {
+            reader.align();
+            int length = reader.readLsb(16);
+            int complement = reader.readLsb(16);
+            if (length < 0 || complement < 0) fail("unexpected-eof");
+            if (length != (complement ^ 0xffff)) fail("stored-length-mismatch");
+            output.ensure(length);
+            for (int index = 0; index < length; index++) {
+                int value = reader.readLsb(8);
+                if (value < 0) fail("unexpected-eof");
+                output.add(value);
+            }
+        }
+
+        private static Tables fixedTables() throws RawInflateException {
+            int[] literalLengths = new int[288];
+            Arrays.fill(literalLengths, 0, 144, 8);
+            Arrays.fill(literalLengths, 144, 256, 9);
+            Arrays.fill(literalLengths, 256, 280, 7);
+            Arrays.fill(literalLengths, 280, 288, 8);
+            int[] distanceLengths = new int[32];
+            Arrays.fill(distanceLengths, 5);
+            return new Tables(
+                buildHuffman(literalLengths, Completeness.LITERAL_LENGTH),
+                buildHuffman(distanceLengths, Completeness.DISTANCE));
+        }
+
+        private static Tables readDynamicTables(Zip.BitReader reader)
+                throws RawInflateException {
+            int literalCount = reader.readLsb(5);
+            int distanceCount = reader.readLsb(5);
+            int codeLengthCount = reader.readLsb(4);
+            if (literalCount < 0 || distanceCount < 0 || codeLengthCount < 0)
+                fail("unexpected-eof");
+            literalCount += 257;
+            distanceCount += 1;
+            codeLengthCount += 4;
+            if (literalCount > 286) fail("invalid-literal-length-symbol");
+
+            int[] order = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+            int[] codeLengths = new int[19];
+            for (int index = 0; index < codeLengthCount; index++) {
+                int length = reader.readLsb(3);
+                if (length < 0) fail("unexpected-eof");
+                codeLengths[order[index]] = length;
+            }
+            HuffmanTable codeLengthTable = buildHuffman(codeLengths, Completeness.CODE_LENGTH);
+
+            int total = literalCount + distanceCount;
+            int[] lengths = new int[total];
+            int count = 0;
+            while (count < total) {
+                int symbol = codeLengthTable.decode(reader);
+                if (symbol >= 0 && symbol <= 15) {
+                    lengths[count++] = symbol;
+                } else if (symbol == 16) {
+                    if (count == 0) fail("repeat-without-previous");
+                    int extra = reader.readLsb(2);
+                    if (extra < 0) fail("unexpected-eof");
+                    count = repeat(lengths, count, lengths[count - 1], extra + 3);
+                } else if (symbol == 17) {
+                    int extra = reader.readLsb(3);
+                    if (extra < 0) fail("unexpected-eof");
+                    count = repeat(lengths, count, 0, extra + 3);
+                } else if (symbol == 18) {
+                    int extra = reader.readLsb(7);
+                    if (extra < 0) fail("unexpected-eof");
+                    count = repeat(lengths, count, 0, extra + 11);
+                } else {
+                    fail("unexpected-eof");
+                }
+            }
+
+            int[] literalLengths = Arrays.copyOfRange(lengths, 0, literalCount);
+            int[] distanceLengths = Arrays.copyOfRange(lengths, literalCount, total);
+            if (literalLengths[256] == 0) fail("incomplete-literal-length-tree");
+            return new Tables(
+                buildHuffman(literalLengths, Completeness.LITERAL_LENGTH),
+                buildHuffman(distanceLengths, Completeness.DISTANCE));
+        }
+
+        private static int repeat(int[] target, int start, int value, int count)
+                throws RawInflateException {
+            if (count > target.length - start) fail("repeat-overrun");
+            Arrays.fill(target, start, start + count, value);
+            return start + count;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static HuffmanTable buildHuffman(int[] lengths, Completeness completeness)
+                throws RawInflateException {
+            int[] counts = new int[16];
+            for (int length : lengths) {
+                if (length > 15) fail("huffman-oversubscribed");
+                if (length > 0) counts[length]++;
+            }
+            int left = 1;
+            for (int length = 1; length <= 15; length++) {
+                left = left * 2 - counts[length];
+                if (left < 0) fail("huffman-oversubscribed");
+            }
+            int symbolCount = Arrays.stream(counts).sum();
+            if (left != 0) {
+                switch (completeness) {
+                    case CODE_LENGTH -> fail("incomplete-code-length-tree");
+                    case LITERAL_LENGTH -> fail("incomplete-literal-length-tree");
+                    case DISTANCE -> {
+                        if (symbolCount != 0 && !(symbolCount == 1 && counts[1] == 1))
+                            fail("incomplete-distance-tree");
+                    }
+                }
+            }
+
+            int[] nextCode = new int[16];
+            int code = 0;
+            for (int length = 1; length <= 15; length++) {
+                code = (code + counts[length - 1]) << 1;
+                nextCode[length] = code;
+            }
+            Map<Integer, Integer>[] tables = new Map[16];
+            for (int index = 0; index < tables.length; index++) tables[index] = new HashMap<>();
+            int maximumLength = 0;
+            for (int symbol = 0; symbol < lengths.length; symbol++) {
+                int length = lengths[symbol];
+                if (length == 0) continue;
+                tables[length].put(nextCode[length]++, symbol);
+                maximumLength = Math.max(maximumLength, length);
+            }
+            return new HuffmanTable(tables, maximumLength);
+        }
+
+        private static void decodeCompressed(
+                Zip.BitReader reader,
+                OutputBuffer output,
+                HuffmanTable literalLength,
+                HuffmanTable distance) throws RawInflateException {
+            while (true) {
+                int symbol = literalLength.decode(reader);
+                if (symbol >= 0 && symbol <= 255) {
+                    output.add(symbol);
+                } else if (symbol == 256) {
+                    return;
+                } else if (symbol >= 257 && symbol <= 285) {
+                    int[] lengthRow = Zip.DeflateTable.LENGTH[symbol - 257];
+                    int extraLength = reader.readLsb(lengthRow[1]);
+                    if (extraLength < 0) fail("unexpected-eof");
+                    int length = lengthRow[0] + extraLength;
+                    int distanceSymbol = distance.decode(reader);
+                    if (distanceSymbol >= 30) fail("reserved-distance-symbol");
+                    int[] distanceRow = Zip.DeflateTable.DIST[distanceSymbol];
+                    int extraDistance = reader.readLsb(distanceRow[1]);
+                    if (extraDistance < 0) fail("unexpected-eof");
+                    output.copy(distanceRow[0] + extraDistance, length);
+                } else {
+                    fail("invalid-literal-length-symbol");
+                }
+            }
+        }
+
+        private static void fail(String code) throws RawInflateException {
+            throw new RawInflateException(code);
+        }
+
+        private static <T> T failResult(String code) throws RawInflateException {
+            throw new RawInflateException(code);
+        }
+    }
+}

--- a/code/packages/java/zip/src/main/java/com/codingadventures/zip/Zip.java
+++ b/code/packages/java/zip/src/main/java/com/codingadventures/zip/Zip.java
@@ -360,27 +360,6 @@ public final class Zip {
         }
 
         /**
-         * Read {@code nbits} bits and bit-reverse the result.
-         *
-         * <p>Used when decoding Huffman codes, which are logically MSB-first.</p>
-         *
-         * @param nbits number of bits to read
-         * @return bit-reversed extracted value, or -1 on EOF
-         */
-        int readMsb(int nbits) {
-            int v = readLsb(nbits);
-            if (v < 0) return -1;
-            // Reverse the bottom nbits bits.
-            int rev = 0;
-            int u = v;
-            for (int i = 0; i < nbits; i++) {
-                rev = (rev << 1) | (u & 1);
-                u >>>= 1;
-            }
-            return rev;
-        }
-
-        /**
          * Discard partial-byte bits, aligning to the next byte boundary.
          *
          * <p>Required before reading stored-block length fields (RFC 1951 §3.2.4).</p>
@@ -391,6 +370,11 @@ public final class Zip {
                 buf >>>= discard;
                 bits -= discard;
             }
+        }
+
+        /** Exact number of source bytes fetched, including a partial final byte. */
+        int position() {
+            return pos;
         }
     }
 
@@ -410,7 +394,7 @@ public final class Zip {
     //
     // Distance codes: 5-bit codes equal to the code number (0–29).
 
-    /** Encode/decode helpers for the RFC 1951 fixed Huffman alphabet. */
+    /** Encoding helper for the RFC 1951 fixed Huffman alphabet. */
     static final class FixedHuffman {
 
         private FixedHuffman() {}
@@ -442,51 +426,6 @@ public final class Zip {
             }
         }
 
-        /**
-         * Decode one literal/length symbol from {@code br} using the fixed table.
-         *
-         * <p>Reads incrementally: 7 bits first (covers 256–279), then 8 bits
-         * (covers 0–143, 280–287), then 9 bits (covers 144–255).</p>
-         *
-         * @param br source bit reader
-         * @return decoded symbol (0–287), or -1 on EOF
-         */
-        static int decodeLL(BitReader br) {
-            // Try 7 bits first (covers symbols 256–279, codes 0–23).
-            int v7 = br.readMsb(7);
-            if (v7 < 0) return -1;
-
-            if (v7 <= 23) {
-                // 7-bit code → symbols 256–279 (EOB + length codes).
-                return v7 + 256;
-            }
-
-            // Need one more bit to reach 8-bit codes.
-            int extra1 = br.readLsb(1);
-            if (extra1 < 0) return -1;
-            int v8 = (v7 << 1) | extra1;
-
-            if (v8 >= 48 && v8 <= 191) {
-                // 8-bit codes: literals 0–143  (0x30 … 0xBF).
-                return v8 - 48;
-            }
-            if (v8 >= 192 && v8 <= 199) {
-                // 8-bit codes: symbols 280–287 (0xC0 … 0xC7).
-                return v8 + 88;
-            }
-
-            // Need one more bit for 9-bit codes (literals 144–255).
-            int extra2 = br.readLsb(1);
-            if (extra2 < 0) return -1;
-            int v9 = (v8 << 1) | extra2;
-
-            if (v9 >= 400 && v9 <= 511) {
-                // 9-bit codes: literals 144–255 (0x190 … 0x1FF).
-                return v9 - 256;
-            }
-
-            return -1; // malformed bit-stream
-        }
     }
 
     // =============================================================================
@@ -651,151 +590,6 @@ public final class Zip {
     }
 
     // =============================================================================
-    // RFC 1951 DEFLATE — Decompressor
-    // =============================================================================
-    //
-    // Handles stored blocks (BTYPE=00) and fixed Huffman blocks (BTYPE=01).
-    // Dynamic Huffman blocks (BTYPE=10) throw IOException — we only write
-    // BTYPE=01 ourselves, but stored blocks from other tools must be accepted.
-    //
-    // Security limits:
-    //   - Maximum output: 256 MB (decompression bomb guard)
-    //   - LEN/NLEN validation on stored blocks
-
-    /**
-     * Decompresses raw RFC 1951 DEFLATE bytes.
-     *
-     * <p>Security limits: output is capped at 256 MB to guard against
-     * decompression bombs.  LEN/NLEN fields on stored blocks are validated.</p>
-     */
-    static final class DeflateDecompressor {
-
-        /** Maximum allowed decompressed output size (decompression bomb guard). */
-        private static final int MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
-
-        private DeflateDecompressor() {}
-
-        /**
-         * Decompress raw DEFLATE bytes into the original data.
-         *
-         * @param data raw DEFLATE-compressed bytes
-         * @return decompressed bytes
-         * @throws IOException for corrupt or unsupported input
-         */
-        static byte[] decompress(byte[] data) throws IOException {
-            BitReader br = new BitReader(data);
-            List<Byte> output = new ArrayList<>();
-
-            while (true) {
-                int bfinal = br.readLsb(1);
-                if (bfinal < 0) throw new IOException("deflate: unexpected EOF reading BFINAL");
-                int btype = br.readLsb(2);
-                if (btype < 0) throw new IOException("deflate: unexpected EOF reading BTYPE");
-
-                if (btype == 0b00) {
-                    // ── Stored block ──────────────────────────────────────────
-                    // Align to byte boundary before reading the length fields.
-                    br.align();
-                    int len  = br.readLsb(16);
-                    int nlen = br.readLsb(16);
-                    if (len < 0) throw new IOException("deflate: EOF reading stored LEN");
-                    if (nlen < 0) throw new IOException("deflate: EOF reading stored NLEN");
-                    // RFC 1951 §3.2.4: NLEN must be the one's complement of LEN.
-                    if ((nlen ^ 0xFFFF) != len) {
-                        throw new IOException(
-                            "deflate: stored LEN/NLEN mismatch (" + len + " vs " + nlen + ")");
-                    }
-                    if (output.size() + len > MAX_OUTPUT_BYTES) {
-                        throw new IOException("deflate: output size limit exceeded");
-                    }
-                    for (int i = 0; i < len; i++) {
-                        int b = br.readLsb(8);
-                        if (b < 0) throw new IOException("deflate: EOF inside stored block");
-                        output.add((byte) b);
-                    }
-
-                } else if (btype == 0b01) {
-                    // ── Fixed Huffman block ───────────────────────────────────
-                    while (true) {
-                        int sym = FixedHuffman.decodeLL(br);
-                        if (sym < 0) throw new IOException("deflate: EOF decoding LL symbol");
-
-                        if (sym >= 0 && sym <= 255) {
-                            if (output.size() >= MAX_OUTPUT_BYTES) {
-                                throw new IOException("deflate: output size limit exceeded");
-                            }
-                            output.add((byte) sym);
-
-                        } else if (sym == 256) {
-                            // End-of-block: leave the inner loop.
-                            break;
-
-                        } else if (sym >= 257 && sym <= 285) {
-                            // Back-reference: decode length then distance.
-                            int idx = sym - 257;
-                            if (idx >= DeflateTable.LENGTH.length) {
-                                throw new IOException("deflate: invalid length sym " + sym);
-                            }
-
-                            int baseLen = DeflateTable.LENGTH[idx][0];
-                            int extraLenBits = DeflateTable.LENGTH[idx][1];
-                            int extraLen = (extraLenBits > 0) ? br.readLsb(extraLenBits) : 0;
-                            if (extraLen < 0) throw new IOException("deflate: EOF reading length extra");
-                            int matchLen = baseLen + extraLen;
-
-                            // Distance code is always 5 bits, read MSB-first.
-                            int distCode = br.readMsb(5);
-                            if (distCode < 0) throw new IOException("deflate: EOF reading distance code");
-                            if (distCode >= DeflateTable.DIST.length) {
-                                throw new IOException("deflate: invalid dist code " + distCode);
-                            }
-
-                            int baseDist = DeflateTable.DIST[distCode][0];
-                            int extraDistBits = DeflateTable.DIST[distCode][1];
-                            int extraDist = (extraDistBits > 0) ? br.readLsb(extraDistBits) : 0;
-                            if (extraDist < 0) throw new IOException("deflate: EOF reading distance extra");
-                            int offset = baseDist + extraDist;
-
-                            if (offset > output.size()) {
-                                throw new IOException(
-                                    "deflate: back-ref offset " + offset +
-                                    " > output len " + output.size());
-                            }
-                            if (output.size() + matchLen > MAX_OUTPUT_BYTES) {
-                                throw new IOException("deflate: output size limit exceeded");
-                            }
-
-                            // Copy byte-by-byte to handle overlapping matches.
-                            // Example: offset=1, length=4 expands one byte into a run of 4.
-                            for (int i = 0; i < matchLen; i++) {
-                                output.add(output.get(output.size() - offset));
-                            }
-
-                        } else {
-                            throw new IOException("deflate: invalid LL symbol " + sym);
-                        }
-                    }
-
-                } else if (btype == 0b10) {
-                    throw new IOException(
-                        "deflate: dynamic Huffman blocks (BTYPE=10) not supported");
-                } else {
-                    throw new IOException("deflate: reserved BTYPE=11");
-                }
-
-                if (bfinal == 1) break;
-            }
-
-            // Materialise List<Byte> → byte[].
-            byte[] result = new byte[output.size()];
-            for (int i = 0; i < result.length; i++) {
-                result[i] = output.get(i);
-            }
-            return result;
-        }
-    }
-
-    // =============================================================================
     // Public API — ZipEntry
     // =============================================================================
 
@@ -900,7 +694,7 @@ public final class Zip {
             byte[] fileData;
 
             if (compress && data.length > 0) {
-                byte[] compressed = DeflateCompressor.compress(data);
+                byte[] compressed = RawRfc1951.rawDeflate(data);
                 if (compressed.length < data.length) {
                     method = METHOD_DEFLATE;
                     fileData = compressed;
@@ -1180,6 +974,14 @@ public final class Zip {
             return List.copyOf(entryList);
         }
 
+        /** Return the Central Directory's declared uncompressed size without decoding. */
+        int declaredUncompressedSize(String name) throws IOException {
+            for (EntryMeta m : meta) {
+                if (m.name.equals(name)) return m.uncompressedSize;
+            }
+            throw new IOException("zip: entry '" + name + "' not found");
+        }
+
         /**
          * Decompress and return the data for the named entry.
          *
@@ -1243,22 +1045,31 @@ public final class Zip {
             byte[] decompressed;
             int method = em.method & 0xFFFF;
             if (method == 0) {
-                // Stored — verbatim copy.
+                if (em.compressedSize != em.uncompressedSize) {
+                    throw new IOException("zip: stored entry sizes do not match");
+                }
                 decompressed = compressed;
             } else if (method == 8) {
-                // DEFLATE.
-                decompressed = DeflateDecompressor.decompress(compressed);
+                if (em.uncompressedSize > RawRfc1951.MAX_OUTPUT) {
+                    throw new IOException("zip: uncompressed size exceeds the raw inflate ceiling");
+                }
+                RawRfc1951.InflateResult inflated;
+                try {
+                    inflated = RawRfc1951.rawInflateCounted(compressed, em.uncompressedSize);
+                } catch (RawRfc1951.RawInflateException error) {
+                    throw new IOException("zip: raw inflate failed: " + error.code(), error);
+                }
+                if (inflated.bytesConsumed() != compressed.length) {
+                    throw new IOException("zip: compressed payload contains trailing bytes");
+                }
+                decompressed = inflated.output();
+                if (decompressed.length != em.uncompressedSize) {
+                    throw new IOException("zip: uncompressed size does not match the directory");
+                }
             } else {
                 throw new IOException(
                     "zip: unsupported compression method " + method +
                     " for '" + em.name + "'");
-            }
-
-            // Trim to declared uncompressed size to guard against decompressor over-read.
-            if (decompressed.length > em.uncompressedSize) {
-                byte[] trimmed = new byte[em.uncompressedSize];
-                System.arraycopy(decompressed, 0, trimmed, 0, em.uncompressedSize);
-                decompressed = trimmed;
             }
 
             // Verify CRC-32 — detects corruption of the decompressed content.
@@ -1376,13 +1187,37 @@ public final class Zip {
      * @throws IOException on corrupt archive or CRC mismatch
      */
     public static List<ZipEntry> unzip(byte[] data) throws IOException {
+        return unzip(data, RawRfc1951.MAX_OUTPUT);
+    }
+
+    /**
+     * Extract all entries with a caller-lowerable aggregate output ceiling.
+     * Individual DEFLATE entries are independently capped by {@link RawRfc1951}.
+     */
+    public static List<ZipEntry> unzip(byte[] data, long maxTotalBytes) throws IOException {
         if (data == null) throw new NullPointerException("data must not be null");
+        if (maxTotalBytes < 0 || maxTotalBytes > RawRfc1951.MAX_OUTPUT) {
+            throw new IOException("zip: invalid aggregate output limit");
+        }
         ZipReader reader = new ZipReader(data);
         List<ZipEntry> result = new ArrayList<>();
+        long totalBytes = 0;
         for (ZipEntry entry : reader.entries()) {
+            long declaredSize = entry.name().endsWith("/")
+                ? 0
+                : reader.declaredUncompressedSize(entry.name());
+            if (declaredSize > maxTotalBytes - totalBytes) {
+                throw new IOException("zip: aggregate decompressed size exceeds the "
+                    + maxTotalBytes + "-byte limit (decompression bomb guard)");
+            }
             byte[] bytes = entry.name().endsWith("/")
                 ? new byte[0]
                 : reader.read(entry.name());
+            totalBytes += bytes.length;
+            if (totalBytes > maxTotalBytes) {
+                throw new IOException("zip: aggregate decompressed size exceeds the "
+                    + maxTotalBytes + "-byte limit (decompression bomb guard)");
+            }
             result.add(new ZipEntry(entry.name(), bytes));
         }
         return result;

--- a/code/packages/java/zip/src/test/java/com/codingadventures/zip/RawRfc1951ConformanceTest.java
+++ b/code/packages/java/zip/src/test/java/com/codingadventures/zip/RawRfc1951ConformanceTest.java
@@ -1,0 +1,211 @@
+package com.codingadventures.zip;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HexFormat;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import org.junit.jupiter.api.Test;
+
+/** Runs the shared CMP09 raw RFC 1951 corpus against the Java lane. */
+final class RawRfc1951ConformanceTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final HexFormat HEX = HexFormat.of();
+
+    @Test
+    void closedPortableCorpusPasses() throws Exception {
+        JsonNode root = JSON.readTree(Files.readString(findFixture()));
+        assertEquals(1, root.path("schema_version").asInt());
+        assertEquals("zip-owned-raw-rfc1951-v1", root.path("profile").asText());
+        assertEquals(RawRfc1951.MAX_OUTPUT, root.path("limits").path("default_max_output").asInt());
+        assertEquals(RawRfc1951.MAX_OUTPUT, root.path("limits").path("hard_max_output").asInt());
+        assertEquals(RawRfc1951.ERROR_CODES, JSON.convertValue(root.path("error_ids"),
+            JSON.getTypeFactory().constructCollectionType(java.util.List.class, String.class)));
+        assertEquals(34, root.path("cases").size());
+
+        for (JsonNode testCase : root.path("cases")) {
+            String id = testCase.path("id").asText();
+            int limit = testCase.has("max_output")
+                ? testCase.path("max_output").asInt()
+                : RawRfc1951.MAX_OUTPUT;
+            switch (testCase.path("operation").asText()) {
+                case "inflate" -> {
+                    byte[] input = fromHex(testCase.path("input_hex").asText());
+                    byte[] expected = materialize(testCase.path("expected").path("output"));
+                    RawRfc1951.InflateResult result = RawRfc1951.rawInflateCounted(input, limit);
+                    assertArrayEquals(expected, result.output(), id);
+                    assertEquals(testCase.path("expected").path("bytes_consumed").asInt(),
+                        result.bytesConsumed(), id);
+                    assertArrayEquals(expected, RawRfc1951.rawInflate(input, limit), id);
+                }
+                case "inflate-error" -> {
+                    byte[] input = fromHex(testCase.path("input_hex").asText());
+                    String expected = testCase.path("expected").path("error_id").asText();
+                    RawRfc1951.RawInflateException error = assertThrows(
+                        RawRfc1951.RawInflateException.class,
+                        () -> RawRfc1951.rawInflateCounted(input, limit), id);
+                    assertEquals(expected, error.code(), id);
+                    assertEquals(expected, error.getMessage(), id);
+                }
+                case "deflate-interoperability" -> {
+                    byte[] input = fromHex(testCase.path("input_hex").asText());
+                    byte[] expected = materialize(testCase.path("expected").path("output"));
+                    assertArrayEquals(expected, jdkCodec("decompress", RawRfc1951.rawDeflate(input)), id);
+                }
+                case "crc32" -> {
+                    long checksum = testCase.has("initial_crc32_hex")
+                        ? Long.parseUnsignedLong(testCase.path("initial_crc32_hex").asText(), 16)
+                        : 0L;
+                    for (JsonNode chunk : testCase.path("chunks_hex")) {
+                        checksum = RawRfc1951.crc32(fromHex(chunk.asText()), checksum);
+                    }
+                    assertEquals(testCase.path("expected").path("crc32_hex").asText(),
+                        String.format("%08x", checksum), id);
+                }
+                default -> throw new AssertionError(id + ": unknown operation");
+            }
+        }
+    }
+
+    @Test
+    void foreignFullWindowAndHistoricalWrapperPass() throws Exception {
+        byte[] expected = new byte[65_536];
+        for (int index = 0; index < 32_768; index++) {
+            expected[index] = (byte) ((index * 73 + index / 251) & 0xff);
+            expected[index + 32_768] = expected[index];
+        }
+        assertArrayEquals(expected,
+            RawRfc1951.rawInflate(jdkCodec("compress", expected), expected.length));
+
+        byte[] historical = "historical wrapper compatibility".getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(historical, RawRfc1951.rawInflate(RawRfc1951.rawDeflate(historical)));
+    }
+
+    @Test
+    void zipReaderRequiresExactContainerBoundaries() throws Exception {
+        byte[] compressed = fromHex("0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e");
+        byte[] plain = fromHex("0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201");
+        assertArrayEquals(plain, new Zip.ZipReader(rawZip("dynamic.bin", compressed, plain, plain.length, 8))
+            .read("dynamic.bin"));
+
+        byte[] cavity = java.util.Arrays.copyOf(compressed, compressed.length + 2);
+        cavity[cavity.length - 2] = (byte) 0xde;
+        cavity[cavity.length - 1] = (byte) 0xad;
+        assertMessage("zip: compressed payload contains trailing bytes", () ->
+            new Zip.ZipReader(rawZip("cavity.bin", cavity, plain, plain.length, 8)).read("cavity.bin"));
+        assertMessage("zip: uncompressed size does not match the directory", () ->
+            new Zip.ZipReader(rawZip("size.bin", compressed, plain, plain.length + 1, 8)).read("size.bin"));
+        assertMessage("zip: stored entry sizes do not match", () ->
+            new Zip.ZipReader(rawZip("stored.bin", plain, plain, plain.length + 1, 0)).read("stored.bin"));
+        assertMessage("zip: raw inflate failed: reserved-block-type", () ->
+            new Zip.ZipReader(rawZip("malformed.bin", new byte[]{0x07}, new byte[0], 0, 8))
+                .read("malformed.bin"));
+
+        Zip.ZipWriter writer = new Zip.ZipWriter();
+        writer.addFile("a.bin", new byte[4], false);
+        writer.addFile("b.bin", new byte[4], false);
+        assertMessage("zip: aggregate decompressed size exceeds the 7-byte limit (decompression bomb guard)",
+            () -> Zip.unzip(writer.finish(), 7));
+
+        byte[] invalidLargeEntry = rawZip(
+            "preflight.bin", new byte[]{0x07}, new byte[0], 8, 8);
+        assertMessage("zip: aggregate decompressed size exceeds the 7-byte limit (decompression bomb guard)",
+            () -> Zip.unzip(invalidLargeEntry, 7));
+    }
+
+    private static void assertMessage(String expected, ThrowingAction action) {
+        IOException error = assertThrows(IOException.class, action::run);
+        assertEquals(expected, error.getMessage());
+    }
+
+    private static byte[] materialize(JsonNode output) {
+        if (output.has("hex")) return fromHex(output.path("hex").asText());
+        byte value = fromHex(output.path("repeat_hex").asText())[0];
+        byte[] result = new byte[output.path("count").asInt()];
+        java.util.Arrays.fill(result, value);
+        return result;
+    }
+
+    private static byte[] fromHex(String value) {
+        return HEX.parseHex(value);
+    }
+
+    private static Path findFixture() throws IOException {
+        for (Path directory = Path.of("").toAbsolutePath(); directory != null; directory = directory.getParent()) {
+            Path candidate = directory.resolve("code/specs/fixtures/zip-raw-rfc1951-v1/cases.json");
+            if (Files.isRegularFile(candidate)) return candidate;
+        }
+        throw new IOException("zip-raw-rfc1951-v1 fixture not found");
+    }
+
+    private static byte[] jdkCodec(String mode, byte[] input) throws DataFormatException {
+        byte[] buffer = new byte[4096];
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        if (mode.equals("compress")) {
+            Deflater codec = new Deflater(9, true);
+            try {
+                codec.setInput(input);
+                codec.finish();
+                while (!codec.finished()) output.write(buffer, 0, codec.deflate(buffer));
+            } finally {
+                codec.end();
+            }
+            return output.toByteArray();
+        }
+
+        Inflater codec = new Inflater(true);
+        try {
+            // JDK's nowrap inflater requires one dummy byte after a raw stream.
+            codec.setInput(java.util.Arrays.copyOf(input, input.length + 1));
+            while (!codec.finished()) {
+                int count = codec.inflate(buffer);
+                if (count == 0 && (codec.needsInput() || codec.needsDictionary())) {
+                    throw new DataFormatException("JDK raw inflater did not reach end-of-stream");
+                }
+                output.write(buffer, 0, count);
+            }
+        } finally {
+            codec.end();
+        }
+        return output.toByteArray();
+    }
+
+    private static byte[] rawZip(String name, byte[] compressed, byte[] plain, int declaredSize, int method) {
+        ByteArrayOutputStream archive = new ByteArrayOutputStream();
+        byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        long checksum = RawRfc1951.crc32(plain);
+        u32(archive, 0x04034b50L); u16(archive, 20); u16(archive, 0x0800); u16(archive, method);
+        u16(archive, 0); u16(archive, 0); u32(archive, checksum); u32(archive, compressed.length);
+        u32(archive, declaredSize); u16(archive, nameBytes.length); u16(archive, 0); archive.writeBytes(nameBytes); archive.writeBytes(compressed);
+        int centralOffset = archive.size();
+        u32(archive, 0x02014b50L); u16(archive, 0x031e); u16(archive, 20); u16(archive, 0x0800); u16(archive, method);
+        u16(archive, 0); u16(archive, 0); u32(archive, checksum); u32(archive, compressed.length); u32(archive, declaredSize);
+        u16(archive, nameBytes.length); u16(archive, 0); u16(archive, 0); u16(archive, 0); u16(archive, 0);
+        u32(archive, 0); u32(archive, 0); archive.writeBytes(nameBytes);
+        int centralSize = archive.size() - centralOffset;
+        u32(archive, 0x06054b50L); u16(archive, 0); u16(archive, 0); u16(archive, 1); u16(archive, 1);
+        u32(archive, centralSize); u32(archive, centralOffset); u16(archive, 0);
+        return archive.toByteArray();
+    }
+
+    private static void u16(ByteArrayOutputStream out, int value) {
+        out.write(value); out.write(value >>> 8);
+    }
+
+    private static void u32(ByteArrayOutputStream out, long value) {
+        u16(out, (int) value); u16(out, (int) (value >>> 16));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingAction { void run() throws Exception; }
+}

--- a/code/packages/kotlin/zip/BUILD
+++ b/code/packages/kotlin/zip/BUILD
@@ -1,1 +1,1 @@
-gradle test
+gradle test jacocoTestReport jacocoTestCoverageVerification

--- a/code/packages/kotlin/zip/BUILD_windows
+++ b/code/packages/kotlin/zip/BUILD_windows
@@ -1,1 +1,1 @@
-gradle test
+gradle test jacocoTestReport jacocoTestCoverageVerification

--- a/code/packages/kotlin/zip/CHANGELOG.md
+++ b/code/packages/kotlin/zip/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog — kotlin/zip
 
-## [Unreleased] — 2026-08-03
+## [Unreleased] — 2026-08-20
+
+### Added
+
+- Added the CMP09 portable raw RFC 1951 surface: `rawDeflate`, `rawInflate`,
+  `rawInflateCounted`, incremental `crc32`, exact consumed-byte reporting, a
+  caller-lowerable 256 MiB ceiling, and the closed 14-code payload-blind error
+  taxonomy.
+- Added all 34 language-neutral fixture cases, JDK raw-codec interoperability,
+  a foreign full-window stream, and strict ZIP boundary/aggregate-budget tests.
+- Added JaCoCo reporting and an executable 80% line-coverage gate to both
+  BUILD front doors.
+
+### Changed
+
+- Method-8 ZIP reads now accept dynamic Huffman streams, reject trailing
+  compressed bytes and declared-size mismatches, and map typed raw failures to
+  the established `IOException` container contract.
+- Removed the superseded stored/fixed-only decoder so Kotlin ZIP has one
+  canonical raw codec path. Package version is now 0.2.0.
+
+### Security
+
+- Replaced the boxed `MutableList<Byte>` decoder output with a primitive,
+  bounded growable buffer that checks the caller limit before every append or
+  back-reference copy. One-shot unzip also enforces a configurable 256 MiB
+  aggregate output budget.
 
 ### Fixed
 

--- a/code/packages/kotlin/zip/README.md
+++ b/code/packages/kotlin/zip/README.md
@@ -53,6 +53,27 @@ val archive = ZipArchive.zip(listOf(
 val entries: List<ZipEntry> = ZipArchive.unzip(archive)
 ```
 
+### Raw RFC 1951 and CRC-32
+
+The ZIP-owned raw codec is public so zlib, gzip, and PNG wrappers can share one
+RFC 1951 implementation instead of carrying another DEFLATE decoder:
+
+```kotlin
+val encoded = rawDeflate(data)
+val decoded = rawInflateCounted(encoded, maxOutput = 8 * 1024 * 1024)
+check(decoded.bytesConsumed == encoded.size)
+check(decoded.output.contentEquals(data))
+
+var checksum = crc32(firstChunk)
+checksum = crc32(secondChunk, checksum)
+```
+
+The decoder accepts stored, fixed-Huffman, and dynamic-Huffman blocks,
+multi-block streams, overlapping copies, and the full 32 KiB distance window.
+The caller may lower the output ceiling; 256 MiB is both the default and hard
+maximum. `RawInflateError` exposes the closed 14-code CMP09 taxonomy and keeps
+messages payload-blind.
+
 ## Wire format
 
 ZIP stores Local File Headers before each entry's data, then a Central Directory
@@ -74,9 +95,17 @@ verbatim (method 0). This implementation uses fixed-Huffman blocks (BTYPE=01)
 with the LZSS package for LZ77 match finding. DEFLATE is only used when it
 actually reduces size; otherwise the entry falls back to Stored automatically.
 
+Archive extraction requires exact compressed and uncompressed boundaries.
+`ZipArchive.unzip(data, maxTotalBytes)` defaults to a 256 MiB aggregate output
+budget and lets callers lower it. CRC-32 detects accidental corruption only;
+it is not authentication or cryptographic integrity.
+
 ## Running tests
 
 ```bash
 cd code/packages/kotlin/zip
-gradle test
+gradle test jacocoTestReport jacocoTestCoverageVerification
 ```
+
+Requires JDK 21 and Gradle. The Gradle `check` task enforces JaCoCo line
+coverage above 80%; the LZSS dependency resolves through a composite build.

--- a/code/packages/kotlin/zip/build.gradle.kts
+++ b/code/packages/kotlin/zip/build.gradle.kts
@@ -3,10 +3,11 @@ layout.buildDirectory = file("gradle-build")
 plugins {
     kotlin("jvm") version "2.1.20"
     `java-library`
+    jacoco
 }
 
 group = "com.codingadventures"
-version = "0.1.0"
+version = "0.2.0"
 
 repositories {
     mavenCentral()
@@ -26,6 +27,7 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     api("com.codingadventures:lzss")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -33,4 +35,34 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
 }

--- a/code/packages/kotlin/zip/required_capabilities.json
+++ b/code/packages/kotlin/zip/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "kotlin/zip",
   "capabilities": [],
-  "justification": "Pure in-memory Kotlin ZIP archive format implementation and tests."
+  "justification": "Pure in-memory Kotlin ZIP, raw RFC 1951, and CRC-32 byte transforms; fixture reads and JDK interoperability oracles are test-only."
 }

--- a/code/packages/kotlin/zip/src/main/kotlin/com/codingadventures/zip/RawRfc1951.kt
+++ b/code/packages/kotlin/zip/src/main/kotlin/com/codingadventures/zip/RawRfc1951.kt
@@ -1,0 +1,254 @@
+package com.codingadventures.zip
+
+import java.io.IOException
+
+/** Default and hard raw-inflate output ceiling: 256 MiB. */
+const val MAX_RAW_OUTPUT: Int = 256 * 1024 * 1024
+
+/** Complete payload-blind failure taxonomy, in fixture order. */
+val RAW_INFLATE_ERROR_CODES: List<String> = listOf(
+    "invalid-output-limit",
+    "unexpected-eof",
+    "reserved-block-type",
+    "stored-length-mismatch",
+    "huffman-oversubscribed",
+    "incomplete-code-length-tree",
+    "incomplete-literal-length-tree",
+    "incomplete-distance-tree",
+    "repeat-without-previous",
+    "repeat-overrun",
+    "invalid-literal-length-symbol",
+    "reserved-distance-symbol",
+    "invalid-back-reference",
+    "output-limit-exceeded",
+)
+
+/** A stable raw-inflate failure whose message contains only its code. */
+class RawInflateError(val code: String) : IOException(code)
+
+/** Decoded bytes and the exact compressed byte count reached. */
+data class RawInflateResult(val output: ByteArray, val bytesConsumed: Int)
+
+/** Compress bytes as raw RFC 1951 without ZIP, zlib, or gzip framing. */
+fun rawDeflate(data: ByteArray): ByteArray = deflateCompress(data)
+
+/** Inflate raw RFC 1951 with a caller-lowerable output ceiling. */
+fun rawInflate(data: ByteArray, maxOutput: Int = MAX_RAW_OUTPUT): ByteArray =
+    rawInflateCounted(data, maxOutput).output
+
+/** Inflate and report the exact final compressed input byte reached. */
+fun rawInflateCounted(data: ByteArray, maxOutput: Int = MAX_RAW_OUTPUT): RawInflateResult =
+    RawInflater.inflate(data, maxOutput)
+
+/**
+ * Hardened raw RFC 1951 decoder owned by ZIP.
+ *
+ * Production is a pure in-memory byte transform and owns no filesystem,
+ * process, network, environment, clock, entropy, FFI, or credential authority.
+ */
+private object RawInflater {
+    private enum class Completeness { CODE_LENGTH, LITERAL_LENGTH, DISTANCE }
+
+    private data class Tables(val literalLength: HuffmanTable, val distance: HuffmanTable)
+
+    private class HuffmanTable(
+        private val codesByLength: Array<Map<Int, Int>>,
+        private val maximumLength: Int,
+    ) {
+        fun decode(reader: BitReader): Int {
+            if (maximumLength == 0) fail("unexpected-eof")
+            var code = 0
+            for (length in 1..maximumLength) {
+                val bit = reader.readLsb(1) ?: fail("unexpected-eof")
+                code = (code shl 1) or bit
+                codesByLength[length][code]?.let { return it }
+            }
+            fail("unexpected-eof")
+        }
+    }
+
+    /** A capped growable byte vector with overlap-safe back-reference copying. */
+    private class OutputBuffer(private val maximum: Int) {
+        private var data = ByteArray(minOf(maximum, 8192))
+        var size: Int = 0
+            private set
+
+        fun add(value: Int) {
+            ensure(1)
+            data[size++] = value.toByte()
+        }
+
+        fun copy(distance: Int, length: Int) {
+            if (distance <= 0 || distance > size) fail("invalid-back-reference")
+            ensure(length)
+            repeat(length) {
+                data[size] = data[size - distance]
+                size++
+            }
+        }
+
+        fun ensure(additional: Int) {
+            if (additional > maximum - size) fail("output-limit-exceeded")
+            val required = size + additional
+            if (required <= data.size) return
+            val doubled = if (data.isEmpty()) 1 else data.size * 2
+            data = data.copyOf(minOf(maximum, maxOf(required, doubled)))
+        }
+
+        fun toByteArray(): ByteArray = data.copyOf(size)
+    }
+
+    fun inflate(data: ByteArray, maximumOutput: Int): RawInflateResult {
+        if (maximumOutput < 0 || maximumOutput > MAX_RAW_OUTPUT) fail("invalid-output-limit")
+        val reader = BitReader(data)
+        val output = OutputBuffer(maximumOutput)
+
+        while (true) {
+            val finalBlock = reader.readLsb(1) ?: fail("unexpected-eof")
+            when (reader.readLsb(2) ?: fail("unexpected-eof")) {
+                0 -> readStored(reader, output)
+                1 -> fixedTables().also {
+                    decodeCompressed(reader, output, it.literalLength, it.distance)
+                }
+                2 -> readDynamicTables(reader).also {
+                    decodeCompressed(reader, output, it.literalLength, it.distance)
+                }
+                else -> fail("reserved-block-type")
+            }
+            if (finalBlock == 1) return RawInflateResult(output.toByteArray(), reader.position())
+        }
+    }
+
+    private fun readStored(reader: BitReader, output: OutputBuffer) {
+        reader.align()
+        val length = reader.readLsb(16) ?: fail("unexpected-eof")
+        val complement = reader.readLsb(16) ?: fail("unexpected-eof")
+        if (length != (complement xor 0xffff)) fail("stored-length-mismatch")
+        output.ensure(length)
+        repeat(length) { output.add(reader.readLsb(8) ?: fail("unexpected-eof")) }
+    }
+
+    private fun fixedTables(): Tables {
+        val literalLengths = IntArray(288)
+        java.util.Arrays.fill(literalLengths, 0, 144, 8)
+        java.util.Arrays.fill(literalLengths, 144, 256, 9)
+        java.util.Arrays.fill(literalLengths, 256, 280, 7)
+        java.util.Arrays.fill(literalLengths, 280, 288, 8)
+        return Tables(
+            buildHuffman(literalLengths, Completeness.LITERAL_LENGTH),
+            buildHuffman(IntArray(32) { 5 }, Completeness.DISTANCE),
+        )
+    }
+
+    private fun readDynamicTables(reader: BitReader): Tables {
+        val literalCount = (reader.readLsb(5) ?: fail("unexpected-eof")) + 257
+        val distanceCount = (reader.readLsb(5) ?: fail("unexpected-eof")) + 1
+        val codeLengthCount = (reader.readLsb(4) ?: fail("unexpected-eof")) + 4
+        if (literalCount > 286) fail("invalid-literal-length-symbol")
+
+        val order = intArrayOf(16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15)
+        val codeLengths = IntArray(19)
+        repeat(codeLengthCount) { index ->
+            codeLengths[order[index]] = reader.readLsb(3) ?: fail("unexpected-eof")
+        }
+        val codeLengthTable = buildHuffman(codeLengths, Completeness.CODE_LENGTH)
+
+        val total = literalCount + distanceCount
+        val lengths = IntArray(total)
+        var count = 0
+        while (count < total) {
+            when (val symbol = codeLengthTable.decode(reader)) {
+                in 0..15 -> lengths[count++] = symbol
+                16 -> {
+                    if (count == 0) fail("repeat-without-previous")
+                    count = repeatInto(lengths, count, lengths[count - 1],
+                        (reader.readLsb(2) ?: fail("unexpected-eof")) + 3)
+                }
+                17 -> count = repeatInto(lengths, count, 0,
+                    (reader.readLsb(3) ?: fail("unexpected-eof")) + 3)
+                18 -> count = repeatInto(lengths, count, 0,
+                    (reader.readLsb(7) ?: fail("unexpected-eof")) + 11)
+                else -> fail("unexpected-eof")
+            }
+        }
+
+        val literalLengths = lengths.copyOfRange(0, literalCount)
+        val distanceLengths = lengths.copyOfRange(literalCount, total)
+        if (literalLengths[256] == 0) fail("incomplete-literal-length-tree")
+        return Tables(
+            buildHuffman(literalLengths, Completeness.LITERAL_LENGTH),
+            buildHuffman(distanceLengths, Completeness.DISTANCE),
+        )
+    }
+
+    private fun repeatInto(target: IntArray, start: Int, value: Int, count: Int): Int {
+        if (count > target.size - start) fail("repeat-overrun")
+        java.util.Arrays.fill(target, start, start + count, value)
+        return start + count
+    }
+
+    private fun buildHuffman(lengths: IntArray, completeness: Completeness): HuffmanTable {
+        val counts = IntArray(16)
+        for (length in lengths) {
+            if (length > 15) fail("huffman-oversubscribed")
+            if (length > 0) counts[length]++
+        }
+        var left = 1
+        for (length in 1..15) {
+            left = left * 2 - counts[length]
+            if (left < 0) fail("huffman-oversubscribed")
+        }
+        val symbolCount = counts.sum()
+        if (left != 0) {
+            when (completeness) {
+                Completeness.CODE_LENGTH -> fail("incomplete-code-length-tree")
+                Completeness.LITERAL_LENGTH -> fail("incomplete-literal-length-tree")
+                Completeness.DISTANCE -> if (symbolCount != 0 && !(symbolCount == 1 && counts[1] == 1))
+                    fail("incomplete-distance-tree")
+            }
+        }
+
+        val nextCode = IntArray(16)
+        var code = 0
+        for (length in 1..15) {
+            code = (code + counts[length - 1]) shl 1
+            nextCode[length] = code
+        }
+        val tables = Array<MutableMap<Int, Int>>(16) { mutableMapOf() }
+        var maximumLength = 0
+        for (symbol in lengths.indices) {
+            val length = lengths[symbol]
+            if (length == 0) continue
+            tables[length][nextCode[length]++] = symbol
+            maximumLength = maxOf(maximumLength, length)
+        }
+        return HuffmanTable(Array(16) { tables[it].toMap() }, maximumLength)
+    }
+
+    private fun decodeCompressed(
+        reader: BitReader,
+        output: OutputBuffer,
+        literalLength: HuffmanTable,
+        distance: HuffmanTable,
+    ) {
+        while (true) {
+            when (val symbol = literalLength.decode(reader)) {
+                in 0..255 -> output.add(symbol)
+                256 -> return
+                in 257..285 -> {
+                    val (baseLength, extraLengthBits) = LENGTH_TABLE[symbol - 257]
+                    val length = baseLength + (reader.readLsb(extraLengthBits) ?: fail("unexpected-eof"))
+                    val distanceSymbol = distance.decode(reader)
+                    if (distanceSymbol >= 30) fail("reserved-distance-symbol")
+                    val (baseDistance, extraDistanceBits) = DIST_TABLE[distanceSymbol]
+                    val backwardDistance = baseDistance +
+                        (reader.readLsb(extraDistanceBits) ?: fail("unexpected-eof"))
+                    output.copy(backwardDistance, length)
+                }
+                else -> fail("invalid-literal-length-symbol")
+            }
+        }
+    }
+
+    private fun fail(code: String): Nothing = throw RawInflateError(code)
+}

--- a/code/packages/kotlin/zip/src/main/kotlin/com/codingadventures/zip/Zip.kt
+++ b/code/packages/kotlin/zip/src/main/kotlin/com/codingadventures/zip/Zip.kt
@@ -270,7 +270,7 @@ private class BitWriter {
  * Mirrors BitWriter: fills a 64-bit accumulator from bytes in the source array.
  * Huffman code decoding reads MSB-first by bit-reversing the extracted value.
  */
-private class BitReader(private val data: ByteArray) {
+internal class BitReader(private val data: ByteArray) {
     private var pos: Int = 0   // next byte to consume from data
     private var buf: Long = 0L // bit accumulator
     private var bits: Int = 0  // valid bits in buf
@@ -304,21 +304,6 @@ private class BitReader(private val data: ByteArray) {
     }
 
     /**
-     * Read [nbits] bits and bit-reverse the result.
-     * Used when decoding Huffman codes (logically MSB-first).
-     */
-    fun readMsb(nbits: Int): Int? {
-        val v = readLsb(nbits) ?: return null
-        var rev = 0
-        var u = v
-        repeat(nbits) {
-            rev = (rev shl 1) or (u and 1)
-            u = u ushr 1
-        }
-        return rev
-    }
-
-    /**
      * Discard any partial-byte bits, aligning to the next byte boundary.
      * Required before reading stored-block length fields.
      */
@@ -329,6 +314,9 @@ private class BitReader(private val data: ByteArray) {
             bits -= discard
         }
     }
+
+    /** Exact number of source bytes fetched, including a partial final byte. */
+    fun position(): Int = pos
 }
 
 // =============================================================================
@@ -361,61 +349,28 @@ private fun fixedLlEncode(sym: Int): Pair<Int, Int> = when (sym) {
     else        -> throw IOException("fixedLlEncode: invalid LL symbol $sym")
 }
 
-/**
- * Decode one literal/length symbol from [br] using the RFC 1951 fixed Huffman table.
- *
- * Reads bits incrementally — first 7, then up to 9 — and decodes in order
- * of increasing code length per the canonical Huffman property.
- * Returns null on end-of-input.
- *
- * Decode order:
- *   1. Try 7 bits: codes 0–23 → symbols 256–279 (end-of-block + length codes)
- *   2. Need 8 bits: codes 48–191 → literals 0–143; codes 192–199 → symbols 280–287
- *   3. Need 9 bits: codes 400–511 → literals 144–255
- */
-private fun fixedLlDecode(br: BitReader): Int? {
-    val v7 = br.readMsb(7) ?: return null
-    if (v7 <= 23) {
-        // 7-bit code: symbols 256–279.
-        return v7 + 256
-    }
-    // Need one more bit for 8-bit codes.
-    val extra1 = br.readLsb(1) ?: return null
-    val v8 = (v7 shl 1) or extra1
-    return when {
-        v8 in 48..191  -> v8 - 48                  // literals 0–143
-        v8 in 192..199 -> v8 + 88                  // symbols 280–287 (192+88=280)
-        else           -> {
-            // Need one more bit for 9-bit codes (literals 144–255).
-            val extra2 = br.readLsb(1) ?: return null
-            val v9 = (v8 shl 1) or extra2
-            if (v9 in 400..511) v9 - 256 else null // literals 144–255 (400-256=144)
-        }
-    }
-}
-
 // =============================================================================
 // RFC 1951 DEFLATE — Length / Distance Tables
 // =============================================================================
 //
-// Match lengths (3-255) map to LL symbols 257-284 + extra bits.
+// Match lengths (3-258) map to LL symbols 257-285 + extra bits.
 // Match distances (1-32768) map to distance codes 0-29 + extra bits.
 // The tables come directly from RFC 1951 §3.2.5.
 
 /**
- * (base_length, extra_bits) for LL symbols 257..284, indexed by (symbol - 257).
+ * (base_length, extra_bits) for LL symbols 257..285, indexed by (symbol - 257).
  *
  * To encode a match of length L: find the largest base ≤ L, emit the
  * corresponding LL symbol + (L - base) as extra bits.
  */
-private val LENGTH_TABLE: Array<Pair<Int, Int>> = arrayOf(
+internal val LENGTH_TABLE: Array<Pair<Int, Int>> = arrayOf(
     Pair(3, 0), Pair(4, 0), Pair(5, 0), Pair(6, 0),
     Pair(7, 0), Pair(8, 0), Pair(9, 0), Pair(10, 0), // 257–264
     Pair(11, 1), Pair(13, 1), Pair(15, 1), Pair(17, 1),                 // 265–268
     Pair(19, 2), Pair(23, 2), Pair(27, 2), Pair(31, 2),                 // 269–272
     Pair(35, 3), Pair(43, 3), Pair(51, 3), Pair(59, 3),                 // 273–276
     Pair(67, 4), Pair(83, 4), Pair(99, 4), Pair(115, 4),               // 277–280
-    Pair(131, 5), Pair(163, 5), Pair(195, 5), Pair(227, 5)             // 281–284
+    Pair(131, 5), Pair(163, 5), Pair(195, 5), Pair(227, 5), Pair(258, 0) // 281–285
 )
 
 /**
@@ -424,7 +379,7 @@ private val LENGTH_TABLE: Array<Pair<Int, Int>> = arrayOf(
  * To encode a match at distance D: find the largest base ≤ D, emit the
  * distance code number (5 bits) + (D - base) as extra bits.
  */
-private val DIST_TABLE: Array<Pair<Int, Int>> = arrayOf(
+internal val DIST_TABLE: Array<Pair<Int, Int>> = arrayOf(
     Pair(1, 0), Pair(2, 0), Pair(3, 0), Pair(4, 0),
     Pair(5, 1), Pair(7, 1), Pair(9, 2), Pair(13, 2),
     Pair(17, 3), Pair(25, 3), Pair(33, 4), Pair(49, 4),
@@ -436,7 +391,7 @@ private val DIST_TABLE: Array<Pair<Int, Int>> = arrayOf(
 )
 
 /**
- * Map a match length (3–255) to its RFC 1951 LL symbol, base, and extra-bit count.
+ * Map a match length (3–258) to its RFC 1951 LL symbol, base, and extra-bit count.
  *
  * Returns `Triple(ll_symbol, base, extra_bits)`.
  * Scans from the highest entry downward to find the rightmost entry where base ≤ length.
@@ -546,129 +501,6 @@ internal fun deflateCompress(data: ByteArray): ByteArray {
 }
 
 // =============================================================================
-// RFC 1951 DEFLATE — Decompress
-// =============================================================================
-//
-// Handles stored blocks (BTYPE=00) and fixed Huffman blocks (BTYPE=01).
-// Dynamic Huffman blocks (BTYPE=10) throw IOException — we only produce BTYPE=01,
-// but we must be able to decompress stored blocks written by other tools.
-//
-// Security limits:
-//   - Maximum output: 256 MB (decompression bomb guard)
-//   - LEN/NLEN validation on stored blocks
-
-private const val MAX_OUTPUT_BYTES = 256 * 1024 * 1024  // 256 MB
-
-/**
- * Decompress a raw RFC 1951 DEFLATE bit-stream into its original bytes.
- *
- * Throws [IOException] on malformed or unsupported (BTYPE=10 dynamic Huffman) input.
- *
- * Security: a 256 MB hard limit prevents decompression bomb attacks where
- * a tiny compressed input expands to gigabytes of output.
- */
-internal fun deflateDecompress(data: ByteArray): ByteArray {
-    val br = BitReader(data)
-    val out = mutableListOf<Byte>()
-
-    while (true) {
-        val bfinal = br.readLsb(1)
-            ?: throw IOException("deflate: unexpected EOF reading BFINAL")
-        val btype = br.readLsb(2)
-            ?: throw IOException("deflate: unexpected EOF reading BTYPE")
-
-        when (btype) {
-            0b00 -> {
-                // ── Stored block ──────────────────────────────────────────────
-                // Align to byte boundary before reading the length fields.
-                br.align()
-                val len = br.readLsb(16)
-                    ?: throw IOException("deflate: EOF reading stored LEN")
-                val nlen = br.readLsb(16)
-                    ?: throw IOException("deflate: EOF reading stored NLEN")
-                // RFC 1951 §3.2.4: NLEN is the one's complement of LEN.
-                if ((nlen xor 0xFFFF) != len) {
-                    throw IOException("deflate: stored LEN/NLEN mismatch: $len vs $nlen")
-                }
-                if (out.size + len > MAX_OUTPUT_BYTES) {
-                    throw IOException("deflate: output size limit exceeded")
-                }
-                repeat(len) {
-                    val b = br.readLsb(8)
-                        ?: throw IOException("deflate: EOF inside stored block data")
-                    out.add(b.toByte())
-                }
-            }
-            0b01 -> {
-                // ── Fixed Huffman block ───────────────────────────────────────
-                while (true) {
-                    val sym = fixedLlDecode(br)
-                        ?: throw IOException("deflate: EOF decoding fixed Huffman symbol")
-                    when {
-                        sym in 0..255 -> {
-                            // Guard against decompression bombs.
-                            if (out.size >= MAX_OUTPUT_BYTES) {
-                                throw IOException("deflate: output size limit exceeded")
-                            }
-                            out.add(sym.toByte())
-                        }
-                        sym == 256 -> break  // end-of-block
-                        sym in 257..285 -> {
-                            // Back-reference: decode length, then distance.
-                            val idx = sym - 257
-                            if (idx >= LENGTH_TABLE.size) {
-                                throw IOException("deflate: invalid length sym $sym")
-                            }
-                            val (baseLen, extraLenBits) = LENGTH_TABLE[idx]
-                            val extraLen = if (extraLenBits > 0) {
-                                br.readLsb(extraLenBits)
-                                    ?: throw IOException("deflate: EOF reading length extra bits")
-                            } else 0
-                            val matchLen = baseLen + extraLen
-
-                            // Distance code: 5-bit fixed, read MSB-first.
-                            val distCode = br.readMsb(5)
-                                ?: throw IOException("deflate: EOF reading distance code")
-                            if (distCode >= DIST_TABLE.size) {
-                                throw IOException("deflate: invalid dist code $distCode")
-                            }
-                            val (baseDist, extraDistBits) = DIST_TABLE[distCode]
-                            val extraDist = if (extraDistBits > 0) {
-                                br.readLsb(extraDistBits)
-                                    ?: throw IOException("deflate: EOF reading distance extra bits")
-                            } else 0
-                            val offset = baseDist + extraDist
-
-                            // Bounds check: offset must not exceed decoded output.
-                            if (offset > out.size) {
-                                throw IOException(
-                                    "deflate: back-reference offset $offset > output len ${out.size}"
-                                )
-                            }
-                            if (out.size + matchLen > MAX_OUTPUT_BYTES) {
-                                throw IOException("deflate: output size limit exceeded")
-                            }
-                            // Copy byte-by-byte to handle overlapping matches
-                            // (e.g. offset=1, length=10 encodes a run of one byte × 10).
-                            repeat(matchLen) {
-                                out.add(out[out.size - offset])
-                            }
-                        }
-                        else -> throw IOException("deflate: invalid LL symbol $sym")
-                    }
-                }
-            }
-            0b10 -> throw IOException("deflate: dynamic Huffman blocks (BTYPE=10) not supported")
-            else -> throw IOException("deflate: reserved BTYPE=11")
-        }
-
-        if (bfinal == 1) break
-    }
-
-    return out.toByteArray()
-}
-
-// =============================================================================
 // MS-DOS Date / Time Encoding
 // =============================================================================
 //
@@ -766,7 +598,7 @@ class ZipWriter {
 
         // Decide compression: try DEFLATE and fall back to Stored if it doesn't help.
         val (method, fileData) = if (compress && data.isNotEmpty()) {
-            val compressed = deflateCompress(data)
+            val compressed = rawDeflate(data)
             if (compressed.size < data.size) {
                 Pair(METHOD_DEFLATE, compressed)
             } else {
@@ -1017,6 +849,11 @@ class ZipReader(private val data: ByteArray) {
         entries = meta.map { ZipEntry(it.name, ByteArray(0)) }
     }
 
+    /** Return the Central Directory's declared uncompressed size without decoding. */
+    internal fun declaredUncompressedSize(name: String): Int =
+        meta.find { it.name == name }?.uncompressedSize
+            ?: throw IOException("zip: entry '$name' not found")
+
     /**
      * Decompress and return the data for the named entry. Verifies CRC-32.
      *
@@ -1088,23 +925,36 @@ class ZipReader(private val data: ByteArray) {
 
         // Decompress according to method.
         val decompressed: ByteArray = when (m.method.toInt()) {
-            0 -> compressed                         // Stored — verbatim copy
-            8 -> deflateDecompress(compressed)      // DEFLATE
+            0 -> {
+                if (m.compressedSize != m.uncompressedSize) {
+                    throw IOException("zip: stored entry sizes do not match")
+                }
+                compressed
+            }
+            8 -> {
+                if (m.uncompressedSize > MAX_RAW_OUTPUT) {
+                    throw IOException("zip: uncompressed size exceeds the raw inflate ceiling")
+                }
+                val inflated = try {
+                    rawInflateCounted(compressed, m.uncompressedSize)
+                } catch (error: RawInflateError) {
+                    throw IOException("zip: raw inflate failed: ${error.code}", error)
+                }
+                if (inflated.bytesConsumed != compressed.size) {
+                    throw IOException("zip: compressed payload contains trailing bytes")
+                }
+                if (inflated.output.size != m.uncompressedSize) {
+                    throw IOException("zip: uncompressed size does not match the directory")
+                }
+                inflated.output
+            }
             else -> throw IOException(
                 "zip: unsupported compression method ${m.method} for '${m.name}'"
             )
         }
 
-        // Trim to declared uncompressed size (guards against decompressor over-read).
-        // m.uncompressedSize was validated non-negative above.
-        val trimmed = if (decompressed.size > m.uncompressedSize) {
-            decompressed.copyOf(m.uncompressedSize)
-        } else {
-            decompressed
-        }
-
         // Verify CRC-32 — detects corruption of the decompressed content.
-        val actualCrc = crc32(trimmed)
+        val actualCrc = crc32(decompressed)
         if (actualCrc != m.crc) {
             throw IOException(
                 "zip: CRC-32 mismatch for '${m.name}': expected ${Integer.toHexString(m.crc).uppercase()}, " +
@@ -1112,7 +962,7 @@ class ZipReader(private val data: ByteArray) {
             )
         }
 
-        return trimmed
+        return decompressed
     }
 
     // ── Private helpers ────────────────────────────────────────────────────────
@@ -1202,14 +1052,37 @@ object ZipArchive {
      * File entries have their data decompressed; directory entries have empty data.
      * Throws [IOException] on corrupt archives.
      */
-    fun unzip(data: ByteArray): List<ZipEntry> {
+    fun unzip(data: ByteArray, maxTotalBytes: Long = MAX_RAW_OUTPUT.toLong()): List<ZipEntry> {
+        if (maxTotalBytes < 0 || maxTotalBytes > MAX_RAW_OUTPUT) {
+            throw IOException("zip: invalid aggregate output limit")
+        }
         val reader = ZipReader(data)
+        var totalBytes = 0L
         return reader.entries.map { entry ->
-            if (entry.name.endsWith('/')) {
-                ZipEntry(entry.name, ByteArray(0))
+            val declaredSize = if (entry.name.endsWith('/')) {
+                0L
             } else {
-                ZipEntry(entry.name, reader.read(entry.name))
+                reader.declaredUncompressedSize(entry.name).toLong()
             }
+            if (declaredSize > maxTotalBytes - totalBytes) {
+                throw IOException(
+                    "zip: aggregate decompressed size exceeds the $maxTotalBytes-byte limit " +
+                        "(decompression bomb guard)"
+                )
+            }
+            val bytes = if (entry.name.endsWith('/')) {
+                ByteArray(0)
+            } else {
+                reader.read(entry.name)
+            }
+            totalBytes += bytes.size
+            if (totalBytes > maxTotalBytes) {
+                throw IOException(
+                    "zip: aggregate decompressed size exceeds the $maxTotalBytes-byte limit " +
+                        "(decompression bomb guard)"
+                )
+            }
+            ZipEntry(entry.name, bytes)
         }
     }
 }

--- a/code/packages/kotlin/zip/src/test/kotlin/com/codingadventures/zip/RawRfc1951ConformanceTest.kt
+++ b/code/packages/kotlin/zip/src/test/kotlin/com/codingadventures/zip/RawRfc1951ConformanceTest.kt
@@ -1,0 +1,190 @@
+package com.codingadventures.zip
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.HexFormat
+import java.util.zip.DataFormatException
+import java.util.zip.Deflater
+import java.util.zip.Inflater
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Runs the shared CMP09 raw RFC 1951 corpus against the Kotlin lane. */
+class RawRfc1951ConformanceTest {
+    @Test
+    fun closedPortableCorpusPasses() {
+        val root = json.readTree(Files.readString(findFixture()))
+        assertEquals(1, root.path("schema_version").asInt())
+        assertEquals("zip-owned-raw-rfc1951-v1", root.path("profile").asText())
+        assertEquals(MAX_RAW_OUTPUT, root.path("limits").path("default_max_output").asInt())
+        assertEquals(MAX_RAW_OUTPUT, root.path("limits").path("hard_max_output").asInt())
+        assertEquals(RAW_INFLATE_ERROR_CODES, root.path("error_ids").map { it.asText() })
+        assertEquals(34, root.path("cases").size())
+
+        for (testCase in root.path("cases")) {
+            val id = testCase.path("id").asText()
+            val limit = if (testCase.has("max_output")) testCase.path("max_output").asInt() else MAX_RAW_OUTPUT
+            when (testCase.path("operation").asText()) {
+                "inflate" -> {
+                    val input = fromHex(testCase.path("input_hex").asText())
+                    val expected = materialize(testCase.path("expected").path("output"))
+                    val result = rawInflateCounted(input, limit)
+                    assertContentEquals(expected, result.output, id)
+                    assertEquals(testCase.path("expected").path("bytes_consumed").asInt(), result.bytesConsumed, id)
+                    assertContentEquals(expected, rawInflate(input, limit), id)
+                }
+                "inflate-error" -> {
+                    val input = fromHex(testCase.path("input_hex").asText())
+                    val expected = testCase.path("expected").path("error_id").asText()
+                    val error = assertFailsWith<RawInflateError>(id) { rawInflateCounted(input, limit) }
+                    assertEquals(expected, error.code, id)
+                    assertEquals(expected, error.message, id)
+                }
+                "deflate-interoperability" -> {
+                    val input = fromHex(testCase.path("input_hex").asText())
+                    val expected = materialize(testCase.path("expected").path("output"))
+                    assertContentEquals(expected, jdkCodec("decompress", rawDeflate(input)), id)
+                }
+                "crc32" -> {
+                    var checksum = if (testCase.has("initial_crc32_hex"))
+                        testCase.path("initial_crc32_hex").asText().toLong(16).toInt() else 0
+                    for (chunk in testCase.path("chunks_hex")) checksum = crc32(fromHex(chunk.asText()), checksum)
+                    assertEquals(testCase.path("expected").path("crc32_hex").asText(),
+                        checksum.toUInt().toString(16).padStart(8, '0'), id)
+                }
+                else -> error("$id: unknown operation")
+            }
+        }
+    }
+
+    @Test
+    fun foreignFullWindowAndHistoricalWrapperPass() {
+        val expected = ByteArray(65_536)
+        for (index in 0 until 32_768) {
+            expected[index] = ((index * 73 + index / 251) and 0xff).toByte()
+            expected[index + 32_768] = expected[index]
+        }
+        assertContentEquals(expected, rawInflate(jdkCodec("compress", expected), expected.size))
+        val historical = "historical wrapper compatibility".toByteArray()
+        assertContentEquals(historical, rawInflate(rawDeflate(historical)))
+    }
+
+    @Test
+    fun zipReaderRequiresExactContainerBoundaries() {
+        val compressed = fromHex("0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e")
+        val plain = fromHex("0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201")
+        assertContentEquals(plain, ZipReader(rawZip("dynamic.bin", compressed, plain, plain.size, 8)).read("dynamic.bin"))
+        assertMessage("zip: compressed payload contains trailing bytes") {
+            ZipReader(rawZip("cavity.bin", compressed + byteArrayOf(0xde.toByte(), 0xad.toByte()), plain, plain.size, 8)).read("cavity.bin")
+        }
+        assertMessage("zip: uncompressed size does not match the directory") {
+            ZipReader(rawZip("size.bin", compressed, plain, plain.size + 1, 8)).read("size.bin")
+        }
+        assertMessage("zip: stored entry sizes do not match") {
+            ZipReader(rawZip("stored.bin", plain, plain, plain.size + 1, 0)).read("stored.bin")
+        }
+        assertMessage("zip: raw inflate failed: reserved-block-type") {
+            ZipReader(rawZip("malformed.bin", byteArrayOf(0x07), byteArrayOf(), 0, 8)).read("malformed.bin")
+        }
+
+        val writer = ZipWriter()
+        writer.addFile("a.bin", ByteArray(4), compress = false)
+        writer.addFile("b.bin", ByteArray(4), compress = false)
+        assertMessage("zip: aggregate decompressed size exceeds the 7-byte limit (decompression bomb guard)") {
+            ZipArchive.unzip(writer.finish(), maxTotalBytes = 7)
+        }
+
+        val invalidLargeEntry = rawZip(
+            "preflight.bin", byteArrayOf(0x07), byteArrayOf(), 8, 8
+        )
+        assertMessage("zip: aggregate decompressed size exceeds the 7-byte limit (decompression bomb guard)") {
+            ZipArchive.unzip(invalidLargeEntry, maxTotalBytes = 7)
+        }
+    }
+
+    private fun assertMessage(expected: String, action: () -> Unit) {
+        assertEquals(expected, assertFailsWith<IOException> { action() }.message)
+    }
+
+    companion object {
+        private val json = ObjectMapper()
+        private val hex = HexFormat.of()
+
+        private fun materialize(output: JsonNode): ByteArray {
+            if (output.has("hex")) return fromHex(output.path("hex").asText())
+            return ByteArray(output.path("count").asInt()) { fromHex(output.path("repeat_hex").asText())[0] }
+        }
+
+        private fun fromHex(value: String): ByteArray = hex.parseHex(value)
+
+        private fun findFixture(): Path {
+            var directory: Path? = Path.of("").toAbsolutePath()
+            while (directory != null) {
+                val candidate = directory.resolve("code/specs/fixtures/zip-raw-rfc1951-v1/cases.json")
+                if (Files.isRegularFile(candidate)) return candidate
+                directory = directory.parent
+            }
+            throw IOException("zip-raw-rfc1951-v1 fixture not found")
+        }
+
+        private fun jdkCodec(mode: String, input: ByteArray): ByteArray {
+            val buffer = ByteArray(4096)
+            val output = ByteArrayOutputStream()
+            if (mode == "compress") {
+                val codec = Deflater(9, true)
+                try {
+                    codec.setInput(input)
+                    codec.finish()
+                    while (!codec.finished()) output.write(buffer, 0, codec.deflate(buffer))
+                } finally {
+                    codec.end()
+                }
+                return output.toByteArray()
+            }
+
+            val codec = Inflater(true)
+            try {
+                // JDK's nowrap inflater requires one dummy byte after a raw stream.
+                codec.setInput(input + byteArrayOf(0))
+                while (!codec.finished()) {
+                    val count = codec.inflate(buffer)
+                    if (count == 0 && (codec.needsInput() || codec.needsDictionary())) {
+                        throw DataFormatException("JDK raw inflater did not reach end-of-stream")
+                    }
+                    output.write(buffer, 0, count)
+                }
+            } finally {
+                codec.end()
+            }
+            return output.toByteArray()
+        }
+
+        private fun rawZip(name: String, compressed: ByteArray, plain: ByteArray, declaredSize: Int, method: Int): ByteArray {
+            val archive = ByteArrayOutputStream()
+            val nameBytes = name.toByteArray(StandardCharsets.UTF_8)
+            val checksum = crc32(plain).toUInt().toLong()
+            u32(archive, 0x04034b50); u16(archive, 20); u16(archive, 0x0800); u16(archive, method)
+            u16(archive, 0); u16(archive, 0); u32(archive, checksum); u32(archive, compressed.size.toLong())
+            u32(archive, declaredSize.toLong()); u16(archive, nameBytes.size); u16(archive, 0); archive.writeBytes(nameBytes); archive.writeBytes(compressed)
+            val centralOffset = archive.size()
+            u32(archive, 0x02014b50); u16(archive, 0x031e); u16(archive, 20); u16(archive, 0x0800); u16(archive, method)
+            u16(archive, 0); u16(archive, 0); u32(archive, checksum); u32(archive, compressed.size.toLong()); u32(archive, declaredSize.toLong())
+            u16(archive, nameBytes.size); u16(archive, 0); u16(archive, 0); u16(archive, 0); u16(archive, 0)
+            u32(archive, 0); u32(archive, 0); archive.writeBytes(nameBytes)
+            val centralSize = archive.size() - centralOffset
+            u32(archive, 0x06054b50); u16(archive, 0); u16(archive, 0); u16(archive, 1); u16(archive, 1)
+            u32(archive, centralSize.toLong()); u32(archive, centralOffset.toLong()); u16(archive, 0)
+            return archive.toByteArray()
+        }
+
+        private fun u16(out: ByteArrayOutputStream, value: Int) { out.write(value); out.write(value ushr 8) }
+        private fun u32(out: ByteArrayOutputStream, value: Long) { u16(out, value.toInt()); u16(out, (value ushr 16).toInt()) }
+    }
+}

--- a/code/packages/kotlin/zip/src/test/kotlin/com/codingadventures/zip/ZipTest.kt
+++ b/code/packages/kotlin/zip/src/test/kotlin/com/codingadventures/zip/ZipTest.kt
@@ -60,8 +60,8 @@ class ZipTest {
     // =========================================================================
 
     private fun deflateRt(data: ByteArray) {
-        val compressed = deflateCompress(data)
-        val decompressed = deflateDecompress(compressed)
+        val compressed = rawDeflate(data)
+        val decompressed = rawInflate(compressed)
         assertArrayEquals(data, decompressed, "DEFLATE round-trip mismatch")
     }
 
@@ -83,8 +83,8 @@ class ZipTest {
                 for (i in out.indices) out[i] = base[i % base.size]
             }
         }}
-        val compressed = deflateCompress(data)
-        val decompressed = deflateDecompress(compressed)
+        val compressed = rawDeflate(data)
+        val decompressed = rawInflate(compressed)
         assertArrayEquals(data, decompressed)
         assertTrue(compressed.size < data.size, "DEFLATE must compress repetitive data")
     }

--- a/code/specs/CMP09-zip.md
+++ b/code/specs/CMP09-zip.md
@@ -437,6 +437,7 @@ dependency-shaped deliveries.
 |------------|------------------------------|--------------------------------|
 | Python     | `coding-adventures-zip`      | `coding_adventures_zip`        |
 | Go         | module `…/go/zip`            | package `zip`                  |
+| Java       | `com.codingadventures:zip`   | `com.codingadventures.zip`     |
 | Ruby       | `coding_adventures_zip`      | `CodingAdventures::Zip`        |
 | TypeScript | `@coding-adventures/zip`     | `CodingAdventures.Zip`         |
 | Rust       | `coding-adventures-zip`      | `coding_adventures_zip`        |

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -3994,6 +3994,45 @@ fixture and capability suites, state-DAG validation, authority and credential
 scans, collision reporting, and diff checks all pass. Production remains pure
 in-memory; fixture reads and the independent Python zlib oracle are test-only.
 
+## Post-#12271 Refresh and JVM ZIP Raw-Conformance Selection
+
+After all required checks became terminal and acceptable, the loop enabled
+squash auto-merge for ready-for-review .NET ZIP PR #12271. GitHub merged final
+reviewed head `b3c4eac6b8020717fd8be985b933a5f2815efc27` as
+`993c78f1d65304f696cce4aeb765de40ac2f34cf` at
+2026-08-20T14:10:41Z. Its final 29 reported checks ended with 23 successes,
+six expected skips, and no failure or pending job. The parity loop did not
+exercise manual merge authority, and GitHub deleted the source remote branch.
+
+The collision-checked schema-3 inventory at exact merge main remains unchanged
+from `6694384516b8bd2d2b7696daf2604fa5d0118d8f`: 15 established lanes,
+1,367 normalized implementation identities, 4,551 established slots, 174
+high-consensus identities with 271 gaps, 905 singletons with 12,670 singleton
+gaps, 715 Rust singletons, zero canonical collisions, and zero unknown buckets.
+The exact root comparison found no added or retired identity, no lane expansion,
+and no newly discovered work requiring classification before selection.
+Before publication, the branch rebased cleanly over unrelated Gujarati,
+Telugu, and French human-language merges through
+`d6baf53b3ef32353fc8e4fcd9b8087349aad788e`; the exact collision gate at that
+current main retained every count above with zero collisions or unknown buckets.
+
+The dependency/leverage pass therefore selected the sole remaining ZIP child,
+`zip-raw-rfc1951-jvm-lane-parity`, on fresh branch
+`codex/jvm-zip-raw-rfc1951` from `993c78f1d6`. Completing Java and Kotlin closes
+the last two established-lane gaps in the strict raw RFC 1951 profile, unlocks
+the ZIP portable-conformance umbrella, and in turn releases fourteen dependent
+PNG parity slots. A fresh ownership audit found no open ZIP/parity PR. The only
+overlapping remote remains the ancient no-PR
+`worktree-feat+zstd-and-catchups` residue; it will not be reused or
+cherry-picked.
+
+This coherent tranche consumes CMP09 and every neutral fixture case in both JVM
+lanes, adds dynamic canonical Huffman decoding, caller output limits, exact
+input consumption, the closed payload-blind error taxonomy, strict ZIP size and
+CRC boundaries, package documentation and metadata, and real local package,
+coverage, BUILD, parity, diff, and security evidence. Production remains a
+pure in-memory byte transform with explicitly empty capability profiles.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- expose ZIP-owned raw RFC 1951 deflate, counted inflate, stable error-taxonomy, and CRC-32 APIs in Java and Kotlin
- add strict stored/fixed/dynamic Huffman decoding with 256 MiB hard ceilings, caller-lowerable limits, exact compressed-byte consumption, exact ZIP size/CRC checks, and pre-decode aggregate budget enforcement
- consume every language-neutral `zip-raw-rfc1951-v1` case in both lanes, remove the superseded fixed-only decoder paths, add Kotlin JaCoCo enforcement, and refresh package docs, metadata, CMP09, roadmap, and parity state

## Validation

- Java ZIP: Gradle 8.11.1 `clean test jacocoTestReport jacocoTestCoverageVerification build --warning-mode=fail` — 17 tests, 0 failures, 93.12% line coverage
- Kotlin ZIP: same full gate — 31 tests, 0 failures, 94.10% line coverage
- exact Java and Kotlin `BUILD_windows` front doors pass under `cmd.exe`
- repository neutral-fixture and capability suites: 16 tests plus 719 subtests pass
- Go build tool: `go test ./...`, `go vet ./...`, and `go build ./...` pass; fresh diff-aware Java and Kotlin runs each identify one changed package and build only `lzss` plus `zip`
- collision report at `d6baf53b3ef32353fc8e4fcd9b8087349aad788e`: schema 3, 15 lanes, 1,367 identities, 4,551 slots, 0 collisions, 0 unknown buckets
- state DAG: 393 unique items, valid statuses, all dependencies resolved, acyclic, exactly this item in progress before publication
- final security review: no blocker; production authority and credential scans clean, bounded primitive decoder buffers, aggregate size preflight before decode, Jackson confined to tests, empty capability profiles remain accurate
- `git diff --check` passes; no downstream JVM ZIP importer was found