### PR TITLE
feat(image-codec-png): add Go portable codec

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,9 +11,9 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": 12319,
+  "active_pr": null,
   "last_inventory": {
-    "revision": "929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5",
+    "revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1368,
@@ -3945,7 +3945,7 @@
     {
       "id": "image-codec-png-language-neutral-conformance",
       "title": "Define language-neutral IC18 PNG conformance with TypeScript reference consumption",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["zip-raw-rfc1951-portable-conformance"],
       "branch": "codex/png-language-neutral-conformance",
       "pr_number": 12319,
@@ -3954,15 +3954,27 @@
       "selection_revision": "2780825f2a7b5bf93936b6927175e975b611cb5c",
       "selection_notes": "Selected immediately after ZIP portable closure PR #12307 completed all 29 checks and merged through auto-merge, making this neutral foundation the sole newly dependency-ready prerequisite for all twelve PNG lane children. The canonical schema-3 inventory at exact live main 2780825f2a reports the same 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets, with no added, retired, or expanded package root. This bounded tranche first tightens the TypeScript reference, then defines and validates a language-neutral IC18 corpus and stable error contract for exact chunks, CRC, zlib framing, filters, supported colour forms, split IDAT, foreign interoperability, exact consumption, and caller-lowerable resource ceilings. It does not start any non-TypeScript lane port.",
       "implementation_revision": "d237fd922c714c39deb9dc4fd3a30aea47518e04",
+      "final_review_revision": "e9ae38873f3606d764e2786e824d6fd1c297a8dc",
+      "merged_at": "2026-08-20T20:03:24Z",
+      "merge_revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
       "validation_notes": "The closed Draft 2020-12 schema and deterministic generator pin 82 portable cases and 29 ordered stable error identifiers. The corpus covers stored, fixed, and a checked dynamic RFC 1951 stream; all five filters; Paeth a/b/c and tie behavior; split IDAT; exact CRC, Adler-32, chunk-order, PLTE, tRNS, zlib-framing, truncation, and caller-lowered limit boundaries; and independent encode filter inspection without compressor-byte pins. TypeScript build and 141 tests pass with 100% statement, branch, function, and line coverage. The literal package BUILD, full and production npm audits with zero vulnerabilities, eight independent PNG fixture tests, nine ZIP fixture tests, four ZIP closure tests, seven capability tests, ten parity-reporter tests, Ruff, formatting, strict MyPy, Bandit, Go test/vet/trimpath build, strict JSON and state DAG checks, collision reporting, diff, credential, and production-authority scans pass. The repository build plan selects exactly image-codec-png and its pixel-container, ZIP, and LZSS prerequisites on Unix and Windows, and the repository-native build tool executes that four-package closure successfully. The live inventory remains 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets.",
-      "publication_notes": "Opened ready-for-review PR #12319 from validated implementation revision d237fd922c714c39deb9dc4fd3a30aea47518e04 after two clean late-main rebases and full recertification against origin/main 929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5. The PR is mergeable, and CI is pending; auto-merge remains disabled until every required check is terminal acceptable and GitHub reports no conflict.",
+      "publication_notes": "Opened ready-for-review PR #12319 from validated implementation revision d237fd922c714c39deb9dc4fd3a30aea47518e04 after two clean late-main rebases and full recertification against origin/main 929de1d639ea9e76e2f38fcf9fbfaf55d596a5d5. All 30 reported checks reached terminal acceptable conclusions with 23 successes, six expected skips, and one neutral CodeQL conclusion; both CI gates and every Linux, macOS, and Windows build succeeded. GitHub reported final reviewed head e9ae38873f3606d764e2786e824d6fd1c297a8dc clean and mergeable. The loop enabled squash auto-merge, and GitHub merged that exact head as a09bb28bd19ab24760322f7fcf940184c0912409 at 2026-08-20T20:03:24Z without manual merge authority.",
       "notes": "Decomposed from the broad image-codec-png owner during the ZIP closure security and leverage audit. Close exact chunk ordering and CRC, zlib CM/CINFO/FCHECK and Adler-32 framing, split IDAT, every supported colour type, bit depth, and filter, foreign interoperability, exact consumption and covert-cavity rejection, stable payload-blind errors, dimension/pixel/inflation ceilings, and an explicit empty capability profile. The TypeScript reference must reject CINFO above 7 and require maxPixels to be an integer no larger than the 32 Mi-pixel default before it becomes the oracle."
+    },
+    {
+      "id": "image-codec-png-apng-neutral-rejection-conformance",
+      "title": "Close APNG refusal in the IC18 neutral PNG contract",
+      "status": "pending",
+      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Go PNG child security audit. IC18 says APNG is refused, but the merged TypeScript reference and 82-case neutral corpus treat acTL, fcTL, and fdAT as skippable ancillary chunks. Add valid-CRC neutral rejection vectors, make the TypeScript oracle reject all three as unsupported-feature, and update the corpus summary pins before the remaining lane ports start. The already-selected Go child carries a focused direct regression and explicit refusal so it does not reproduce the ambiguity."
     },
     {
       "id": "image-codec-png-dotnet-lane-parity",
       "title": "Port IC18 image-codec-png to C# and F#",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Toolchain-shaped .NET child. Consume the neutral PNG corpus and the established ZIP raw/CRC surface in both lanes without duplicating DEFLATE."
@@ -3971,7 +3983,7 @@
       "id": "image-codec-png-dart-lane-parity",
       "title": "Port IC18 image-codec-png to Dart",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Dart child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -3980,7 +3992,7 @@
       "id": "image-codec-png-elixir-lane-parity",
       "title": "Port IC18 image-codec-png to Elixir",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Elixir child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -3988,17 +4000,19 @@
     {
       "id": "image-codec-png-go-lane-parity",
       "title": "Port IC18 image-codec-png to Go",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["image-codec-png-language-neutral-conformance"],
-      "branch": null,
+      "branch": "codex/image-codec-png-go-lane-parity",
       "pr_number": null,
+      "selection_revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
+      "selection_notes": "Selected immediately after PNG neutral-foundation PR #12319 completed all 30 checks and merged through auto-merge. The collision-checked schema-3 inventory at exact merge main a09bb28bd1 remains 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets; the intervening human-language commits and merged TypeScript PNG work add no package identity or lane expansion. All twelve PNG toolchain children are newly ready. Go has the strongest safe dependency leverage: the installed Go 1.26.4 toolchain and existing pixel-container plus ZIP raw/count/CRC packages pass their native tests, vet, race/coverage, and build front doors, and this child unlocks both the final PNG umbrella and the separate unblocked paint-codec-png reconciliation. This tranche adds exactly go/image-codec-png, consumes every representable neutral case through its public API, documents the typed PixelContainer boundary for non-integer fixture inputs, preserves pure in-memory operation with empty capabilities, and leaves paint-adapter migration and every other lane pending.",
       "notes": "Standalone Go child consuming the neutral PNG corpus and repo ZIP raw/CRC surface. Existing go/paint-codec-png delegates to the standard-library image/png codec and is not parity evidence for this portable package."
     },
     {
       "id": "image-codec-png-haskell-lane-parity",
       "title": "Port IC18 image-codec-png to Haskell",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Haskell child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -4007,7 +4021,7 @@
       "id": "image-codec-png-jvm-lane-parity",
       "title": "Port IC18 image-codec-png to Java and Kotlin",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Toolchain-shaped JVM child. Consume the neutral PNG corpus and established ZIP raw/CRC surface in both lanes without duplicating DEFLATE."
@@ -4016,7 +4030,7 @@
       "id": "image-codec-png-lua-lane-parity",
       "title": "Port IC18 image-codec-png to Lua",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Lua child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -4025,7 +4039,7 @@
       "id": "image-codec-png-perl-lane-parity",
       "title": "Port IC18 image-codec-png to Perl",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Perl child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -4034,7 +4048,7 @@
       "id": "image-codec-png-python-lane-parity",
       "title": "Port IC18 image-codec-png to Python",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Python child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -4043,7 +4057,7 @@
       "id": "image-codec-png-ruby-lane-parity",
       "title": "Port IC18 image-codec-png to Ruby",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Ruby child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."
@@ -4052,7 +4066,7 @@
       "id": "image-codec-png-rust-lane-parity",
       "title": "Port IC18 image-codec-png to Rust",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Rust child consuming the neutral PNG corpus and established ZIP raw/CRC surface. The legacy rust/png crate duplicates CRC/DEFLATE and exposes filesystem writes while declaring empty capabilities, so it is migration input rather than parity evidence."
@@ -4061,7 +4075,7 @@
       "id": "image-codec-png-swift-lane-parity",
       "title": "Port IC18 image-codec-png to Swift",
       "status": "pending",
-      "depends_on": ["image-codec-png-language-neutral-conformance"],
+      "depends_on": ["image-codec-png-language-neutral-conformance", "image-codec-png-apng-neutral-rejection-conformance"],
       "branch": null,
       "pr_number": null,
       "notes": "Standalone Swift child consuming the neutral PNG corpus and established ZIP raw/CRC surface with empty production capabilities."

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -13,7 +13,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
+    "revision": "7020ebbb1a85976dc5aec170ac61df15d7d46e25",
     "schema_version": 3,
     "established_languages": 15,
     "implementation_identities": 1368,
@@ -4006,6 +4006,8 @@
       "pr_number": null,
       "selection_revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
       "selection_notes": "Selected immediately after PNG neutral-foundation PR #12319 completed all 30 checks and merged through auto-merge. The collision-checked schema-3 inventory at exact merge main a09bb28bd1 remains 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets; the intervening human-language commits and merged TypeScript PNG work add no package identity or lane expansion. All twelve PNG toolchain children are newly ready. Go has the strongest safe dependency leverage: the installed Go 1.26.4 toolchain and existing pixel-container plus ZIP raw/count/CRC packages pass their native tests, vet, race/coverage, and build front doors, and this child unlocks both the final PNG umbrella and the separate unblocked paint-codec-png reconciliation. This tranche adds exactly go/image-codec-png, consumes every representable neutral case through its public API, documents the typed PixelContainer boundary for non-integer fixture inputs, preserves pure in-memory operation with empty capabilities, and leaves paint-adapter migration and every other lane pending.",
+      "implementation_revision": "1f801e4a9ed95ea9625096ac8991dc1890f5f3a1",
+      "validation_notes": "The Go codec consumes all 82 neutral IC18 cases and all 29 ordered stable errors through the public API wherever Go's uint32 PixelContainer can represent the fixture; the one fractional encoder input is rejected before typed conversion. Three additional valid-CRC regressions refuse APNG acTL, fcTL, and fdAT as unsupported-feature, and a temporary control removal proved those regressions fail against the generic ancillary path. Direct go test -race reports 99.0% statement coverage; gofmt, vet, trimpath build, and go mod tidy pass. The real ZIP, pixel-container, and LZSS prerequisites pass race tests at 90.9%, 92.9%, and 97.7% coverage plus vet and trimpath builds; the existing paint adapter baseline also passes while remaining separately owned. A freshly compiled repository build tool discovers 4,973 packages, validates metadata, selects exactly go/image-codec-png plus ZIP, pixel-container, and LZSS on Linux, Darwin, and Windows, and executes the Go plan successfully. Eight neutral PNG validator tests, seven capability tests, ten parity-reporter tests, Ruff, strict MyPy, Bandit, strict JSON and state DAG checks pass. The branch collision report has 1,368 identities and 4,553 slots, moving image-codec-png from the singleton band to the 2-4 band with zero collisions and zero unknown buckets; the stored exact-main inventory remains topology-neutral at 4,552 slots. Production imports only byte/math helpers and repository pixel-container/ZIP, the capability manifest is explicitly empty, and authority, credential, diff, and final read-only security scans pass.",
       "notes": "Standalone Go child consuming the neutral PNG corpus and repo ZIP raw/CRC surface. Existing go/paint-codec-png delegates to the standard-library image/png codec and is not parity evidence for this portable package."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -11,7 +11,7 @@
     "selection_rule": "host-security, credential, native-runtime, and external-approval work may inform classification but is never selected by this parity loop",
     "excluded_delivery_classes": ["onvif", "host-security-hardening", "native-runtime", "external-approval"]
   },
-  "active_pr": null,
+  "active_pr": 12324,
   "last_inventory": {
     "revision": "7020ebbb1a85976dc5aec170ac61df15d7d46e25",
     "schema_version": 3,
@@ -4000,14 +4000,17 @@
     {
       "id": "image-codec-png-go-lane-parity",
       "title": "Port IC18 image-codec-png to Go",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["image-codec-png-language-neutral-conformance"],
       "branch": "codex/image-codec-png-go-lane-parity",
-      "pr_number": null,
+      "pr_number": 12324,
+      "pr_url": "https://github.com/adhithyan15/coding-adventures/pull/12324",
+      "opened_at": "2026-08-20T20:48:18Z",
       "selection_revision": "a09bb28bd19ab24760322f7fcf940184c0912409",
       "selection_notes": "Selected immediately after PNG neutral-foundation PR #12319 completed all 30 checks and merged through auto-merge. The collision-checked schema-3 inventory at exact merge main a09bb28bd1 remains 15 established lanes, 1,368 identities, 4,552 slots, zero collisions, and zero unknown buckets; the intervening human-language commits and merged TypeScript PNG work add no package identity or lane expansion. All twelve PNG toolchain children are newly ready. Go has the strongest safe dependency leverage: the installed Go 1.26.4 toolchain and existing pixel-container plus ZIP raw/count/CRC packages pass their native tests, vet, race/coverage, and build front doors, and this child unlocks both the final PNG umbrella and the separate unblocked paint-codec-png reconciliation. This tranche adds exactly go/image-codec-png, consumes every representable neutral case through its public API, documents the typed PixelContainer boundary for non-integer fixture inputs, preserves pure in-memory operation with empty capabilities, and leaves paint-adapter migration and every other lane pending.",
       "implementation_revision": "1f801e4a9ed95ea9625096ac8991dc1890f5f3a1",
       "validation_notes": "The Go codec consumes all 82 neutral IC18 cases and all 29 ordered stable errors through the public API wherever Go's uint32 PixelContainer can represent the fixture; the one fractional encoder input is rejected before typed conversion. Three additional valid-CRC regressions refuse APNG acTL, fcTL, and fdAT as unsupported-feature, and a temporary control removal proved those regressions fail against the generic ancillary path. Direct go test -race reports 99.0% statement coverage; gofmt, vet, trimpath build, and go mod tidy pass. The real ZIP, pixel-container, and LZSS prerequisites pass race tests at 90.9%, 92.9%, and 97.7% coverage plus vet and trimpath builds; the existing paint adapter baseline also passes while remaining separately owned. A freshly compiled repository build tool discovers 4,973 packages, validates metadata, selects exactly go/image-codec-png plus ZIP, pixel-container, and LZSS on Linux, Darwin, and Windows, and executes the Go plan successfully. Eight neutral PNG validator tests, seven capability tests, ten parity-reporter tests, Ruff, strict MyPy, Bandit, strict JSON and state DAG checks pass. The branch collision report has 1,368 identities and 4,553 slots, moving image-codec-png from the singleton band to the 2-4 band with zero collisions and zero unknown buckets; the stored exact-main inventory remains topology-neutral at 4,552 slots. Production imports only byte/math helpers and repository pixel-container/ZIP, the capability manifest is explicitly empty, and authority, credential, diff, and final read-only security scans pass.",
+      "publication_notes": "Opened ready-for-review PR #12324 from clean validated head 1b5e34acf32d31feac5acdabf460b0f870dc1606 after a normal first push from exact origin/main 7020ebbb1a85976dc5aec170ac61df15d7d46e25. The source branch had no prior remote or PR owner, all live open-PR and no-PR branch audits were disjoint from the owned Go PNG, dependency, fixture, state, and roadmap surfaces, and GitHub initially reported the PR mergeable with required checks queued.",
       "notes": "Standalone Go child consuming the neutral PNG corpus and repo ZIP raw/CRC surface. Existing go/paint-codec-png delegates to the standard-library image/png codec and is not parity evidence for this portable package."
     },
     {

--- a/code/packages/go/image-codec-png/BUILD
+++ b/code/packages/go/image-codec-png/BUILD
@@ -1,0 +1,12 @@
+load("code/packages/starlark/library-rules/go_library.star", "go_library")
+
+_targets = [
+    go_library(
+        name = "image-codec-png",
+        srcs = ["**/*.go"],
+        deps = [
+            "//code/packages/go/pixel-container",
+            "//code/packages/go/zip",
+        ],
+    ),
+]

--- a/code/packages/go/image-codec-png/BUILD_windows
+++ b/code/packages/go/image-codec-png/BUILD_windows
@@ -1,0 +1,12 @@
+load("code/packages/starlark/library-rules/go_library.star", "go_library")
+
+_targets = [
+    go_library(
+        name = "image-codec-png",
+        srcs = ["**/*.go"],
+        deps = [
+            "//code/packages/go/pixel-container",
+            "//code/packages/go/zip",
+        ],
+    ),
+]

--- a/code/packages/go/image-codec-png/CHANGELOG.md
+++ b/code/packages/go/image-codec-png/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — image-codec-png (Go)
+
+## 0.1.0 — 2026-08-20
+
+- Added the bounded IC18 PNG encoder and decoder for 8-bit colour types 0, 2,
+  4, and 6.
+- Reused the repository ZIP package for CRC-32, raw RFC 1951 encoding, counted
+  decoding, exact-consumption checks, and the 256 MiB hard inflate ceiling.
+- Added all five PNG filters with the normative signed encoder heuristic and
+  Paeth tie order.
+- Added suggested-palette and transparency handling, split-IDAT support, exact
+  chunk/zlib/Adler validation, APNG refusal, and stable payload-blind errors.
+- Added caller-lowerable pixel limits and independent edge, product, and exact
+  filtered-output allocation bounds.
+- Added consumption of the complete 82-case language-neutral corpus, direct
+  APNG refusal regressions, standard-library foreign decoding and zlib filter
+  inspection, race testing, vet, build, and coverage gates.
+- Added matching Unix and Windows build metadata plus an explicit empty
+  capability declaration.

--- a/code/packages/go/image-codec-png/README.md
+++ b/code/packages/go/image-codec-png/README.md
@@ -1,0 +1,87 @@
+# image-codec-png (Go)
+
+`image-codec-png` is the Go implementation of the bounded IC18 portable PNG
+profile. It encodes RGBA8 `PixelContainer` values and decodes non-interlaced,
+8-bit greyscale, truecolour, greyscale-alpha, and RGBA PNGs.
+
+The production package is a pure in-memory byte transform. CRC-32 and raw
+RFC 1951 compression come from the repository's `go/zip` package; this module
+does not duplicate either codec and does not call Go's `image/png` or
+`compress/zlib` packages. Those standard-library packages appear only in tests
+as independent interoperability oracles.
+
+## Supported profile
+
+- exact PNG signature, chunk type, ordering, CRC-32, and end-of-file checks;
+- stored, fixed-Huffman, and dynamic-Huffman RFC 1951 decoding;
+- exact DEFLATE consumption plus RFC 1950 CM/CINFO/FCHECK, FDICT, and Adler-32;
+- filters None, Sub, Up, Average, and Paeth, including normative tie handling;
+- colour types 0, 2, 4, and 6 at 8-bit depth;
+- suggested `PLTE`, greyscale/truecolour `tRNS`, split consecutive `IDAT`, and
+  unknown ancillary chunks;
+- 16,384-pixel edge and 33,554,432-pixel product ceilings, with a caller limit
+  that may only lower the product ceiling;
+- the closed 29-code `PngError` taxonomy from the shared 82-case corpus.
+
+Palette images, Adam7 interlacing, alternate bit depths, preset zlib
+dictionaries, unknown critical chunks, and APNG control/data chunks are refused
+with stable errors.
+
+## Usage
+
+```go
+import (
+    png "github.com/adhithyan15/coding-adventures/code/packages/go/image-codec-png"
+    pixel "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+)
+
+image := pixel.New(2, 1)
+pixel.SetPixel(image, 0, 0, 255, 0, 0, 255)
+pixel.SetPixel(image, 1, 0, 0, 0, 255, 255)
+
+encoded, err := png.EncodePNG(image)
+if err != nil {
+    panic(err)
+}
+
+maxPixels := float64(4096)
+decoded, err := png.DecodePNG(encoded, png.DecodeOptions{MaxPixels: &maxPixels})
+if err != nil {
+    panic(err)
+}
+_ = decoded
+```
+
+`PngCodec` implements `pixelcontainer.ImageCodec`. Because that historical
+interface cannot return an encode error, its `Encode` method panics with the
+same typed `*PngError` that `EncodePNG` returns. New code that handles untrusted
+or dynamically assembled containers should call `EncodePNG` directly.
+
+## Portable conformance
+
+The test suite consumes every case in
+`code/specs/fixtures/image-codec-png-v1/cases.json` through the public API when
+the value can inhabit Go's typed `PixelContainer`. JSON can express a fractional
+width, while `PixelContainer.Width` is a `uint32`; the fixture adapter therefore
+rejects that one invalid value before conversion instead of truncating it. All
+representable encode cases use `EncodePNG`, are independently inflated and
+filter-inspected with `compress/zlib`, and are decoded by `image/png`.
+
+Run the full package gates with:
+
+```sh
+go test ./... -race -cover
+go vet ./...
+go build -trimpath ./...
+```
+
+## Dependency graph
+
+```text
+pixel-container ─┐
+                 ├─ image-codec-png
+zip ─ lzss ──────┘
+```
+
+The later `go/paint-codec-png` reconciliation is intentionally separate; that
+adapter still delegates to the standard library until its own queued migration.

--- a/code/packages/go/image-codec-png/go.mod
+++ b/code/packages/go/image-codec-png/go.mod
@@ -1,0 +1,16 @@
+module github.com/adhithyan15/coding-adventures/code/packages/go/image-codec-png
+
+go 1.26
+
+require (
+	github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container v0.0.0
+	github.com/adhithyan15/coding-adventures/code/packages/go/zip v0.0.0
+)
+
+require github.com/adhithyan15/coding-adventures/code/packages/go/lzss v0.0.0 // indirect
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container => ../pixel-container
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/zip => ../zip
+
+replace github.com/adhithyan15/coding-adventures/code/packages/go/lzss => ../lzss

--- a/code/packages/go/image-codec-png/png.go
+++ b/code/packages/go/image-codec-png/png.go
@@ -1,0 +1,595 @@
+// Package imagecodecpng implements the bounded IC18 portable PNG profile.
+//
+// The codec is pure and in-memory. It deliberately delegates CRC-32 and raw
+// RFC 1951 work to the repository's ZIP package so every portable image lane
+// shares one compression implementation and one set of bomb limits.
+package imagecodecpng
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+
+	pc "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+	zipcodec "github.com/adhithyan15/coding-adventures/code/packages/go/zip"
+)
+
+const (
+	// PNGMaxDimension is the largest accepted width or height.
+	PNGMaxDimension uint32 = 16384
+	// PNGMaxPixels is the default and hard pixel-count ceiling.
+	PNGMaxPixels uint64 = 32 * 1024 * 1024
+)
+
+// PngErrorCode is a stable, payload-blind IC18 failure identifier.
+type PngErrorCode string
+
+const (
+	InvalidMaxPixels       PngErrorCode = "invalid-max-pixels"
+	InvalidImageDimensions PngErrorCode = "invalid-image-dimensions"
+	InvalidPixelDataLength PngErrorCode = "invalid-pixel-data-length"
+	FileTooShort           PngErrorCode = "file-too-short"
+	InvalidSignature       PngErrorCode = "invalid-signature"
+	TruncatedChunk         PngErrorCode = "truncated-chunk"
+	InvalidChunkType       PngErrorCode = "invalid-chunk-type"
+	ChunkCRCMismatch       PngErrorCode = "chunk-crc-mismatch"
+	ChunkBeforeIHDR        PngErrorCode = "chunk-before-ihdr"
+	DuplicateIHDR          PngErrorCode = "duplicate-ihdr"
+	InvalidIHDRLength      PngErrorCode = "invalid-ihdr-length"
+	InvalidDimensions      PngErrorCode = "invalid-dimensions"
+	DimensionLimit         PngErrorCode = "dimension-limit"
+	PixelLimit             PngErrorCode = "pixel-limit"
+	UnsupportedFeature     PngErrorCode = "unsupported-feature"
+	InvalidPLTE            PngErrorCode = "invalid-plte"
+	InvalidTRNS            PngErrorCode = "invalid-trns"
+	NonconsecutiveIDAT     PngErrorCode = "nonconsecutive-idat"
+	InvalidIEND            PngErrorCode = "invalid-iend"
+	TrailingData           PngErrorCode = "trailing-data"
+	UnknownCriticalChunk   PngErrorCode = "unknown-critical-chunk"
+	MissingRequiredChunk   PngErrorCode = "missing-required-chunk"
+	InvalidZlibHeader      PngErrorCode = "invalid-zlib-header"
+	PresetDictionary       PngErrorCode = "preset-dictionary"
+	InflateFailed          PngErrorCode = "inflate-failed"
+	InflatedLengthMismatch PngErrorCode = "inflated-length-mismatch"
+	IDATCavity             PngErrorCode = "idat-cavity"
+	AdlerMismatch          PngErrorCode = "adler-mismatch"
+	InvalidFilter          PngErrorCode = "invalid-filter"
+)
+
+var pngErrorCodes = []string{
+	string(InvalidMaxPixels),
+	string(InvalidImageDimensions),
+	string(InvalidPixelDataLength),
+	string(FileTooShort),
+	string(InvalidSignature),
+	string(TruncatedChunk),
+	string(InvalidChunkType),
+	string(ChunkCRCMismatch),
+	string(ChunkBeforeIHDR),
+	string(DuplicateIHDR),
+	string(InvalidIHDRLength),
+	string(InvalidDimensions),
+	string(DimensionLimit),
+	string(PixelLimit),
+	string(UnsupportedFeature),
+	string(InvalidPLTE),
+	string(InvalidTRNS),
+	string(NonconsecutiveIDAT),
+	string(InvalidIEND),
+	string(TrailingData),
+	string(UnknownCriticalChunk),
+	string(MissingRequiredChunk),
+	string(InvalidZlibHeader),
+	string(PresetDictionary),
+	string(InflateFailed),
+	string(InflatedLengthMismatch),
+	string(IDATCavity),
+	string(AdlerMismatch),
+	string(InvalidFilter),
+}
+
+// PNGErrorCodes returns the closed IC18 taxonomy in normative order.
+func PNGErrorCodes() []string { return append([]string(nil), pngErrorCodes...) }
+
+// PngError is a portable failure whose Error string contains no input data.
+type PngError struct {
+	Code PngErrorCode
+}
+
+func (e *PngError) Error() string { return string(e.Code) }
+
+func fail(code PngErrorCode) error { return &PngError{Code: code} }
+
+// DecodeOptions configures a single DecodePNG call.
+//
+// MaxPixels is a pointer so nil means "use the default", while zero remains an
+// explicitly invalid caller value. A caller may only lower the hard ceiling.
+type DecodeOptions struct {
+	MaxPixels *float64
+}
+
+func maxPixels(options []DecodeOptions) (uint64, error) {
+	if len(options) > 1 {
+		return 0, fail(InvalidMaxPixels)
+	}
+	if len(options) == 0 || options[0].MaxPixels == nil {
+		return PNGMaxPixels, nil
+	}
+	value := *options[0].MaxPixels
+	if math.IsNaN(value) || math.IsInf(value, 0) || math.Trunc(value) != value ||
+		value <= 0 || value > float64(PNGMaxPixels) {
+		return 0, fail(InvalidMaxPixels)
+	}
+	return uint64(value), nil
+}
+
+// PngCodec implements pixelcontainer.ImageCodec. The zero value uses the
+// default limit; NewPngCodec validates a caller-lowered limit eagerly.
+type PngCodec struct {
+	options DecodeOptions
+}
+
+// NewPngCodec constructs an interface codec with an optional lower limit.
+func NewPngCodec(options ...DecodeOptions) (*PngCodec, error) {
+	if _, err := maxPixels(options); err != nil {
+		return nil, err
+	}
+	if len(options) == 0 {
+		return &PngCodec{}, nil
+	}
+	return &PngCodec{options: options[0]}, nil
+}
+
+// MimeType returns the registered PNG media type.
+func (PngCodec) MimeType() string { return "image/png" }
+
+// Encode implements pixelcontainer.ImageCodec. The legacy interface cannot
+// return an error, so malformed in-memory containers panic just as the existing
+// Go paint adapter does; direct callers should prefer EncodePNG.
+func (PngCodec) Encode(pixels *pc.PixelContainer) []byte {
+	encoded, err := EncodePNG(pixels)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+// Decode implements pixelcontainer.ImageCodec.
+func (codec PngCodec) Decode(data []byte) (*pc.PixelContainer, error) {
+	return DecodePNG(data, codec.options)
+}
+
+var signature = [...]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+
+const adlerMod uint32 = 65521
+
+// Adler32 computes the RFC 1950 checksum used by the PNG zlib wrapper.
+func Adler32(data []byte) uint32 {
+	var a uint32 = 1
+	var b uint32
+	for start := 0; start < len(data); start += 5552 {
+		end := min(start+5552, len(data))
+		for _, value := range data[start:end] {
+			a += uint32(value)
+			b += a
+		}
+		a %= adlerMod
+		b %= adlerMod
+	}
+	return b<<16 | a
+}
+
+func paeth(a, b, c byte) byte {
+	p := int(a) + int(b) - int(c)
+	pa := abs(p - int(a))
+	pb := abs(p - int(b))
+	pcDistance := abs(p - int(c))
+	if pa <= pb && pa <= pcDistance {
+		return a
+	}
+	if pb <= pcDistance {
+		return b
+	}
+	return c
+}
+
+func abs(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func applyFilter(filter byte, raw, prior []byte, bytesPerPixel int, out []byte) {
+	for i, value := range raw {
+		var left, above, aboveLeft byte
+		if i >= bytesPerPixel {
+			left = raw[i-bytesPerPixel]
+			aboveLeft = prior[i-bytesPerPixel]
+		}
+		above = prior[i]
+		var predicted byte
+		switch filter {
+		case 1:
+			predicted = left
+		case 2:
+			predicted = above
+		case 3:
+			predicted = byte((uint16(left) + uint16(above)) / 2)
+		case 4:
+			predicted = paeth(left, above, aboveLeft)
+		}
+		out[i] = value - predicted
+	}
+}
+
+func chooseFilter(raw, prior []byte, bytesPerPixel int, scratch, best []byte) byte {
+	var bestFilter byte
+	bestScore := math.MaxInt
+	for filter := byte(0); filter <= 4; filter++ {
+		applyFilter(filter, raw, prior, bytesPerPixel, scratch)
+		score := 0
+		for _, value := range scratch {
+			if value < 128 {
+				score += int(value)
+			} else {
+				score += 256 - int(value)
+			}
+		}
+		if score < bestScore {
+			bestScore = score
+			bestFilter = filter
+			copy(best, scratch)
+		}
+	}
+	return bestFilter
+}
+
+func undoFilter(filter byte, row, prior []byte, bytesPerPixel int) error {
+	switch filter {
+	case 0:
+		return nil
+	case 1:
+		for i := bytesPerPixel; i < len(row); i++ {
+			row[i] += row[i-bytesPerPixel]
+		}
+	case 2:
+		for i := range row {
+			row[i] += prior[i]
+		}
+	case 3:
+		for i := range row {
+			var left byte
+			if i >= bytesPerPixel {
+				left = row[i-bytesPerPixel]
+			}
+			row[i] += byte((uint16(left) + uint16(prior[i])) / 2)
+		}
+	case 4:
+		for i := range row {
+			var left, aboveLeft byte
+			if i >= bytesPerPixel {
+				left = row[i-bytesPerPixel]
+				aboveLeft = prior[i-bytesPerPixel]
+			}
+			row[i] += paeth(left, prior[i], aboveLeft)
+		}
+	default:
+		return fail(InvalidFilter)
+	}
+	return nil
+}
+
+func appendChunk(out []byte, chunkType string, data []byte) []byte {
+	out = binary.BigEndian.AppendUint32(out, uint32(len(data)))
+	typeBytes := []byte(chunkType)
+	out = append(out, typeBytes...)
+	out = append(out, data...)
+	crc := zipcodec.CRC32(typeBytes, 0)
+	crc = zipcodec.CRC32(data, crc)
+	return binary.BigEndian.AppendUint32(out, crc)
+}
+
+// EncodePNG encodes an RGBA PixelContainer as a bounded 8-bit colour-type-6
+// PNG using the normative signed filter heuristic.
+func EncodePNG(pixels *pc.PixelContainer) ([]byte, error) {
+	if pixels == nil || pixels.Width == 0 || pixels.Height == 0 ||
+		pixels.Width > PNGMaxDimension || pixels.Height > PNGMaxDimension {
+		return nil, fail(InvalidImageDimensions)
+	}
+	pixelCount := uint64(pixels.Width) * uint64(pixels.Height)
+	if pixelCount > PNGMaxPixels {
+		return nil, fail(InvalidImageDimensions)
+	}
+	if uint64(len(pixels.Data)) != pixelCount*4 {
+		return nil, fail(InvalidPixelDataLength)
+	}
+
+	out := append([]byte(nil), signature[:]...)
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], pixels.Width)
+	binary.BigEndian.PutUint32(ihdr[4:8], pixels.Height)
+	ihdr[8], ihdr[9] = 8, 6
+	out = appendChunk(out, "IHDR", ihdr)
+
+	stride := int(pixels.Width) * 4
+	filtered := make([]byte, int(pixels.Height)*(stride+1))
+	prior := make([]byte, stride)
+	scratch := make([]byte, stride)
+	best := make([]byte, stride)
+	for y := 0; y < int(pixels.Height); y++ {
+		raw := pixels.Data[y*stride : (y+1)*stride]
+		at := y * (stride + 1)
+		filtered[at] = chooseFilter(raw, prior, 4, scratch, best)
+		copy(filtered[at+1:at+1+stride], best)
+		copy(prior, raw)
+	}
+
+	deflated := zipcodec.RawDeflate(filtered)
+	idat := make([]byte, 2+len(deflated)+4)
+	idat[0], idat[1] = 0x78, 0x9c
+	copy(idat[2:], deflated)
+	binary.BigEndian.PutUint32(idat[len(idat)-4:], Adler32(filtered))
+	out = appendChunk(out, "IDAT", idat)
+	out = appendChunk(out, "IEND", nil)
+	return out, nil
+}
+
+func validChunkType(chunkType []byte) bool {
+	if len(chunkType) != 4 || chunkType[2]&0x20 != 0 {
+		return false
+	}
+	for _, value := range chunkType {
+		if !((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z')) {
+			return false
+		}
+	}
+	return true
+}
+
+// DecodePNG decodes the bounded, non-interlaced 8-bit IC18 PNG profile.
+func DecodePNG(data []byte, options ...DecodeOptions) (*pc.PixelContainer, error) {
+	limit, err := maxPixels(options)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < len(signature) {
+		return nil, fail(FileTooShort)
+	}
+	if !bytes.Equal(data[:len(signature)], signature[:]) {
+		return nil, fail(InvalidSignature)
+	}
+
+	var width, height uint32
+	var bitDepth, colourType byte
+	var sawIHDR, sawIEND, sawPLTE, sawTRNS bool
+	var inIDAT, idatEnded bool
+	var transparentGrey *byte
+	var transparentRGB *[3]byte
+	var idatParts [][]byte
+
+	for pos := len(signature); pos < len(data); {
+		if len(data)-pos < 8 {
+			return nil, fail(TruncatedChunk)
+		}
+		length := binary.BigEndian.Uint32(data[pos : pos+4])
+		if uint64(length)+12 > uint64(len(data)-pos) {
+			return nil, fail(TruncatedChunk)
+		}
+		typeStart := pos + 4
+		dataStart := pos + 8
+		dataEnd := dataStart + int(length)
+		chunkTypeBytes := data[typeStart:dataStart]
+		if !validChunkType(chunkTypeBytes) {
+			return nil, fail(InvalidChunkType)
+		}
+		declaredCRC := binary.BigEndian.Uint32(data[dataEnd : dataEnd+4])
+		if zipcodec.CRC32(data[typeStart:dataEnd], 0) != declaredCRC {
+			return nil, fail(ChunkCRCMismatch)
+		}
+		chunkType := string(chunkTypeBytes)
+		chunkData := data[dataStart:dataEnd]
+		if !sawIHDR && chunkType != "IHDR" {
+			return nil, fail(ChunkBeforeIHDR)
+		}
+
+		switch chunkType {
+		case "IHDR":
+			if sawIHDR {
+				return nil, fail(DuplicateIHDR)
+			}
+			if length != 13 {
+				return nil, fail(InvalidIHDRLength)
+			}
+			width = binary.BigEndian.Uint32(chunkData[0:4])
+			height = binary.BigEndian.Uint32(chunkData[4:8])
+			bitDepth, colourType = chunkData[8], chunkData[9]
+			if width == 0 || height == 0 {
+				return nil, fail(InvalidDimensions)
+			}
+			if width > PNGMaxDimension || height > PNGMaxDimension {
+				return nil, fail(DimensionLimit)
+			}
+			if uint64(width)*uint64(height) > limit {
+				return nil, fail(PixelLimit)
+			}
+			if chunkData[10] != 0 || chunkData[11] != 0 || chunkData[12] != 0 {
+				return nil, fail(UnsupportedFeature)
+			}
+			if colourType == 3 || (colourType != 0 && colourType != 2 && colourType != 4 && colourType != 6) || bitDepth != 8 {
+				return nil, fail(UnsupportedFeature)
+			}
+			sawIHDR = true
+
+		case "PLTE":
+			if sawPLTE || len(idatParts) > 0 || sawTRNS || (colourType != 2 && colourType != 6) ||
+				length < 3 || length > 768 || length%3 != 0 {
+				return nil, fail(InvalidPLTE)
+			}
+			sawPLTE = true
+
+		case "tRNS":
+			if sawTRNS || len(idatParts) > 0 {
+				return nil, fail(InvalidTRNS)
+			}
+			switch colourType {
+			case 0:
+				if length != 2 || binary.BigEndian.Uint16(chunkData) > math.MaxUint8 {
+					return nil, fail(InvalidTRNS)
+				}
+				value := byte(binary.BigEndian.Uint16(chunkData))
+				transparentGrey = &value
+			case 2:
+				if length != 6 {
+					return nil, fail(InvalidTRNS)
+				}
+				var rgb [3]byte
+				for i := range rgb {
+					value := binary.BigEndian.Uint16(chunkData[i*2 : i*2+2])
+					if value > math.MaxUint8 {
+						return nil, fail(InvalidTRNS)
+					}
+					rgb[i] = byte(value)
+				}
+				transparentRGB = &rgb
+			default:
+				return nil, fail(InvalidTRNS)
+			}
+			sawTRNS = true
+
+		case "IDAT":
+			if idatEnded {
+				return nil, fail(NonconsecutiveIDAT)
+			}
+			idatParts = append(idatParts, chunkData)
+			inIDAT = true
+
+		case "IEND":
+			if length != 0 {
+				return nil, fail(InvalidIEND)
+			}
+			if dataEnd+4 != len(data) {
+				return nil, fail(TrailingData)
+			}
+			sawIEND = true
+			pos = dataEnd + 4
+			continue
+
+		case "acTL", "fcTL", "fdAT":
+			// APNG is outside IC18. These chunks are ancillary by PNG's bit
+			// convention but semantically change the image, so never skip them.
+			return nil, fail(UnsupportedFeature)
+
+		default:
+			if chunkTypeBytes[0]&0x20 == 0 {
+				return nil, fail(UnknownCriticalChunk)
+			}
+		}
+
+		if chunkType != "IDAT" && inIDAT {
+			inIDAT = false
+			idatEnded = true
+		}
+		pos = dataEnd + 4
+	}
+
+	if !sawIHDR || !sawIEND || len(idatParts) == 0 {
+		return nil, fail(MissingRequiredChunk)
+	}
+	var zlibLength uint64
+	for _, part := range idatParts {
+		zlibLength += uint64(len(part))
+	}
+	if zlibLength > uint64(len(data)) {
+		return nil, fail(TruncatedChunk)
+	}
+	zlibData := make([]byte, 0, int(zlibLength))
+	for _, part := range idatParts {
+		zlibData = append(zlibData, part...)
+	}
+	if len(zlibData) < 6 {
+		return nil, fail(InvalidZlibHeader)
+	}
+	cmf, flg := zlibData[0], zlibData[1]
+	if cmf&0x0f != 8 || cmf>>4 > 7 || (uint16(cmf)<<8|uint16(flg))%31 != 0 {
+		return nil, fail(InvalidZlibHeader)
+	}
+	if flg&0x20 != 0 {
+		return nil, fail(PresetDictionary)
+	}
+
+	channels := 4
+	switch colourType {
+	case 0:
+		channels = 1
+	case 2:
+		channels = 3
+	case 4:
+		channels = 2
+	}
+	stride := uint64(width) * uint64(channels)
+	expected := uint64(height) * (stride + 1)
+	deflateData := zlibData[2 : len(zlibData)-4]
+	result, inflateErr := zipcodec.RawInflateCounted(deflateData, int64(expected))
+	if inflateErr != nil {
+		var rawErr *zipcodec.RawInflateError
+		if errors.As(inflateErr, &rawErr) && rawErr.Code == zipcodec.OutputLimitExceeded {
+			return nil, fail(InflatedLengthMismatch)
+		}
+		return nil, fail(InflateFailed)
+	}
+	if uint64(len(result.Output)) != expected {
+		return nil, fail(InflatedLengthMismatch)
+	}
+	if result.BytesConsumed != len(deflateData) {
+		return nil, fail(IDATCavity)
+	}
+	if Adler32(result.Output) != binary.BigEndian.Uint32(zlibData[len(zlibData)-4:]) {
+		return nil, fail(AdlerMismatch)
+	}
+	rowSize := int(stride) + 1
+	for y := 0; y < int(height); y++ {
+		if result.Output[y*rowSize] > 4 {
+			return nil, fail(InvalidFilter)
+		}
+	}
+
+	container := pc.New(width, height)
+	prior := make([]byte, int(stride))
+	for y := 0; y < int(height); y++ {
+		at := y * rowSize
+		row := result.Output[at+1 : at+rowSize]
+		if err := undoFilter(result.Output[at], row, prior, channels); err != nil {
+			return nil, err
+		}
+		destRow := y * int(width) * 4
+		for x := 0; x < int(width); x++ {
+			source := x * channels
+			dest := destRow + x*4
+			switch channels {
+			case 1:
+				value := row[source]
+				container.Data[dest], container.Data[dest+1], container.Data[dest+2] = value, value, value
+				container.Data[dest+3] = 255
+				if transparentGrey != nil && value == *transparentGrey {
+					container.Data[dest+3] = 0
+				}
+			case 2:
+				value := row[source]
+				container.Data[dest], container.Data[dest+1], container.Data[dest+2] = value, value, value
+				container.Data[dest+3] = row[source+1]
+			case 3:
+				red, green, blue := row[source], row[source+1], row[source+2]
+				container.Data[dest], container.Data[dest+1], container.Data[dest+2], container.Data[dest+3] = red, green, blue, 255
+				if transparentRGB != nil && red == transparentRGB[0] && green == transparentRGB[1] && blue == transparentRGB[2] {
+					container.Data[dest+3] = 0
+				}
+			default:
+				copy(container.Data[dest:dest+4], row[source:source+4])
+			}
+		}
+		copy(prior, row)
+	}
+	return container, nil
+}

--- a/code/packages/go/image-codec-png/png_test.go
+++ b/code/packages/go/image-codec-png/png_test.go
@@ -3,6 +3,7 @@ package imagecodecpng_test
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"testing"
 
 	png "github.com/adhithyan15/coding-adventures/code/packages/go/image-codec-png"
@@ -49,9 +50,24 @@ func TestPngCodecInterface(t *testing.T) {
 	if _, err := limited.Decode(encoded); err != nil {
 		t.Fatalf("limited Decode: %v", err)
 	}
-	zero := float64(0)
-	_, err = png.NewPngCodec(png.DecodeOptions{MaxPixels: &zero})
-	requireCode(t, err, png.InvalidMaxPixels)
+	invalidLimits := []struct {
+		name  string
+		value float64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"fractional", 1.5},
+		{"raised", float64(png.PNGMaxPixels) + 1},
+		{"nan", math.NaN()},
+		{"positive-infinity", math.Inf(1)},
+		{"negative-infinity", math.Inf(-1)},
+	}
+	for _, test := range invalidLimits {
+		t.Run("invalid-limit-"+test.name, func(t *testing.T) {
+			_, err := png.NewPngCodec(png.DecodeOptions{MaxPixels: &test.value})
+			requireCode(t, err, png.InvalidMaxPixels)
+		})
+	}
 	_, err = png.DecodePNG(encoded, png.DecodeOptions{}, png.DecodeOptions{})
 	requireCode(t, err, png.InvalidMaxPixels)
 }

--- a/code/packages/go/image-codec-png/png_test.go
+++ b/code/packages/go/image-codec-png/png_test.go
@@ -1,0 +1,128 @@
+package imagecodecpng_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	png "github.com/adhithyan15/coding-adventures/code/packages/go/image-codec-png"
+	pc "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+	zipcodec "github.com/adhithyan15/coding-adventures/code/packages/go/zip"
+)
+
+func requireCode(t *testing.T, err error, want png.PngErrorCode) {
+	t.Helper()
+	var pngErr *png.PngError
+	if !errors.As(err, &pngErr) {
+		t.Fatalf("error = %T %v, want *PngError", err, err)
+	}
+	if pngErr.Code != want || pngErr.Error() != string(want) {
+		t.Fatalf("error = (%q,%q), want %q", pngErr.Code, pngErr.Error(), want)
+	}
+}
+
+func TestPngCodecInterface(t *testing.T) {
+	codec, err := png.NewPngCodec()
+	if err != nil {
+		t.Fatalf("NewPngCodec: %v", err)
+	}
+	var imageCodec pc.ImageCodec = codec
+	if imageCodec.MimeType() != "image/png" {
+		t.Fatalf("MIME type = %q", imageCodec.MimeType())
+	}
+	container := pc.New(1, 1)
+	pc.SetPixel(container, 0, 0, 1, 2, 3, 4)
+	encoded := imageCodec.Encode(container)
+	decoded, err := imageCodec.Decode(encoded)
+	if err != nil {
+		t.Fatalf("codec Decode: %v", err)
+	}
+	if decoded.Width != 1 || decoded.Height != 1 || len(decoded.Data) != 4 {
+		t.Fatalf("decoded container = %#v", decoded)
+	}
+
+	one := float64(1)
+	limited, err := png.NewPngCodec(png.DecodeOptions{MaxPixels: &one})
+	if err != nil {
+		t.Fatalf("limited NewPngCodec: %v", err)
+	}
+	if _, err := limited.Decode(encoded); err != nil {
+		t.Fatalf("limited Decode: %v", err)
+	}
+	zero := float64(0)
+	_, err = png.NewPngCodec(png.DecodeOptions{MaxPixels: &zero})
+	requireCode(t, err, png.InvalidMaxPixels)
+	_, err = png.DecodePNG(encoded, png.DecodeOptions{}, png.DecodeOptions{})
+	requireCode(t, err, png.InvalidMaxPixels)
+}
+
+func TestPngCodecEncodePanicPreservesTypedError(t *testing.T) {
+	deferred := func() {
+		recovered := recover()
+		pngErr, ok := recovered.(*png.PngError)
+		if !ok {
+			t.Fatalf("panic = %T %v, want *PngError", recovered, recovered)
+		}
+		if pngErr.Code != png.InvalidImageDimensions {
+			t.Fatalf("panic code = %q", pngErr.Code)
+		}
+	}
+	defer deferred()
+	var codec pc.ImageCodec = png.PngCodec{}
+	codec.Encode(nil)
+}
+
+func TestPNGErrorCodesReturnsCopy(t *testing.T) {
+	first := png.PNGErrorCodes()
+	first[0] = "changed"
+	if png.PNGErrorCodes()[0] != string(png.InvalidMaxPixels) {
+		t.Fatal("PNGErrorCodes exposed mutable package state")
+	}
+}
+
+func TestEncodePNGRejectsResourceAndShapeErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		pixels *pc.PixelContainer
+		code   png.PngErrorCode
+	}{
+		{"nil", nil, png.InvalidImageDimensions},
+		{"zero-width", &pc.PixelContainer{Width: 0, Height: 1}, png.InvalidImageDimensions},
+		{"edge-limit", &pc.PixelContainer{Width: png.PNGMaxDimension + 1, Height: 1}, png.InvalidImageDimensions},
+		{"product-limit", &pc.PixelContainer{Width: 8192, Height: 4097}, png.InvalidImageDimensions},
+		{"data-length", &pc.PixelContainer{Width: 1, Height: 1, Data: []byte{1, 2, 3}}, png.InvalidPixelDataLength},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := png.EncodePNG(test.pixels)
+			requireCode(t, err, test.code)
+		})
+	}
+}
+
+func insertChunkAfterIHDR(t *testing.T, encoded []byte, chunkType string) []byte {
+	t.Helper()
+	const ihdrEnd = 8 + 12 + 13
+	chunk := make([]byte, 0, 12)
+	chunk = binary.BigEndian.AppendUint32(chunk, 0)
+	chunk = append(chunk, chunkType...)
+	chunk = binary.BigEndian.AppendUint32(chunk, zipcodec.CRC32([]byte(chunkType), 0))
+	result := make([]byte, 0, len(encoded)+len(chunk))
+	result = append(result, encoded[:ihdrEnd]...)
+	result = append(result, chunk...)
+	result = append(result, encoded[ihdrEnd:]...)
+	return result
+}
+
+func TestDecodePNGRejectsAPNGControlChunks(t *testing.T) {
+	encoded, err := png.EncodePNG(pc.New(1, 1))
+	if err != nil {
+		t.Fatalf("EncodePNG: %v", err)
+	}
+	for _, chunkType := range []string{"acTL", "fcTL", "fdAT"} {
+		t.Run(chunkType, func(t *testing.T) {
+			_, err := png.DecodePNG(insertChunkAfterIHDR(t, encoded, chunkType))
+			requireCode(t, err, png.UnsupportedFeature)
+		})
+	}
+}

--- a/code/packages/go/image-codec-png/portable_conformance_test.go
+++ b/code/packages/go/image-codec-png/portable_conformance_test.go
@@ -1,0 +1,277 @@
+package imagecodecpng_test
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image/color"
+	stdpng "image/png"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	png "github.com/adhithyan15/coding-adventures/code/packages/go/image-codec-png"
+	pc "github.com/adhithyan15/coding-adventures/code/packages/go/pixel-container"
+)
+
+type fixturePixels struct {
+	Width   float64 `json:"width"`
+	Height  float64 `json:"height"`
+	RGBAHex string  `json:"rgba_hex"`
+}
+
+type fixtureOptions struct {
+	MaxPixels float64 `json:"max_pixels"`
+}
+
+type fixtureExpected struct {
+	Width       float64  `json:"width"`
+	Height      float64  `json:"height"`
+	RGBAHex     string   `json:"rgba_hex"`
+	ErrorID     string   `json:"error_id"`
+	ChunkTypes  []string `json:"chunk_types"`
+	FilterTypes []byte   `json:"filter_types"`
+	BitDepth    byte     `json:"bit_depth"`
+	ColourType  byte     `json:"colour_type"`
+	Interlace   byte     `json:"interlace"`
+	Adler32Hex  string   `json:"adler32_hex"`
+}
+
+type fixtureCase struct {
+	ID        string          `json:"id"`
+	Operation string          `json:"operation"`
+	PNGHex    string          `json:"png_hex"`
+	InputHex  string          `json:"input_hex"`
+	Input     *fixturePixels  `json:"input"`
+	Options   *fixtureOptions `json:"options"`
+	Expected  fixtureExpected `json:"expected"`
+}
+
+type fixtureDocument struct {
+	Limits struct {
+		MaxDimension     uint32 `json:"max_dimension"`
+		DefaultMaxPixels uint64 `json:"default_max_pixels"`
+	} `json:"limits"`
+	ErrorIDs []string      `json:"error_ids"`
+	Cases    []fixtureCase `json:"cases"`
+}
+
+type pngChunk struct {
+	Type string
+	Data []byte
+}
+
+func fixturePath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not locate the fixture consumer")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..", "specs", "fixtures", "image-codec-png-v1", "cases.json"))
+}
+
+func loadFixtures(t *testing.T) fixtureDocument {
+	t.Helper()
+	data, err := os.ReadFile(fixturePath(t))
+	if err != nil {
+		t.Fatalf("read fixture corpus: %v", err)
+	}
+	var fixtures fixtureDocument
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("parse fixture corpus: %v", err)
+	}
+	return fixtures
+}
+
+func fromHex(t *testing.T, value string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatalf("decode fixture hex: %v", err)
+	}
+	return data
+}
+
+func decodeOptions(fixture *fixtureOptions) []png.DecodeOptions {
+	if fixture == nil {
+		return nil
+	}
+	value := fixture.MaxPixels
+	return []png.DecodeOptions{{MaxPixels: &value}}
+}
+
+func fixtureEncode(t *testing.T, input fixturePixels) ([]byte, error) {
+	t.Helper()
+	if math.IsNaN(input.Width) || math.IsInf(input.Width, 0) ||
+		math.IsNaN(input.Height) || math.IsInf(input.Height, 0) ||
+		math.Trunc(input.Width) != input.Width || math.Trunc(input.Height) != input.Height ||
+		input.Width < 0 || input.Height < 0 ||
+		input.Width > math.MaxUint32 || input.Height > math.MaxUint32 {
+		// PixelContainer has uint32 dimensions, so a fixture adapter must reject
+		// non-integral JSON values before converting them to the typed boundary.
+		return nil, &png.PngError{Code: png.InvalidImageDimensions}
+	}
+	container := &pc.PixelContainer{
+		Width:  uint32(input.Width),
+		Height: uint32(input.Height),
+		Data:   fromHex(t, input.RGBAHex),
+	}
+	return png.EncodePNG(container)
+}
+
+func assertPngError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("fixture unexpectedly succeeded")
+	}
+	var pngErr *png.PngError
+	if !errors.As(err, &pngErr) {
+		t.Fatalf("error type = %T, want *PngError", err)
+	}
+	if string(pngErr.Code) != want {
+		t.Fatalf("error code = %q, want %q", pngErr.Code, want)
+	}
+}
+
+func parseChunks(t *testing.T, encoded []byte) []pngChunk {
+	t.Helper()
+	var chunks []pngChunk
+	for offset := 8; offset < len(encoded); {
+		if len(encoded)-offset < 12 {
+			t.Fatalf("encoded PNG has truncated chunk at %d", offset)
+		}
+		length := int(binary.BigEndian.Uint32(encoded[offset : offset+4]))
+		end := offset + 12 + length
+		if end > len(encoded) {
+			t.Fatalf("encoded PNG chunk exceeds output at %d", offset)
+		}
+		chunks = append(chunks, pngChunk{
+			Type: string(encoded[offset+4 : offset+8]),
+			Data: append([]byte(nil), encoded[offset+8:offset+8+length]...),
+		})
+		offset = end
+	}
+	return chunks
+}
+
+func foreignRGBA(t *testing.T, encoded []byte) (uint32, uint32, []byte) {
+	t.Helper()
+	decoded, err := stdpng.Decode(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("standard-library PNG decode: %v", err)
+	}
+	bounds := decoded.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	rgba := make([]byte, 0, width*height*4)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			pixel := color.NRGBAModel.Convert(decoded.At(x, y)).(color.NRGBA)
+			rgba = append(rgba, pixel.R, pixel.G, pixel.B, pixel.A)
+		}
+	}
+	return uint32(width), uint32(height), rgba
+}
+
+func filteredBytes(t *testing.T, chunks []pngChunk) []byte {
+	t.Helper()
+	var idat bytes.Buffer
+	for _, chunk := range chunks {
+		if chunk.Type == "IDAT" {
+			idat.Write(chunk.Data)
+		}
+	}
+	reader, err := zlib.NewReader(bytes.NewReader(idat.Bytes()))
+	if err != nil {
+		t.Fatalf("standard-library zlib reader: %v", err)
+	}
+	filtered, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("standard-library zlib inflate: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close standard-library zlib reader: %v", err)
+	}
+	return filtered
+}
+
+func TestPortableConformance(t *testing.T) {
+	fixtures := loadFixtures(t)
+	if len(fixtures.Cases) != 82 {
+		t.Fatalf("portable case count = %d, want 82", len(fixtures.Cases))
+	}
+	if fixtures.Limits.MaxDimension != png.PNGMaxDimension || fixtures.Limits.DefaultMaxPixels != png.PNGMaxPixels {
+		t.Fatalf("public limits = (%d,%d), fixture = (%d,%d)", png.PNGMaxDimension, png.PNGMaxPixels, fixtures.Limits.MaxDimension, fixtures.Limits.DefaultMaxPixels)
+	}
+	if !reflect.DeepEqual(png.PNGErrorCodes(), fixtures.ErrorIDs) {
+		t.Fatalf("error taxonomy = %#v, want %#v", png.PNGErrorCodes(), fixtures.ErrorIDs)
+	}
+
+	for _, fixture := range fixtures.Cases {
+		fixture := fixture
+		t.Run(fixture.ID, func(t *testing.T) {
+			switch fixture.Operation {
+			case "decode":
+				actual, err := png.DecodePNG(fromHex(t, fixture.PNGHex), decodeOptions(fixture.Options)...)
+				if err != nil {
+					t.Fatalf("DecodePNG: %v", err)
+				}
+				if actual.Width != uint32(fixture.Expected.Width) || actual.Height != uint32(fixture.Expected.Height) {
+					t.Fatalf("dimensions = %dx%d, want %.0fx%.0f", actual.Width, actual.Height, fixture.Expected.Width, fixture.Expected.Height)
+				}
+				if want := fromHex(t, fixture.Expected.RGBAHex); !bytes.Equal(actual.Data, want) {
+					t.Fatalf("RGBA = %x, want %x", actual.Data, want)
+				}
+			case "decode-error":
+				_, err := png.DecodePNG(fromHex(t, fixture.PNGHex), decodeOptions(fixture.Options)...)
+				assertPngError(t, err, fixture.Expected.ErrorID)
+			case "encode":
+				encoded, err := fixtureEncode(t, *fixture.Input)
+				if err != nil {
+					t.Fatalf("EncodePNG: %v", err)
+				}
+				chunks := parseChunks(t, encoded)
+				gotTypes := make([]string, len(chunks))
+				for i := range chunks {
+					gotTypes[i] = chunks[i].Type
+				}
+				if !reflect.DeepEqual(gotTypes, fixture.Expected.ChunkTypes) {
+					t.Fatalf("chunk types = %#v, want %#v", gotTypes, fixture.Expected.ChunkTypes)
+				}
+				if encoded[24] != fixture.Expected.BitDepth || encoded[25] != fixture.Expected.ColourType || encoded[28] != fixture.Expected.Interlace {
+					t.Fatalf("IHDR profile = (%d,%d,%d), want (%d,%d,%d)", encoded[24], encoded[25], encoded[28], fixture.Expected.BitDepth, fixture.Expected.ColourType, fixture.Expected.Interlace)
+				}
+				filtered := filteredBytes(t, chunks)
+				stride := int(fixture.Input.Width) * 4
+				filters := make([]byte, int(fixture.Input.Height))
+				for row := range filters {
+					filters[row] = filtered[row*(stride+1)]
+				}
+				if !bytes.Equal(filters, fixture.Expected.FilterTypes) {
+					t.Fatalf("filter types = %v, want %v", filters, fixture.Expected.FilterTypes)
+				}
+				width, height, rgba := foreignRGBA(t, encoded)
+				if width != uint32(fixture.Input.Width) || height != uint32(fixture.Input.Height) || !bytes.Equal(rgba, fromHex(t, fixture.Input.RGBAHex)) {
+					t.Fatalf("foreign decode = %dx%d %x", width, height, rgba)
+				}
+			case "encode-error":
+				_, err := fixtureEncode(t, *fixture.Input)
+				assertPngError(t, err, fixture.Expected.ErrorID)
+			case "adler32":
+				got := fmt.Sprintf("%08x", png.Adler32(fromHex(t, fixture.InputHex)))
+				if got != fixture.Expected.Adler32Hex {
+					t.Fatalf("Adler32 = %s, want %s", got, fixture.Expected.Adler32Hex)
+				}
+			default:
+				t.Fatalf("unknown fixture operation %q", fixture.Operation)
+			}
+		})
+	}
+}

--- a/code/packages/go/image-codec-png/required_capabilities.json
+++ b/code/packages/go/image-codec-png/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "go/image-codec-png",
+  "capabilities": [],
+  "justification": "Pure in-memory PNG encoding and decoding through repository-owned pixel-container and ZIP byte transforms, with no filesystem, network, process, environment, clock, entropy, console, credential, or native-image authority."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -4184,6 +4184,33 @@ for it. The in-progress Go child remains coherent by refusing all three chunk
 types as `unsupported-feature` with a focused valid-CRC regression; it does not
 modify the merged neutral corpus or broaden into another lane.
 
+Before the first implementation commit was recertified, `origin/main` advanced
+to `7020ebbb1a85976dc5aec170ac61df15d7d46e25` through #12321's human-language
+gentle-ramp snapshot sharding. Its 30 changed paths are confined to the
+human-language workflow, snapshots, verifier, and existing TypeScript
+human-language-data root, with no intersection with parity or PNG surfaces and
+no added package identity. The Go branch rebased cleanly onto that exact main;
+the stored main inventory is repinned there with all counts unchanged.
+
+The implemented Go package now delegates CRC-32, raw RFC 1951 encoding, and
+counted exact-cap decoding to `go/zip`; supports the required 8-bit colour,
+filter, suggested-palette, transparency, split-IDAT, zlib, checksum, ordering,
+and stable-error behavior; and enforces both encoder and decoder edge/product
+ceilings before allocation. Its public fixture consumer passes all 82 neutral
+cases and the ordered 29-code taxonomy, while focused valid-CRC APNG controls
+cover the newly classified neutral omission. A temporary removal of the APNG
+branch made all three regressions fail, proving that evidence load-bearing.
+
+Fresh race tests report 99.0% Go statement coverage; format, vet, trimpath
+build, module tidiness, eight neutral-fixture validator tests, seven capability
+tests, ten parity-reporter tests, Ruff, strict MyPy, Bandit, state/DAG, diff,
+credential, and authority checks pass. ZIP, pixel-container, and LZSS pass race
+tests at 90.9%, 92.9%, and 97.7% coverage plus their native quality gates. A
+fresh repository build-tool binary discovers 4,973 packages, selects the exact
+four-node Go dependency closure on Linux, Darwin, and Windows, and executes the
+real front door successfully. The branch inventory remains collision-clean at
+1,368 identities and advances only the intended established Go slot to 4,553.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -4131,6 +4131,59 @@ stable payload-blind errors, and caller-lowerable resource ceilings. It will not
 start any non-TypeScript lane port. Once this full lifecycle merges, all twelve
 toolchain-shaped PNG children become dependency-ready.
 
+## Post-#12319 Refresh and Go PNG Selection
+
+Ready-for-review PNG neutral-foundation PR #12319 completed all 30 reported
+checks with 23 successes, six expected skips, and one neutral CodeQL
+conclusion. Both CI gates and every Linux, macOS, and Windows build succeeded.
+After GitHub reported final reviewed head
+`e9ae38873f3606d764e2786e824d6fd1c297a8dc` clean and mergeable, the loop
+enabled squash auto-merge; GitHub merged that exact head as
+`a09bb28bd19ab24760322f7fcf940184c0912409` at 2026-08-20T20:03:24Z without
+manual merge authority and deleted the source branch.
+
+The canonical schema-3 collision inventory at exact merge main remains 15
+established lanes, 1,368 normalized implementation identities, 4,552
+established slots, 174 high-consensus identities with 271 gaps, 906 singletons
+with 12,684 missing slots, 716 Rust singletons, zero canonical collisions, and
+zero unknown buckets. The intervening Tamil, Gujarati, and Punjabi curriculum
+commits modify only existing roots, while #12319 modifies the established
+TypeScript image-codec-png root. The exact topology comparison therefore found
+no added or retired identity, no new package root, and no existing-identity
+lane expansion; no additional classification owner was needed.
+
+Merging the neutral foundation made all twelve toolchain-shaped PNG children
+dependency-ready. The quick leverage and delivery-risk pass selected
+`image-codec-png-go-lane-parity` on fresh branch
+`codex/image-codec-png-go-lane-parity` from exact merge main. Go has the strongest safe
+dependency leverage: it unlocks both the final PNG umbrella and the separate
+unblocked paint-codec-png reconciliation. Go 1.26.4 is installed, and its
+pixel-container and ZIP raw-deflate, counted-inflate, and CRC-32 prerequisites
+pass native tests, race/coverage, vet, and build front doors. No live PR or
+remote branch owns the selected PNG surface.
+
+The tranche will add exactly the Go image-codec-png package, consume every
+representable closed `image-codec-png-v1` case through its public API, and
+implement exact IC18 chunk, zlib, filter, transparency, resource-limit, and
+stable-error behavior without duplicating DEFLATE or CRC. Go's typed
+`PixelContainer` cannot represent the neutral corpus's fractional encoder
+dimensions, so the fixture consumer will validate that schema boundary before
+routing every representable case through the public codec. Production remains
+an in-memory byte transform with explicit empty capabilities. The existing Go
+paint adapter continues to use the standard library until its separately owned
+reconciliation, every other lane remains pending, and the completion umbrella
+stays blocked until all twelve children merge.
+
+The Go security pass also found one neutral-contract omission before source
+publication: IC18 requires APNG refusal, but the merged TypeScript reference and
+82-case corpus currently skip the APNG `acTL`, `fcTL`, and `fdAT` chunks as
+ordinary ancillary data. The queue now records
+`image-codec-png-apng-neutral-rejection-conformance` as a separate pending
+reference-and-fixture correction and makes every not-yet-started PNG child wait
+for it. The in-progress Go child remains coherent by refusing all three chunk
+types as `unsupported-feature` with a focused valid-CRC regression; it does not
+modify the merged neutral corpus or broaden into another lane.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -4211,6 +4211,12 @@ four-node Go dependency closure on Linux, Darwin, and Windows, and executes the
 real front door successfully. The branch inventory remains collision-clean at
 1,368 identities and advances only the intended established Go slot to 4,553.
 
+The validated branch was published as ready-for-review PR #12324 from exact
+head `1b5e34acf32d31feac5acdabf460b0f870dc1606`. The state now records the Go
+child as `pr-open`, with that PR as the loop's sole active parity publication;
+all remaining PNG children and the newly classified APNG neutral correction
+remain pending while its required checks run.
+
 ## Autonomous Loop Protocol
 
 Only one parity PR should be active at a time.


### PR DESCRIPTION
## Summary

- add a first-class pure Go `image-codec-png` package backed by the repository `pixel-container` and `zip` packages
- consume all 82 language-neutral IC18 fixture cases and preserve the ordered 29-code error taxonomy
- implement bounded RGBA encoding plus 8-bit grayscale/truecolour/grayscale-alpha/RGBA decoding, filters 0-4, split IDAT, PLTE/tRNS, exact CRC/zlib/Adler/count checks, and stable limits
- explicitly reject APNG control chunks and classify the newly discovered neutral/reference omission as a separate follow-up owner
- refresh package-parity state after #12319, advance only the Go PNG child, and keep paint-codec-png reconciliation out of this tranche

## Validation

- `go test ./... -race -cover -count=1` — 99.0% statements
- `go vet ./...`
- `go build -trimpath ./...`
- `go mod verify`; `go mod tidy -diff`; `gofmt -d`
- real ZIP, pixel-container, and LZSS prerequisite tests with race coverage: 90.9%, 92.9%, and 97.7%
- existing paint-codec-png downstream baseline tests/vet/build (migration remains separately owned)
- 82-case portable fixture plus exact 29-error taxonomy; test-only foreign PNG/zlib oracle evidence
- load-bearing valid-CRC APNG control: removing the rejection branch made all three regressions fail
- eight fixture-validator tests, seven capability-taxonomy tests, ten parity-reporter tests
- Ruff, strict MyPy, Bandit, strict JSON, state dependency/DAG validation, credential/authority scan, and `git diff --check`
- freshly compiled repository build tool discovered 4,973 packages, selected exactly `go/image-codec-png`, `go/zip`, `go/pixel-container`, and `go/lzss` on Linux/Darwin/Windows, and executed the real front door successfully
- collision inventory: 15 established lanes, 1,368 identities, 4,553 slots, zero collisions, zero unknown buckets; exactly one new Go slot for the existing PNG identity

## Scope boundaries

This PR does not migrate `go/paint-codec-png`, change the neutral corpus after its merge, or implement another language lane. Those remain explicit dependency-shaped state items.