### PR TITLE
human-languages: repair Hindi forward review

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1304,7 +1304,7 @@
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:0dea8590c0d94d96",
+      "sourceHash": "fnv1a64:4fa51946d5b4ccee",
       "lessonIds": [
         "HI-C05-bolna",
         "HI-C05-rahna",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -2461,7 +2461,7 @@
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:2d9f4dcbd7e52fe5",
+      "sourceHash": "fnv1a64:5d90c350329583d4",
       "lessonIds": [
         "HI-C05-bolna",
         "HI-C05-rahna",
@@ -2475,7 +2475,7 @@
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
       "textHash": "fnv1a64:ed05b74f37ece7e7",
-      "jsonHash": "fnv1a64:44d8739fa410a94a"
+      "jsonHash": "fnv1a64:7072cbf12ea872df"
     },
     {
       "language": "hindi",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/hindi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/hindi.json
@@ -10,10 +10,10 @@
   "scriptSystemSpikes": 0,
   "scriptClosureViolations": 72,
   "neverTaughtGlyphs": 12,
-  "orderDefects": 1,
+  "orderDefects": 0,
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
-  "forwardReviews": 1,
+  "forwardReviews": 0,
   "forwardReferences": 10,
   "atomsTaught": 350,
   "atomsNeverRevisited": 76,
@@ -23,13 +23,6 @@
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
-    {
-      "language": "hindi",
-      "kind": "order-integrity",
-      "count": 1,
-      "unit": "order/dependency defect(s)",
-      "detail": "declare a unique reading order and close every prerequisite and review before use"
-    },
     {
       "language": "hindi",
       "kind": "forward-language",
@@ -75,9 +68,9 @@
   ],
   "next": {
     "language": "hindi",
-    "kind": "order-integrity",
-    "count": 1,
-    "unit": "order/dependency defect(s)",
-    "detail": "declare a unique reading order and close every prerequisite and review before use"
+    "kind": "forward-language",
+    "count": 10,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
   }
 }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:04c7d8087660055f",
+  "sourceHash": "fnv1a64:97633941699be916",
   "summary": {
     "totalLessons": 3416,
     "voice": 2461,
@@ -29144,7 +29144,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:c6878088b621d894",
+      "sourceHash": "fnv1a64:dbbb3cb59f48db12",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed — one false forward-review claim
+
+`HI-C05-rahna` now records only the earlier `HI-C05-bolna` lesson that its
+warm-up, knowledge ledger, and practice actually rehearse. The removed
+`HI-C05-main-hindi-bolta-hun` claim pointed three lessons into the future.
+Hindi's authored order and the lesson's 240-second cap do not change; its
+order-integrity debt falls from one to zero.
+
 ### Added — Chapters 60-66: Thirty-five more everyday words, round three
 
 The third HL-C198 tranche for Hindi. The track stood at **120** distinct pre-A1

--- a/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:0dea8590c0d94d96
+% canonical-source-hash: fnv1a64:4fa51946d5b4ccee
 % canonical-lessons: HI-C05-bolna, HI-C05-rahna, HI-C05-karna, HI-C05-bolta-hun, HI-C05-main-hindi-bolta-hun, HI-C05-practice
 
 \chapter{The First Verbs}

--- a/code/learning/human-languages/hindi/lessons/HI-C05-rahna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-rahna.md
@@ -24,7 +24,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-hindi
-reviews_of: [HI-C05-bolna, HI-C05-main-hindi-bolta-hun]
+reviews_of: [HI-C05-bolna]
 ---
 
 # रहना (rahnā) — "to live, to stay"

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "The First Verbs",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:2d9f4dcbd7e52fe5",
+  "sourceHash": "fnv1a64:5d90c350329583d4",
   "lessons": [
     {
       "id": "HI-C05-bolna",
@@ -165,7 +165,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c6878088b621d894",
+      "sourceHash": "fnv1a64:dbbb3cb59f48db12",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -504,7 +504,7 @@ describe("the real corpus", () => {
     // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
     // under the old alphabetical fallback too; the hand-authored book runs them the
     // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
-    expect(report.summary.forwardReviews).toBeLessThanOrEqual(39) // Gujarati and Bengali each repair three false future-review claims; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
+    expect(report.summary.forwardReviews).toBeLessThanOrEqual(38) // Hindi removes one false future-review claim; Gujarati and Bengali each repair three; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -193,6 +193,11 @@ describe("the corpus-wide super-gentle ramp", () => {
       forwardPrerequisites: 0,
       forwardReviews: 0,
     });
+    expect(report.tracks.find((track) => track.language === "hindi")).toMatchObject({
+      orderDefects: 0,
+      forwardPrerequisites: 0,
+      forwardReviews: 0,
+    });
 
     const changed = structuredClone(report);
     changed.tracks.find((track) => track.language === "german")!.lessonCount += 1;


### PR DESCRIPTION
## Summary
- remove Hindi's one false `reviews_of` claim pointing three lessons into the future
- retain the real `HI-C05-bolna` review named by the warm-up and knowledge ledger
- keep authored order and the 240-second lesson cap unchanged
- add a Hindi zero-order-defect regression and refresh generated artifacts

## Measured improvement
- Hindi order-integrity defects: 1 -> 0
- corpus forward-review debt: 39 -> 38 after the Bengali and Gujarati parent repairs
- no duration, prerequisite, atom-load, glyph-load, or continuity-window regression

## Validation
- 233 focused continuity, gentle-ramp, modality, narration, and curriculum tests pass
- book, narration, modality, gentle-snapshot, and progress artifact checks pass
- Hindi XeLaTeX build is clean: no missing glyphs, overfull boxes, or underfull boxes
- TypeScript build and `git diff --check` pass

## Dependency
Stacked on #12345 because this sequence intentionally accumulates the shared forward-review ratchet and generated manifests. After #12345 merges, retarget to `main` and arm auto-merge.

Closes #12346