### PR TITLE
test(human-languages): shard gentle-ramp snapshots by language

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -158,6 +158,10 @@ jobs:
           # language visible without hand-maintained chapter or lesson claims.
           # Regenerate with `npm run generate:progress`.
           npm run check:progress
+          # Corpus debt stays exact, but each language owns a separate generated
+          # snapshot so independent curriculum PRs do not collide on one test line.
+          # Regenerate with `npm run generate:gentle-snapshots`.
+          npm run check:gentle-snapshots
           # The modality manifest (core/lesson-modality.json) is derived from the
           # lessons and is what lets the complete book, the app, and the future
           # dictation-friendly driving edition be filtered out of one source. A stale

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/arabic.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/arabic.json
@@ -1,0 +1,83 @@
+{
+  "language": "arabic",
+  "lessonCount": 100,
+  "atomMeasurableLessons": 74,
+  "atomMeasurementBlindLessons": 26,
+  "durationViolations": 0,
+  "atomLessonSpikes": 0,
+  "atomChapterSpikes": 2,
+  "glyphLessonSpikes": 4,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 71,
+  "neverTaughtGlyphs": 16,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 14,
+  "atomsTaught": 147,
+  "atomsNeverRevisited": 85,
+  "reinforcementWindowMisses": 315,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 51,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "arabic",
+      "kind": "forward-language",
+      "count": 14,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "arabic",
+      "kind": "script-closure",
+      "count": 16,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "arabic",
+      "kind": "atom-step",
+      "count": 2,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "arabic",
+      "kind": "glyph-step",
+      "count": 4,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "arabic",
+      "kind": "reinforcement",
+      "count": 315,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "arabic",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "arabic",
+      "kind": "measurement-blind",
+      "count": 26,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "arabic",
+    "kind": "forward-language",
+    "count": 14,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/bengali.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/bengali.json
@@ -1,0 +1,76 @@
+{
+  "language": "bengali",
+  "lessonCount": 80,
+  "atomMeasurableLessons": 80,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 3,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 65,
+  "neverTaughtGlyphs": 39,
+  "orderDefects": 3,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 3,
+  "forwardReferences": 6,
+  "atomsTaught": 104,
+  "atomsNeverRevisited": 7,
+  "reinforcementWindowMisses": 152,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 65,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "bengali",
+      "kind": "order-integrity",
+      "count": 3,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "bengali",
+      "kind": "forward-language",
+      "count": 6,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "bengali",
+      "kind": "script-closure",
+      "count": 39,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "bengali",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "bengali",
+      "kind": "glyph-step",
+      "count": 3,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "bengali",
+      "kind": "reinforcement",
+      "count": 152,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    }
+  ],
+  "next": {
+    "language": "bengali",
+    "kind": "order-integrity",
+    "count": 3,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/chinese.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/chinese.json
@@ -1,0 +1,48 @@
+{
+  "language": "chinese",
+  "lessonCount": 63,
+  "atomMeasurableLessons": 63,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 0,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 1,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 4,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 0,
+  "atomsTaught": 72,
+  "atomsNeverRevisited": 15,
+  "reinforcementWindowMisses": 98,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 32,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "chinese",
+      "kind": "glyph-step",
+      "count": 1,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "chinese",
+      "kind": "reinforcement",
+      "count": 98,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    }
+  ],
+  "next": {
+    "language": "chinese",
+    "kind": "glyph-step",
+    "count": 1,
+    "unit": "lesson/system spike(s)",
+    "detail": "split new glyphs and writing systems across gentler steps"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/french.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/french.json
@@ -1,0 +1,69 @@
+{
+  "language": "french",
+  "lessonCount": 118,
+  "atomMeasurableLessons": 54,
+  "atomMeasurementBlindLessons": 64,
+  "durationViolations": 0,
+  "atomLessonSpikes": 6,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 52,
+  "atomsTaught": 122,
+  "atomsNeverRevisited": 33,
+  "reinforcementWindowMisses": 230,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 3,
+  "firstWritingPracticeAt": 32,
+  "lessonsBeforeWritingPractice": 32,
+  "findings": [
+    {
+      "language": "french",
+      "kind": "forward-language",
+      "count": 52,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "french",
+      "kind": "writing-ramp",
+      "count": 32,
+      "unit": "opening lesson(s)",
+      "detail": "move the first gentle writing microstep to lesson one"
+    },
+    {
+      "language": "french",
+      "kind": "atom-step",
+      "count": 6,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "french",
+      "kind": "reinforcement",
+      "count": 230,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "french",
+      "kind": "measurement-blind",
+      "count": 64,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "french",
+    "kind": "forward-language",
+    "count": 52,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/german.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/german.json
@@ -1,0 +1,69 @@
+{
+  "language": "german",
+  "lessonCount": 107,
+  "atomMeasurableLessons": 41,
+  "atomMeasurementBlindLessons": 66,
+  "durationViolations": 0,
+  "atomLessonSpikes": 8,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 55,
+  "atomsTaught": 126,
+  "atomsNeverRevisited": 32,
+  "reinforcementWindowMisses": 190,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 5,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "german",
+      "kind": "forward-language",
+      "count": 55,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "german",
+      "kind": "atom-step",
+      "count": 8,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "german",
+      "kind": "reinforcement",
+      "count": 190,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "german",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "german",
+      "kind": "measurement-blind",
+      "count": 66,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "german",
+    "kind": "forward-language",
+    "count": 55,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/gujarati.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/gujarati.json
@@ -1,0 +1,76 @@
+{
+  "language": "gujarati",
+  "lessonCount": 69,
+  "atomMeasurableLessons": 69,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 2,
+  "atomChapterSpikes": 1,
+  "glyphLessonSpikes": 2,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 50,
+  "neverTaughtGlyphs": 32,
+  "orderDefects": 3,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 3,
+  "forwardReferences": 8,
+  "atomsTaught": 115,
+  "atomsNeverRevisited": 10,
+  "reinforcementWindowMisses": 174,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 53,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "gujarati",
+      "kind": "order-integrity",
+      "count": 3,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "gujarati",
+      "kind": "forward-language",
+      "count": 8,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "gujarati",
+      "kind": "script-closure",
+      "count": 32,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "gujarati",
+      "kind": "atom-step",
+      "count": 3,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "gujarati",
+      "kind": "glyph-step",
+      "count": 2,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "gujarati",
+      "kind": "reinforcement",
+      "count": 174,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    }
+  ],
+  "next": {
+    "language": "gujarati",
+    "kind": "order-integrity",
+    "count": 3,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/hindi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/hindi.json
@@ -1,0 +1,83 @@
+{
+  "language": "hindi",
+  "lessonCount": 273,
+  "atomMeasurableLessons": 273,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 2,
+  "glyphLessonSpikes": 3,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 72,
+  "neverTaughtGlyphs": 12,
+  "orderDefects": 1,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 1,
+  "forwardReferences": 10,
+  "atomsTaught": 350,
+  "atomsNeverRevisited": 76,
+  "reinforcementWindowMisses": 1014,
+  "payoffSurprises": 13,
+  "writingPracticeLessons": 83,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "hindi",
+      "kind": "order-integrity",
+      "count": 1,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "hindi",
+      "kind": "forward-language",
+      "count": 10,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "hindi",
+      "kind": "script-closure",
+      "count": 12,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "hindi",
+      "kind": "atom-step",
+      "count": 3,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "hindi",
+      "kind": "glyph-step",
+      "count": 3,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "hindi",
+      "kind": "reinforcement",
+      "count": 1014,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "hindi",
+      "kind": "payoff-surprise",
+      "count": 13,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    }
+  ],
+  "next": {
+    "language": "hindi",
+    "kind": "order-integrity",
+    "count": 1,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/italian.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/italian.json
@@ -1,0 +1,76 @@
+{
+  "language": "italian",
+  "lessonCount": 88,
+  "atomMeasurableLessons": 79,
+  "atomMeasurementBlindLessons": 9,
+  "durationViolations": 0,
+  "atomLessonSpikes": 3,
+  "atomChapterSpikes": 2,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 22,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 6,
+  "forwardReviews": 7,
+  "forwardReferences": 48,
+  "atomsTaught": 197,
+  "atomsNeverRevisited": 19,
+  "reinforcementWindowMisses": 273,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 0,
+  "firstWritingPracticeAt": null,
+  "lessonsBeforeWritingPractice": 88,
+  "findings": [
+    {
+      "language": "italian",
+      "kind": "order-integrity",
+      "count": 22,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "italian",
+      "kind": "forward-language",
+      "count": 48,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "italian",
+      "kind": "writing-ramp",
+      "count": 88,
+      "unit": "opening lesson(s)",
+      "detail": "add observable, guided writing practice from the opening lesson"
+    },
+    {
+      "language": "italian",
+      "kind": "atom-step",
+      "count": 5,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "italian",
+      "kind": "reinforcement",
+      "count": 273,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "italian",
+      "kind": "measurement-blind",
+      "count": 9,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "italian",
+    "kind": "order-integrity",
+    "count": 22,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
@@ -1,0 +1,62 @@
+{
+  "language": "japanese",
+  "lessonCount": 29,
+  "atomMeasurableLessons": 29,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 0,
+  "atomChapterSpikes": 1,
+  "glyphLessonSpikes": 4,
+  "scriptSystemSpikes": 5,
+  "scriptClosureViolations": 8,
+  "neverTaughtGlyphs": 21,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 0,
+  "atomsTaught": 39,
+  "atomsNeverRevisited": 8,
+  "reinforcementWindowMisses": 54,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 28,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "japanese",
+      "kind": "script-closure",
+      "count": 21,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "japanese",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "japanese",
+      "kind": "glyph-step",
+      "count": 9,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "japanese",
+      "kind": "reinforcement",
+      "count": 54,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    }
+  ],
+  "next": {
+    "language": "japanese",
+    "kind": "script-closure",
+    "count": 21,
+    "unit": "glyph(s)",
+    "detail": "teach every load-bearing glyph before asking the learner to decode it"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/kannada.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/kannada.json
@@ -1,0 +1,83 @@
+{
+  "language": "kannada",
+  "lessonCount": 242,
+  "atomMeasurableLessons": 212,
+  "atomMeasurementBlindLessons": 30,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 7,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 37,
+  "neverTaughtGlyphs": 18,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 17,
+  "atomsTaught": 282,
+  "atomsNeverRevisited": 8,
+  "reinforcementWindowMisses": 727,
+  "payoffSurprises": 3,
+  "writingPracticeLessons": 49,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "kannada",
+      "kind": "forward-language",
+      "count": 17,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "kannada",
+      "kind": "script-closure",
+      "count": 18,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "kannada",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "kannada",
+      "kind": "glyph-step",
+      "count": 7,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "kannada",
+      "kind": "reinforcement",
+      "count": 727,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "kannada",
+      "kind": "payoff-surprise",
+      "count": 3,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "kannada",
+      "kind": "measurement-blind",
+      "count": 30,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "kannada",
+    "kind": "forward-language",
+    "count": 17,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/latin.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/latin.json
@@ -1,0 +1,62 @@
+{
+  "language": "latin",
+  "lessonCount": 109,
+  "atomMeasurableLessons": 108,
+  "atomMeasurementBlindLessons": 1,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 2,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 25,
+  "atomsTaught": 210,
+  "atomsNeverRevisited": 26,
+  "reinforcementWindowMisses": 430,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 2,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "latin",
+      "kind": "forward-language",
+      "count": 25,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "latin",
+      "kind": "atom-step",
+      "count": 3,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "latin",
+      "kind": "reinforcement",
+      "count": 430,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "latin",
+      "kind": "measurement-blind",
+      "count": 1,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "latin",
+    "kind": "forward-language",
+    "count": 25,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/malayalam.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/malayalam.json
@@ -1,0 +1,83 @@
+{
+  "language": "malayalam",
+  "lessonCount": 247,
+  "atomMeasurableLessons": 216,
+  "atomMeasurementBlindLessons": 31,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 6,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 43,
+  "neverTaughtGlyphs": 18,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 20,
+  "atomsTaught": 281,
+  "atomsNeverRevisited": 51,
+  "reinforcementWindowMisses": 789,
+  "payoffSurprises": 7,
+  "writingPracticeLessons": 57,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "malayalam",
+      "kind": "forward-language",
+      "count": 20,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "malayalam",
+      "kind": "script-closure",
+      "count": 18,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "malayalam",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "malayalam",
+      "kind": "glyph-step",
+      "count": 6,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "malayalam",
+      "kind": "reinforcement",
+      "count": 789,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "malayalam",
+      "kind": "payoff-surprise",
+      "count": 7,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "malayalam",
+      "kind": "measurement-blind",
+      "count": 31,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "malayalam",
+    "kind": "forward-language",
+    "count": 20,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marathi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marathi.json
@@ -1,0 +1,76 @@
+{
+  "language": "marathi",
+  "lessonCount": 73,
+  "atomMeasurableLessons": 40,
+  "atomMeasurementBlindLessons": 33,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 2,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 62,
+  "neverTaughtGlyphs": 36,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 3,
+  "atomsTaught": 79,
+  "atomsNeverRevisited": 3,
+  "reinforcementWindowMisses": 98,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 52,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "marathi",
+      "kind": "forward-language",
+      "count": 3,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "marathi",
+      "kind": "script-closure",
+      "count": 36,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "marathi",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "marathi",
+      "kind": "glyph-step",
+      "count": 2,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "marathi",
+      "kind": "reinforcement",
+      "count": 98,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "marathi",
+      "kind": "measurement-blind",
+      "count": 33,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "marathi",
+    "kind": "forward-language",
+    "count": 3,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
@@ -1,0 +1,48 @@
+{
+  "language": "marwadi",
+  "lessonCount": 7,
+  "atomMeasurableLessons": 7,
+  "atomMeasurementBlindLessons": 0,
+  "durationViolations": 0,
+  "atomLessonSpikes": 0,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 3,
+  "atomsTaught": 9,
+  "atomsNeverRevisited": 1,
+  "reinforcementWindowMisses": 1,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 5,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "marwadi",
+      "kind": "forward-language",
+      "count": 3,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "marwadi",
+      "kind": "reinforcement",
+      "count": 1,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    }
+  ],
+  "next": {
+    "language": "marwadi",
+    "kind": "forward-language",
+    "count": 3,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/persian.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/persian.json
@@ -1,0 +1,97 @@
+{
+  "language": "persian",
+  "lessonCount": 69,
+  "atomMeasurableLessons": 65,
+  "atomMeasurementBlindLessons": 4,
+  "durationViolations": 0,
+  "atomLessonSpikes": 2,
+  "atomChapterSpikes": 3,
+  "glyphLessonSpikes": 1,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 50,
+  "neverTaughtGlyphs": 25,
+  "orderDefects": 6,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 2,
+  "forwardReviews": 0,
+  "forwardReferences": 10,
+  "atomsTaught": 148,
+  "atomsNeverRevisited": 7,
+  "reinforcementWindowMisses": 204,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 11,
+  "firstWritingPracticeAt": 7,
+  "lessonsBeforeWritingPractice": 7,
+  "findings": [
+    {
+      "language": "persian",
+      "kind": "order-integrity",
+      "count": 6,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "persian",
+      "kind": "forward-language",
+      "count": 10,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "persian",
+      "kind": "script-closure",
+      "count": 25,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "persian",
+      "kind": "writing-ramp",
+      "count": 7,
+      "unit": "opening lesson(s)",
+      "detail": "move the first gentle writing microstep to lesson one"
+    },
+    {
+      "language": "persian",
+      "kind": "atom-step",
+      "count": 5,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "persian",
+      "kind": "glyph-step",
+      "count": 1,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "persian",
+      "kind": "reinforcement",
+      "count": 204,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "persian",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "persian",
+      "kind": "measurement-blind",
+      "count": 4,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "persian",
+    "kind": "order-integrity",
+    "count": 6,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/portuguese.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/portuguese.json
@@ -1,0 +1,76 @@
+{
+  "language": "portuguese",
+  "lessonCount": 96,
+  "atomMeasurableLessons": 87,
+  "atomMeasurementBlindLessons": 9,
+  "durationViolations": 0,
+  "atomLessonSpikes": 0,
+  "atomChapterSpikes": 2,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 21,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 6,
+  "forwardReviews": 6,
+  "forwardReferences": 59,
+  "atomsTaught": 189,
+  "atomsNeverRevisited": 8,
+  "reinforcementWindowMisses": 296,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 0,
+  "firstWritingPracticeAt": null,
+  "lessonsBeforeWritingPractice": 96,
+  "findings": [
+    {
+      "language": "portuguese",
+      "kind": "order-integrity",
+      "count": 21,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "portuguese",
+      "kind": "forward-language",
+      "count": 59,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "portuguese",
+      "kind": "writing-ramp",
+      "count": 96,
+      "unit": "opening lesson(s)",
+      "detail": "add observable, guided writing practice from the opening lesson"
+    },
+    {
+      "language": "portuguese",
+      "kind": "atom-step",
+      "count": 2,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "portuguese",
+      "kind": "reinforcement",
+      "count": 296,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "portuguese",
+      "kind": "measurement-blind",
+      "count": 9,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "portuguese",
+    "kind": "order-integrity",
+    "count": 21,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/punjabi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/punjabi.json
@@ -1,0 +1,69 @@
+{
+  "language": "punjabi",
+  "lessonCount": 71,
+  "atomMeasurableLessons": 40,
+  "atomMeasurementBlindLessons": 31,
+  "durationViolations": 0,
+  "atomLessonSpikes": 4,
+  "atomChapterSpikes": 1,
+  "glyphLessonSpikes": 2,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 51,
+  "neverTaughtGlyphs": 36,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 0,
+  "atomsTaught": 92,
+  "atomsNeverRevisited": 5,
+  "reinforcementWindowMisses": 137,
+  "payoffSurprises": 0,
+  "writingPracticeLessons": 53,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "punjabi",
+      "kind": "script-closure",
+      "count": 36,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "punjabi",
+      "kind": "atom-step",
+      "count": 5,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "punjabi",
+      "kind": "glyph-step",
+      "count": 2,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "punjabi",
+      "kind": "reinforcement",
+      "count": 137,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "punjabi",
+      "kind": "measurement-blind",
+      "count": 31,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "punjabi",
+    "kind": "script-closure",
+    "count": 36,
+    "unit": "glyph(s)",
+    "detail": "teach every load-bearing glyph before asking the learner to decode it"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/russian.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/russian.json
@@ -1,0 +1,90 @@
+{
+  "language": "russian",
+  "lessonCount": 84,
+  "atomMeasurableLessons": 83,
+  "atomMeasurementBlindLessons": 1,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 4,
+  "glyphLessonSpikes": 4,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 59,
+  "neverTaughtGlyphs": 23,
+  "orderDefects": 1,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 1,
+  "forwardReferences": 8,
+  "atomsTaught": 160,
+  "atomsNeverRevisited": 22,
+  "reinforcementWindowMisses": 269,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 36,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "russian",
+      "kind": "order-integrity",
+      "count": 1,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "russian",
+      "kind": "forward-language",
+      "count": 8,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "russian",
+      "kind": "script-closure",
+      "count": 23,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "russian",
+      "kind": "atom-step",
+      "count": 5,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "russian",
+      "kind": "glyph-step",
+      "count": 4,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "russian",
+      "kind": "reinforcement",
+      "count": 269,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "russian",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "russian",
+      "kind": "measurement-blind",
+      "count": 1,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "russian",
+    "kind": "order-integrity",
+    "count": 1,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/sanskrit.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/sanskrit.json
@@ -1,0 +1,83 @@
+{
+  "language": "sanskrit",
+  "lessonCount": 266,
+  "atomMeasurableLessons": 236,
+  "atomMeasurementBlindLessons": 30,
+  "durationViolations": 0,
+  "atomLessonSpikes": 3,
+  "atomChapterSpikes": 1,
+  "glyphLessonSpikes": 6,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 56,
+  "neverTaughtGlyphs": 18,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 4,
+  "atomsTaught": 274,
+  "atomsNeverRevisited": 13,
+  "reinforcementWindowMisses": 716,
+  "payoffSurprises": 6,
+  "writingPracticeLessons": 49,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "sanskrit",
+      "kind": "forward-language",
+      "count": 4,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "script-closure",
+      "count": 18,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "atom-step",
+      "count": 4,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "glyph-step",
+      "count": 6,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "reinforcement",
+      "count": 716,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "payoff-surprise",
+      "count": 6,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "sanskrit",
+      "kind": "measurement-blind",
+      "count": 30,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "sanskrit",
+    "kind": "forward-language",
+    "count": 4,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/spanish.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/spanish.json
@@ -1,0 +1,76 @@
+{
+  "language": "spanish",
+  "lessonCount": 584,
+  "atomMeasurableLessons": 488,
+  "atomMeasurementBlindLessons": 96,
+  "durationViolations": 0,
+  "atomLessonSpikes": 6,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 91,
+  "atomsTaught": 876,
+  "atomsNeverRevisited": 128,
+  "reinforcementWindowMisses": 2326,
+  "payoffSurprises": 26,
+  "writingPracticeLessons": 7,
+  "firstWritingPracticeAt": 26,
+  "lessonsBeforeWritingPractice": 26,
+  "findings": [
+    {
+      "language": "spanish",
+      "kind": "forward-language",
+      "count": 91,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "spanish",
+      "kind": "writing-ramp",
+      "count": 26,
+      "unit": "opening lesson(s)",
+      "detail": "move the first gentle writing microstep to lesson one"
+    },
+    {
+      "language": "spanish",
+      "kind": "atom-step",
+      "count": 6,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "spanish",
+      "kind": "reinforcement",
+      "count": 2326,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "spanish",
+      "kind": "payoff-surprise",
+      "count": 26,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "spanish",
+      "kind": "measurement-blind",
+      "count": 96,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "spanish",
+    "kind": "forward-language",
+    "count": 91,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/tamil.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/tamil.json
@@ -1,0 +1,83 @@
+{
+  "language": "tamil",
+  "lessonCount": 283,
+  "atomMeasurableLessons": 251,
+  "atomMeasurementBlindLessons": 32,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 6,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 35,
+  "neverTaughtGlyphs": 11,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 16,
+  "atomsTaught": 351,
+  "atomsNeverRevisited": 53,
+  "reinforcementWindowMisses": 948,
+  "payoffSurprises": 13,
+  "writingPracticeLessons": 77,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "tamil",
+      "kind": "forward-language",
+      "count": 16,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "tamil",
+      "kind": "script-closure",
+      "count": 11,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "tamil",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "tamil",
+      "kind": "glyph-step",
+      "count": 6,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "tamil",
+      "kind": "reinforcement",
+      "count": 948,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "tamil",
+      "kind": "payoff-surprise",
+      "count": 13,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "tamil",
+      "kind": "measurement-blind",
+      "count": 32,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "tamil",
+    "kind": "forward-language",
+    "count": 16,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/telugu.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/telugu.json
@@ -1,0 +1,83 @@
+{
+  "language": "telugu",
+  "lessonCount": 276,
+  "atomMeasurableLessons": 246,
+  "atomMeasurementBlindLessons": 30,
+  "durationViolations": 0,
+  "atomLessonSpikes": 1,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 6,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 46,
+  "neverTaughtGlyphs": 24,
+  "orderDefects": 0,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 0,
+  "forwardReviews": 0,
+  "forwardReferences": 14,
+  "atomsTaught": 313,
+  "atomsNeverRevisited": 14,
+  "reinforcementWindowMisses": 823,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 57,
+  "firstWritingPracticeAt": 0,
+  "lessonsBeforeWritingPractice": 0,
+  "findings": [
+    {
+      "language": "telugu",
+      "kind": "forward-language",
+      "count": 14,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "telugu",
+      "kind": "script-closure",
+      "count": 24,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "telugu",
+      "kind": "atom-step",
+      "count": 1,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "telugu",
+      "kind": "glyph-step",
+      "count": 6,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "telugu",
+      "kind": "reinforcement",
+      "count": 823,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "telugu",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "telugu",
+      "kind": "measurement-blind",
+      "count": 30,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "telugu",
+    "kind": "forward-language",
+    "count": 14,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
+  }
+}

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/urdu.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/urdu.json
@@ -1,0 +1,97 @@
+{
+  "language": "urdu",
+  "lessonCount": 68,
+  "atomMeasurableLessons": 64,
+  "atomMeasurementBlindLessons": 4,
+  "durationViolations": 0,
+  "atomLessonSpikes": 3,
+  "atomChapterSpikes": 3,
+  "glyphLessonSpikes": 2,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 47,
+  "neverTaughtGlyphs": 30,
+  "orderDefects": 5,
+  "unknownPrerequisites": 0,
+  "forwardPrerequisites": 1,
+  "forwardReviews": 0,
+  "forwardReferences": 7,
+  "atomsTaught": 151,
+  "atomsNeverRevisited": 8,
+  "reinforcementWindowMisses": 214,
+  "payoffSurprises": 2,
+  "writingPracticeLessons": 27,
+  "firstWritingPracticeAt": 7,
+  "lessonsBeforeWritingPractice": 7,
+  "findings": [
+    {
+      "language": "urdu",
+      "kind": "order-integrity",
+      "count": 5,
+      "unit": "order/dependency defect(s)",
+      "detail": "declare a unique reading order and close every prerequisite and review before use"
+    },
+    {
+      "language": "urdu",
+      "kind": "forward-language",
+      "count": 7,
+      "unit": "use(s)",
+      "detail": "teach target-language material before load-bearing use"
+    },
+    {
+      "language": "urdu",
+      "kind": "script-closure",
+      "count": 30,
+      "unit": "glyph(s)",
+      "detail": "teach every load-bearing glyph before asking the learner to decode it"
+    },
+    {
+      "language": "urdu",
+      "kind": "writing-ramp",
+      "count": 7,
+      "unit": "opening lesson(s)",
+      "detail": "move the first gentle writing microstep to lesson one"
+    },
+    {
+      "language": "urdu",
+      "kind": "atom-step",
+      "count": 6,
+      "unit": "lesson/chapter spike(s)",
+      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
+    },
+    {
+      "language": "urdu",
+      "kind": "glyph-step",
+      "count": 2,
+      "unit": "lesson/system spike(s)",
+      "detail": "split new glyphs and writing systems across gentler steps"
+    },
+    {
+      "language": "urdu",
+      "kind": "reinforcement",
+      "count": 214,
+      "unit": "missed window(s)",
+      "detail": "add retrieval at the expanding R1-R4 intervals"
+    },
+    {
+      "language": "urdu",
+      "kind": "payoff-surprise",
+      "count": 2,
+      "unit": "chapter payoff finding(s)",
+      "detail": "make each chapter payoff assess only taught, representative material"
+    },
+    {
+      "language": "urdu",
+      "kind": "measurement-blind",
+      "count": 4,
+      "unit": "lesson(s)",
+      "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
+    }
+  ],
+  "next": {
+    "language": "urdu",
+    "kind": "order-integrity",
+    "count": 5,
+    "unit": "order/dependency defect(s)",
+    "detail": "declare a unique reading order and close every prerequisite and review before use"
+  }
+}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added - conflict-resistant gentle-ramp corpus snapshots (#12320)
+
+- Replace the hand-maintained global gentle-ramp totals and queue head with one
+  deterministic, full-fidelity snapshot per language.
+- Rebuild and verify the global summary and work queue from the shards so exact
+  regression coverage remains fail-closed without making unrelated language PRs
+  edit the same test lines.
+- Add write/check commands, CI and local verification wiring, stale-file detection,
+  and a regression proving a one-language change alters exactly one output shard.
+
 ### Added - Arabic STAMP 4S A1 performance target (#12290)
 
 - Inventory Avant's current four-skill STAMP 4S format for second-language

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -292,6 +292,19 @@ opening defect cannot be averaged away. Writing exposure does not count as writi
 practice, and the report names how many opening lessons precede the first real
 writing/script lesson or block.
 
+The exact corpus regression lives in one generated snapshot per language rather
+than six hand-edited totals in the test body:
+
+```bash
+npm run generate:gentle-snapshots  # write core/gentle-ramp-snapshots/*.json
+npm run check:gentle-snapshots     # fail if any language shard is stale or orphaned
+```
+
+The test reconstructs the global summary and priority queue from those full track
+snapshots. A Tamil-only change therefore updates `tamil.json`; it cannot collide
+with a simultaneous Punjabi-only change, while a hidden debt increase still changes
+the responsible shard and fails the byte-for-byte drift gate.
+
 ### Continuity — does the course have a memory of itself? (HL09)
 
 The ramp budgets measure how big each **step** is. This measures whether the steps

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -16,6 +16,8 @@
     "check:narration": "node dist/narration-cli.js --check",
     "generate:progress": "node dist/track-progress-cli.js --write",
     "check:progress": "node dist/track-progress-cli.js --check",
+    "generate:gentle-snapshots": "node dist/gentle-ramp-snapshot-cli.js --write",
+    "check:gentle-snapshots": "node dist/gentle-ramp-snapshot-cli.js --check",
     "report": "node dist/report-cli.js",
     "report:gentle-ramp": "node dist/gentle-ramp-cli.js",
     "plan": "node dist/plan-cli.js",

--- a/code/packages/typescript/human-language-data/src/gentle-ramp-snapshot-cli.ts
+++ b/code/packages/typescript/human-language-data/src/gentle-ramp-snapshot-cli.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, normalize, relative as pathRelative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { buildCurriculumGapReport } from "./report.js";
+import {
+  defaultCurriculumRoot,
+  loadChapterPolicy,
+  loadEverything,
+  loadTrackChapters,
+} from "./loader.js";
+import type { GentleRampReport, TrackGentleRamp } from "./gentle-ramp.js";
+
+export const GENTLE_RAMP_SNAPSHOT_DIR = "core/gentle-ramp-snapshots";
+
+function safeSnapshotOutput(root: string, relative: string): string {
+  const output = resolve(root, relative);
+  const fromRoot = normalize(pathRelative(resolve(root), output)).replaceAll("\\", "/");
+  if (
+    fromRoot === "" ||
+    fromRoot === ".." ||
+    fromRoot.startsWith("../") ||
+    !fromRoot.startsWith(`${GENTLE_RAMP_SNAPSHOT_DIR}/`) ||
+    !fromRoot.endsWith(".json")
+  ) {
+    throw new Error(`unsafe gentle-ramp snapshot output '${relative}'`);
+  }
+  return output;
+}
+
+export function serializeGentleRampTrack(track: TrackGentleRamp): string {
+  return `${JSON.stringify(track, null, 2)}\n`;
+}
+
+export function generatedGentleRampSnapshotOutputsFromReport(
+  report: GentleRampReport,
+): Map<string, string> {
+  return new Map(
+    [...report.tracks]
+      .sort((a, b) => a.language.localeCompare(b.language))
+      .map((track) => [
+        `${GENTLE_RAMP_SNAPSHOT_DIR}/${track.language}.json`,
+        serializeGentleRampTrack(track),
+      ]),
+  );
+}
+
+export function generatedGentleRampSnapshotOutputs(
+  root = defaultCurriculumRoot(),
+): Map<string, string> {
+  const { registry, lessons, books, curricula, spine } = loadEverything(root);
+  const report = buildCurriculumGapReport({
+    registry,
+    lessons,
+    books,
+    curricula,
+    spine,
+    chapterPolicy: loadChapterPolicy(root),
+    trackChapters: loadTrackChapters(root),
+  }).gentleRamp;
+  if (!report) throw new Error("chapter policy was not loaded; cannot snapshot the gentle ramp");
+  return generatedGentleRampSnapshotOutputsFromReport(report);
+}
+
+export function runGentleRampSnapshots(
+  args = process.argv.slice(2),
+  root = defaultCurriculumRoot(),
+): number {
+  const mode = args.length === 1 ? args[0] : undefined;
+  if (mode !== "--check" && mode !== "--write") {
+    process.stderr.write("usage: gentle-ramp-snapshot-cli (--check | --write)\n");
+    return 2;
+  }
+
+  const outputs = generatedGentleRampSnapshotOutputs(root);
+  let mismatch = false;
+  for (const [relative, expected] of outputs) {
+    const output = safeSnapshotOutput(root, relative);
+    if (mode === "--write") {
+      mkdirSync(dirname(output), { recursive: true });
+      writeFileSync(output, expected, "utf8");
+      process.stdout.write(`generated ${relative}\n`);
+      continue;
+    }
+    const actual = existsSync(output) ? readFileSync(output, "utf8") : undefined;
+    if (actual !== expected) {
+      process.stderr.write(`${relative}: generated output is missing or stale\n`);
+      mismatch = true;
+    }
+  }
+
+  if (mode === "--check") {
+    const snapshotDir = resolve(root, GENTLE_RAMP_SNAPSHOT_DIR);
+    const expectedNames = new Set([...outputs.keys()].map((path) => path.split("/").at(-1)!));
+    const actualNames = existsSync(snapshotDir)
+      ? readdirSync(snapshotDir).filter((name) => name.endsWith(".json"))
+      : [];
+    for (const name of actualNames) {
+      if (!expectedNames.has(name)) {
+        process.stderr.write(`${GENTLE_RAMP_SNAPSHOT_DIR}/${name}: unexpected stale snapshot\n`);
+        mismatch = true;
+      }
+    }
+  }
+  return mismatch ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exit(runGentleRampSnapshots());
+}

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { parseLesson } from "../src/parse.js";
 import { buildCurriculumGapReport } from "../src/report.js";
-import { renderGentleRamp } from "../src/gentle-ramp.js";
+import { GENTLE_RAMP_PRIORITIES, renderGentleRamp, type TrackGentleRamp } from "../src/gentle-ramp.js";
 import { runGentleRampReport } from "../src/gentle-ramp-cli.js";
-import { loadChapterPolicy, loadEverything, loadTrackChapters } from "../src/loader.js";
+import {
+  GENTLE_RAMP_SNAPSHOT_DIR,
+  generatedGentleRampSnapshotOutputsFromReport,
+} from "../src/gentle-ramp-snapshot-cli.js";
+import { defaultCurriculumRoot, loadChapterPolicy, loadEverything, loadTrackChapters } from "../src/loader.js";
 import type { BookCorpus, ChapterPolicy, LanguageRegistry } from "../src/types.js";
 
 const registry: LanguageRegistry = {
@@ -102,34 +108,44 @@ describe("the corpus-wide super-gentle ramp", () => {
       trackChapters: loadTrackChapters(),
     }).gentleRamp!;
 
+    const outputs = generatedGentleRampSnapshotOutputsFromReport(report);
+    for (const [relative, expected] of outputs) {
+      expect(readFileSync(resolve(defaultCurriculumRoot(), relative), "utf8"), relative).toBe(expected);
+    }
+
+    const snappedTracks = [...outputs.values()].map((value) => JSON.parse(value) as TrackGentleRamp);
+    const priority = new Map(GENTLE_RAMP_PRIORITIES.map((kind, index) => [kind, index]));
+    const snappedQueue = snappedTracks.flatMap((track) => track.findings).sort(
+      (a, b) =>
+        (priority.get(a.kind) ?? Number.MAX_SAFE_INTEGER) -
+          (priority.get(b.kind) ?? Number.MAX_SAFE_INTEGER) ||
+        b.count - a.count ||
+        a.language.localeCompare(b.language),
+    );
+    expect(report.tracks).toEqual(snappedTracks);
+    expect(report.workQueue).toEqual(snappedQueue);
     expect(report.summary).toEqual({
-      tracks: 23,
-      tracksWithDetectedCliffs: 23,
-      tracksWithNoWritingPractice: 2, // Latin now starts with observe-trace and guided copy.
-      tracksWhereWritingStartsLate: 4, // German and Tamil now join Chinese with writing in lesson one.
-      atomMeasurementBlindLessons: 497, // Tamil's first writing lesson now measures its introduced atoms.
-      findings: 138, // Punjabi closes its order-integrity finding after Tamil's writing repair.
+      tracks: snappedTracks.length,
+      tracksWithDetectedCliffs: snappedTracks.filter((track) => track.findings.length > 0).length,
+      tracksWithNoWritingPractice: snappedTracks.filter(
+        (track) => track.lessonCount > 0 && track.firstWritingPracticeAt === null,
+      ).length,
+      tracksWhereWritingStartsLate: snappedTracks.filter(
+        (track) => (track.firstWritingPracticeAt ?? 0) > 0,
+      ).length,
+      atomMeasurementBlindLessons: snappedTracks.reduce(
+        (sum, track) => sum + track.atomMeasurementBlindLessons,
+        0,
+      ),
+      findings: snappedQueue.length,
     });
-    expect(report.workQueue.slice(0, 3).map(({ language, kind, count }) => ({ language, kind, count }))).toEqual([
-      { language: "italian", kind: "order-integrity", count: 22 },
-      { language: "portuguese", kind: "order-integrity", count: 21 },
-      { language: "persian", kind: "order-integrity", count: 6 },
-    ]);
-    expect(report.tracks.find((track) => track.language === "german")).toMatchObject({
-      orderDefects: 0,
-      forwardPrerequisites: 0,
-      forwardReviews: 0,
-    });
-    expect(report.tracks.find((track) => track.language === "french")).toMatchObject({
-      orderDefects: 0,
-      forwardPrerequisites: 0,
-      forwardReviews: 0,
-    });
-    expect(report.tracks.find((track) => track.language === "marathi")).toMatchObject({
-      orderDefects: 0,
-      forwardPrerequisites: 0,
-      forwardReviews: 0,
-    });
+
+    const changed = structuredClone(report);
+    changed.tracks.find((track) => track.language === "german")!.lessonCount += 1;
+    const changedOutputs = generatedGentleRampSnapshotOutputsFromReport(changed);
+    expect(
+      [...outputs.keys()].filter((path) => outputs.get(path) !== changedOutputs.get(path)),
+    ).toEqual([`${GENTLE_RAMP_SNAPSHOT_DIR}/german.json`]);
     expect(report.tracks.every((track) => track.findings.length > 0)).toBe(true);
   }, 30_000);
 });

--- a/code/scripts/verify-human-languages.sh
+++ b/code/scripts/verify-human-languages.sh
@@ -62,6 +62,7 @@ if [ "$MODE" != "books" ]; then
   step "drift gates (exactly what CI runs)"
   ( cd "$PKG" && run "check:figures" npm run check:figures )
   ( cd "$PKG" && run "check:books" npm run check:books )
+  ( cd "$PKG" && run "check:gentle-snapshots" npm run check:gentle-snapshots )
   ( cd "$PKG" && run "check:modality" npm run check:modality )
   ( cd "$PKG" && run "check:narration" npm run check:narration )
 


### PR DESCRIPTION
## Summary

- replace hand-edited corpus-wide gentle-ramp totals with one deterministic full-fidelity snapshot per language
- reconstruct and verify the global summary and learner-first work queue from those shards
- add write/check commands, stale-orphan detection, CI wiring, local verification wiring, and author documentation
- prove that changing one language changes exactly one snapshot file

## Why

Independent language PRs currently edit the same few snapshot lines, so every merge creates conflicts across all other language branches. This tranche removes that conflict surface for the highest-churn gentle-ramp gate without weakening exact debt detection.

## Validation

- 225/225 focused curriculum tests
- `npm run build`
- `npm run check:gentle-snapshots`
- all existing generated artifact checks
- `git diff --check`

Closes #12320