### PR TITLE
human-languages: repair Bengali forward reviews

### DIFF
--- a/code/learning/human-languages/bengali/CHANGELOG.md
+++ b/code/learning/human-languages/bengali/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Fixed — three false forward-review claims
+
+- `BN-C02-alaap` now records the earlier `BN-C02-amar-naam` lesson that its
+  warm-up and knowledge directives actually rehearse.
+- `BN-C02-ki` now records its real name-word review instead of pointing ahead
+  to the not-yet-taught pronoun lesson.
+- `BN-C05-kaj-kora` no longer claims to review the following `thaka` lesson;
+  its exercises revisit `BN-C05-bola` exactly as the knowledge ledger says.
+
+The authored reading order does not change. Bengali's order-integrity debt
+falls from three false forward reviews to zero, so the five-minute ramp now
+describes what the learner actually encounters.
+
 ### Added — Chapter 16, the first nine pieces of the script (HL-C222)
 
 Ten lessons. **Nine teach one piece each; one introduces nothing** and assembles

--- a/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:687cbb726f9250a3
+% canonical-source-hash: fnv1a64:dcda8e5e7aa8d135
 % canonical-lessons: BN-C02-naam, BN-C02-amar, BN-C02-amar-naam, BN-C02-alaap, BN-C02-ki, BN-C02-tumi-apni, BN-C02-tomar-naam-ki, BN-C02-practice
 
 \chapter{Introducing Yourself}

--- a/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:604ebb6fadbc7bc9
+% canonical-source-hash: fnv1a64:26c27f34d6626e40
 % canonical-lessons: BN-C05-bola, BN-C05-ami-bangla-boli, BN-C05-kaj-kora, BN-C05-thaka, BN-C05-practice
 
 \chapter{The First Verbs}

--- a/code/learning/human-languages/bengali/lessons/BN-C02-alaap.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C02-alaap.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-bengali
-reviews_of: [BN-C02-tomar-naam-ki]
+reviews_of: [BN-C02-amar-naam]
 ---
 
 # আলাপ করে ভালো লাগলো (ālāp kore bhālo lāglo) — "pleased to meet you"

--- a/code/learning/human-languages/bengali/lessons/BN-C02-ki.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C02-ki.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-bengali
-reviews_of: [BN-C02-tumi-apni]
+reviews_of: [BN-C02-naam]
 ---
 
 # কি (ki) — "what"

--- a/code/learning/human-languages/bengali/lessons/BN-C05-kaj-kora.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C05-kaj-kora.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-bengali
-reviews_of: [BN-C05-bola, BN-C05-thaka]
+reviews_of: [BN-C05-bola]
 ---
 
 # কাজ করা (kāj kôrā) — "to work"

--- a/code/learning/human-languages/bengali/narration/ch02.json
+++ b/code/learning/human-languages/bengali/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:e32fde4e95bc490f",
+  "sourceHash": "fnv1a64:4f0af9de6c0a13b5",
   "lessons": [
     {
       "id": "BN-C02-naam",
@@ -379,7 +379,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e58c8a7e80a37473",
+      "sourceHash": "fnv1a64:62a910da1c2e20d4",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -493,7 +493,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:710263335894332b",
+      "sourceHash": "fnv1a64:80fe4e60718b754a",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/bengali/narration/ch05.json
+++ b/code/learning/human-languages/bengali/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:e0481b47dd26e085",
+  "sourceHash": "fnv1a64:15618e854fd87ec4",
   "lessons": [
     {
       "id": "BN-C05-bola",
@@ -287,7 +287,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dc58edf3dabd8fc8",
+      "sourceHash": "fnv1a64:3a3821ca2f0ab905",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -365,7 +365,7 @@
     {
       "language": "bengali",
       "chapter": 2,
-      "sourceHash": "fnv1a64:687cbb726f9250a3",
+      "sourceHash": "fnv1a64:dcda8e5e7aa8d135",
       "lessonIds": [
         "BN-C02-naam",
         "BN-C02-amar",
@@ -408,7 +408,7 @@
     {
       "language": "bengali",
       "chapter": 5,
-      "sourceHash": "fnv1a64:604ebb6fadbc7bc9",
+      "sourceHash": "fnv1a64:26c27f34d6626e40",
       "lessonIds": [
         "BN-C05-bola",
         "BN-C05-ami-bangla-boli",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -600,7 +600,7 @@
     {
       "language": "bengali",
       "chapter": 2,
-      "sourceHash": "fnv1a64:e32fde4e95bc490f",
+      "sourceHash": "fnv1a64:4f0af9de6c0a13b5",
       "lessonIds": [
         "BN-C02-naam",
         "BN-C02-amar",
@@ -616,7 +616,7 @@
       "text": "bengali/narration/ch02.txt",
       "json": "bengali/narration/ch02.json",
       "textHash": "fnv1a64:90786881b184ce52",
-      "jsonHash": "fnv1a64:d9a20b61ddbf95a3"
+      "jsonHash": "fnv1a64:5a338a6dc643b9e7"
     },
     {
       "language": "bengali",
@@ -658,7 +658,7 @@
     {
       "language": "bengali",
       "chapter": 5,
-      "sourceHash": "fnv1a64:e0481b47dd26e085",
+      "sourceHash": "fnv1a64:15618e854fd87ec4",
       "lessonIds": [
         "BN-C05-bola",
         "BN-C05-ami-bangla-boli",
@@ -671,7 +671,7 @@
       "text": "bengali/narration/ch05.txt",
       "json": "bengali/narration/ch05.json",
       "textHash": "fnv1a64:d4cd887f96d2eb89",
-      "jsonHash": "fnv1a64:3a6f3bad75597f39"
+      "jsonHash": "fnv1a64:16945b88291e7cc9"
     },
     {
       "language": "bengali",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/bengali.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/bengali.json
@@ -10,10 +10,10 @@
   "scriptSystemSpikes": 0,
   "scriptClosureViolations": 65,
   "neverTaughtGlyphs": 39,
-  "orderDefects": 3,
+  "orderDefects": 0,
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
-  "forwardReviews": 3,
+  "forwardReviews": 0,
   "forwardReferences": 6,
   "atomsTaught": 104,
   "atomsNeverRevisited": 7,
@@ -23,13 +23,6 @@
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
-    {
-      "language": "bengali",
-      "kind": "order-integrity",
-      "count": 3,
-      "unit": "order/dependency defect(s)",
-      "detail": "declare a unique reading order and close every prerequisite and review before use"
-    },
     {
       "language": "bengali",
       "kind": "forward-language",
@@ -68,9 +61,9 @@
   ],
   "next": {
     "language": "bengali",
-    "kind": "order-integrity",
-    "count": 3,
-    "unit": "order/dependency defect(s)",
-    "detail": "declare a unique reading order and close every prerequisite and review before use"
+    "kind": "forward-language",
+    "count": 6,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
   }
 }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:e7d73be8b3cb5be4",
+  "sourceHash": "fnv1a64:98ef6a232975887d",
   "summary": {
     "totalLessons": 3412,
     "voice": 2460,
@@ -20074,7 +20074,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e58c8a7e80a37473",
+      "sourceHash": "fnv1a64:62a910da1c2e20d4",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -20095,7 +20095,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:710263335894332b",
+      "sourceHash": "fnv1a64:80fe4e60718b754a",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -20437,7 +20437,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dc58edf3dabd8fc8",
+      "sourceHash": "fnv1a64:3a3821ca2f0ab905",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -504,7 +504,7 @@ describe("the real corpus", () => {
     // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
     // under the old alphabetical fallback too; the hand-authored book runs them the
     // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
-    expect(report.summary.forwardReviews).toBeLessThanOrEqual(45) // Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
+    expect(report.summary.forwardReviews).toBeLessThanOrEqual(42) // Bengali repairs three false future-review claims; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -183,6 +183,11 @@ describe("the corpus-wide super-gentle ramp", () => {
       forwardPrerequisites: 0,
       forwardReviews: 0,
     });
+    expect(report.tracks.find((track) => track.language === "bengali")).toMatchObject({
+      orderDefects: 0,
+      forwardPrerequisites: 0,
+      forwardReviews: 0,
+    });
 
     const changed = structuredClone(report);
     changed.tracks.find((track) => track.language === "german")!.lessonCount += 1;


### PR DESCRIPTION
## Summary
- replace three Bengali `reviews_of` claims that pointed at not-yet-taught lessons
- bind each declaration to the earlier lesson its warm-up and knowledge directives actually rehearse
- keep the authored reading order and all lesson durations unchanged
- add a Bengali zero-order-defect regression and refresh generated artifacts

## Measured improvement
- Bengali order-integrity defects: 3 -> 0
- corpus forward-review debt: 45 -> 42
- no duration, prerequisite, atom-load, glyph-load, or continuity-window regression

## Validation
- 233 focused continuity, gentle-ramp, modality, narration, and curriculum tests pass
- book, narration, modality, gentle-snapshot, and progress artifact checks pass
- Bengali XeLaTeX build is clean: no missing glyphs, overfull boxes, or underfull boxes
- TypeScript build and `git diff --check` pass

Closes #12342