### PR TITLE
feat(image-codec-png): add portable conformance foundation

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 12307,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "12c26b50ae755ec88704c457d8264558433b96f0",
+    "revision": "929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1368,
@@ -3926,7 +3926,7 @@
     {
       "id": "zip-raw-rfc1951-portable-conformance",
       "title": "Fixture and expose ZIP-owned raw RFC 1951 primitives across established lanes",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-dotnet-lane-parity", "zip-raw-rfc1951-dart-lane-parity", "zip-raw-rfc1951-elixir-lane-parity", "zip-raw-rfc1951-go-lane-parity", "zip-raw-rfc1951-haskell-lane-parity", "zip-raw-rfc1951-jvm-lane-parity", "zip-raw-rfc1951-lua-lane-parity", "zip-raw-rfc1951-perl-lane-parity", "zip-raw-rfc1951-python-lane-parity", "zip-raw-rfc1951-ruby-lane-parity", "zip-raw-rfc1951-rust-lane-parity", "zip-raw-rfc1951-swift-lane-parity"],
       "branch": "codex/zip-raw-rfc1951-portable-closure",
       "pr_number": 12307,
@@ -3935,17 +3935,22 @@
       "selection_revision": "f65567daa53a484eac081a750e554096b4241210",
       "selection_notes": "Selected only after JVM ZIP PR #12283 completed all 29 checks and auto-merged cleanly, the collision-checked schema-3 inventory remained exactly 15 established lanes, 1,367 identities, 4,551 slots, zero collisions, and zero unknown buckets through live main f65567daa5, and a full ownership audit found no active PR on the ZIP closure surface. All twelve toolchain-shaped children are now merged, making this the sole newly dependency-ready item. This bounded closure tranche adds a durable 15-lane adoption registry and gate over the shared 34-case corpus, public raw/count/cap/error surface, BUILD front doors, and truthful empty capabilities; it does not modify production codecs or start dependent PNG work.",
       "implementation_revision": "c4fd950cd8df692972c0bf743c10928c2e52e632",
+      "final_review_revision": "adb93159e901a352b37f534b2c8f4a345ebf1f42",
+      "merged_at": "2026-08-20T18:18:50Z",
+      "merge_revision": "2780825f2a7b5bf93936b6927175e975b611cb5c",
       "validation_notes": "The closed registry schema pins all 15 established ZIP roots, the shared 34-case corpus and 14 stable error identifiers, each native public raw/count/cap/error surface, every BUILD front door, and package-local empty capability manifests. The aggregate CI gate passes four closure tests; the neutral fixture, capability taxonomy, and parity suites pass 30 tests plus 719 subtests; and the collision report at exact main 12c26b50ae reports 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets. All 15 native package front doors pass with real coverage or language-native quality gates: C# 30 tests, F# 21, Dart 66, Elixir 69, Go race/vet/build, Haskell 21, Java 17, Kotlin 31, Lua 68 plus 40 coverage cases, Perl 74, Python 76, Ruby 72, Rust 24 unit plus two portable and five doctests, Swift 36, and TypeScript 98. The dependent TypeScript PNG front door passes 58 tests with 100% line coverage. Production npm audits report zero vulnerabilities; the Go build tool passes test, vet, trimpath build, BUILD validation, and a three-platform plan over 4,972 packages. State strict JSON, dependency uniqueness and acyclicity, safe-path traversal and symlink probes, capability and production-authority review, credential scan, diff check, and the final read-only security audit pass. No production codec or authority-bearing source changes in this closure tranche.",
-      "publication_notes": "Ready-for-review PR #12307 opened from the clean, current-main reviewed head d8288fc57076599357a2a72995d24616fb9fed31. This lifecycle-only follow-up records the required in-progress to pr-open transition and active PR identity; CI and mergeability remain pending, so auto-merge is not yet enabled.",
+      "publication_notes": "Ready-for-review PR #12307 opened from the clean, current-main reviewed head d8288fc57076599357a2a72995d24616fb9fed31. The final lifecycle commit advanced the state to pr-open at adb93159e901a352b37f534b2c8f4a345ebf1f42. All 29 reported checks reached terminal acceptable conclusions with 23 successes and six expected skips; both required gates succeeded and GitHub reported the PR clean and mergeable. The loop enabled squash auto-merge and GitHub merged that exact reviewed head as 2780825f2a7b5bf93936b6927175e975b611cb5c at 2026-08-20T18:18:50Z without manual merge authority.",
       "notes": "Completion umbrella discovered in the collision-clean 86f47eb4c3 inventory after merged PR #11088 added the TypeScript image-codec-png singleton. The neutral profile and all twelve toolchain-shaped children (.NET pair, Dart, Elixir, Go, Haskell, JVM pair, Lua, Perl, Python, Ruby, Rust, and Swift) are merged. Close the established denominator with one checked consumer registry and aggregate validation before direct PNG work becomes dependency-ready."
     },
     {
       "id": "image-codec-png-language-neutral-conformance",
       "title": "Define language-neutral IC18 PNG conformance with TypeScript reference consumption",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["zip-raw-rfc1951-portable-conformance"],
-      "branch": null,
+      "branch": "codex/png-language-neutral-conformance",
       "pr_number": null,
+      "selection_revision": "2780825f2a7b5bf93936b6927175e975b611cb5c",
+      "selection_notes": "Selected immediately after ZIP portable closure PR #12307 completed all 29 checks and merged through auto-merge, making this neutral foundation the sole newly dependency-ready prerequisite for all twelve PNG lane children. The canonical schema-3 inventory at exact live main 2780825f2a reports the same 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets, with no added, retired, or expanded package root. This bounded tranche first tightens the TypeScript reference, then defines and validates a language-neutral IC18 corpus and stable error contract for exact chunks, CRC, zlib framing, filters, supported colour forms, split IDAT, foreign interoperability, exact consumption, and caller-lowerable resource ceilings. It does not start any non-TypeScript lane port.",
       "notes": "Decomposed from the broad image-codec-png owner during the ZIP closure security and leverage audit. Close exact chunk ordering and CRC, zlib CM/CINFO/FCHECK and Adler-32 framing, split IDAT, every supported colour type, bit depth, and filter, foreign interoperability, exact consumption and covert-cavity rejection, stable payload-blind errors, dimension/pixel/inflation ceilings, and an explicit empty capability profile. The TypeScript reference must reject CINFO above 7 and require maxPixels to be an integer no larger than the 32 Mi-pixel default before it becomes the oracle."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 12319,
   "last_inventory": {
     "revision": "929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5",
     "schema_version": 3,
@@ -3945,12 +3945,17 @@
     {
       "id": "image-codec-png-language-neutral-conformance",
       "title": "Define language-neutral IC18 PNG conformance with TypeScript reference consumption",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["zip-raw-rfc1951-portable-conformance"],
       "branch": "codex/png-language-neutral-conformance",
-      "pr_number": null,
+      "pr_number": 12319,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/12319",
+      "opened_at": "2026-08-20T19:12:43Z",
       "selection_revision": "2780825f2a7b5bf93936b6927175e975b611cb5c",
       "selection_notes": "Selected immediately after ZIP portable closure PR #12307 completed all 29 checks and merged through auto-merge, making this neutral foundation the sole newly dependency-ready prerequisite for all twelve PNG lane children. The canonical schema-3 inventory at exact live main 2780825f2a reports the same 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets, with no added, retired, or expanded package root. This bounded tranche first tightens the TypeScript reference, then defines and validates a language-neutral IC18 corpus and stable error contract for exact chunks, CRC, zlib framing, filters, supported colour forms, split IDAT, foreign interoperability, exact consumption, and caller-lowerable resource ceilings. It does not start any non-TypeScript lane port.",
+      "implementation_revision": "d237fd922c714c39deb9dc4fd3a30aea47518e04",
+      "validation_notes": "The closed Draft 2020-12 schema and deterministic generator pin 82 portable cases and 29 ordered stable error identifiers. The corpus covers stored, fixed, and a checked dynamic RFC 1951 stream; all five filters; Paeth a/b/c and tie behavior; split IDAT; exact CRC, Adler-32, chunk-order, PLTE, tRNS, zlib-framing, truncation, and caller-lowered limit boundaries; and independent encode filter inspection without compressor-byte pins. TypeScript build and 141 tests pass with 100% statement, branch, function, and line coverage. The literal package BUILD, full and production npm audits with zero vulnerabilities, eight independent PNG fixture tests, nine ZIP fixture tests, four ZIP closure tests, seven capability tests, ten parity-reporter tests, Ruff, formatting, strict MyPy, Bandit, Go test/vet/trimpath build, strict JSON and state DAG checks, collision reporting, diff, credential, and production-authority scans pass. The repository build plan selects exactly image-codec-png and its pixel-container, ZIP, and LZSS prerequisites on Unix and Windows, and the repository-native build tool executes that four-package closure successfully. The live inventory remains 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets.",
+      "publication_notes": "Opened ready-for-review PR #12319 from validated implementation revision d237fd922c714c39deb9dc4fd3a30aea47518e04 after two clean late-main rebases and full recertification against origin/main 929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5. The PR is mergeable, and CI is pending; auto-merge remains disabled until every required check is terminal acceptable and GitHub reports no conflict.",
       "notes": "Decomposed from the broad image-codec-png owner during the ZIP closure security and leverage audit. Close exact chunk ordering and CRC, zlib CM/CINFO/FCHECK and Adler-32 framing, split IDAT, every supported colour type, bit depth, and filter, foreign interoperability, exact consumption and covert-cavity rejection, stable payload-blind errors, dimension/pixel/inflation ceilings, and an explicit empty capability profile. The TypeScript reference must reject CINFO above 7 and require maxPixels to be an integer no larger than the 32 Mi-pixel default before it becomes the oracle."
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           cargo build --manifest-path code/packages/rust/adj-lang-cli/Cargo.toml --bin adj-formula-audit
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_zip_raw_rfc1951_portable_coverage.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_image_codec_png_fixtures.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_typescript_tsconfig_portability.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_haskell_required_capabilities.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_ocaml_toolchain_lock.py'

--- a/code/packages/typescript/image-codec-png/CHANGELOG.md
+++ b/code/packages/typescript/image-codec-png/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — @coding-adventures/image-codec-png
 
+## 0.2.0 — 2026-08-20
+
+### Added
+
+- `PngError`, `PngErrorCode`, `PNG_ERROR_CODES`, `PNG_MAX_DIMENSION`, and
+  `PNG_MAX_PIXELS` as the stable public IC18 failure and resource surface.
+- Full consumption of the 82-case language-neutral `image-codec-png-v1`
+  corpus, including exact portable errors and foreign `pngjs` decoding of
+  encoder output.
+- Explicit empty production capability metadata.
+
+### Changed
+
+- `maxPixels` is now a positive safe integer no larger than 32 mebipixels, so a
+  caller can only lower the allocation ceiling.
+- Zlib headers now reject `CINFO > 7`, invalid chunk-type bytes and a lowercase
+  reserved third type letter are refused, and ZIP-owned inflater failures are
+  mapped to the PNG error taxonomy.
+- Suggested `PLTE` acceptance for truecolour images and exact `tRNS`
+  transparency for greyscale/truecolour inputs, with closed malformed ordering,
+  length, duplication, and sample-range failures.
+- Normative encoder filter-choice pins plus explicit Paeth predictor branch and
+  tie vectors.
+
+### Security
+
+- Stable error identifiers no longer require consumers to parse messages.
+- The independent corpus closes exact chunk/IDAT boundaries, CRC and Adler,
+  stored/fixed/dynamic DEFLATE, filter types, unsupported features, pixel and
+  dimension limits, malformed inflation, and covert IDAT cavities.
+
 ## 0.1.0 — 2026-08-12
 
 Initial release. Implements [`IC18`](../../../specs/IC18-image-codec-png.md).

--- a/code/packages/typescript/image-codec-png/README.md
+++ b/code/packages/typescript/image-codec-png/README.md
@@ -116,6 +116,8 @@ Sub for 5, and compresses 96,000 bytes to 2,123 — **45:1**.
 | multiple `IDAT` chunks | writes one | ✅ reads any number |
 | unknown **ancillary** chunks (`gAMA`, `tEXt`, …) | — | ✅ skipped |
 | unknown **critical** chunks | — | ❌ refused, as the spec requires |
+| suggested `PLTE` on truecolour types 2/6 | — | ✅ validated and ignored |
+| `tRNS` transparency on types 0/2 | — | ✅ applied to output alpha |
 
 Encoding always writes colour type 6, because that is exactly what a
 `PixelContainer` holds: no channel is dropped and no palette is guessed at, so
@@ -143,7 +145,9 @@ mis-reads a palette image is worse than one that says it cannot read it.
   `decodePng(bytes, { maxPixels })` or `new PngCodec({ maxPixels })` — decoding
   costs about three times the pixel buffer, so the default admits roughly
   400 MB of peak allocation, and a caller who knows its images are small should
-  say so.
+  say so. The supplied ceiling must be a positive safe integer no larger than
+  the 32 mebipixel default: callers may lower the budget, never raise or
+  fractionalize it.
 - **`IHDR` must be first, `IEND` must be empty and last, `IDAT` chunks must be
   consecutive, and the compressed data must end exactly where the Adler-32
   begins.** Each of those
@@ -170,6 +174,13 @@ round-trip perfectly. So the suite also:
   covering all five filter types in one image and each supported colour type;
 - checks `adler32` against the RFC's worked example and against the trailer zlib
   itself writes, including across the 5552-byte chunking boundary.
+- consumes all 82 cases in the
+  [`image-codec-png-v1`](../../../specs/fixtures/image-codec-png-v1/README.md)
+  language-neutral corpus through the public API, including every stable error
+  code, all supported colour forms and filters, and stored/fixed/dynamic
+  DEFLATE;
+- decodes the encoder's output with test-only `pngjs`, a foreign PNG
+  implementation, rather than trusting this package's own decoder.
 
 The written file has been confirmed readable by `file`, macOS `sips`, and
 Python's `zlib`.
@@ -187,3 +198,6 @@ npx vitest run --coverage
 | `decodePng(bytes, opts?)` | PNG bytes → `PixelContainer`. `opts.maxPixels` lowers the ceiling. |
 | `PngCodec` | `ImageCodec` implementation, mime type `image/png`. Takes the same options. |
 | `adler32(data)` | RFC 1950 checksum, exported because it is testable alone |
+| `PngError` / `PngErrorCode` | Stable portable failure code plus explanatory message |
+| `PNG_ERROR_CODES` | Closed IC18 error-code list shared with the neutral corpus |
+| `PNG_MAX_DIMENSION` / `PNG_MAX_PIXELS` | Public fixed default resource ceilings |

--- a/code/packages/typescript/image-codec-png/package-lock.json
+++ b/code/packages/typescript/image-codec-png/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@coding-adventures/image-codec-png",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/image-codec-png",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/pixel-container": "file:../pixel-container",
         "@coding-adventures/zip": "file:../zip"
       },
       "devDependencies": {
+        "@types/pngjs": "6.0.5",
         "@vitest/coverage-v8": "^4.1.0",
+        "pngjs": "7.0.0",
         "typescript": "^5.0.0",
         "vitest": "^4.1.0"
       }
@@ -441,6 +443,26 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.10",
@@ -1129,6 +1151,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
@@ -1305,6 +1337,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.2.1",

--- a/code/packages/typescript/image-codec-png/package.json
+++ b/code/packages/typescript/image-codec-png/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/image-codec-png",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "IC18: PNG image encoder and decoder using PixelContainer",
   "type": "module",
   "main": "src/index.ts",
@@ -16,8 +16,10 @@
     "@coding-adventures/zip": "file:../zip"
   },
   "devDependencies": {
+    "@types/pngjs": "6.0.5",
     "typescript": "^5.0.0",
     "vitest": "^4.1.0",
-    "@vitest/coverage-v8": "^4.1.0"
+    "@vitest/coverage-v8": "^4.1.0",
+    "pngjs": "7.0.0"
   }
 }

--- a/code/packages/typescript/image-codec-png/required_capabilities.json
+++ b/code/packages/typescript/image-codec-png/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/image-codec-png",
+  "capabilities": [],
+  "justification": "Pure in-memory PNG, zlib-wrapper, filter, checksum, and pixel-buffer transforms. No filesystem, network, process, environment, clock, entropy, native-image, or credential access."
+}

--- a/code/packages/typescript/image-codec-png/src/index.ts
+++ b/code/packages/typescript/image-codec-png/src/index.ts
@@ -123,7 +123,8 @@
  * lost or invented.
  *
  * Reads: 8-bit greyscale, truecolour, greyscale+alpha and truecolour+alpha
- * (types 0, 2, 4, 6), non-interlaced, with unknown ancillary chunks skipped.
+ * (types 0, 2, 4, 6), non-interlaced, with suggested PLTE validated, tRNS
+ * transparency applied, and unknown non-semantic ancillary chunks skipped.
  * Palette (type 3), 16-bit depths and Adam7 interlacing are refused by name
  * rather than half-supported.
  */
@@ -132,7 +133,12 @@ import {
   type ImageCodec,
   createPixelContainer,
 } from "@coding-adventures/pixel-container";
-import { crc32, rawDeflate, rawInflateCounted } from "@coding-adventures/zip";
+import {
+  RawInflateError,
+  crc32,
+  rawDeflate,
+  rawInflateCounted,
+} from "@coding-adventures/zip";
 
 export { type PixelContainer, type ImageCodec };
 
@@ -146,7 +152,7 @@ export { type PixelContainer, type ImageCodec };
  * A PNG header is eight bytes of attacker-controlled integers claiming a size,
  * and `width * height * 4` is allocated on the strength of it.
  */
-const MAX_DIMENSION = 16384;
+export const PNG_MAX_DIMENSION = 16384;
 
 /**
  * Largest total pixel count this codec will decode by default: 32 mebipixels,
@@ -171,16 +177,66 @@ const MAX_DIMENSION = 16384;
  * embedder that knows its images are small should say so: this package's own
  * caller draws single letters and passes a ceiling in the thousands.
  */
-const MAX_PIXELS = 32 * 1024 * 1024;
+export const PNG_MAX_PIXELS = 32 * 1024 * 1024;
+
+/** Closed, language-neutral IC18 error identifiers. */
+export const PNG_ERROR_CODES = [
+  "invalid-max-pixels",
+  "invalid-image-dimensions",
+  "invalid-pixel-data-length",
+  "file-too-short",
+  "invalid-signature",
+  "truncated-chunk",
+  "invalid-chunk-type",
+  "chunk-crc-mismatch",
+  "chunk-before-ihdr",
+  "duplicate-ihdr",
+  "invalid-ihdr-length",
+  "invalid-dimensions",
+  "dimension-limit",
+  "pixel-limit",
+  "unsupported-feature",
+  "invalid-plte",
+  "invalid-trns",
+  "nonconsecutive-idat",
+  "invalid-iend",
+  "trailing-data",
+  "unknown-critical-chunk",
+  "missing-required-chunk",
+  "invalid-zlib-header",
+  "preset-dictionary",
+  "inflate-failed",
+  "inflated-length-mismatch",
+  "idat-cavity",
+  "adler-mismatch",
+  "invalid-filter",
+] as const;
+
+export type PngErrorCode = (typeof PNG_ERROR_CODES)[number];
+
+/** A portable PNG failure with a stable code independent of its message. */
+export class PngError extends Error {
+  constructor(
+    public readonly code: PngErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PngError";
+  }
+}
+
+function fail(code: PngErrorCode, message: string): never {
+  throw new PngError(code, message);
+}
 
 /** Options for {@link decodePng}. */
 export interface DecodePngOptions {
   /**
-   * Largest total pixel count to accept, defaulting to {@link MAX_PIXELS}.
+   * Largest total pixel count to accept, defaulting to {@link PNG_MAX_PIXELS}.
    *
    * Lower it whenever you know roughly how big the images should be -- a
    * library reading files from strangers cannot know its embedder's budget.
-   * Must be a positive finite number.
+   * Must be a positive safe integer no larger than {@link PNG_MAX_PIXELS}.
    */
   maxPixels?: number;
 }
@@ -323,7 +379,7 @@ function undoFilter(type: number, row: Uint8Array, prior: Uint8Array, bpp: numbe
       }
       break;
     default:
-      throw new Error(`PNG: unknown filter type ${type}`);
+      fail("invalid-filter", `PNG: unknown filter type ${type}`);
   }
 }
 
@@ -364,8 +420,11 @@ function chooseFilter(
 /** Reject a ceiling that is not a usable number, wherever it is supplied. */
 function validateMaxPixels(value: number | undefined): void {
   if (value === undefined) return;
-  if (!Number.isFinite(value) || value <= 0) {
-    throw new Error("PNG: maxPixels must be a positive finite number");
+  if (!Number.isSafeInteger(value) || value <= 0 || value > PNG_MAX_PIXELS) {
+    fail(
+      "invalid-max-pixels",
+      `PNG: maxPixels must be a positive safe integer no greater than ${PNG_MAX_PIXELS}`,
+    );
   }
 }
 
@@ -478,13 +537,17 @@ export class PngCodec implements ImageCodec {
 export function encodePng(pixels: PixelContainer): Uint8Array {
   const { width, height } = pixels;
   if (!Number.isInteger(width) || !Number.isInteger(height) || width < 0 || height < 0) {
-    throw new Error("PNG: width and height must be non-negative integers");
+    fail("invalid-image-dimensions", "PNG: width and height must be non-negative integers");
   }
   if (width === 0 || height === 0) {
-    throw new Error("PNG: an image must have at least one pixel in each dimension");
+    fail(
+      "invalid-image-dimensions",
+      "PNG: an image must have at least one pixel in each dimension",
+    );
   }
   if (pixels.data.length !== width * height * 4) {
-    throw new Error(
+    fail(
+      "invalid-pixel-data-length",
       `PNG: pixel data is ${pixels.data.length} bytes, expected ${width * height * 4}`,
     );
   }
@@ -551,10 +614,10 @@ export function encodePng(pixels: PixelContainer): Uint8Array {
  */
 export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): PixelContainer {
   validateMaxPixels(options.maxPixels);
-  const maxPixels = options.maxPixels ?? MAX_PIXELS;
-  if (bytes.length < SIGNATURE.length) throw new Error("PNG: file too short");
+  const maxPixels = options.maxPixels ?? PNG_MAX_PIXELS;
+  if (bytes.length < SIGNATURE.length) fail("file-too-short", "PNG: file too short");
   for (let i = 0; i < SIGNATURE.length; i++) {
-    if (bytes[i] !== SIGNATURE[i]) throw new Error("PNG: invalid signature");
+    if (bytes[i] !== SIGNATURE[i]) fail("invalid-signature", "PNG: invalid signature");
   }
 
   let width = 0;
@@ -563,6 +626,10 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
   let colourType = 0;
   let sawIHDR = false;
   let sawIEND = false;
+  let sawPLTE = false;
+  let sawTRNS = false;
+  let transparentGrey: number | undefined;
+  let transparentRgb: readonly [number, number, number] | undefined;
   const idatParts: Uint8Array[] = [];
   // Tracks the IDAT run: once it has started and then stopped, no further IDAT
   // may appear.
@@ -571,16 +638,28 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
 
   let pos = SIGNATURE.length;
   while (pos < bytes.length) {
-    if (pos + 8 > bytes.length) throw new Error("PNG: truncated chunk header");
+    if (pos + 8 > bytes.length) fail("truncated-chunk", "PNG: truncated chunk header");
     const length =
       ((bytes[pos]! << 24) | (bytes[pos + 1]! << 16) | (bytes[pos + 2]! << 8) | bytes[pos + 3]!) >>> 0;
     // Guard before using `length` in any arithmetic: the field is four
     // attacker-chosen bytes and can claim four gigabytes.
-    if (length > bytes.length) throw new Error("PNG: chunk length exceeds file size");
+    if (length > bytes.length) {
+      fail("truncated-chunk", "PNG: chunk length exceeds file size");
+    }
     const typeStart = pos + 4;
     const dataStart = typeStart + 4;
     const dataEnd = dataStart + length;
-    if (dataEnd + 4 > bytes.length) throw new Error("PNG: truncated chunk data");
+    if (dataEnd + 4 > bytes.length) fail("truncated-chunk", "PNG: truncated chunk data");
+
+    const typeBytes = bytes.subarray(typeStart, typeStart + 4);
+    const hasOnlyLetters = typeBytes.every(
+      (byte) =>
+        (byte >= 0x41 && byte <= 0x5a) ||
+        (byte >= 0x61 && byte <= 0x7a),
+    );
+    if (!hasOnlyLetters || (typeBytes[2]! & 0x20) !== 0) {
+      fail("invalid-chunk-type", "PNG: invalid chunk type");
+    }
 
     const type = String.fromCharCode(
       bytes[typeStart]!, bytes[typeStart + 1]!, bytes[typeStart + 2]!, bytes[typeStart + 3]!,
@@ -590,7 +669,7 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
       ((bytes[dataEnd]! << 24) | (bytes[dataEnd + 1]! << 16) | (bytes[dataEnd + 2]! << 8) | bytes[dataEnd + 3]!) >>> 0;
     const actualCRC = crc32(bytes.subarray(typeStart, dataEnd));
     if (declaredCRC !== actualCRC) {
-      throw new Error(`PNG: CRC-32 mismatch in '${type}' chunk`);
+      fail("chunk-crc-mismatch", `PNG: CRC-32 mismatch in '${type}' chunk`);
     }
 
     const data = bytes.subarray(dataStart, dataEnd);
@@ -600,12 +679,14 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
     // place, libpng refuses it, and accepting what the reference implementation
     // rejects is the differential this decoder exists not to have.
     if (!sawIHDR && type !== "IHDR") {
-      throw new Error(`PNG: '${type}' chunk before IHDR`);
+      fail("chunk-before-ihdr", `PNG: '${type}' chunk before IHDR`);
     }
 
     if (type === "IHDR") {
-      if (sawIHDR) throw new Error("PNG: more than one IHDR chunk");
-      if (length !== 13) throw new Error(`PNG: IHDR must be 13 bytes, got ${length}`);
+      if (sawIHDR) fail("duplicate-ihdr", "PNG: more than one IHDR chunk");
+      if (length !== 13) {
+        fail("invalid-ihdr-length", `PNG: IHDR must be 13 bytes, got ${length}`);
+      }
       width = ((data[0]! << 24) | (data[1]! << 16) | (data[2]! << 8) | data[3]!) >>> 0;
       height = ((data[4]! << 24) | (data[5]! << 16) | (data[6]! << 8) | data[7]!) >>> 0;
       bitDepth = data[8]!;
@@ -614,34 +695,82 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
       const filterMethod = data[11]!;
       const interlace = data[12]!;
 
-      if (width === 0 || height === 0) throw new Error("PNG: zero width or height");
-      if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
-        throw new Error(`PNG: dimensions ${width}x${height} exceed maximum ${MAX_DIMENSION}`);
+      if (width === 0 || height === 0) fail("invalid-dimensions", "PNG: zero width or height");
+      if (width > PNG_MAX_DIMENSION || height > PNG_MAX_DIMENSION) {
+        fail(
+          "dimension-limit",
+          `PNG: dimensions ${width}x${height} exceed maximum ${PNG_MAX_DIMENSION}`,
+        );
       }
       // Checked here, before anything derived from the dimensions is computed
       // or allocated. Both operands are already below 16384, so the product
       // cannot leave the exactly-representable range.
       if (width * height > maxPixels) {
-        throw new Error(
+        fail(
+          "pixel-limit",
           `PNG: ${width}x${height} is ${width * height} pixels, above the limit of ${maxPixels}`,
         );
       }
-      if (compression !== 0) throw new Error(`PNG: unsupported compression method ${compression}`);
-      if (filterMethod !== 0) throw new Error(`PNG: unsupported filter method ${filterMethod}`);
-      if (interlace !== 0) throw new Error("PNG: Adam7 interlacing is not supported");
-      if (colourType === 3) throw new Error("PNG: palette images (colour type 3) are not supported");
+      if (compression !== 0) {
+        fail("unsupported-feature", `PNG: unsupported compression method ${compression}`);
+      }
+      if (filterMethod !== 0) {
+        fail("unsupported-feature", `PNG: unsupported filter method ${filterMethod}`);
+      }
+      if (interlace !== 0) fail("unsupported-feature", "PNG: Adam7 interlacing is not supported");
+      if (colourType === 3) {
+        fail("unsupported-feature", "PNG: palette images (colour type 3) are not supported");
+      }
       if (colourType !== 0 && colourType !== 2 && colourType !== 4 && colourType !== 6) {
-        throw new Error(`PNG: unknown colour type ${colourType}`);
+        fail("unsupported-feature", `PNG: unknown colour type ${colourType}`);
       }
       if (bitDepth !== 8) {
-        throw new Error(`PNG: unsupported bit depth ${bitDepth}, only 8 is supported`);
+        fail("unsupported-feature", `PNG: unsupported bit depth ${bitDepth}, only 8 is supported`);
       }
       sawIHDR = true;
+    } else if (type === "PLTE") {
+      // PLTE is required for palette images, but it is also a legal suggested
+      // palette for truecolour images. Palette images themselves remain out of
+      // scope; for types 2 and 6 we validate the bounded table and ignore it.
+      if (sawPLTE) fail("invalid-plte", "PNG: more than one PLTE chunk");
+      if (idatParts.length > 0) fail("invalid-plte", "PNG: PLTE must precede IDAT");
+      if (sawTRNS) fail("invalid-plte", "PNG: PLTE must precede tRNS");
+      if (colourType !== 2 && colourType !== 6) {
+        fail("invalid-plte", `PNG: PLTE is not allowed for colour type ${colourType}`);
+      }
+      if (length < 3 || length > 768 || length % 3 !== 0) {
+        fail("invalid-plte", `PNG: PLTE length ${length} is not 1 to 256 RGB entries`);
+      }
+      sawPLTE = true;
+    } else if (type === "tRNS") {
+      // tRNS changes rendered alpha, so it is a known ancillary chunk rather
+      // than something the generic ancillary skip may ignore.
+      if (sawTRNS) fail("invalid-trns", "PNG: more than one tRNS chunk");
+      if (idatParts.length > 0) fail("invalid-trns", "PNG: tRNS must precede IDAT");
+      if (colourType === 0) {
+        if (length !== 2) fail("invalid-trns", "PNG: greyscale tRNS must be 2 bytes");
+        transparentGrey = (data[0]! << 8) | data[1]!;
+        if (transparentGrey > 0xff) {
+          fail("invalid-trns", "PNG: greyscale tRNS sample exceeds 8-bit depth");
+        }
+      } else if (colourType === 2) {
+        if (length !== 6) fail("invalid-trns", "PNG: truecolour tRNS must be 6 bytes");
+        const red = (data[0]! << 8) | data[1]!;
+        const green = (data[2]! << 8) | data[3]!;
+        const blue = (data[4]! << 8) | data[5]!;
+        if (red > 0xff || green > 0xff || blue > 0xff) {
+          fail("invalid-trns", "PNG: truecolour tRNS sample exceeds 8-bit depth");
+        }
+        transparentRgb = [red, green, blue];
+      } else {
+        fail("invalid-trns", `PNG: tRNS is not allowed for colour type ${colourType}`);
+      }
+      sawTRNS = true;
     } else if (type === "IDAT") {
       // RFC 2083: multiple IDATs "shall appear consecutively with no other
       // intervening chunks". They are one stream cut into pieces, so a chunk
       // between them is either corruption or someone using the gap.
-      if (idatEnded) throw new Error("PNG: IDAT chunks are not consecutive");
+      if (idatEnded) fail("nonconsecutive-idat", "PNG: IDAT chunks are not consecutive");
       idatParts.push(data);
       inIdat = true;
     } else if (type === "IEND") {
@@ -649,9 +778,9 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
       // both are checked because a decoder that stops reading at IEND and looks
       // no further turns the rest of the file into free carriage: bytes that
       // travel inside something every tool calls a valid PNG.
-      if (length !== 0) throw new Error(`PNG: IEND must be empty, got ${length} bytes`);
+      if (length !== 0) fail("invalid-iend", `PNG: IEND must be empty, got ${length} bytes`);
       if (dataEnd + 4 !== bytes.length) {
-        throw new Error(`PNG: ${bytes.length - (dataEnd + 4)} bytes follow IEND`);
+        fail("trailing-data", `PNG: ${bytes.length - (dataEnd + 4)} bytes follow IEND`);
       }
       sawIEND = true;
       pos = dataEnd + 4;
@@ -660,7 +789,7 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
       // Uppercase first letter: a CRITICAL chunk. The spec says a decoder that
       // does not understand one must refuse the file, because ignoring it would
       // mean showing the user something other than what the file describes.
-      throw new Error(`PNG: unsupported critical chunk '${type}'`);
+      fail("unknown-critical-chunk", `PNG: unsupported critical chunk '${type}'`);
     }
     // Anything else is ancillary (lowercase) -- gAMA, pHYs, tEXt and so on --
     // and is skipped by design.
@@ -673,9 +802,9 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
     pos = dataEnd + 4;
   }
 
-  if (!sawIHDR) throw new Error("PNG: no IHDR chunk");
-  if (!sawIEND) throw new Error("PNG: no IEND chunk");
-  if (idatParts.length === 0) throw new Error("PNG: no IDAT chunk");
+  if (!sawIHDR) fail("missing-required-chunk", "PNG: no IHDR chunk");
+  if (!sawIEND) fail("missing-required-chunk", "PNG: no IEND chunk");
+  if (idatParts.length === 0) fail("missing-required-chunk", "PNG: no IDAT chunk");
 
   // The IDATs are one zlib stream that happens to be split across chunks, so
   // they are joined BEFORE anything is parsed. A split may fall anywhere,
@@ -691,12 +820,23 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
     }
   }
 
-  if (zlib.length < 6) throw new Error("PNG: IDAT too short to be a zlib stream");
+  if (zlib.length < 6) {
+    fail("invalid-zlib-header", "PNG: IDAT too short to be a zlib stream");
+  }
   const cmf = zlib[0]!;
   const flg = zlib[1]!;
-  if ((cmf & 0x0f) !== 8) throw new Error(`PNG: zlib compression method ${cmf & 0x0f}, expected 8`);
-  if (((cmf << 8) | flg) % 31 !== 0) throw new Error("PNG: corrupt zlib header");
-  if ((flg & 0x20) !== 0) throw new Error("PNG: zlib preset dictionary is not supported");
+  if ((cmf & 0x0f) !== 8) {
+    fail("invalid-zlib-header", `PNG: zlib compression method ${cmf & 0x0f}, expected 8`);
+  }
+  if ((cmf >> 4) > 7) {
+    fail("invalid-zlib-header", `PNG: zlib CINFO ${cmf >> 4} exceeds the maximum 7`);
+  }
+  if (((cmf << 8) | flg) % 31 !== 0) {
+    fail("invalid-zlib-header", "PNG: corrupt zlib header");
+  }
+  if ((flg & 0x20) !== 0) {
+    fail("preset-dictionary", "PNG: zlib preset dictionary is not supported");
+  }
 
   const channels = colourType === 0 ? 1 : colourType === 2 ? 3 : colourType === 4 ? 2 : 4;
   const stride = width * channels;
@@ -706,9 +846,21 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
   // stopped at the size this image could possibly need rather than at a
   // generic ceiling.
   const deflateStream = zlib.subarray(2, zlib.length - 4);
-  const { output: filtered, bytesConsumed } = rawInflateCounted(deflateStream, expected);
+  let inflateResult: { output: Uint8Array; bytesConsumed: number };
+  try {
+    inflateResult = rawInflateCounted(deflateStream, expected);
+  } catch (error: unknown) {
+    if (error instanceof RawInflateError && error.code === "output-limit-exceeded") {
+      fail("inflated-length-mismatch", "PNG: decompressed data exceeds the expected length");
+    }
+    fail("inflate-failed", "PNG: invalid DEFLATE stream");
+  }
+  const { output: filtered, bytesConsumed } = inflateResult;
   if (filtered.length !== expected) {
-    throw new Error(`PNG: decompressed ${filtered.length} bytes, expected ${expected}`);
+    fail(
+      "inflated-length-mismatch",
+      `PNG: decompressed ${filtered.length} bytes, expected ${expected}`,
+    );
   }
   // DEFLATE says where it ends -- the last block sets BFINAL -- so a stream can
   // finish well before the Adler-32 that follows it, and everything in between
@@ -718,7 +870,8 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
   // identical either way, which is exactly why it has to be rejected rather
   // than tolerated.
   if (bytesConsumed !== deflateStream.length) {
-    throw new Error(
+    fail(
+      "idat-cavity",
       `PNG: ${deflateStream.length - bytesConsumed} unused bytes between the ` +
       `compressed data and its checksum`,
     );
@@ -727,7 +880,9 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
   const declaredAdler =
     ((zlib[zlib.length - 4]! << 24) | (zlib[zlib.length - 3]! << 16) |
      (zlib[zlib.length - 2]! << 8) | zlib[zlib.length - 1]!) >>> 0;
-  if (adler32(filtered) !== declaredAdler) throw new Error("PNG: Adler-32 mismatch");
+  if (adler32(filtered) !== declaredAdler) {
+    fail("adler-mismatch", "PNG: Adler-32 mismatch");
+  }
 
   // Unfilter in place, row by row, each against the row already restored above.
   const bpp = channels; // 8-bit, so one byte per channel
@@ -752,7 +907,7 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
         container.data[dest] = v;
         container.data[dest + 1] = v;
         container.data[dest + 2] = v;
-        container.data[dest + 3] = 255;
+        container.data[dest + 3] = v === transparentGrey ? 0 : 255;
       } else if (channels === 2) {
         const v = row[src]!;
         container.data[dest] = v;
@@ -760,10 +915,19 @@ export function decodePng(bytes: Uint8Array, options: DecodePngOptions = {}): Pi
         container.data[dest + 2] = v;
         container.data[dest + 3] = row[src + 1]!;
       } else if (channels === 3) {
-        container.data[dest] = row[src]!;
-        container.data[dest + 1] = row[src + 1]!;
-        container.data[dest + 2] = row[src + 2]!;
-        container.data[dest + 3] = 255;
+        const red = row[src]!;
+        const green = row[src + 1]!;
+        const blue = row[src + 2]!;
+        container.data[dest] = red;
+        container.data[dest + 1] = green;
+        container.data[dest + 2] = blue;
+        container.data[dest + 3] =
+          transparentRgb !== undefined &&
+          red === transparentRgb[0] &&
+          green === transparentRgb[1] &&
+          blue === transparentRgb[2]
+            ? 0
+            : 255;
       } else {
         container.data[dest] = row[src]!;
         container.data[dest + 1] = row[src + 1]!;

--- a/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
+++ b/code/packages/typescript/image-codec-png/tests/image-codec-png.test.ts
@@ -567,10 +567,10 @@ describe("total-pixel ceiling", () => {
 
   it("rejects a nonsensical ceiling rather than ignoring it", () => {
     const png = encodePng(sampleImage(2, 2));
-    expect(() => decodePng(png, { maxPixels: 0 })).toThrow(/positive finite/);
-    expect(() => decodePng(png, { maxPixels: -1 })).toThrow(/positive finite/);
-    expect(() => decodePng(png, { maxPixels: Infinity })).toThrow(/positive finite/);
-    expect(() => decodePng(png, { maxPixels: Number.NaN })).toThrow(/positive finite/);
+    expect(() => decodePng(png, { maxPixels: 0 })).toThrow(/positive safe integer/);
+    expect(() => decodePng(png, { maxPixels: -1 })).toThrow(/positive safe integer/);
+    expect(() => decodePng(png, { maxPixels: Infinity })).toThrow(/positive safe integer/);
+    expect(() => decodePng(png, { maxPixels: Number.NaN })).toThrow(/positive safe integer/);
   });
 
   it("carries the ceiling through PngCodec, the shared interface", () => {
@@ -691,8 +691,8 @@ describe("IHDR must be the first chunk", () => {
 
 describe("PngCodec validates its ceiling when it is supplied", () => {
   it("rejects a bad maxPixels at construction, not at first decode", () => {
-    expect(() => new PngCodec({ maxPixels: Infinity })).toThrow(/positive finite/);
-    expect(() => new PngCodec({ maxPixels: 0 })).toThrow(/positive finite/);
-    expect(() => new PngCodec({ maxPixels: Number.NaN })).toThrow(/positive finite/);
+    expect(() => new PngCodec({ maxPixels: Infinity })).toThrow(/positive safe integer/);
+    expect(() => new PngCodec({ maxPixels: 0 })).toThrow(/positive safe integer/);
+    expect(() => new PngCodec({ maxPixels: Number.NaN })).toThrow(/positive safe integer/);
   });
 });

--- a/code/packages/typescript/image-codec-png/tests/portable-conformance.test.ts
+++ b/code/packages/typescript/image-codec-png/tests/portable-conformance.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { inflateSync } from "node:zlib";
+import { PNG } from "pngjs";
+import { describe, expect, it } from "vitest";
+
+import {
+  PNG_ERROR_CODES,
+  PNG_MAX_DIMENSION,
+  PNG_MAX_PIXELS,
+  PngError,
+  adler32,
+  decodePng,
+  encodePng,
+  type PixelContainer,
+} from "../src/index.js";
+
+interface Pixels {
+  width: number;
+  height: number;
+  rgba_hex: string;
+}
+
+interface FixtureOptions {
+  max_pixels: number;
+}
+
+interface FixtureCase {
+  id: string;
+  operation: "decode" | "decode-error" | "encode" | "encode-error" | "adler32";
+  png_hex?: string;
+  input_hex?: string;
+  input?: Pixels;
+  options?: FixtureOptions;
+  expected:
+    | Pixels
+    | { error_id: string }
+    | {
+        chunk_types: string[];
+        filter_types: number[];
+        bit_depth: number;
+        colour_type: number;
+        interlace: number;
+      }
+    | { adler32_hex: string };
+}
+
+interface FixtureDocument {
+  limits: { max_dimension: number; default_max_pixels: number };
+  error_ids: string[];
+  cases: FixtureCase[];
+}
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL("../../../../specs/fixtures/image-codec-png-v1/cases.json", import.meta.url),
+);
+const FIXTURES = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as FixtureDocument;
+
+function fromHex(value: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(value, "hex"));
+}
+
+interface PngChunk {
+  type: string;
+  data: Uint8Array;
+}
+
+function chunks(png: Uint8Array): PngChunk[] {
+  const result: PngChunk[] = [];
+  let offset = 8;
+  while (offset < png.length) {
+    const length =
+      ((png[offset]! << 24) |
+        (png[offset + 1]! << 16) |
+        (png[offset + 2]! << 8) |
+        png[offset + 3]!) >>>
+      0;
+    result.push({
+      type: String.fromCharCode(...png.subarray(offset + 4, offset + 8)),
+      data: png.slice(offset + 8, offset + 8 + length),
+    });
+    offset += 12 + length;
+  }
+  return result;
+}
+
+function makePixels(input: Pixels): PixelContainer {
+  return {
+    width: input.width,
+    height: input.height,
+    data: fromHex(input.rgba_hex),
+  };
+}
+
+function expectPngError(action: () => unknown, errorId: string): void {
+  try {
+    action();
+    throw new Error("fixture unexpectedly succeeded");
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(PngError);
+    expect((error as PngError).code).toBe(errorId);
+  }
+}
+
+describe("IC18 image-codec-png v1 language-neutral fixtures", () => {
+  it("pins the public limits and closed error taxonomy", () => {
+    expect(PNG_MAX_DIMENSION).toBe(FIXTURES.limits.max_dimension);
+    expect(PNG_MAX_PIXELS).toBe(FIXTURES.limits.default_max_pixels);
+    expect([...PNG_ERROR_CODES]).toEqual(FIXTURES.error_ids);
+  });
+
+  for (const fixture of FIXTURES.cases) {
+    if (fixture.operation === "decode") {
+      it(`decodes ${fixture.id}`, () => {
+        const expected = fixture.expected as Pixels;
+        const options = fixture.options
+          ? { maxPixels: fixture.options.max_pixels }
+          : undefined;
+        const actual = decodePng(fromHex(fixture.png_hex!), options);
+        expect(actual.width).toBe(expected.width);
+        expect(actual.height).toBe(expected.height);
+        expect(actual.data).toEqual(fromHex(expected.rgba_hex));
+      });
+    } else if (fixture.operation === "decode-error") {
+      it(`fails closed for ${fixture.id}`, () => {
+        const expected = fixture.expected as { error_id: string };
+        const options = fixture.options
+          ? { maxPixels: fixture.options.max_pixels }
+          : undefined;
+        expectPngError(
+          () => decodePng(fromHex(fixture.png_hex!), options),
+          expected.error_id,
+        );
+      });
+    } else if (fixture.operation === "encode") {
+      it(`foreign-decodes ${fixture.id}`, () => {
+        const input = fixture.input!;
+        const expected = fixture.expected as {
+          chunk_types: string[];
+          filter_types: number[];
+          bit_depth: number;
+          colour_type: number;
+          interlace: number;
+        };
+        const encoded = encodePng(makePixels(input));
+        const encodedChunks = chunks(encoded);
+        expect(encodedChunks.map((chunk) => chunk.type)).toEqual(expected.chunk_types);
+        expect(encoded[24]).toBe(expected.bit_depth);
+        expect(encoded[25]).toBe(expected.colour_type);
+        expect(encoded[28]).toBe(expected.interlace);
+        const idat = Buffer.concat(
+          encodedChunks
+            .filter((chunk) => chunk.type === "IDAT")
+            .map((chunk) => Buffer.from(chunk.data)),
+        );
+        const filtered = inflateSync(idat);
+        const stride = input.width * 4;
+        const filterTypes = Array.from(
+          { length: input.height },
+          (_, row) => filtered[row * (stride + 1)]!,
+        );
+        expect(filterTypes).toEqual(expected.filter_types);
+        const foreign = PNG.sync.read(Buffer.from(encoded));
+        expect(foreign.width).toBe(input.width);
+        expect(foreign.height).toBe(input.height);
+        expect(Uint8Array.from(foreign.data)).toEqual(fromHex(input.rgba_hex));
+      });
+    } else if (fixture.operation === "encode-error") {
+      it(`rejects encoder input ${fixture.id}`, () => {
+        const expected = fixture.expected as { error_id: string };
+        expectPngError(() => encodePng(makePixels(fixture.input!)), expected.error_id);
+      });
+    } else {
+      it(`checks Adler-32 for ${fixture.id}`, () => {
+        const expected = fixture.expected as { adler32_hex: string };
+        expect(adler32(fromHex(fixture.input_hex!)).toString(16).padStart(8, "0"))
+          .toBe(expected.adler32_hex);
+      });
+    }
+  }
+});

--- a/code/scripts/tests/test_image_codec_png_fixtures.py
+++ b/code/scripts/tests/test_image_codec_png_fixtures.py
@@ -1,0 +1,419 @@
+"""Validate the language-neutral IC18 PNG corpus independently."""
+
+from __future__ import annotations
+
+import binascii
+import importlib.util
+import json
+import struct
+import unittest
+import zlib
+from copy import deepcopy
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
+
+from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "code/specs/fixtures/image-codec-png-v1"
+SIGNATURE = b"\x89PNG\r\n\x1a\n"
+EXPECTED_ERROR_IDS = (
+    "invalid-max-pixels",
+    "invalid-image-dimensions",
+    "invalid-pixel-data-length",
+    "file-too-short",
+    "invalid-signature",
+    "truncated-chunk",
+    "invalid-chunk-type",
+    "chunk-crc-mismatch",
+    "chunk-before-ihdr",
+    "duplicate-ihdr",
+    "invalid-ihdr-length",
+    "invalid-dimensions",
+    "dimension-limit",
+    "pixel-limit",
+    "unsupported-feature",
+    "invalid-plte",
+    "invalid-trns",
+    "nonconsecutive-idat",
+    "invalid-iend",
+    "trailing-data",
+    "unknown-critical-chunk",
+    "missing-required-chunk",
+    "invalid-zlib-header",
+    "preset-dictionary",
+    "inflate-failed",
+    "inflated-length-mismatch",
+    "idat-cavity",
+    "adler-mismatch",
+    "invalid-filter",
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load JSON while rejecting duplicate object keys."""
+
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    return cast(
+        dict[str, Any],
+        json.loads(path.read_text("utf-8"), object_pairs_hook=reject_duplicates),
+    )
+
+
+def fixture_document() -> dict[str, Any]:
+    return load_json(FIXTURE_ROOT / "cases.json")
+
+
+def require(condition: object, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_generator() -> ModuleType:
+    path = FIXTURE_ROOT / "generate_cases.py"
+    spec = importlib.util.spec_from_file_location("image_codec_png_cases", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load the fixture generator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def parse_chunks(png: bytes) -> list[tuple[str, bytes]]:
+    require(png.startswith(SIGNATURE), "valid fixture lost the PNG signature")
+    chunks: list[tuple[str, bytes]] = []
+    offset = len(SIGNATURE)
+    while offset < len(png):
+        require(offset + 12 <= len(png), "valid fixture has a truncated chunk")
+        length = struct.unpack_from(">I", png, offset)[0]
+        type_bytes = png[offset + 4 : offset + 8]
+        data_start = offset + 8
+        data_end = data_start + length
+        require(data_end + 4 <= len(png), "valid fixture chunk exceeds the file")
+        require(
+            all(
+                ord("A") <= byte <= ord("Z") or ord("a") <= byte <= ord("z")
+                for byte in type_bytes
+            ),
+            "valid fixture has a non-letter chunk type",
+        )
+        require(type_bytes[2] & 0x20 == 0, "valid fixture sets the reserved chunk bit")
+        expected_crc = struct.unpack_from(">I", png, data_end)[0]
+        require(
+            binascii.crc32(type_bytes + png[data_start:data_end]) == expected_crc,
+            "valid fixture has a bad chunk CRC",
+        )
+        chunks.append((type_bytes.decode("ascii"), png[data_start:data_end]))
+        offset = data_end + 4
+    require(offset == len(png), "valid fixture has trailing chunk bytes")
+    return chunks
+
+
+def paeth(a: int, b: int, c: int) -> int:
+    estimate = a + b - c
+    da, db, dc = abs(estimate - a), abs(estimate - b), abs(estimate - c)
+    if da <= db and da <= dc:
+        return a
+    if db <= dc:
+        return b
+    return c
+
+
+def unfilter(row: bytearray, prior: bytes, kind: int, bpp: int) -> None:
+    for index in range(len(row)):
+        left = row[index - bpp] if index >= bpp else 0
+        above = prior[index]
+        upper_left = prior[index - bpp] if index >= bpp else 0
+        if kind == 0:
+            predictor = 0
+        elif kind == 1:
+            predictor = left
+        elif kind == 2:
+            predictor = above
+        elif kind == 3:
+            predictor = (left + above) // 2
+        elif kind == 4:
+            predictor = paeth(left, above, upper_left)
+        else:
+            raise AssertionError(f"fixture success case has filter {kind}")
+        row[index] = (row[index] + predictor) & 0xFF
+
+
+def independent_decode(png: bytes) -> tuple[int, int, bytes, int]:
+    chunks = parse_chunks(png)
+    require(chunks[0][0] == "IHDR", "valid fixture does not start with IHDR")
+    require(chunks[-1] == ("IEND", b""), "valid fixture does not end with empty IEND")
+    require(
+        [kind for kind, _ in chunks].count("IHDR") == 1,
+        "valid fixture does not contain exactly one IHDR",
+    )
+    idat_indexes = [index for index, (kind, _) in enumerate(chunks) if kind == "IDAT"]
+    require(idat_indexes, "valid fixture has no IDAT")
+    require(
+        idat_indexes == list(range(idat_indexes[0], idat_indexes[-1] + 1)),
+        "valid fixture IDAT chunks are not consecutive",
+    )
+
+    header = chunks[0][1]
+    require(len(header) == 13, "valid fixture IHDR is not 13 bytes")
+    width, height = struct.unpack_from(">II", header)
+    depth, colour, compression, filter_method, interlace = header[8:]
+    require(depth == 8, "valid fixture depth is not 8")
+    require(colour in (0, 2, 4, 6), "valid fixture colour type is unsupported")
+    require(
+        (compression, filter_method, interlace) == (0, 0, 0),
+        "valid fixture has an unsupported IHDR method",
+    )
+    plte_chunks = [
+        (index, data) for index, (kind, data) in enumerate(chunks) if kind == "PLTE"
+    ]
+    require(len(plte_chunks) <= 1, "valid fixture repeats PLTE")
+    if plte_chunks:
+        index, palette = plte_chunks[0]
+        require(index < idat_indexes[0], "valid fixture puts PLTE after IDAT")
+        require(colour in (2, 6), "valid fixture puts PLTE on a greyscale image")
+        require(
+            3 <= len(palette) <= 768 and len(palette) % 3 == 0,
+            "valid fixture has an invalid PLTE length",
+        )
+
+    transparent_grey: int | None = None
+    transparent_rgb: tuple[int, int, int] | None = None
+    trns_chunks = [
+        (index, data) for index, (kind, data) in enumerate(chunks) if kind == "tRNS"
+    ]
+    require(len(trns_chunks) <= 1, "valid fixture repeats tRNS")
+    if trns_chunks:
+        index, transparency = trns_chunks[0]
+        require(index < idat_indexes[0], "valid fixture puts tRNS after IDAT")
+        if plte_chunks:
+            require(plte_chunks[0][0] < index, "valid fixture puts PLTE after tRNS")
+        if colour == 0:
+            require(len(transparency) == 2, "greyscale tRNS is not two bytes")
+            transparent_grey = struct.unpack(">H", transparency)[0]
+            require(transparent_grey <= 255, "greyscale tRNS exceeds 8-bit depth")
+        elif colour == 2:
+            require(len(transparency) == 6, "truecolour tRNS is not six bytes")
+            transparent_rgb = struct.unpack(">HHH", transparency)
+            require(max(transparent_rgb) <= 255, "truecolour tRNS exceeds 8-bit depth")
+        else:
+            raise AssertionError("valid fixture puts tRNS on a colour type with alpha")
+    channels = {0: 1, 2: 3, 4: 2, 6: 4}[colour]
+    stream = b"".join(data for kind, data in chunks if kind == "IDAT")
+    require(len(stream) >= 6, "valid fixture has a short zlib stream")
+    require(stream[0] & 0x0F == 8, "valid fixture zlib method is not DEFLATE")
+    require(stream[0] >> 4 <= 7, "valid fixture zlib CINFO is too large")
+    require((stream[0] << 8 | stream[1]) % 31 == 0, "valid fixture FCHECK is invalid")
+    require(stream[1] & 0x20 == 0, "valid fixture requests a preset dictionary")
+    inflater = zlib.decompressobj()
+    filtered = inflater.decompress(stream) + inflater.flush()
+    require(inflater.eof, "valid fixture zlib stream is incomplete")
+    require(not inflater.unused_data, "valid fixture zlib stream has trailing bytes")
+    require(not inflater.unconsumed_tail, "valid fixture zlib input was not consumed")
+    require(
+        zlib.adler32(filtered) == struct.unpack(">I", stream[-4:])[0],
+        "valid fixture Adler-32 is incorrect",
+    )
+
+    stride = width * channels
+    require(
+        len(filtered) == height * (stride + 1),
+        "valid fixture filtered size disagrees with IHDR",
+    )
+    prior = bytes(stride)
+    rgba = bytearray()
+    filter_mask = 0
+    for y in range(height):
+        start = y * (stride + 1)
+        kind = filtered[start]
+        filter_mask |= 1 << kind
+        row = bytearray(filtered[start + 1 : start + 1 + stride])
+        unfilter(row, prior, kind, channels)
+        for x in range(width):
+            pixel = row[x * channels : (x + 1) * channels]
+            if colour == 0:
+                alpha = 0 if pixel[0] == transparent_grey else 255
+                rgba.extend([pixel[0], pixel[0], pixel[0], alpha])
+            elif colour == 2:
+                alpha = 0 if tuple(pixel) == transparent_rgb else 255
+                rgba.extend([pixel[0], pixel[1], pixel[2], alpha])
+            elif colour == 4:
+                rgba.extend([pixel[0], pixel[0], pixel[0], pixel[1]])
+            else:
+                rgba.extend(pixel)
+        prior = bytes(row)
+    return width, height, bytes(rgba), filter_mask
+
+
+def validate_encode_cases(document: dict[str, Any]) -> None:
+    """Validate semantic constraints that JSON Schema cannot express."""
+
+    encode_cases = [case for case in document["cases"] if case["operation"] == "encode"]
+    require(encode_cases, "fixture has no successful encode case")
+    for case in encode_cases:
+        pixels = case["input"]
+        width = pixels["width"]
+        height = pixels["height"]
+        require(
+            type(width) is int and width > 0,
+            f"{case['id']} width is not a positive integer",
+        )
+        require(
+            type(height) is int and height > 0,
+            f"{case['id']} height is not a positive integer",
+        )
+        require(
+            len(bytes.fromhex(pixels["rgba_hex"])) == width * height * 4,
+            f"{case['id']} RGBA length disagrees with its dimensions",
+        )
+        expected = case["expected"]
+        require(
+            set(expected)
+            == {"chunk_types", "filter_types", "bit_depth", "colour_type", "interlace"},
+            f"{case['id']} encode expectations are not closed",
+        )
+        require(
+            expected["chunk_types"] == ["IHDR", "IDAT", "IEND"]
+            and expected["bit_depth"] == 8
+            and expected["colour_type"] == 6
+            and expected["interlace"] == 0,
+            f"{case['id']} does not pin the required encoded PNG profile",
+        )
+        require(
+            len(expected["filter_types"]) == height
+            and all(
+                type(value) is int and 0 <= value <= 4
+                for value in expected["filter_types"]
+            ),
+            f"{case['id']} does not pin one valid filter type per row",
+        )
+
+
+class ImageCodecPngFixtureTests(unittest.TestCase):
+    def test_schema_closes_profile_limits_and_case_shapes(self) -> None:
+        schema = load_json(FIXTURE_ROOT / "schema.json")
+        document = fixture_document()
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(document)
+        self.assertEqual(document["schema_version"], 1)
+        self.assertEqual(document["profile"], "image-codec-png-v1")
+        self.assertEqual(
+            document["limits"],
+            {"max_dimension": 16384, "default_max_pixels": 33554432},
+        )
+        self.assertEqual(tuple(document["error_ids"]), EXPECTED_ERROR_IDS)
+
+    def test_case_ids_are_unique_and_every_error_is_exercised(self) -> None:
+        document = fixture_document()
+        identifiers = [case["id"] for case in document["cases"]]
+        self.assertEqual(len(identifiers), len(set(identifiers)))
+        exercised = {
+            case["expected"]["error_id"]
+            for case in document["cases"]
+            if case["operation"] in ("decode-error", "encode-error")
+        }
+        self.assertEqual(exercised, set(EXPECTED_ERROR_IDS))
+
+    def test_encode_vectors_have_exact_pixel_and_chunk_contracts(self) -> None:
+        schema = load_json(FIXTURE_ROOT / "schema.json")
+        document = fixture_document()
+        validate_encode_cases(document)
+
+        empty_chunks = deepcopy(document)
+        encode = next(
+            case for case in empty_chunks["cases"] if case["operation"] == "encode"
+        )
+        encode["expected"]["chunk_types"] = []
+        self.assertTrue(list(Draft202012Validator(schema).iter_errors(empty_chunks)))
+
+        wrong_length = deepcopy(document)
+        encode = next(
+            case for case in wrong_length["cases"] if case["operation"] == "encode"
+        )
+        encode["input"]["rgba_hex"] = "00"
+        with self.assertRaisesRegex(AssertionError, "RGBA length"):
+            validate_encode_cases(wrong_length)
+
+        fractional_width = deepcopy(document)
+        encode = next(
+            case for case in fractional_width["cases"] if case["operation"] == "encode"
+        )
+        encode["input"]["width"] = 1.5
+        with self.assertRaisesRegex(AssertionError, "positive integer"):
+            validate_encode_cases(fractional_width)
+
+    def test_success_vectors_decode_with_independent_python_zlib(self) -> None:
+        cases = [
+            case
+            for case in fixture_document()["cases"]
+            if case["operation"] == "decode"
+        ]
+        masks: dict[str, int] = {}
+        for case in cases:
+            width, height, rgba, mask = independent_decode(
+                bytes.fromhex(case["png_hex"])
+            )
+            expected = case["expected"]
+            self.assertEqual(
+                (width, height), (expected["width"], expected["height"]), case["id"]
+            )
+            self.assertEqual(rgba.hex(), expected["rgba_hex"], case["id"])
+            masks[case["id"]] = mask
+        self.assertEqual(masks["png-v1-decode-all-filters"] & 0b11111, 0b11111)
+
+    def test_paeth_vectors_pin_all_predictors_and_ties(self) -> None:
+        identifiers = {case["id"] for case in fixture_document()["cases"]}
+        self.assertTrue(
+            {
+                "png-v1-decode-paeth-a",
+                "png-v1-decode-paeth-b",
+                "png-v1-decode-paeth-c",
+                "png-v1-decode-paeth-a-b-tie",
+                "png-v1-decode-paeth-all-tie",
+            }.issubset(identifiers)
+        )
+
+    def test_corpus_contains_stored_fixed_and_dynamic_deflate(self) -> None:
+        expected = {
+            "png-v1-decode-stored-deflate": 0,
+            "png-v1-decode-fixed-deflate": 1,
+            "png-v1-decode-dynamic-deflate": 2,
+        }
+        by_id = {case["id"]: case for case in fixture_document()["cases"]}
+        for identifier, block_type in expected.items():
+            chunks = parse_chunks(bytes.fromhex(by_id[identifier]["png_hex"]))
+            stream = b"".join(data for kind, data in chunks if kind == "IDAT")
+            self.assertEqual((stream[2] >> 1) & 0x03, block_type)
+
+    def test_generator_is_deterministic_and_fixture_is_bounded(self) -> None:
+        module = load_generator()
+        rendered = module.rendered()
+        self.assertEqual((FIXTURE_ROOT / "cases.json").read_text("utf-8"), rendered)
+        document = fixture_document()
+        self.assertGreaterEqual(len(document["cases"]), 40)
+        self.assertLess(len(rendered.encode("utf-8")), 256 * 1024)
+        for case in document["cases"]:
+            if "png_hex" in case:
+                self.assertLessEqual(len(case["png_hex"]) // 2, 1024 * 1024)
+
+    def test_schema_rejects_unknown_fields_and_duplicate_case_shapes(self) -> None:
+        schema = load_json(FIXTURE_ROOT / "schema.json")
+        document = deepcopy(fixture_document())
+        document["unexpected"] = True
+        self.assertTrue(list(Draft202012Validator(schema).iter_errors(document)))
+
+        taxonomy = deepcopy(fixture_document())
+        taxonomy["error_ids"] = [f"arbitrary-code-{index}" for index in range(29)]
+        self.assertTrue(list(Draft202012Validator(schema).iter_errors(taxonomy)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/IC18-image-codec-png.md
+++ b/code/specs/IC18-image-codec-png.md
@@ -95,6 +95,23 @@ lowercase means **ancillary**. A decoder MUST skip an unknown ancillary chunk
 one, because a critical chunk it does not understand may change what the image
 means.
 
+All four chunk-type bytes MUST be ASCII letters. The third letter's bit 5 is
+reserved by PNG and MUST be zero, so the third letter MUST be uppercase. Reject
+an invalid type before interpreting its critical/ancillary flag.
+
+`PLTE` is a known critical chunk even when palette images are out of scope.
+For truecolour types 2 and 6 it is an optional suggested palette: a decoder
+MUST accept and ignore one well-formed table before `tRNS` and `IDAT`. It MUST reject a
+duplicate, a table after `IDAT`, a table on greyscale types 0 or 4, or a length
+that is not 1 to 256 complete three-byte RGB entries.
+
+`tRNS` is ancillary in spelling but changes rendered pixels, so it MUST NOT be
+silently skipped. Before `IDAT`, one `tRNS` supplies a two-byte transparent
+greyscale sample for type 0 or three two-byte transparent samples for type 2.
+At depth 8 each sample MUST fit in 0 through 255. A matching pixel receives
+alpha 0 and every other pixel alpha 255. Reject `tRNS` on types 4 and 6, after
+`IDAT`, with the wrong length, outside the active bit depth, or when repeated.
+
 `IHDR` is:
 
 ```
@@ -129,6 +146,9 @@ CMF  FLG   <raw DEFLATE stream>   Adler-32 (u32 BE)
 ```
 
 - `CMF` low nibble is the method (8 = deflate); high nibble is the window size.
+- `CMF` high nibble (`CINFO`) MUST be at most 7. Larger values advertise a
+  window above DEFLATE's 32 KiB maximum and MUST be rejected even when the
+  mod-31 header check passes.
 - `FLG` low five bits are chosen so `CMF * 256 + FLG` is a multiple of 31. Bit 5
   is `FDICT`, a preset dictionary, which PNG forbids.
 - The trailing Adler-32 covers the **uncompressed** bytes.
@@ -215,9 +235,10 @@ differently produce different images.
 ### Choosing a filter
 
 The spec's own heuristic, and what every real encoder does: apply all five, sum
-the filtered bytes read as SIGNED values, keep the smallest total. The signed
-reading is the point -- a filtered byte of 255 means -1, a tiny correction, and
-reading it as 255 would rank the best filter worst.
+the absolute values of the filtered bytes read as SIGNED values, and keep the
+smallest total. Ties keep the lowest-numbered filter. The signed reading is the
+point -- a filtered byte of 255 means -1, a tiny correction, and reading it as
+255 would rank the best filter worst.
 
 Running DEFLATE five times per row would be more accurate and costs far more than
 it saves.
@@ -255,6 +276,8 @@ the round trip is lossless by construction rather than by luck.
        in any arithmetic
      - verify the CRC over type + data
      - IHDR: parse and validate; reject a second IHDR
+     - PLTE: validate one optional suggested palette for types 2/6 before IDAT
+     - tRNS: validate one optional transparency key for types 0/2 before IDAT
      - IDAT: collect (must follow IHDR)
      - IEND: stop
      - otherwise: skip if ancillary (lowercase first letter), reject if critical
@@ -275,7 +298,8 @@ the round trip is lossless by construction rather than by luck.
 
 - **Encode:** 8-bit colour type 6, non-interlaced, one `IDAT`.
 - **Decode:** 8-bit colour types 0, 2, 4 and 6, non-interlaced, any number of
-  `IDAT` chunks, unknown ancillary chunks skipped.
+  `IDAT` chunks, suggested `PLTE` for types 2/6, `tRNS` transparency for types
+  0/2, and unknown non-semantic ancillary chunks skipped.
 
 ### Explicitly out of scope
 
@@ -300,7 +324,9 @@ PNG is a format a program reads from strangers, so these are normative.
    filtered buffer and the transient copy made while sizing it are counted.
    A port MUST cap the edges (16384, matching IC01) AND the total pixel count
    (32 mebipixels by default, a 128 MiB RGBA buffer), and SHOULD let the caller
-   lower the latter and validate it where it is supplied.
+   lower the latter and validate it where it is supplied. A caller-supplied
+   ceiling MUST be a positive integer no larger than the 32 mebipixel default;
+   it lowers the package ceiling and can never raise or fractionalize it.
 
    The pixel ceiling is a judgement, not a law, and a port should state its
    arithmetic: decoding costs roughly THREE times the pixel buffer -- the
@@ -332,7 +358,51 @@ encode_png(pixels: PixelContainer) -> bytes
 decode_png(bytes) -> PixelContainer
 adler32(bytes) -> u32          # exported: it is testable on its own
 PngCodec implements ImageCodec # mime type "image/png"
+PngError(code, message)         # stable portable code plus explanatory text
 ```
+
+The package MUST also expose the default edge and pixel ceilings and the closed
+set of portable error identifiers. This lets an embedder and a neutral fixture
+reason about the same boundaries without parsing prose or exception messages.
+
+### Portable error taxonomy
+
+Every malformed-input or invalid-option failure MUST use one of these stable,
+payload-blind identifiers. Messages may add the bounded numbers or chunk type
+called for by the error table, but consumers MUST branch on the identifier, not
+the message.
+
+| Identifier | Boundary |
+|---|---|
+| `invalid-max-pixels` | caller ceiling is non-integer, non-positive, non-finite, or above the default |
+| `invalid-image-dimensions` | encoder dimensions are invalid or empty |
+| `invalid-pixel-data-length` | encoder RGBA byte count disagrees with dimensions |
+| `file-too-short` | input cannot contain the complete PNG signature |
+| `invalid-signature` | signature differs |
+| `truncated-chunk` | chunk header/data/CRC extends beyond input |
+| `invalid-chunk-type` | type contains a non-letter or a lowercase reserved third letter |
+| `chunk-crc-mismatch` | chunk CRC differs |
+| `chunk-before-ihdr` | any chunk precedes IHDR |
+| `duplicate-ihdr` | a second IHDR appears |
+| `invalid-ihdr-length` | IHDR is not 13 bytes |
+| `invalid-dimensions` | decoded width or height is zero |
+| `dimension-limit` | decoded edge exceeds 16,384 |
+| `pixel-limit` | decoded product exceeds the active ceiling |
+| `unsupported-feature` | unsupported compression/filter method, depth, colour type, palette, or interlace |
+| `invalid-plte` | PLTE is repeated, misplaced, malformed, or forbidden for the colour type |
+| `invalid-trns` | tRNS is repeated, misplaced, malformed, out of range, or forbidden for the colour type |
+| `nonconsecutive-idat` | an IDAT appears after the IDAT run ended |
+| `invalid-iend` | IEND is non-empty |
+| `trailing-data` | bytes follow IEND |
+| `unknown-critical-chunk` | an unrecognised critical chunk appears |
+| `missing-required-chunk` | IHDR, IDAT, or IEND is absent |
+| `invalid-zlib-header` | zlib stream is too short, has the wrong method/CINFO, or fails FCHECK |
+| `preset-dictionary` | zlib FDICT is set |
+| `inflate-failed` | the ZIP-owned raw inflater rejects the DEFLATE stream |
+| `inflated-length-mismatch` | decompressed byte count differs from IHDR's exact promise |
+| `idat-cavity` | whole bytes remain between BFINAL and Adler-32 |
+| `adler-mismatch` | Adler-32 differs |
+| `invalid-filter` | a scanline filter byte is above 4 |
 
 ## Error Cases
 
@@ -347,8 +417,10 @@ PngCodec implements ImageCodec # mime type "image/png"
 | second IHDR | error |
 | IDAT before IHDR | error |
 | colour type 3, depth != 8, interlace 1 | error naming the unsupported feature |
+| invalid, repeated, misplaced, or forbidden `PLTE` / `tRNS` | stable typed error |
 | dimension 0, or above the cap | error |
 | zlib header not method 8, or failing mod 31 | error |
+| zlib CINFO above 7 | error |
 | zlib preset dictionary requested | error |
 | inflated length != the header's promise | error |
 | Adler-32 mismatch | error |
@@ -361,6 +433,7 @@ PngCodec implements ImageCodec # mime type "image/png"
 | pixel count above the cap | error naming both numbers |
 | encoding a 0-pixel image | error |
 | encoding data of the wrong length | error naming both lengths |
+| caller `maxPixels` is fractional or above 32 mebipixels | error |
 
 ## Round-Trip Property
 
@@ -386,6 +459,20 @@ implementation:
   chunking boundary;
 - confirm the written file is accepted by at least one real image tool.
 
+The repository-owned portable corpus is
+`code/specs/fixtures/image-codec-png-v1/cases.json`. Every port MUST consume the
+same document through its public API and assert the exact stable error
+identifier for rejection cases. Fixture vectors use deterministic stored and
+fixed encoders plus a checked independent dynamic-Huffman stream; Python zlib
+independently decodes them. A package's own round trip is never sufficient
+evidence. Encode cases also pin the per-row filter choices without pinning the
+compressed bytes.
+
+Production is a pure in-memory byte transform. Every package MUST carry
+`required_capabilities.json` with an empty `capabilities` array. Filesystem,
+process, environment, time, entropy, network, and native image-tool access are
+test-only evidence and are not part of the codec API.
+
 ---
 
 ## Package Layout
@@ -397,6 +484,7 @@ code/packages/<language>/image-codec-png/
   BUILD                 chain-installs pixel-container, lzss, zip, then self
   README.md
   CHANGELOG.md
+  required_capabilities.json
 ```
 
 **Dependencies:** `pixel-container` (IC00) for the pixel type, and the language's

--- a/code/specs/fixtures/image-codec-png-v1/CHANGELOG.md
+++ b/code/specs/fixtures/image-codec-png-v1/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog — IC18 portable PNG fixtures
+
+## 1.0.0 — 2026-08-20
+
+### Added
+
+- Closed Draft 2020-12 schema for the IC18 PNG profile, fixed resource limits,
+  five operations, and 29 stable error identifiers.
+- Added suggested `PLTE`, semantic `tRNS`, Paeth branch/tie, and normative
+  encoder filter-selection evidence.
+- Replaced host-zlib compression choices with deterministic stored/fixed
+  encoders and a checked dynamic-Huffman vector.
+- Eighty-two deterministic cases covering all supported colour forms and
+  filters, stored/fixed/dynamic DEFLATE, split IDAT, independent Adler-32,
+  encoder interoperability, malformed framing and zlib streams, exact
+  consumption, and caller-lowerable resource limits.
+- Reproducible standard-library Python generator and an independent repository
+  validator that pins schema, cases, all error paths, regeneration, size bounds,
+  filter coverage, DEFLATE block coverage, CRCs, zlib framing, unfiltering, and
+  RGBA widening.

--- a/code/specs/fixtures/image-codec-png-v1/README.md
+++ b/code/specs/fixtures/image-codec-png-v1/README.md
@@ -1,0 +1,57 @@
+# IC18 portable PNG v1 fixtures
+
+This directory is the language-neutral contract for `image-codec-png` under
+IC18. It separates PNG interoperability evidence from any one implementation's
+encoder/decoder round trip.
+
+## Files
+
+- `schema.json` closes the profile, limits, operations, expected results, and
+  29 stable error identifiers.
+- `cases.json` contains 82 deterministic vectors: valid decoding, foreign
+  encoder interoperability, Adler-32, malformed input, and resource limits.
+- `generate_cases.py` constructs stable stored/fixed streams, wraps a checked
+  dynamic-Huffman vector, and reproduces `cases.json` exactly across zlib
+  versions.
+
+## Operations
+
+- `decode` supplies complete PNG bytes and exact RGBA8 output.
+- `decode-error` requires the exact portable error identifier and no partial
+  image.
+- `encode` supplies RGBA8 pixels. Compressed bytes are deliberately not pinned;
+  a foreign PNG decoder must recover the pixels, the structural expectations
+  must hold, and each normative row-filter choice is pinned.
+- `encode-error` requires the exact portable encoder-input error identifier.
+- `adler32` pins the zlib checksum independently.
+
+Hex is lowercase and byte-aligned. Valid vectors cover colour types 0, 2, 4,
+and 6; all five filters; stored, fixed, and dynamic DEFLATE blocks; split IDAT;
+Paeth predictor branches and ties; suggested `PLTE`; `tRNS` transparency; and
+an unknown ancillary chunk. Rejection vectors cover every IC18 framing,
+checksum, zlib, filter, exact-consumption, and caller-lowerable allocation
+boundary.
+
+## Oracle and security boundary
+
+Python zlib independently decodes the success corpus but never chooses its
+canonical compressed bytes. TypeScript
+uses `pngjs` only in tests to prove that encoded files are accepted by a foreign
+PNG implementation. Production consumers remain pure in-memory transforms and
+must declare an empty capability profile.
+
+The corpus caps each embedded PNG at 1 MiB and the complete JSON document at
+256 KiB. `maxPixels` is a positive safe integer no larger than 33,554,432; a
+caller may lower but never raise that ceiling. Error identifiers are stable and
+do not contain attacker-controlled payload bytes.
+
+Validate schema, regeneration, independent decoding, filter coverage, DEFLATE
+block coverage, error coverage, and size bounds from the repository root:
+
+```bash
+python -m unittest discover -s code/scripts/tests -p test_image_codec_png_fixtures.py -v
+```
+
+Every future lane must consume `cases.json` through its public codec API. A
+15-lane consumer registry belongs to the final PNG completion umbrella, after
+the toolchain-shaped lane children merge.

--- a/code/specs/fixtures/image-codec-png-v1/cases.json
+++ b/code/specs/fixtures/image-codec-png-v1/cases.json
@@ -1,0 +1,831 @@
+{
+  "schema_version": 1,
+  "profile": "image-codec-png-v1",
+  "limits": {
+    "max_dimension": 16384,
+    "default_max_pixels": 33554432
+  },
+  "error_ids": [
+    "invalid-max-pixels",
+    "invalid-image-dimensions",
+    "invalid-pixel-data-length",
+    "file-too-short",
+    "invalid-signature",
+    "truncated-chunk",
+    "invalid-chunk-type",
+    "chunk-crc-mismatch",
+    "chunk-before-ihdr",
+    "duplicate-ihdr",
+    "invalid-ihdr-length",
+    "invalid-dimensions",
+    "dimension-limit",
+    "pixel-limit",
+    "unsupported-feature",
+    "invalid-plte",
+    "invalid-trns",
+    "nonconsecutive-idat",
+    "invalid-iend",
+    "trailing-data",
+    "unknown-critical-chunk",
+    "missing-required-chunk",
+    "invalid-zlib-header",
+    "preset-dictionary",
+    "inflate-failed",
+    "inflated-length-mismatch",
+    "idat-cavity",
+    "adler-mismatch",
+    "invalid-filter"
+  ],
+  "cases": [
+    {
+      "id": "png-v1-decode-rgba-none",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-all-filters",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000020000000508060000006fb33d9c0000003549444154780163e01291d330b2710b60e41695d7d4d0d0d06062646464646464646466e7111413151515656164646464646464040060130319d3f24f150000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 5,
+        "rgba_hex": "0a141e28323c46500b151f29333d47510c16202a343e48520d17212b353f49530e18222c36404a54"
+      }
+    },
+    {
+      "id": "png-v1-decode-paeth-b",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000001000000020800000000bceae9fb0000000c494441547801633062b90a000177010cc2825b6d0000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 2,
+        "rgba_hex": "323232ff070707ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-paeth-a",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000200000002080000000057dd52f80000000e4944415478016348496159f6170005df02701154cc440000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 2,
+        "rgba_hex": "646464ff646464ff0a0a0aff070707ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-paeth-c",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000200000002080000000057dd52f80000000e49444154780163e01761f9fd0300039b021b45a210590000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 2,
+        "rgba_hex": "0f0f0fff141414ff0a0a0aff070707ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-paeth-a-b-tie",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000200000002080000000057dd52f80000000e4944415478016360e062e1fa0b00014b01160de8ca5b0000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 2,
+        "rgba_hex": "000000ff0a0a0aff0a0a0aff070707ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-paeth-all-tie",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000200000002080000000057dd52f80000000e49444154780163e0e26261f80b0001690116819129840000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 2,
+        "rgba_hex": "0a0a0aff0a0a0aff0a0a0aff070707ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-greyscale",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000002000000010800000000d14920560000000b4944415478016314dc0e0000df00caf11835980000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "111111ffc8c8c8ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-truecolour",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000020000000108020000007b40e8dd0000000f49444154780163e01291d330b20100023700d3096df20d0000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "0a141eff28323cff"
+      }
+    },
+    {
+      "id": "png-v1-decode-greyscale-alpha",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000020000000108040000005e2bb7010000000d49444154780163700b884a010003250155015f9e220000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "464646505a5a5a64"
+      }
+    },
+    {
+      "id": "png-v1-decode-greyscale-trns",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000002000000010800000000d14920560000000274524e5300111c23edca0000000b4944415478016310140200003700241d2164920000000049454e44ae426082",
+      "oracle": "rfc2083-hand",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "11111100121212ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-truecolour-trns",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000020000000108020000007b40e8dd0000000674524e53000100020003c94babf50000000f494441547801636064626661650300003f0016738177810000000049454e44ae426082",
+      "oracle": "rfc2083-hand",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "01020300040506ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-truecolour-plte-trns",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000020000000108020000007b40e8dd00000003504c5445090807fe1619fe0000000674524e53000100020003c94babf50000000f494441547801636064626661650300003f0016738177810000000049454e44ae426082",
+      "oracle": "rfc2083-hand",
+      "expected": {
+        "width": 2,
+        "height": 1,
+        "rgba_hex": "01020300040506ff"
+      }
+    },
+    {
+      "id": "png-v1-decode-split-idat",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000001494441547876e684e600000002494441540163b15bbc190000000949444154606462660100001900cd16af9500000001494441540bbfeaa4600000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-ancillary",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000007744558746669787475726524f6bfed0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-suggested-plte",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000003504c5445090807fe1619fe0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "oracle": "rfc2083-hand",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-lowered-limit",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      },
+      "options": {
+        "max_pixels": 1
+      }
+    },
+    {
+      "id": "png-v1-decode-stored-deflate",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000010494441547801010500faff00010203040019000bb9b0e3eb0000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-fixed-deflate",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      }
+    },
+    {
+      "id": "png-v1-decode-dynamic-deflate",
+      "operation": "decode",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000003f0000000108000000004c4429de000000354944415478010dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e269b0128facf6fb60000000049454e44ae426082",
+      "oracle": "python-zlib",
+      "expected": {
+        "width": 63,
+        "height": 1,
+        "rgba_hex": "060606ff090909ff141414ff141414ff222222ff292929ff323232ff3b3b3bff3c3c3cff454545ff4b4b4bff4c4c4cff565656ff5a5a5aff616161ff616161ff686868ff686868ff686868ff686868ff686868ff6d6d6dff6e6e6eff6f6f6fff787878ff808080ff838383ff848484ff8c8c8cff919191ff949494ff969696ff999999ff9d9d9dff9e9e9eff9e9e9effa2a2a2ffa3a3a3ffa3a3a3ffa5a5a5ffacacacffb5b5b5ffb5b5b5ffbebebeffc0c0c0ffcacacaffd4d4d4ffd6d6d6ffdcdcdcffe1e1e1ffe3e3e3fff0f0f0fff6f6f6ff020202ff030303ff050505ff101010ff121212ff151515ff171717ff202020ff222222ff232323ff"
+      }
+    },
+    {
+      "id": "png-v1-encode-single-rgba",
+      "operation": "encode",
+      "input": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "01020304"
+      },
+      "oracle": "foreign-zlib",
+      "expected": {
+        "chunk_types": [
+          "IHDR",
+          "IDAT",
+          "IEND"
+        ],
+        "filter_types": [
+          0
+        ],
+        "bit_depth": 8,
+        "colour_type": 6,
+        "interlace": 0
+      }
+    },
+    {
+      "id": "png-v1-encode-two-by-two",
+      "operation": "encode",
+      "input": {
+        "width": 2,
+        "height": 2,
+        "rgba_hex": "000102030405060708090a0b0c0d0e0f"
+      },
+      "oracle": "foreign-zlib",
+      "expected": {
+        "chunk_types": [
+          "IHDR",
+          "IDAT",
+          "IEND"
+        ],
+        "filter_types": [
+          1,
+          4
+        ],
+        "bit_depth": 8,
+        "colour_type": 6,
+        "interlace": 0
+      }
+    },
+    {
+      "id": "png-v1-encode-all-filters",
+      "operation": "encode",
+      "input": {
+        "width": 2,
+        "height": 5,
+        "rgba_hex": "0ceaad0dd4010353de4215549a044c75e328c65b05bc6e3e3d4c28fd54ab76685d7c5e0dbea95aca"
+      },
+      "oracle": "foreign-zlib",
+      "expected": {
+        "chunk_types": [
+          "IHDR",
+          "IDAT",
+          "IEND"
+        ],
+        "filter_types": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "bit_depth": 8,
+        "colour_type": 6,
+        "interlace": 0
+      }
+    },
+    {
+      "id": "png-v1-adler-wikipedia",
+      "operation": "adler32",
+      "input_hex": "57696b697065646961",
+      "expected": {
+        "adler32_hex": "11e60398"
+      }
+    },
+    {
+      "id": "png-v1-adler-chunk-boundary",
+      "operation": "adler32",
+      "input_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+      "expected": {
+        "adler32_hex": "3222f597"
+      }
+    },
+    {
+      "id": "png-v1-error-too-short",
+      "operation": "decode-error",
+      "png_hex": "89504e47",
+      "expected": {
+        "error_id": "file-too-short"
+      }
+    },
+    {
+      "id": "png-v1-error-signature",
+      "operation": "decode-error",
+      "png_hex": "00504e470d0a1a0a",
+      "expected": {
+        "error_id": "invalid-signature"
+      }
+    },
+    {
+      "id": "png-v1-error-truncated-header",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d",
+      "expected": {
+        "error_id": "truncated-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-truncated-data",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000000",
+      "expected": {
+        "error_id": "truncated-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-crc",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010100000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "chunk-crc-mismatch"
+      }
+    },
+    {
+      "id": "png-v1-error-chunk-type-character",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000031424144821ee2bb0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-chunk-type"
+      }
+    },
+    {
+      "id": "png-v1-error-chunk-type-reserved-bit",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000000414263444e9304070000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-chunk-type"
+      }
+    },
+    {
+      "id": "png-v1-error-before-ihdr",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a000000017445587478119823e90000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "chunk-before-ihdr"
+      }
+    },
+    {
+      "id": "png-v1-error-duplicate-ihdr",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "duplicate-ihdr"
+      }
+    },
+    {
+      "id": "png-v1-error-ihdr-length",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000c494844520000000000000000000000002b0ffe5b0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-ihdr-length"
+      }
+    },
+    {
+      "id": "png-v1-error-zero-dimension",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000000000000010806000000f0d7afb70000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-dimensions"
+      }
+    },
+    {
+      "id": "png-v1-error-edge-limit",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200004001000000010806000000c95ddd660000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "dimension-limit"
+      }
+    },
+    {
+      "id": "png-v1-error-pixel-limit",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200004000000040000806000000a9c810840000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "pixel-limit"
+      }
+    },
+    {
+      "id": "png-v1-error-compression-method",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060100001ed7aebe0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-filter-method",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000001000000010806000100060ef5c80000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-interlace",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000016812f41f0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-palette",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d494844520000000100000001080300000028cb34bb0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-colour-type",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108050000000da06b670000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-bit-depth",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000110060000004f8518ca0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unsupported-feature"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-greyscale",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108000000003a7e9b5500000003504c54450102030d8764d50000000a49444154780163100400001300129dd61bbc0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-length",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000002504c54450102e5649baf0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-incomplete-entry",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000004504c54450102030423db8aab0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-entry-cap",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000303504c5445000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000466e878c0000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-duplicate",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000003504c54450102030d8764d500000003504c54450405063467c4760000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-after-idat",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac55600000003504c54450102030d8764d50000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-plte-after-trns",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de0000000674524e53000100020003c94babf500000003504c5445090807fe1619fe0000000c494441547801636064620600000e0007c5ec582b0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-plte"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-alpha-colour",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000674524e53000100020003c94babf50000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-length",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108000000003a7e9b550000000174524e53112a56f8940000000a49444154780163100400001300129dd61bbc0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-truecolour-length",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de0000000474524e53000100025c5f6d810000000c494441547801636064620600000e0007c5ec582b0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-duplicate",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108000000003a7e9b550000000274524e5300111c23edca0000000274524e530012852abc700000000a49444154780163100400001300129dd61bbc0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-after-idat",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108000000003a7e9b550000000a49444154780163100400001300129dd61bbc0000000274524e5300111c23edca0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-sample-range",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108000000003a7e9b550000000274524e5301006f88fc790000000a49444154780163100400001300129dd61bbc0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-trns-truecolour-sample-range",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d4948445200000001000000010802000000907753de0000000674524e530100000200033f7751e00000000c494441547801636064620600000e0007c5ec582b0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-trns"
+      }
+    },
+    {
+      "id": "png-v1-error-idat-order",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000003494441547801636e8876e90000000374455874676170579bf5270000000a494441546064626601000019000bc57847610000000049454e44ae426082",
+      "expected": {
+        "error_id": "nonconsecutive-idat"
+      }
+    },
+    {
+      "id": "png-v1-error-iend-payload",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000149454e44788fc4b6ef",
+      "expected": {
+        "error_id": "invalid-iend"
+      }
+    },
+    {
+      "id": "png-v1-error-after-iend",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae42608270617373656e676572",
+      "expected": {
+        "error_id": "trailing-data"
+      }
+    },
+    {
+      "id": "png-v1-error-critical-chunk",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000041424344db1720a50000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "unknown-critical-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-missing-ihdr",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a",
+      "expected": {
+        "error_id": "missing-required-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-missing-iend",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac556",
+      "expected": {
+        "error_id": "missing-required-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-missing-idat",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000049454e44ae426082",
+      "expected": {
+        "error_id": "missing-required-chunk"
+      }
+    },
+    {
+      "id": "png-v1-error-zlib-short",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000349444154789c007edcb25c0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-zlib-header"
+      }
+    },
+    {
+      "id": "png-v1-error-zlib-method",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547918636064626601000019000b590dcbbe0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-zlib-header"
+      }
+    },
+    {
+      "id": "png-v1-error-zlib-cinfo",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154881c636064626601000019000b9d0370d70000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-zlib-header"
+      }
+    },
+    {
+      "id": "png-v1-error-zlib-fcheck",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547800636064626601000019000b8e8f89390000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-zlib-header"
+      }
+    },
+    {
+      "id": "png-v1-error-zlib-dictionary",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547820636064626601000019000b96be52c10000000049454e44ae426082",
+      "expected": {
+        "error_id": "preset-dictionary"
+      }
+    },
+    {
+      "id": "png-v1-error-inflate",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000749444154789c070000000139527fd60000000049454e44ae426082",
+      "expected": {
+        "error_id": "inflate-failed"
+      }
+    },
+    {
+      "id": "png-v1-error-inflated-length",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000c494441547801636064620600000e0007c5ec582b0000000049454e44ae426082",
+      "expected": {
+        "error_id": "inflated-length-mismatch"
+      }
+    },
+    {
+      "id": "png-v1-error-inflated-over-limit",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000e4944415478016360646266610500002900106faa400a0000000049454e44ae426082",
+      "expected": {
+        "error_id": "inflated-length-mismatch"
+      }
+    },
+    {
+      "id": "png-v1-error-idat-cavity",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c48900000013494441547801636064626601004341564954590019000b456164d30000000049454e44ae426082",
+      "expected": {
+        "error_id": "idat-cavity"
+      }
+    },
+    {
+      "id": "png-v1-error-adler",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000a622df5c00000000049454e44ae426082",
+      "expected": {
+        "error_id": "adler-mismatch"
+      }
+    },
+    {
+      "id": "png-v1-error-filter",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154780163656462660100003200104d7e6eff0000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-filter"
+      }
+    },
+    {
+      "id": "png-v1-error-max-pixels-zero",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-max-pixels"
+      },
+      "options": {
+        "max_pixels": 0
+      }
+    },
+    {
+      "id": "png-v1-error-max-pixels-fractional",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-max-pixels"
+      },
+      "options": {
+        "max_pixels": 1.5
+      }
+    },
+    {
+      "id": "png-v1-error-max-pixels-raised",
+      "operation": "decode-error",
+      "png_hex": "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d494441547801636064626601000019000b152ac5560000000049454e44ae426082",
+      "expected": {
+        "error_id": "invalid-max-pixels"
+      },
+      "options": {
+        "max_pixels": 33554433
+      }
+    },
+    {
+      "id": "png-v1-error-encode-empty",
+      "operation": "encode-error",
+      "input": {
+        "width": 0,
+        "height": 1,
+        "rgba_hex": ""
+      },
+      "expected": {
+        "error_id": "invalid-image-dimensions"
+      }
+    },
+    {
+      "id": "png-v1-error-encode-fractional",
+      "operation": "encode-error",
+      "input": {
+        "width": 1.5,
+        "height": 1,
+        "rgba_hex": ""
+      },
+      "expected": {
+        "error_id": "invalid-image-dimensions"
+      }
+    },
+    {
+      "id": "png-v1-error-encode-data-length",
+      "operation": "encode-error",
+      "input": {
+        "width": 1,
+        "height": 1,
+        "rgba_hex": "010203"
+      },
+      "expected": {
+        "error_id": "invalid-pixel-data-length"
+      }
+    }
+  ]
+}

--- a/code/specs/fixtures/image-codec-png-v1/generate_cases.py
+++ b/code/specs/fixtures/image-codec-png-v1/generate_cases.py
@@ -1,0 +1,1028 @@
+"""Generate deterministic IC18 PNG vectors without host-zlib byte choices."""
+
+from __future__ import annotations
+
+import argparse
+import binascii
+import itertools
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+SIGNATURE = b"\x89PNG\r\n\x1a\n"
+MAX_PIXELS = 32 * 1024 * 1024
+
+ERROR_IDS = [
+    "invalid-max-pixels",
+    "invalid-image-dimensions",
+    "invalid-pixel-data-length",
+    "file-too-short",
+    "invalid-signature",
+    "truncated-chunk",
+    "invalid-chunk-type",
+    "chunk-crc-mismatch",
+    "chunk-before-ihdr",
+    "duplicate-ihdr",
+    "invalid-ihdr-length",
+    "invalid-dimensions",
+    "dimension-limit",
+    "pixel-limit",
+    "unsupported-feature",
+    "invalid-plte",
+    "invalid-trns",
+    "nonconsecutive-idat",
+    "invalid-iend",
+    "trailing-data",
+    "unknown-critical-chunk",
+    "missing-required-chunk",
+    "invalid-zlib-header",
+    "preset-dictionary",
+    "inflate-failed",
+    "inflated-length-mismatch",
+    "idat-cavity",
+    "adler-mismatch",
+    "invalid-filter",
+]
+
+# Checked RFC 1951 dynamic-Huffman vector shared with the ZIP neutral corpus.
+# Keeping the raw bytes here avoids asking a host zlib version to choose a block
+# strategy, which is deliberately not stable across zlib releases.
+DYNAMIC_RAW = bytes.fromhex(
+    "0dc28911c0200c03b0d8f97028ec3f6ed129cab7dd96a0c2445bdb93809663a5d303f6b265e20c2b79ea03379d227e"
+)
+DYNAMIC_FILTERED = bytes.fromhex(
+    "0406030b000e070909010906010a04070007000000000501010908030108050302030401000401000207090009020a0a020605020d060c01020b020302090201"
+)
+
+
+def u32(value: int) -> bytes:
+    return struct.pack(">I", value)
+
+
+def chunk(kind: bytes, data: bytes) -> bytes:
+    return u32(len(data)) + kind + data + u32(binascii.crc32(kind + data))
+
+
+def ihdr(
+    width: int,
+    height: int,
+    *,
+    depth: int = 8,
+    colour: int = 6,
+    compression: int = 0,
+    filter_method: int = 0,
+    interlace: int = 0,
+) -> bytes:
+    return chunk(
+        b"IHDR",
+        u32(width)
+        + u32(height)
+        + bytes([depth, colour, compression, filter_method, interlace]),
+    )
+
+
+def paeth(a: int, b: int, c: int) -> int:
+    p = a + b - c
+    pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+    if pa <= pb and pa <= pc:
+        return a
+    if pb <= pc:
+        return b
+    return c
+
+
+def filter_row(kind: int, raw: bytes, prior: bytes, bpp: int) -> bytes:
+    out = bytearray(len(raw))
+    for index, value in enumerate(raw):
+        left = raw[index - bpp] if index >= bpp else 0
+        above = prior[index]
+        upper_left = prior[index - bpp] if index >= bpp else 0
+        predictor = {
+            0: 0,
+            1: left,
+            2: above,
+            3: (left + above) // 2,
+            4: paeth(left, above, upper_left),
+        }[kind]
+        out[index] = (value - predictor) & 0xFF
+    return bytes([kind]) + bytes(out)
+
+
+def filtered_rows(rows: list[bytes], filters: list[int], bpp: int) -> bytes:
+    prior = bytes(len(rows[0]))
+    output = bytearray()
+    for raw, kind in zip(rows, filters, strict=True):
+        output.extend(filter_row(kind, raw, prior, bpp))
+        prior = raw
+    return bytes(output)
+
+
+def choose_filter_types(rows: list[bytes], bpp: int) -> list[int]:
+    """Apply IC18's signed-byte score and lowest-number tie break."""
+
+    prior = bytes(len(rows[0]))
+    result = []
+    for raw in rows:
+        candidates = [filter_row(kind, raw, prior, bpp) for kind in range(5)]
+        scores = [
+            sum(abs(value if value < 128 else value - 256) for value in row[1:])
+            for row in candidates
+        ]
+        result.append(min(range(5), key=scores.__getitem__))
+        prior = raw
+    return result
+
+
+def greyscale_rgba(rows: list[bytes]) -> bytes:
+    return b"".join(bytes([value, value, value, 255]) for row in rows for value in row)
+
+
+def adler32(data: bytes) -> int:
+    """Return RFC 1950 Adler-32 without depending on a host zlib build."""
+
+    first = 1
+    second = 0
+    for value in data:
+        first = (first + value) % 65521
+        second = (second + first) % 65521
+    return (second << 16) | first
+
+
+def zlib_stream(raw_deflate: bytes, decoded: bytes) -> bytes:
+    """Wrap deterministic RFC 1951 bytes in an RFC 1950 stream."""
+
+    return b"\x78\x01" + raw_deflate + u32(adler32(decoded))
+
+
+def stored_raw(data: bytes) -> bytes:
+    """Encode deterministic stored RFC 1951 blocks."""
+
+    output = bytearray()
+    chunks = [data[index : index + 65535] for index in range(0, len(data), 65535)]
+    if not chunks:
+        chunks = [b""]
+    for index, value in enumerate(chunks):
+        output.append(1 if index == len(chunks) - 1 else 0)
+        output.extend(struct.pack("<H", len(value)))
+        output.extend(struct.pack("<H", (~len(value)) & 0xFFFF))
+        output.extend(value)
+    return bytes(output)
+
+
+def reverse_bits(value: int, width: int) -> int:
+    result = 0
+    for _ in range(width):
+        result = (result << 1) | (value & 1)
+        value >>= 1
+    return result
+
+
+def fixed_code(symbol: int) -> tuple[int, int]:
+    if symbol <= 143:
+        return 0x30 + symbol, 8
+    if symbol <= 255:
+        return 0x190 + symbol - 144, 9
+    if symbol <= 279:
+        return symbol - 256, 7
+    return 0xC0 + symbol - 280, 8
+
+
+def fixed_literal_raw(data: bytes) -> bytes:
+    """Encode one final fixed-Huffman block using literal symbols only."""
+
+    output = bytearray()
+    bit_buffer = 0
+    bit_count = 0
+
+    def write_bits(value: int, width: int) -> None:
+        nonlocal bit_buffer, bit_count
+        bit_buffer |= value << bit_count
+        bit_count += width
+        while bit_count >= 8:
+            output.append(bit_buffer & 0xFF)
+            bit_buffer >>= 8
+            bit_count -= 8
+
+    write_bits(0b011, 3)  # BFINAL=1, BTYPE=01 (fixed Huffman).
+    for symbol in [*data, 256]:
+        code, width = fixed_code(symbol)
+        write_bits(reverse_bits(code, width), width)
+    if bit_count:
+        output.append(bit_buffer)
+    return bytes(output)
+
+
+def fixed_zlib(data: bytes) -> bytes:
+    return zlib_stream(fixed_literal_raw(data), data)
+
+
+def stored_zlib(data: bytes) -> bytes:
+    return zlib_stream(stored_raw(data), data)
+
+
+def png_from_zlib(
+    width: int,
+    height: int,
+    zstream: bytes,
+    *,
+    depth: int = 8,
+    colour: int = 6,
+    compression: int = 0,
+    filter_method: int = 0,
+    interlace: int = 0,
+    split_at: list[int] | None = None,
+    between_idat: bytes | None = None,
+    after_ihdr: bytes = b"",
+    before_iend: bytes = b"",
+    iend_data: bytes = b"",
+    trailing: bytes = b"",
+) -> bytes:
+    header = ihdr(
+        width,
+        height,
+        depth=depth,
+        colour=colour,
+        compression=compression,
+        filter_method=filter_method,
+        interlace=interlace,
+    )
+    boundaries = [0, *(split_at or []), len(zstream)]
+    idats = []
+    for index, (start, end) in enumerate(itertools.pairwise(boundaries)):
+        idats.append(chunk(b"IDAT", zstream[start:end]))
+        if between_idat is not None and index == 0:
+            idats.append(between_idat)
+    return (
+        SIGNATURE
+        + header
+        + after_ihdr
+        + b"".join(idats)
+        + before_iend
+        + chunk(b"IEND", iend_data)
+        + trailing
+    )
+
+
+def png_from_rows(
+    width: int,
+    rows: list[bytes],
+    filters: list[int],
+    *,
+    colour: int,
+    bpp: int,
+    **kwargs: Any,
+) -> bytes:
+    filtered = filtered_rows(rows, filters, bpp)
+    return png_from_zlib(
+        width, len(rows), fixed_zlib(filtered), colour=colour, **kwargs
+    )
+
+
+def valid_flg(cmf: int, *, dictionary: bool = False) -> int:
+    base = 0x20 if dictionary else 0
+    for check in range(32):
+        value = base | check
+        if ((cmf << 8) | value) % 31 == 0:
+            return value
+    raise AssertionError("FCHECK has no solution")
+
+
+def decode_case(
+    identifier: str,
+    png: bytes,
+    width: int,
+    height: int,
+    rgba: bytes,
+    *,
+    oracle: str = "python-zlib",
+    max_pixels: int | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "id": identifier,
+        "operation": "decode",
+        "png_hex": png.hex(),
+        "oracle": oracle,
+        "expected": {"width": width, "height": height, "rgba_hex": rgba.hex()},
+    }
+    if max_pixels is not None:
+        result["options"] = {"max_pixels": max_pixels}
+    return result
+
+
+def decode_error(
+    identifier: str,
+    png: bytes,
+    error_id: str,
+    *,
+    max_pixels: float | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "id": identifier,
+        "operation": "decode-error",
+        "png_hex": png.hex(),
+        "expected": {"error_id": error_id},
+    }
+    if max_pixels is not None:
+        result["options"] = {"max_pixels": max_pixels}
+    return result
+
+
+def document() -> dict[str, Any]:
+    rgba_one = bytes([1, 2, 3, 4])
+    rgba_one_png = png_from_rows(1, [rgba_one], [0], colour=6, bpp=4)
+    rows = [
+        bytes([10 + y, 20 + y, 30 + y, 40 + y, 50 + y, 60 + y, 70 + y, 80 + y])
+        for y in range(5)
+    ]
+    all_filters = png_from_rows(2, rows, [0, 1, 2, 3, 4], colour=6, bpp=4)
+    paeth_b_rows = [bytes([50]), bytes([7])]
+    paeth_a_rows = [bytes([100, 100]), bytes([10, 7])]
+    paeth_c_rows = [bytes([15, 20]), bytes([10, 7])]
+    paeth_ab_tie_rows = [bytes([0, 10]), bytes([10, 7])]
+    paeth_all_tie_rows = [bytes([10, 10]), bytes([10, 7])]
+    grey = bytes([17, 200])
+    grey_png = png_from_rows(2, [grey], [1], colour=0, bpp=1)
+    grey_rgba = bytes([17, 17, 17, 255, 200, 200, 200, 255])
+    rgb = bytes([10, 20, 30, 40, 50, 60])
+    rgb_png = png_from_rows(2, [rgb], [0], colour=2, bpp=3)
+    rgb_rgba = bytes([10, 20, 30, 255, 40, 50, 60, 255])
+    ga = bytes([70, 80, 90, 100])
+    ga_png = png_from_rows(2, [ga], [0], colour=4, bpp=2)
+    ga_rgba = bytes([70, 70, 70, 80, 90, 90, 90, 100])
+    grey_trns = bytes([17, 18])
+    grey_trns_png = png_from_rows(
+        2,
+        [grey_trns],
+        [0],
+        colour=0,
+        bpp=1,
+        after_ihdr=chunk(b"tRNS", bytes([0, 17])),
+    )
+    grey_trns_rgba = bytes([17, 17, 17, 0, 18, 18, 18, 255])
+    rgb_trns = bytes([1, 2, 3, 4, 5, 6])
+    rgb_trns_png = png_from_rows(
+        2,
+        [rgb_trns],
+        [0],
+        colour=2,
+        bpp=3,
+        after_ihdr=chunk(b"tRNS", bytes([0, 1, 0, 2, 0, 3])),
+    )
+    rgb_trns_rgba = bytes([1, 2, 3, 0, 4, 5, 6, 255])
+    rgb_plte_trns_png = png_from_rows(
+        2,
+        [rgb_trns],
+        [0],
+        colour=2,
+        bpp=3,
+        after_ihdr=(
+            chunk(b"PLTE", bytes([9, 8, 7])) + chunk(b"tRNS", bytes([0, 1, 0, 2, 0, 3]))
+        ),
+    )
+    filtered_one = bytes([0]) + rgba_one
+    z_one = fixed_zlib(filtered_one)
+    stored_z = stored_zlib(filtered_one)
+    fixed_z = fixed_zlib(filtered_one)
+    dynamic_z = zlib_stream(DYNAMIC_RAW, DYNAMIC_FILTERED)
+    dynamic_grey = bytearray()
+    for value in DYNAMIC_FILTERED[1:]:
+        left = dynamic_grey[-1] if dynamic_grey else 0
+        dynamic_grey.append((value + left) & 0xFF)
+    dynamic_rgba = b"".join(bytes([value, value, value, 255]) for value in dynamic_grey)
+    encode_filter_rows = [
+        bytes.fromhex(value)
+        for value in (
+            "0ceaad0dd4010353",
+            "de4215549a044c75",
+            "e328c65b05bc6e3e",
+            "3d4c28fd54ab7668",
+            "5d7c5e0dbea95aca",
+        )
+    ]
+
+    cases: list[dict[str, Any]] = [
+        decode_case("png-v1-decode-rgba-none", rgba_one_png, 1, 1, rgba_one),
+        decode_case(
+            "png-v1-decode-all-filters",
+            all_filters,
+            2,
+            5,
+            b"".join(rows),
+        ),
+        decode_case(
+            "png-v1-decode-paeth-b",
+            png_from_rows(1, paeth_b_rows, [0, 4], colour=0, bpp=1),
+            1,
+            2,
+            greyscale_rgba(paeth_b_rows),
+        ),
+        decode_case(
+            "png-v1-decode-paeth-a",
+            png_from_rows(2, paeth_a_rows, [0, 4], colour=0, bpp=1),
+            2,
+            2,
+            greyscale_rgba(paeth_a_rows),
+        ),
+        decode_case(
+            "png-v1-decode-paeth-c",
+            png_from_rows(2, paeth_c_rows, [0, 4], colour=0, bpp=1),
+            2,
+            2,
+            greyscale_rgba(paeth_c_rows),
+        ),
+        decode_case(
+            "png-v1-decode-paeth-a-b-tie",
+            png_from_rows(2, paeth_ab_tie_rows, [0, 4], colour=0, bpp=1),
+            2,
+            2,
+            greyscale_rgba(paeth_ab_tie_rows),
+        ),
+        decode_case(
+            "png-v1-decode-paeth-all-tie",
+            png_from_rows(2, paeth_all_tie_rows, [0, 4], colour=0, bpp=1),
+            2,
+            2,
+            greyscale_rgba(paeth_all_tie_rows),
+        ),
+        decode_case("png-v1-decode-greyscale", grey_png, 2, 1, grey_rgba),
+        decode_case("png-v1-decode-truecolour", rgb_png, 2, 1, rgb_rgba),
+        decode_case("png-v1-decode-greyscale-alpha", ga_png, 2, 1, ga_rgba),
+        decode_case(
+            "png-v1-decode-greyscale-trns",
+            grey_trns_png,
+            2,
+            1,
+            grey_trns_rgba,
+            oracle="rfc2083-hand",
+        ),
+        decode_case(
+            "png-v1-decode-truecolour-trns",
+            rgb_trns_png,
+            2,
+            1,
+            rgb_trns_rgba,
+            oracle="rfc2083-hand",
+        ),
+        decode_case(
+            "png-v1-decode-truecolour-plte-trns",
+            rgb_plte_trns_png,
+            2,
+            1,
+            rgb_trns_rgba,
+            oracle="rfc2083-hand",
+        ),
+        decode_case(
+            "png-v1-decode-split-idat",
+            png_from_zlib(1, 1, z_one, split_at=[1, 3, len(z_one) - 1]),
+            1,
+            1,
+            rgba_one,
+        ),
+        decode_case(
+            "png-v1-decode-ancillary",
+            png_from_zlib(1, 1, z_one, after_ihdr=chunk(b"tEXt", b"fixture")),
+            1,
+            1,
+            rgba_one,
+        ),
+        decode_case(
+            "png-v1-decode-suggested-plte",
+            png_from_zlib(
+                1,
+                1,
+                z_one,
+                after_ihdr=chunk(b"PLTE", bytes([9, 8, 7])),
+            ),
+            1,
+            1,
+            rgba_one,
+            oracle="rfc2083-hand",
+        ),
+        decode_case(
+            "png-v1-decode-lowered-limit",
+            rgba_one_png,
+            1,
+            1,
+            rgba_one,
+            max_pixels=1,
+        ),
+        decode_case(
+            "png-v1-decode-stored-deflate",
+            png_from_zlib(1, 1, stored_z),
+            1,
+            1,
+            rgba_one,
+        ),
+        decode_case(
+            "png-v1-decode-fixed-deflate",
+            png_from_zlib(1, 1, fixed_z),
+            1,
+            1,
+            rgba_one,
+        ),
+        decode_case(
+            "png-v1-decode-dynamic-deflate",
+            png_from_zlib(63, 1, dynamic_z, colour=0),
+            63,
+            1,
+            dynamic_rgba,
+        ),
+        {
+            "id": "png-v1-encode-single-rgba",
+            "operation": "encode",
+            "input": {"width": 1, "height": 1, "rgba_hex": rgba_one.hex()},
+            "oracle": "foreign-zlib",
+            "expected": {
+                "chunk_types": ["IHDR", "IDAT", "IEND"],
+                "filter_types": choose_filter_types([rgba_one], 4),
+                "bit_depth": 8,
+                "colour_type": 6,
+                "interlace": 0,
+            },
+        },
+        {
+            "id": "png-v1-encode-two-by-two",
+            "operation": "encode",
+            "input": {
+                "width": 2,
+                "height": 2,
+                "rgba_hex": bytes(range(16)).hex(),
+            },
+            "oracle": "foreign-zlib",
+            "expected": {
+                "chunk_types": ["IHDR", "IDAT", "IEND"],
+                "filter_types": choose_filter_types(
+                    [bytes(range(8)), bytes(range(8, 16))], 4
+                ),
+                "bit_depth": 8,
+                "colour_type": 6,
+                "interlace": 0,
+            },
+        },
+        {
+            "id": "png-v1-encode-all-filters",
+            "operation": "encode",
+            "input": {
+                "width": 2,
+                "height": 5,
+                "rgba_hex": b"".join(encode_filter_rows).hex(),
+            },
+            "oracle": "foreign-zlib",
+            "expected": {
+                "chunk_types": ["IHDR", "IDAT", "IEND"],
+                "filter_types": choose_filter_types(encode_filter_rows, 4),
+                "bit_depth": 8,
+                "colour_type": 6,
+                "interlace": 0,
+            },
+        },
+        {
+            "id": "png-v1-adler-wikipedia",
+            "operation": "adler32",
+            "input_hex": b"Wikipedia".hex(),
+            "expected": {"adler32_hex": "11e60398"},
+        },
+        {
+            "id": "png-v1-adler-chunk-boundary",
+            "operation": "adler32",
+            "input_hex": (bytes(range(256)) * 22).hex(),
+            "expected": {"adler32_hex": f"{adler32(bytes(range(256)) * 22):08x}"},
+        },
+    ]
+
+    signature_only = SIGNATURE
+    valid_parts = SIGNATURE + ihdr(1, 1) + chunk(b"IDAT", z_one) + chunk(b"IEND", b"")
+    bad_crc = bytearray(valid_parts)
+    bad_crc[20] ^= 1
+    idat_cavity = z_one[:2] + z_one[2:-4] + b"CAVITY" + z_one[-4:]
+    bad_adler = bytearray(z_one)
+    bad_adler[-1] ^= 1
+    short_filtered = fixed_zlib(bytes([0, 1, 2, 3]))
+    long_filtered = fixed_zlib(bytes([0, 1, 2, 3, 4, 5]))
+    invalid_filter = fixed_zlib(bytes([5, 1, 2, 3, 4]))
+
+    cases.extend(
+        [
+            decode_error("png-v1-error-too-short", b"\x89PNG", "file-too-short"),
+            decode_error(
+                "png-v1-error-signature",
+                bytes([0]) + SIGNATURE[1:],
+                "invalid-signature",
+            ),
+            decode_error(
+                "png-v1-error-truncated-header",
+                SIGNATURE + b"\x00\x00\x00\x0d",
+                "truncated-chunk",
+            ),
+            decode_error(
+                "png-v1-error-truncated-data",
+                SIGNATURE + u32(13) + b"IHDR" + b"\x00" * 5,
+                "truncated-chunk",
+            ),
+            decode_error("png-v1-error-crc", bytes(bad_crc), "chunk-crc-mismatch"),
+            decode_error(
+                "png-v1-error-chunk-type-character",
+                png_from_zlib(1, 1, z_one, after_ihdr=chunk(b"1BAD", b"")),
+                "invalid-chunk-type",
+            ),
+            decode_error(
+                "png-v1-error-chunk-type-reserved-bit",
+                png_from_zlib(1, 1, z_one, after_ihdr=chunk(b"ABcD", b"")),
+                "invalid-chunk-type",
+            ),
+            decode_error(
+                "png-v1-error-before-ihdr",
+                SIGNATURE + chunk(b"tEXt", b"x") + valid_parts[len(SIGNATURE) :],
+                "chunk-before-ihdr",
+            ),
+            decode_error(
+                "png-v1-error-duplicate-ihdr",
+                SIGNATURE
+                + ihdr(1, 1)
+                + ihdr(1, 1)
+                + chunk(b"IDAT", z_one)
+                + chunk(b"IEND", b""),
+                "duplicate-ihdr",
+            ),
+            decode_error(
+                "png-v1-error-ihdr-length",
+                SIGNATURE + chunk(b"IHDR", b"\x00" * 12) + chunk(b"IEND", b""),
+                "invalid-ihdr-length",
+            ),
+            decode_error(
+                "png-v1-error-zero-dimension",
+                png_from_zlib(0, 1, z_one),
+                "invalid-dimensions",
+            ),
+            decode_error(
+                "png-v1-error-edge-limit",
+                png_from_zlib(16385, 1, z_one),
+                "dimension-limit",
+            ),
+            decode_error(
+                "png-v1-error-pixel-limit",
+                png_from_zlib(16384, 16384, z_one),
+                "pixel-limit",
+            ),
+            decode_error(
+                "png-v1-error-compression-method",
+                png_from_zlib(1, 1, z_one, compression=1),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-filter-method",
+                png_from_zlib(1, 1, z_one, filter_method=1),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-interlace",
+                png_from_zlib(1, 1, z_one, interlace=1),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-palette",
+                png_from_zlib(1, 1, z_one, colour=3),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-colour-type",
+                png_from_zlib(1, 1, z_one, colour=5),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-bit-depth",
+                png_from_zlib(1, 1, z_one, depth=16),
+                "unsupported-feature",
+            ),
+            decode_error(
+                "png-v1-error-plte-greyscale",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 17])),
+                    colour=0,
+                    after_ihdr=chunk(b"PLTE", bytes([1, 2, 3])),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-length",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    after_ihdr=chunk(b"PLTE", bytes([1, 2])),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-incomplete-entry",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    after_ihdr=chunk(b"PLTE", bytes([1, 2, 3, 4])),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-entry-cap",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    after_ihdr=chunk(b"PLTE", bytes(771)),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-duplicate",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    after_ihdr=(
+                        chunk(b"PLTE", bytes([1, 2, 3]))
+                        + chunk(b"PLTE", bytes([4, 5, 6]))
+                    ),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-after-idat",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    before_iend=chunk(b"PLTE", bytes([1, 2, 3])),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-plte-after-trns",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 1, 2, 3])),
+                    colour=2,
+                    after_ihdr=(
+                        chunk(b"tRNS", bytes([0, 1, 0, 2, 0, 3]))
+                        + chunk(b"PLTE", bytes([9, 8, 7]))
+                    ),
+                ),
+                "invalid-plte",
+            ),
+            decode_error(
+                "png-v1-error-trns-alpha-colour",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    after_ihdr=chunk(b"tRNS", bytes([0, 1, 0, 2, 0, 3])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-length",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 17])),
+                    colour=0,
+                    after_ihdr=chunk(b"tRNS", bytes([17])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-truecolour-length",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 1, 2, 3])),
+                    colour=2,
+                    after_ihdr=chunk(b"tRNS", bytes([0, 1, 0, 2])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-duplicate",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 17])),
+                    colour=0,
+                    after_ihdr=(
+                        chunk(b"tRNS", bytes([0, 17])) + chunk(b"tRNS", bytes([0, 18]))
+                    ),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-after-idat",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 17])),
+                    colour=0,
+                    before_iend=chunk(b"tRNS", bytes([0, 17])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-sample-range",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 17])),
+                    colour=0,
+                    after_ihdr=chunk(b"tRNS", bytes([1, 0])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-trns-truecolour-sample-range",
+                png_from_zlib(
+                    1,
+                    1,
+                    fixed_zlib(bytes([0, 1, 2, 3])),
+                    colour=2,
+                    after_ihdr=chunk(b"tRNS", bytes([1, 0, 0, 2, 0, 3])),
+                ),
+                "invalid-trns",
+            ),
+            decode_error(
+                "png-v1-error-idat-order",
+                png_from_zlib(
+                    1,
+                    1,
+                    z_one,
+                    split_at=[3],
+                    between_idat=chunk(b"tEXt", b"gap"),
+                ),
+                "nonconsecutive-idat",
+            ),
+            decode_error(
+                "png-v1-error-iend-payload",
+                png_from_zlib(1, 1, z_one, iend_data=b"x"),
+                "invalid-iend",
+            ),
+            decode_error(
+                "png-v1-error-after-iend",
+                png_from_zlib(1, 1, z_one, trailing=b"passenger"),
+                "trailing-data",
+            ),
+            decode_error(
+                "png-v1-error-critical-chunk",
+                png_from_zlib(1, 1, z_one, after_ihdr=chunk(b"ABCD", b"")),
+                "unknown-critical-chunk",
+            ),
+            decode_error(
+                "png-v1-error-missing-ihdr",
+                signature_only,
+                "missing-required-chunk",
+            ),
+            decode_error(
+                "png-v1-error-missing-iend",
+                SIGNATURE + ihdr(1, 1) + chunk(b"IDAT", z_one),
+                "missing-required-chunk",
+            ),
+            decode_error(
+                "png-v1-error-missing-idat",
+                SIGNATURE + ihdr(1, 1) + chunk(b"IEND", b""),
+                "missing-required-chunk",
+            ),
+            decode_error(
+                "png-v1-error-zlib-short",
+                png_from_zlib(1, 1, b"\x78\x9c\x00"),
+                "invalid-zlib-header",
+            ),
+            decode_error(
+                "png-v1-error-zlib-method",
+                png_from_zlib(
+                    1,
+                    1,
+                    bytes([0x79, valid_flg(0x79)]) + z_one[2:],
+                ),
+                "invalid-zlib-header",
+            ),
+            decode_error(
+                "png-v1-error-zlib-cinfo",
+                png_from_zlib(
+                    1,
+                    1,
+                    bytes([0x88, valid_flg(0x88)]) + z_one[2:],
+                ),
+                "invalid-zlib-header",
+            ),
+            decode_error(
+                "png-v1-error-zlib-fcheck",
+                png_from_zlib(1, 1, bytes([z_one[0], z_one[1] ^ 1]) + z_one[2:]),
+                "invalid-zlib-header",
+            ),
+            decode_error(
+                "png-v1-error-zlib-dictionary",
+                png_from_zlib(
+                    1,
+                    1,
+                    bytes([0x78, valid_flg(0x78, dictionary=True)]) + z_one[2:],
+                ),
+                "preset-dictionary",
+            ),
+            decode_error(
+                "png-v1-error-inflate",
+                png_from_zlib(1, 1, b"\x78\x9c\x07\x00\x00\x00\x01"),
+                "inflate-failed",
+            ),
+            decode_error(
+                "png-v1-error-inflated-length",
+                png_from_zlib(1, 1, short_filtered),
+                "inflated-length-mismatch",
+            ),
+            decode_error(
+                "png-v1-error-inflated-over-limit",
+                png_from_zlib(1, 1, long_filtered),
+                "inflated-length-mismatch",
+            ),
+            decode_error(
+                "png-v1-error-idat-cavity",
+                png_from_zlib(1, 1, idat_cavity),
+                "idat-cavity",
+            ),
+            decode_error(
+                "png-v1-error-adler",
+                png_from_zlib(1, 1, bytes(bad_adler)),
+                "adler-mismatch",
+            ),
+            decode_error(
+                "png-v1-error-filter",
+                png_from_zlib(1, 1, invalid_filter),
+                "invalid-filter",
+            ),
+            decode_error(
+                "png-v1-error-max-pixels-zero",
+                rgba_one_png,
+                "invalid-max-pixels",
+                max_pixels=0,
+            ),
+            decode_error(
+                "png-v1-error-max-pixels-fractional",
+                rgba_one_png,
+                "invalid-max-pixels",
+                max_pixels=1.5,
+            ),
+            decode_error(
+                "png-v1-error-max-pixels-raised",
+                rgba_one_png,
+                "invalid-max-pixels",
+                max_pixels=MAX_PIXELS + 1,
+            ),
+            {
+                "id": "png-v1-error-encode-empty",
+                "operation": "encode-error",
+                "input": {"width": 0, "height": 1, "rgba_hex": ""},
+                "expected": {"error_id": "invalid-image-dimensions"},
+            },
+            {
+                "id": "png-v1-error-encode-fractional",
+                "operation": "encode-error",
+                "input": {"width": 1.5, "height": 1, "rgba_hex": ""},
+                "expected": {"error_id": "invalid-image-dimensions"},
+            },
+            {
+                "id": "png-v1-error-encode-data-length",
+                "operation": "encode-error",
+                "input": {"width": 1, "height": 1, "rgba_hex": "010203"},
+                "expected": {"error_id": "invalid-pixel-data-length"},
+            },
+        ]
+    )
+
+    return {
+        "schema_version": 1,
+        "profile": "image-codec-png-v1",
+        "limits": {"max_dimension": 16384, "default_max_pixels": MAX_PIXELS},
+        "error_ids": ERROR_IDS,
+        "cases": cases,
+    }
+
+
+def rendered() -> str:
+    return json.dumps(document(), indent=2, ensure_ascii=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    target = ROOT / "cases.json"
+    expected = rendered()
+    if args.check:
+        return 0 if target.read_text("utf-8") == expected else 1
+    target.write_text(expected, "utf-8", newline="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/specs/fixtures/image-codec-png-v1/schema.json
+++ b/code/specs/fixtures/image-codec-png-v1/schema.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/image-codec-png-v1.json",
+  "title": "IC18 portable PNG v1 conformance corpus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "profile", "limits", "error_ids", "cases"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "profile": { "const": "image-codec-png-v1" },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_dimension", "default_max_pixels"],
+      "properties": {
+        "max_dimension": { "const": 16384 },
+        "default_max_pixels": { "const": 33554432 }
+      }
+    },
+    "error_ids": {
+      "type": "array",
+      "minItems": 29,
+      "maxItems": 29,
+      "uniqueItems": true,
+      "prefixItems": [
+        { "const": "invalid-max-pixels" },
+        { "const": "invalid-image-dimensions" },
+        { "const": "invalid-pixel-data-length" },
+        { "const": "file-too-short" },
+        { "const": "invalid-signature" },
+        { "const": "truncated-chunk" },
+        { "const": "invalid-chunk-type" },
+        { "const": "chunk-crc-mismatch" },
+        { "const": "chunk-before-ihdr" },
+        { "const": "duplicate-ihdr" },
+        { "const": "invalid-ihdr-length" },
+        { "const": "invalid-dimensions" },
+        { "const": "dimension-limit" },
+        { "const": "pixel-limit" },
+        { "const": "unsupported-feature" },
+        { "const": "invalid-plte" },
+        { "const": "invalid-trns" },
+        { "const": "nonconsecutive-idat" },
+        { "const": "invalid-iend" },
+        { "const": "trailing-data" },
+        { "const": "unknown-critical-chunk" },
+        { "const": "missing-required-chunk" },
+        { "const": "invalid-zlib-header" },
+        { "const": "preset-dictionary" },
+        { "const": "inflate-failed" },
+        { "const": "inflated-length-mismatch" },
+        { "const": "idat-cavity" },
+        { "const": "adler-mismatch" },
+        { "const": "invalid-filter" }
+      ],
+      "items": false
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 40,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/decode_case" },
+          { "$ref": "#/$defs/decode_error_case" },
+          { "$ref": "#/$defs/encode_case" },
+          { "$ref": "#/$defs/encode_error_case" },
+          { "$ref": "#/$defs/adler_case" }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "case_id": {
+      "type": "string",
+      "pattern": "^png-v1-[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "error_id": {
+      "type": "string",
+      "enum": [
+        "invalid-max-pixels",
+        "invalid-image-dimensions",
+        "invalid-pixel-data-length",
+        "file-too-short",
+        "invalid-signature",
+        "truncated-chunk",
+        "invalid-chunk-type",
+        "chunk-crc-mismatch",
+        "chunk-before-ihdr",
+        "duplicate-ihdr",
+        "invalid-ihdr-length",
+        "invalid-dimensions",
+        "dimension-limit",
+        "pixel-limit",
+        "unsupported-feature",
+        "invalid-plte",
+        "invalid-trns",
+        "nonconsecutive-idat",
+        "invalid-iend",
+        "trailing-data",
+        "unknown-critical-chunk",
+        "missing-required-chunk",
+        "invalid-zlib-header",
+        "preset-dictionary",
+        "inflate-failed",
+        "inflated-length-mismatch",
+        "idat-cavity",
+        "adler-mismatch",
+        "invalid-filter"
+      ]
+    },
+    "hex": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{2})*$"
+    },
+    "options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_pixels"],
+      "properties": { "max_pixels": { "type": "number" } }
+    },
+    "pixels": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height", "rgba_hex"],
+      "properties": {
+        "width": { "type": "number" },
+        "height": { "type": "number" },
+        "rgba_hex": { "$ref": "#/$defs/hex" }
+      }
+    },
+    "decode_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "png_hex", "oracle", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "decode" },
+        "png_hex": { "$ref": "#/$defs/hex" },
+        "oracle": { "enum": ["python-zlib", "rfc2083-hand"] },
+        "options": { "$ref": "#/$defs/options" },
+        "expected": { "$ref": "#/$defs/pixels" }
+      }
+    },
+    "decode_error_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "png_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "decode-error" },
+        "png_hex": { "$ref": "#/$defs/hex" },
+        "options": { "$ref": "#/$defs/options" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["error_id"],
+          "properties": { "error_id": { "$ref": "#/$defs/error_id" } }
+        }
+      }
+    },
+    "encode_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input", "oracle", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "encode" },
+        "input": { "$ref": "#/$defs/pixels" },
+        "oracle": { "const": "foreign-zlib" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["chunk_types", "filter_types", "bit_depth", "colour_type", "interlace"],
+          "properties": {
+            "chunk_types": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "prefixItems": [
+                { "const": "IHDR" },
+                { "const": "IDAT" },
+                { "const": "IEND" }
+              ],
+              "items": false
+            },
+            "filter_types": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "integer", "minimum": 0, "maximum": 4 }
+            },
+            "bit_depth": { "const": 8 },
+            "colour_type": { "const": 6 },
+            "interlace": { "const": 0 }
+          }
+        }
+      }
+    },
+    "encode_error_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "encode-error" },
+        "input": { "$ref": "#/$defs/pixels" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["error_id"],
+          "properties": { "error_id": { "$ref": "#/$defs/error_id" } }
+        }
+      }
+    },
+    "adler_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "operation", "input_hex", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/case_id" },
+        "operation": { "const": "adler32" },
+        "input_hex": { "$ref": "#/$defs/hex" },
+        "expected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["adler32_hex"],
+          "properties": {
+            "adler32_hex": { "type": "string", "pattern": "^[0-9a-f]{8}$" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -4096,6 +4096,41 @@ unchanged. The final publication rebase onto
 `12c26b50ae755ec88704c457d8264558433b96f0` added only Gujarati and
 Spanish curriculum evidence and likewise left the parity topology unchanged.
 
+## Post-#12307 Refresh and PNG Neutral-Foundation Selection
+
+Ready-for-review ZIP closure PR #12307 completed all 29 reported checks with
+23 successes, six expected skips, and no failure or pending job. Both required
+gates succeeded. After GitHub reported the branch clean and mergeable, the loop
+enabled squash auto-merge; GitHub merged final reviewed head
+`adb93159e901a352b37f534b2c8f4a345ebf1f42` as
+`2780825f2a7b5bf93936b6927175e975b611cb5c` at
+2026-08-20T18:18:50Z without manual merge authority.
+
+The canonical schema-3 collision inventory at that exact live main remains 15
+established lanes, 1,368 normalized implementation identities, 4,552
+established slots, 174 high-consensus identities with 271 gaps, 906 singletons
+with 12,684 missing slots, 716 Rust singletons, zero canonical collisions, and
+zero unknown buckets. The closure added no package root: the exact comparison
+found no added or retired identity and no existing-identity lane expansion, so
+no topology-driven owner was required before selection.
+
+Before publication, `origin/main` advanced through the unrelated Arabic
+curriculum repair in #12316 and Gujarati ductus repair in #12317 to
+`929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5`. The branch was rebased onto that
+exact revision; neither incoming change adds a package root, and the collision
+inventory remains unchanged at the counts above.
+
+Merging the ZIP umbrella made exactly one dependency-shaped item newly ready:
+`image-codec-png-language-neutral-conformance`. The loop selected it on fresh
+branch `codex/png-language-neutral-conformance` from exact merge main. This
+foundation will first correct the TypeScript reference's CINFO and caller pixel
+ceiling boundaries, then bind IC18 to a checked language-neutral corpus for
+chunk ordering and CRC, zlib framing and Adler-32, split IDAT, supported colour
+types, bit depths and filters, independent interoperability, exact consumption,
+stable payload-blind errors, and caller-lowerable resource ceilings. It will not
+start any non-TypeScript lane port. Once this full lifecycle merges, all twelve
+toolchain-shaped PNG children become dependency-ready.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary
- close the language-neutral image-codec-png foundation unlocked by ZIP raw-RFC1951 closure #12307
- add a closed 82-case, 29-error PNG v1 corpus and Draft 2020-12 schema with deterministic stored/fixed/dynamic RFC1951 evidence
- harden the TypeScript reference implementation around bounded decoding, stable errors, filter selection, PLTE, tRNS, zlib framing, and caller-lowered pixel limits
- add explicit authority-free capability metadata and an independent Python CI validator

## Contract evidence
- decode coverage includes colour types 0/2/4/6, all five filters, Paeth a/b/c/tie behavior, split IDAT, PLTE/tRNS ordering and bounds, stored/fixed/dynamic DEFLATE, checksums, truncation, and the closed error taxonomy
- encode coverage independently inspects emitted scanline filters, including a vector selecting 0/1/2/3/4, without pinning compressor bytes
- the corpus generator uses deterministic encoders and a checked dynamic-Huffman vector; host zlib is decode-oracle evidence only
- this PR intentionally establishes only the neutral foundation and TypeScript oracle; the twelve established-lane children and final aggregate remain separate dependency-shaped items

## Validation
- TypeScript build: PASS
- Vitest: 141 tests PASS; 100% statements, branches, functions, and lines
- literal package BUILD: PASS
- npm audit (full and production-only): 0 vulnerabilities
- neutral generator check: PASS
- independent PNG fixture validator: 8 tests PASS
- ZIP neutral fixture validator: 9 tests PASS
- ZIP portable coverage validator: 4 tests PASS
- capability taxonomy: 7 tests PASS
- package-parity reporter: 10 tests PASS
- Ruff check/format, strict MyPy, Bandit: PASS
- Go build-tool tests, vet, and trimpath build: PASS
- repository build plan: exactly image-codec-png plus local pixel-container/zip/lzss dependencies on Unix and Windows
- repository-native build-tool execution for that four-package closure: PASS
- collision inventory: 15 established lanes, 1,368 identities, 4,552 slots, 0 collisions, 0 unknown buckets
- parity state: 411 unique items, all dependencies resolve, acyclic DAG, one selected item
- strict JSON, diff check, credential scan, and production-authority scan: PASS