### PR TITLE
human-languages: repair Russian forward review

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4962,7 +4962,7 @@
     {
       "language": "russian",
       "chapter": 1,
-      "sourceHash": "fnv1a64:dc92887cccce9ba4",
+      "sourceHash": "fnv1a64:e06d77b1635241b5",
       "lessonIds": [
         "RU-C01-privet",
         "RU-C01-zdravstvuyte",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -8152,7 +8152,7 @@
     {
       "language": "russian",
       "chapter": 1,
-      "sourceHash": "fnv1a64:36fb7b7d712393ce",
+      "sourceHash": "fnv1a64:2451a9ab030d898f",
       "lessonIds": [
         "RU-C01-privet",
         "RU-C01-zdravstvuyte",
@@ -8172,7 +8172,7 @@
       "text": "russian/narration/ch01.txt",
       "json": "russian/narration/ch01.json",
       "textHash": "fnv1a64:20574a22bd49071d",
-      "jsonHash": "fnv1a64:044d392372ca83d3"
+      "jsonHash": "fnv1a64:ba61ee68a69f7c31"
     },
     {
       "language": "russian",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/russian.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/russian.json
@@ -10,10 +10,10 @@
   "scriptSystemSpikes": 0,
   "scriptClosureViolations": 59,
   "neverTaughtGlyphs": 23,
-  "orderDefects": 1,
+  "orderDefects": 0,
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
-  "forwardReviews": 1,
+  "forwardReviews": 0,
   "forwardReferences": 8,
   "atomsTaught": 160,
   "atomsNeverRevisited": 22,
@@ -23,13 +23,6 @@
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
-    {
-      "language": "russian",
-      "kind": "order-integrity",
-      "count": 1,
-      "unit": "order/dependency defect(s)",
-      "detail": "declare a unique reading order and close every prerequisite and review before use"
-    },
     {
       "language": "russian",
       "kind": "forward-language",
@@ -82,9 +75,9 @@
   ],
   "next": {
     "language": "russian",
-    "kind": "order-integrity",
-    "count": 1,
-    "unit": "order/dependency defect(s)",
-    "detail": "declare a unique reading order and close every prerequisite and review before use"
+    "kind": "forward-language",
+    "count": 8,
+    "unit": "use(s)",
+    "detail": "teach target-language material before load-bearing use"
   }
 }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:97633941699be916",
+  "sourceHash": "fnv1a64:9dd7b387d65855f3",
   "summary": {
     "totalLessons": 3416,
     "voice": 2461,
@@ -53446,7 +53446,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fbeba526677daaf0",
+      "sourceHash": "fnv1a64:5d32d120d7313ffc",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — Russian track
 
+## Unreleased
+
+### Fixed — the final false forward-review claim
+
+`RU-C01-da` now reviews the two greetings its warm-up actually recalls:
+`RU-C01-privet` and the earlier formal `RU-C01-zdravstvuyte`. The removed
+`RU-C01-spasibo` claim pointed two lessons into the future. Authored order and
+the 180-second cap remain unchanged; Russian's order-integrity debt is now zero.
+
 ## 0.11.0 — 2026-08-12
 
 Pre-A1 vocabulary tranche, round 2 (wave 6 of the cross-track vocabulary

--- a/code/learning/human-languages/russian/book/chapters/ch01-greetings-and-courtesy.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch01-greetings-and-courtesy.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dc92887cccce9ba4
+% canonical-source-hash: fnv1a64:e06d77b1635241b5
 % canonical-lessons: RU-C01-privet, RU-C01-zdravstvuyte, RU-C01-da, RU-C01-net, RU-C01-spasibo, RU-C01-pozhaluysta, RU-C01-practice, RU-W01-false-friends-v-r, RU-W02-false-friends-s-n, RU-W03-new-shapes-b-d, RU-W04-privet-letters-p-i, RU-W05-privet-letters-e-t
 
 \chapter{Greetings and courtesy}

--- a/code/learning/human-languages/russian/lessons/RU-C01-da.md
+++ b/code/learning/human-languages/russian/lessons/RU-C01-da.md
@@ -26,7 +26,7 @@ modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral
 variety: standard-contemporary
-reviews_of: [RU-C01-privet, RU-C01-spasibo]
+reviews_of: [RU-C01-privet, RU-C01-zdravstvuyte]
 ---
 
 # да (da) — "yes"

--- a/code/learning/human-languages/russian/narration/ch01.json
+++ b/code/learning/human-languages/russian/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings and courtesy",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:36fb7b7d712393ce",
+  "sourceHash": "fnv1a64:2451a9ab030d898f",
   "lessons": [
     {
       "id": "RU-C01-privet",
@@ -409,7 +409,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fbeba526677daaf0",
+      "sourceHash": "fnv1a64:5d32d120d7313ffc",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -504,7 +504,7 @@ describe("the real corpus", () => {
     // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
     // under the old alphabetical fallback too; the hand-authored book runs them the
     // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
-    expect(report.summary.forwardReviews).toBeLessThanOrEqual(38) // Hindi removes one false future-review claim; Gujarati and Bengali each repair three; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
+    expect(report.summary.forwardReviews).toBeLessThanOrEqual(37) // Russian and Hindi each remove one false future-review claim; Gujarati and Bengali each repair three; Italian order recovery: -7, including one stray claim to review a future Chapter 4 lesson; CEILING — this is debt; it may fall, never grow; // HL11: -99, same cause as forwardPrerequisites above. With five tracks carrying no declared order, a lesson reviewing an earlier one looked like it reviewed a later one. Recovering the order from their books turned most of these back into what they always were: ordinary backward references
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -198,6 +198,11 @@ describe("the corpus-wide super-gentle ramp", () => {
       forwardPrerequisites: 0,
       forwardReviews: 0,
     });
+    expect(report.tracks.find((track) => track.language === "russian")).toMatchObject({
+      orderDefects: 0,
+      forwardPrerequisites: 0,
+      forwardReviews: 0,
+    });
 
     const changed = structuredClone(report);
     changed.tracks.find((track) => track.language === "german")!.lessonCount += 1;


### PR DESCRIPTION
## Summary
- replace Russian's final false future `reviews_of` claim with the earlier formal greeting genuinely recalled by the lesson
- keep both authored order and the 180-second cap unchanged
- add a Russian zero-order-defect regression and refresh generated artifacts

## Measured improvement
- Russian order-integrity defects: 1 -> 0
- corpus forward-review debt: 38 -> 37 after the Bengali, Gujarati, and Hindi parent repairs
- the entire unowned order-integrity tail is now represented by published fixes

## Validation
- 233 focused continuity, gentle-ramp, modality, narration, and curriculum tests pass
- book, narration, modality, gentle-snapshot, and progress artifact checks pass
- Russian XeLaTeX build is clean: no missing glyphs, overfull boxes, or underfull boxes
- TypeScript build and `git diff --check` pass

## Dependency
Stacked on #12347 to accumulate the shared forward-review ratchet without forcing parallel generated-ledger conflicts. After #12347 merges, retarget to `main` and arm auto-merge.

Closes #12348