### PR TITLE
human-languages: repair Gujarati forward reviews

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1074,7 +1074,7 @@
     {
       "language": "gujarati",
       "chapter": 2,
-      "sourceHash": "fnv1a64:d5b0e868e7ad8b29",
+      "sourceHash": "fnv1a64:a3d95b6d78b1c688",
       "lessonIds": [
         "GU-C02-naam",
         "GU-C02-maarun",
@@ -1105,7 +1105,7 @@
     {
       "language": "gujarati",
       "chapter": 4,
-      "sourceHash": "fnv1a64:e9c89a04a63fdf2c",
+      "sourceHash": "fnv1a64:ece16679fa29a79e",
       "lessonIds": [
         "GU-C04-malishun",
         "GU-C04-kaale",
@@ -1118,7 +1118,7 @@
     {
       "language": "gujarati",
       "chapter": 5,
-      "sourceHash": "fnv1a64:85cfbdfb2d1b62c4",
+      "sourceHash": "fnv1a64:60a19d30501cd678",
       "lessonIds": [
         "GU-C05-bolvun",
         "GU-C05-hun-gujarati-bolun-chhun",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -2151,7 +2151,7 @@
     {
       "language": "gujarati",
       "chapter": 2,
-      "sourceHash": "fnv1a64:2fb4aa7e2e45a3d4",
+      "sourceHash": "fnv1a64:72ecc4bef2b1ad57",
       "lessonIds": [
         "GU-C02-naam",
         "GU-C02-maarun",
@@ -2168,7 +2168,7 @@
       "text": "gujarati/narration/ch02.txt",
       "json": "gujarati/narration/ch02.json",
       "textHash": "fnv1a64:1db377c27cc2b300",
-      "jsonHash": "fnv1a64:3c73f6a916f3e73d"
+      "jsonHash": "fnv1a64:3cab727e12c83d49"
     },
     {
       "language": "gujarati",
@@ -2192,7 +2192,7 @@
     {
       "language": "gujarati",
       "chapter": 4,
-      "sourceHash": "fnv1a64:0bf6cff43642d6f5",
+      "sourceHash": "fnv1a64:3b2f8725cc5205c1",
       "lessonIds": [
         "GU-C04-malishun",
         "GU-C04-kaale",
@@ -2205,12 +2205,12 @@
       "text": "gujarati/narration/ch04.txt",
       "json": "gujarati/narration/ch04.json",
       "textHash": "fnv1a64:93e9ccecd101e2bc",
-      "jsonHash": "fnv1a64:2c0bcb6f92f7a37b"
+      "jsonHash": "fnv1a64:788b491236006331"
     },
     {
       "language": "gujarati",
       "chapter": 5,
-      "sourceHash": "fnv1a64:41d87b88a8cd1af0",
+      "sourceHash": "fnv1a64:f8cd588e7e227769",
       "lessonIds": [
         "GU-C05-bolvun",
         "GU-C05-hun-gujarati-bolun-chhun",
@@ -2223,7 +2223,7 @@
       "text": "gujarati/narration/ch05.txt",
       "json": "gujarati/narration/ch05.json",
       "textHash": "fnv1a64:13ba0da6a2289fd0",
-      "jsonHash": "fnv1a64:ffc705b12f88ae9e"
+      "jsonHash": "fnv1a64:7cc0ba850eb339d7"
     },
     {
       "language": "gujarati",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/gujarati.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/gujarati.json
@@ -10,10 +10,10 @@
   "scriptSystemSpikes": 0,
   "scriptClosureViolations": 50,
   "neverTaughtGlyphs": 32,
-  "orderDefects": 3,
+  "orderDefects": 0,
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
-  "forwardReviews": 3,
+  "forwardReviews": 0,
   "forwardReferences": 8,
   "atomsTaught": 115,
   "atomsNeverRevisited": 10,
@@ -23,13 +23,6 @@
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
-    {
-      "language": "gujarati",
-      "kind": "order-integrity",
-      "count": 3,
-      "unit": "order/dependency defect(s)",
-      "detail": "declare a unique reading order and close every prerequisite and review before use"
-    },
     {
       "language": "gujarati",
       "kind": "forward-language",
@@ -68,9 +61,9 @@
   ],
   "next": {
     "language": "gujarati",
-    "kind": "order-integrity",
-    "count": 3,
-    "unit": "order/dependency defect(s)",
-    "detail": "declare a unique reading order and close every prerequisite and review before use"
+    "kind": "forward-language",
+    "count": 8,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
   }
 }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:98ef6a232975887d",
+  "sourceHash": "fnv1a64:bd76cd8eb1ad6d95",
   "summary": {
     "totalLessons": 3412,
     "voice": 2460,
@@ -27114,7 +27114,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:abd66ef1913eda69",
+      "sourceHash": "fnv1a64:d746ad709dd088aa",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -27354,7 +27354,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:37839346a361286d",
+      "sourceHash": "fnv1a64:d762ef2a619956f7",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -27474,7 +27474,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:86442ae46a716a9f",
+      "sourceHash": "fnv1a64:912370b82cc95378",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed — three false forward-review claims
+
+- `GU-C02-anand` now records the earlier name statement that its warm-up and
+  knowledge directives actually rehearse.
+- `GU-C04-kaale` now records its real `malishun` review instead of pointing
+  ahead to the chapter's later assembled farewell.
+- `GU-C05-kaam-karvun` no longer claims to review the following `rahevun`
+  lesson; its exercises revisit `GU-C05-bolvun`.
+
+The authored order and lesson durations do not change. Gujarati's three
+order-integrity defects are now zero.
+
 ### Added — Chapter 13, the first nine pieces of the script (HL-C215)
 
 Ten lessons. **Nine teach one piece each; one introduces nothing** and assembles

--- a/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d5b0e868e7ad8b29
+% canonical-source-hash: fnv1a64:a3d95b6d78b1c688
 % canonical-lessons: GU-C02-naam, GU-C02-maarun, GU-C02-chhe, GU-C02-maarun-naam-chhe, GU-C02-anand, GU-C02-tu-tame, GU-C02-shun, GU-C02-tamarun-naam-shun-chhe, GU-C02-practice
 
 \chapter{Introducing Yourself}

--- a/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e9c89a04a63fdf2c
+% canonical-source-hash: fnv1a64:ece16679fa29a79e
 % canonical-lessons: GU-C04-malishun, GU-C04-kaale, GU-C04-pachha, GU-C04-pachha-malishun, GU-C04-practice
 
 \chapter{Farewells}

--- a/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:85cfbdfb2d1b62c4
+% canonical-source-hash: fnv1a64:60a19d30501cd678
 % canonical-lessons: GU-C05-bolvun, GU-C05-hun-gujarati-bolun-chhun, GU-C05-kaam-karvun, GU-C05-rahevun, GU-C05-practice
 
 \chapter{The First Verbs}

--- a/code/learning/human-languages/gujarati/lessons/GU-C02-anand.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C02-anand.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-gujarati
-reviews_of: [GU-C02-tamarun-naam-shun-chhe]
+reviews_of: [GU-C02-maarun-naam-chhe]
 ---
 
 # તમને મળીને આનંદ થયો (tamne maḷīne ānand thayo) — "pleased to meet you"

--- a/code/learning/human-languages/gujarati/lessons/GU-C04-kaale.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C04-kaale.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-gujarati
-reviews_of: [GU-C04-pachha-malishun]
+reviews_of: [GU-C04-malishun]
 ---
 
 # કાલે મળીશું (kāle maḷīshũ) — "see you tomorrow"

--- a/code/learning/human-languages/gujarati/lessons/GU-C05-kaam-karvun.md
+++ b/code/learning/human-languages/gujarati/lessons/GU-C05-kaam-karvun.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-gujarati
-reviews_of: [GU-C05-bolvun, GU-C05-rahevun]
+reviews_of: [GU-C05-bolvun]
 ---
 
 # કામ કરવું (kām karvũ) — "to work"

--- a/code/learning/human-languages/gujarati/narration/ch02.json
+++ b/code/learning/human-languages/gujarati/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:2fb4aa7e2e45a3d4",
+  "sourceHash": "fnv1a64:72ecc4bef2b1ad57",
   "lessons": [
     {
       "id": "GU-C02-naam",
@@ -522,7 +522,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:abd66ef1913eda69",
+      "sourceHash": "fnv1a64:d746ad709dd088aa",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch04.json
+++ b/code/learning/human-languages/gujarati/narration/ch04.json
@@ -4,7 +4,7 @@
   "chapter": 4,
   "title": "Farewells",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0bf6cff43642d6f5",
+  "sourceHash": "fnv1a64:3b2f8725cc5205c1",
   "lessons": [
     {
       "id": "GU-C04-malishun",
@@ -153,7 +153,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:37839346a361286d",
+      "sourceHash": "fnv1a64:d762ef2a619956f7",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/gujarati/narration/ch05.json
+++ b/code/learning/human-languages/gujarati/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:41d87b88a8cd1af0",
+  "sourceHash": "fnv1a64:f8cd588e7e227769",
   "lessons": [
     {
       "id": "GU-C05-bolvun",
@@ -307,7 +307,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:86442ae46a716a9f",
+      "sourceHash": "fnv1a64:912370b82cc95378",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -504,7 +504,7 @@ describe("the real corpus", () => {
     // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
     // under the old alphabetical fallback too; the hand-authored book runs them the
     // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
-    expect(report.summary.forwardReviews).toBeLessThanOrEqual(42) // Bengali repairs three false future-review claims; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
+    expect(report.summary.forwardReviews).toBeLessThanOrEqual(39) // Gujarati and Bengali each repair three false future-review claims; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -188,6 +188,11 @@ describe("the corpus-wide super-gentle ramp", () => {
       forwardPrerequisites: 0,
       forwardReviews: 0,
     });
+    expect(report.tracks.find((track) => track.language === "gujarati")).toMatchObject({
+      orderDefects: 0,
+      forwardPrerequisites: 0,
+      forwardReviews: 0,
+    });
 
     const changed = structuredClone(report);
     changed.tracks.find((track) => track.language === "german")!.lessonCount += 1;


### PR DESCRIPTION
## Summary
- repair three Gujarati `reviews_of` claims that pointed at future lessons
- bind each declaration to the earlier lesson its warm-up and knowledge directives actually assess
- keep authored order and all <=5-minute durations unchanged
- add a Gujarati zero-order-defect regression and refresh generated artifacts

## Measured improvement
- Gujarati order-integrity defects: 3 -> 0
- corpus forward-review debt: 42 -> 39 after the Bengali parent repair
- no duration, prerequisite, atom-load, glyph-load, or continuity-window regression

## Validation
- 233 focused continuity, gentle-ramp, modality, narration, and curriculum tests pass
- book, narration, modality, gentle-snapshot, and progress artifact checks pass
- Gujarati XeLaTeX build is clean: no missing glyphs, overfull boxes, or underfull boxes
- TypeScript build and `git diff --check` pass

## Dependency
Stacked on #12343 because both tranches update the shared forward-review ratchet and generated manifests. After #12343 merges, this PR should be retargeted to `main` and auto-merge enabled.

Closes #12344