### PR TITLE
fix(human-languages): soften German opening previews

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1622,7 +1622,7 @@
     {
       "language": "german",
       "chapter": 1,
-      "sourceHash": "fnv1a64:ca5f3cc4bc7edc73",
+      "sourceHash": "fnv1a64:fbdf9f56aa0bf130",
       "lessonIds": [
         "GE-C01-hallo",
         "GE-W01-hallo-guided-copy",
@@ -1638,12 +1638,12 @@
         "GE-C01-gute-nacht",
         "GE-C01-practice"
       ],
-      "voiceLessons": 10,
+      "voiceLessons": 11,
       "drivablePrefix": 0,
       "text": "german/narration/ch01.txt",
       "json": "german/narration/ch01.json",
-      "textHash": "fnv1a64:7712e130236f9460",
-      "jsonHash": "fnv1a64:be027de48acae907"
+      "textHash": "fnv1a64:f37ed25e0596bf8f",
+      "jsonHash": "fnv1a64:e29da4d8c2238dd9"
     },
     {
       "language": "german",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/german.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/german.json
@@ -14,7 +14,7 @@
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
-  "forwardReferences": 55,
+  "forwardReferences": 45,
   "atomsTaught": 126,
   "atomsNeverRevisited": 32,
   "reinforcementWindowMisses": 190,
@@ -26,7 +26,7 @@
     {
       "language": "german",
       "kind": "forward-language",
-      "count": 55,
+      "count": 45,
       "unit": "use(s)",
       "detail": "teach target-language material before load-bearing use"
     },
@@ -62,7 +62,7 @@
   "next": {
     "language": "german",
     "kind": "forward-language",
-    "count": 55,
+    "count": 45,
     "unit": "use(s)",
     "detail": "teach target-language material before load-bearing use"
   }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,13 +7,13 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:9dd7b387d65855f3",
+  "sourceHash": "fnv1a64:1c3ee9e17181a1d6",
   "summary": {
     "totalLessons": 3416,
-    "voice": 2461,
-    "sight": 589,
+    "voice": 2462,
+    "sight": 588,
     "pen": 366,
-    "drivableLessons": 2461,
+    "drivableLessons": 2462,
     "drivablePercent": 72,
     "trackCount": 23,
     "chapterCount": 1005,
@@ -1655,10 +1655,10 @@
     {
       "language": "german",
       "lessonCount": 107,
-      "voice": 94,
-      "sight": 8,
+      "voice": 95,
+      "sight": 7,
       "pen": 5,
-      "drivablePercent": 88,
+      "drivablePercent": 89,
       "drivablePrefixTotal": 81,
       "modalities": [
         "voice",
@@ -1669,8 +1669,8 @@
         {
           "chapter": 1,
           "lessonCount": 13,
-          "voice": 10,
-          "sight": 1,
+          "voice": 11,
+          "sight": 0,
           "pen": 2,
           "modalities": [
             "voice",
@@ -24986,7 +24986,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:998274caa94aeec3",
+      "sourceHash": "fnv1a64:d5fe472729a39be1",
       "detachableSegments": [
         "Writing — follow one word you can see"
       ]
@@ -25047,7 +25047,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6442b9425c44ff75"
+      "sourceHash": "fnv1a64:f73d112c1c82581d"
     },
     {
       "id": "GE-C01-tag",
@@ -25072,18 +25072,18 @@
       "language": "german",
       "chapter": 1,
       "sequence": 25,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "coreModality": "sight",
+      "coreModality": "voice",
       "coreReasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:5c29417226d35125"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ba5164b4c43b07bb"
     },
     {
       "id": "GE-C01-morgen",
@@ -25101,7 +25101,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dd3aadddd2d82dbc"
+      "sourceHash": "fnv1a64:593e968865a53508"
     },
     {
       "id": "GE-C01-guten-morgen",
@@ -25119,7 +25119,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6670390c03e20b0f"
+      "sourceHash": "fnv1a64:9cd0b5cccd0c6367"
     },
     {
       "id": "GE-C01-abend",
@@ -25137,7 +25137,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8e8a86c2d8f81402"
+      "sourceHash": "fnv1a64:200c3e27d69a0cda"
     },
     {
       "id": "GE-C01-guten-abend",
@@ -25209,7 +25209,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a70d2ffe19ee7038"
+      "sourceHash": "fnv1a64:1e71fbad53d81916"
     },
     {
       "id": "GE-C02-ich",

--- a/code/learning/human-languages/german/book/chapter-modalities.tex
+++ b/code/learning/human-languages/german/book/chapter-modalities.tex
@@ -30,7 +30,7 @@
 
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (10) \quad \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (2)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (11) \quad \hlpensign{}~\textbf{pen} (2)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 13 lessons.%
     \par}\medskip
 }

--- a/code/learning/human-languages/german/lessons/GE-C01-abend.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-abend.md
@@ -46,7 +46,8 @@ real one.
 
 *Abend* is **masculine** (*der Abend*) — so, again, *guten* in the greeting.
 Three masculine day-parts in a row (*Tag*, *Morgen*, *Abend*) all take
-*guten*; the feminine *Nacht*, next, will break the streak.
+*guten*. The next day-part is feminine, so it will gently show you a different
+ending without adding a new rule to memorize now.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-der-die-das.md
@@ -45,9 +45,9 @@ Here's the twist. Latin had three genders (masculine, feminine, neuter);
 Spanish and French **collapsed to two**, folding neuter into masculine.
 German **kept all three**: *der* (masc.), *die* (fem.), *das* (neut.). So a
 German noun is one of *three* classes, not two — and, as everywhere, the
-gender is unpredictable and must be learned *with* the noun (*der Tag*, *die
-Nacht*, *das Kind* "the child"). English, meanwhile, threw gender out
-entirely and kept a single "the" — the opposite extreme.
+gender is unpredictable and must be learned *with* the noun and its article.
+English, meanwhile, threw gender out entirely and kept a single "the" — the
+opposite extreme. Your next nouns will let you practise that pairing.
 
 One more thing coming later: German articles also change by **case** (their
 job in the sentence), so *der* has other forms (*den, dem, des*). Ignore that
@@ -58,7 +58,7 @@ for now; just learn *der / die / das* as the three "the"s.
 [PAUSE 1s]
 - [YOU SAY: "der", "die", "das"]
 - [YOU SAY: "das" then English "that" — the t→s shift]
-- [YOU SAY: "der Tag" (masc.), "die Nacht" (fem.) — the nouns are coming]
+- [YOU SAY: "der" for masculine, "die" for feminine, "das" for neuter]
 
 ## Wrap-up Recall
 

--- a/code/learning/human-languages/german/lessons/GE-C01-guten-morgen.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-guten-morgen.md
@@ -30,8 +30,8 @@ morning." *Morgen* is masculine, exactly like *Tag*, so *gut* takes the same
 **-en**: *guten* — no new agreement to learn. Said *GOO-ten MOR-gen*.
 
 Used in the morning (roughly until midday); after that, German switches to
-*Guten Tag*, then *Guten Abend* in the evening — the same day-parts you're
-building.
+*Guten Tag*. You will build the evening greeting next, from the same familiar
+pattern.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/german/lessons/GE-C01-guten-tag.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-guten-tag.md
@@ -35,16 +35,16 @@ polite "hello" for daytime. Said *GOO-ten tahk*.
 Like every Germanic and Romance adjective, German *gut* **agrees** with its
 noun — but German adjectives agree in *more* dimensions than Spanish or
 French: not just gender and number, but **case** (the noun's job in the
-sentence). *Guten Tag* is a frozen leftover of a fuller phrase — *"[ich
-wünsche Ihnen einen] guten Tag,"* "[I wish you a] good day" — where "a good
-day" is the *object* of the wish (the accusative case). For a masculine noun
-in that role, *gut* takes the ending **-en**: *guten*.
+sentence). *Guten Tag* is a frozen piece of a fuller phrase meaning "I wish
+you a good day." In that fuller thought, "a good day" is the *object* of the
+wish (the accusative case). For a masculine noun in that role, *gut* takes the
+ending **-en**: *guten*.
 
 Don't try to master German's ending system now — it's a later chapter. Just
 bank two things: (1) German adjectives take endings that shift with gender,
 number, *and* case; (2) the greeting is really "(I wish you a) good day,"
-which is why it's *guten*. You'll see the contrast next: *Gute Nacht*, with a
-different ending, because *Nacht* is feminine.
+which is why it's *guten*. A later bedtime greeting will give you a gentle
+contrast with a feminine noun and a different ending.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/german/lessons/GE-C01-hallo.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-hallo.md
@@ -62,8 +62,9 @@ even shaped partly by German *hallo*.
 <!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HALLO-01] -->
 
 *hallo* is informal-to-neutral — fine among friends, and increasingly common
-generally, but for polite or first meetings German reaches for *Guten Tag*
-("good day"), which you'll build over the next few lessons.
+generally. Polite or first meetings often use a daytime greeting instead. You
+will build that greeting one familiar piece at a time over the next few
+lessons.
 
 ## Writing — follow one word you can see
 <!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HALLO-01] -->

--- a/code/learning/human-languages/german/lessons/GE-C01-morgen.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-morgen.md
@@ -37,10 +37,10 @@ spot it.
 Latin detour; German *Morgen* and English *morning* are the same Germanic
 word, barely changed.
 
-> A small false-friend warning for later: German *Morgen* also means
-> **"tomorrow"** on its own (*bis morgen* = "until tomorrow"). Context tells
-> them apart. English kept the two senses in separate words (*morning* vs
-> *tomorrow*); German lets *Morgen* do both.
+> A small false-friend warning for later: German *Morgen* can also mean
+> **"tomorrow."** A later farewell will reuse it with that meaning. Context
+> tells the two senses apart; English keeps them in separate words (*morning*
+> vs *tomorrow*), while German lets *Morgen* do both jobs.
 
 ## Grammar Lens
 

--- a/code/learning/human-languages/german/lessons/GE-C01-practice.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-practice.md
@@ -48,5 +48,5 @@ hesitating on *guten*/*gute*.
 ## Wrap-up Recall
 
 [PAUSE 3s] Which German greeting uses *gute*, not *guten*, and why? (*Gute
-Nacht* — *Nacht* is feminine.) Next chapter: introducing yourself — *ich
-heiße…* — and German's formal/informal "you," **du** vs **Sie**.
+Nacht* — *Nacht* is feminine.) Next chapter, you will learn to introduce
+yourself and then build the friendly and respectful ways to address someone.

--- a/code/learning/human-languages/german/narration/ch01.json
+++ b/code/learning/human-languages/german/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:ca5f3cc4bc7edc73",
+  "sourceHash": "fnv1a64:fbdf9f56aa0bf130",
   "lessons": [
     {
       "id": "GE-C01-hallo",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "writing-block"
       ],
-      "sourceHash": "fnv1a64:998274caa94aeec3",
+      "sourceHash": "fnv1a64:d5fe472729a39be1",
       "notice": {
         "modality": "pen",
         "needs": [],
@@ -81,7 +81,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "hallo is informal-to-neutral — fine among friends, and increasingly common generally, but for polite or first meetings German reaches for Guten Tag (\"good day\"), which you'll build over the next few lessons."
+              "text": "hallo is informal-to-neutral — fine among friends, and increasingly common generally. Polite or first meetings often use a daytime greeting instead. You will build that greeting one familiar piece at a time over the next few lessons."
             }
           ]
         },
@@ -378,7 +378,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6442b9425c44ff75",
+      "sourceHash": "fnv1a64:f73d112c1c82581d",
       "notice": null,
       "blocks": [
         {
@@ -439,7 +439,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Here's the twist. Latin had three genders (masculine, feminine, neuter); Spanish and French collapsed to two, folding neuter into masculine. German kept all three: der (masc.), die (fem.), das (neut.). So a German noun is one of three classes, not two — and, as everywhere, the gender is unpredictable and must be learned with the noun (der Tag, die Nacht, das Kind \"the child\"). English, meanwhile, threw gender out entirely and kept a single \"the\" — the opposite extreme."
+              "text": "Here's the twist. Latin had three genders (masculine, feminine, neuter); Spanish and French collapsed to two, folding neuter into masculine. German kept all three: der (masc.), die (fem.), das (neut.). So a German noun is one of three classes, not two — and, as everywhere, the gender is unpredictable and must be learned with the noun and its article. English, meanwhile, threw gender out entirely and kept a single \"the\" — the opposite extreme. Your next nouns will let you practise that pairing."
             },
             {
               "kind": "speech",
@@ -479,11 +479,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"der Tag\" (masc.), \"die Nacht\" (fem.) — the nouns are coming",
+              "instruction": "\"der\" for masculine, \"die\" for feminine, \"das\" for neuter",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"der Tag\" (masc.), \"die Nacht\" (fem.) — the nouns are coming]"
+              "source": "[YOU SAY: \"der\" for masculine, \"die\" for feminine, \"das\" for neuter]"
             }
           ]
         },
@@ -645,20 +645,13 @@
       "romanization": "Guten Tag",
       "gloss": "hello / good day (polite)",
       "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5c29417226d35125",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
-      },
+      "sourceHash": "fnv1a64:ba5164b4c43b07bb",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -706,11 +699,11 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Like every Germanic and Romance adjective, German gut agrees with its noun — but German adjectives agree in more dimensions than Spanish or French: not just gender and number, but case (the noun's job in the sentence). Guten Tag is a frozen leftover of a fuller phrase — \"[ich wünsche Ihnen einen] guten Tag,\" \"[I wish you a] good day\" — where \"a good day\" is the object of the wish (the accusative case). For a masculine noun in that role, gut takes the ending -en: guten."
+              "text": "Like every Germanic and Romance adjective, German gut agrees with its noun — but German adjectives agree in more dimensions than Spanish or French: not just gender and number, but case (the noun's job in the sentence). Guten Tag is a frozen piece of a fuller phrase meaning \"I wish you a good day.\" In that fuller thought, \"a good day\" is the object of the wish (the accusative case). For a masculine noun in that role, gut takes the ending -en: guten."
             },
             {
               "kind": "speech",
-              "text": "Don't try to master German's ending system now — it's a later chapter. Just bank two things: (1) German adjectives take endings that shift with gender, number, and case; (2) the greeting is really \"(I wish you a) good day,\" which is why it's guten. You'll see the contrast next: Gute Nacht, with a different ending, because Nacht is feminine."
+              "text": "Don't try to master German's ending system now — it's a later chapter. Just bank two things: (1) German adjectives take endings that shift with gender, number, and case; (2) the greeting is really \"(I wish you a) good day,\" which is why it's guten. A later bedtime greeting will give you a gentle contrast with a feminine noun and a different ending."
             }
           ]
         },
@@ -777,7 +770,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dd3aadddd2d82dbc",
+      "sourceHash": "fnv1a64:593e968865a53508",
       "notice": null,
       "blocks": [
         {
@@ -830,7 +823,7 @@
             },
             {
               "kind": "speech",
-              "text": "A small false-friend warning for later: German Morgen also means \"tomorrow\" on its own (bis morgen = \"until tomorrow\"). Context tells them apart. English kept the two senses in separate words (morning vs tomorrow); German lets Morgen do both."
+              "text": "A small false-friend warning for later: German Morgen can also mean \"tomorrow.\" A later farewell will reuse it with that meaning. Context tells the two senses apart; English keeps them in separate words (morning vs tomorrow), while German lets Morgen do both jobs."
             }
           ]
         },
@@ -908,7 +901,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6670390c03e20b0f",
+      "sourceHash": "fnv1a64:9cd0b5cccd0c6367",
       "notice": null,
       "blocks": [
         {
@@ -950,7 +943,7 @@
             },
             {
               "kind": "speech",
-              "text": "Used in the morning (roughly until midday); after that, German switches to Guten Tag, then Guten Abend in the evening — the same day-parts you're building."
+              "text": "Used in the morning (roughly until midday); after that, German switches to Guten Tag. You will build the evening greeting next, from the same familiar pattern."
             }
           ]
         },
@@ -1017,7 +1010,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8e8a86c2d8f81402",
+      "sourceHash": "fnv1a64:200c3e27d69a0cda",
       "notice": null,
       "blocks": [
         {
@@ -1081,7 +1074,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Abend is masculine (der Abend) — so, again, guten in the greeting. Three masculine day-parts in a row (Tag, Morgen, Abend) all take guten; the feminine Nacht, next, will break the streak."
+              "text": "Abend is masculine (der Abend) — so, again, guten in the greeting. Three masculine day-parts in a row (Tag, Morgen, Abend) all take guten. The next day-part is feminine, so it will gently show you a different ending without adding a new rule to memorize now."
             }
           ]
         },
@@ -1543,7 +1536,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a70d2ffe19ee7038",
+      "sourceHash": "fnv1a64:1e71fbad53d81916",
       "notice": null,
       "blocks": [
         {
@@ -1665,7 +1658,7 @@
             },
             {
               "kind": "speech",
-              "text": "Which German greeting uses gute, not guten, and why? (Gute Nacht — Nacht is feminine.) Next chapter: introducing yourself — ich heiße… — and German's formal/informal \"you,\" du vs Sie."
+              "text": "Which German greeting uses gute, not guten, and why? (Gute Nacht — Nacht is feminine.) Next chapter, you will learn to introduce yourself and then build the friendly and respectful ways to address someone."
             }
           ]
         }

--- a/code/learning/human-languages/german/narration/ch01.txt
+++ b/code/learning/human-languages/german/narration/ch01.txt
@@ -20,7 +20,7 @@ hallo — informal "hello / hi." Unlike Spanish hola (which only looks like "hel
 The pattern to carry through this whole book: because English is a Germanic language, German words are often direct cousins of English words — same family, no Latin middleman. (The Romance languages like Spanish and French reach English mostly through Latin; German reaches it directly.)
 
 Why it's said this way.
-hallo is informal-to-neutral — fine among friends, and increasingly common generally, but for polite or first meetings German reaches for Guten Tag ("good day"), which you'll build over the next few lessons.
+hallo is informal-to-neutral — fine among friends, and increasingly common generally. Polite or first meetings often use a daytime greeting instead. You will build that greeting one familiar piece at a time over the next few lessons.
 
 Writing — follow one word you can see.
 Keep Hallo visible. Trace directly over it, then copy it once in large, slow letters. Say HA-lo while your hand moves. Stop there.
@@ -109,7 +109,7 @@ die corresponds to the -y of English the/they.
 Unlike Spanish el/la (from Latin ille/illa), German's articles are cousins of English's own "the" — Germanic all the way.
 
 Grammar Lens: German kept THREE genders.
-Here's the twist. Latin had three genders (masculine, feminine, neuter); Spanish and French collapsed to two, folding neuter into masculine. German kept all three: der (masc.), die (fem.), das (neut.). So a German noun is one of three classes, not two — and, as everywhere, the gender is unpredictable and must be learned with the noun (der Tag, die Nacht, das Kind "the child"). English, meanwhile, threw gender out entirely and kept a single "the" — the opposite extreme.
+Here's the twist. Latin had three genders (masculine, feminine, neuter); Spanish and French collapsed to two, folding neuter into masculine. German kept all three: der (masc.), die (fem.), das (neut.). So a German noun is one of three classes, not two — and, as everywhere, the gender is unpredictable and must be learned with the noun and its article. English, meanwhile, threw gender out entirely and kept a single "the" — the opposite extreme. Your next nouns will let you practise that pairing.
 One more thing coming later: German articles also change by case (their job in the sentence), so der has other forms (den, dem, des). Ignore that for now; just learn der / die / das as the three "the"s.
 
 Guided Practice.
@@ -118,7 +118,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: "das" then English "that" — the t becomes s shift]
 [pause 8 seconds for the answer]
-[your turn — say: "der Tag" (masc.), "die Nacht" (fem.) — the nouns are coming]
+[your turn — say: "der" for masculine, "die" for feminine, "das" for neuter]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
@@ -161,8 +161,6 @@ Tag and English day share a Germanic root; the shift is which consonant change? 
 Lesson 6 of 13.
 Guten Tag — assembled, and a first taste of German endings.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
-
 Warm-up.
 [pause 2 seconds]
 Snap gut and Tag together for the standard polite greeting. But notice — gut shows up as guten, and that extra -en is your first glimpse of how German adjectives work.
@@ -174,8 +172,8 @@ The word, taken apart — by assembling it.
 Guten Tag = gut ("good") + Tag ("day") = "good day," the neutral polite "hello" for daytime. Said GOO-ten tahk.
 
 Grammar Lens: why guten, not gut?
-Like every Germanic and Romance adjective, German gut agrees with its noun — but German adjectives agree in more dimensions than Spanish or French: not just gender and number, but case (the noun's job in the sentence). Guten Tag is a frozen leftover of a fuller phrase — "[ich wünsche Ihnen einen] guten Tag," "[I wish you a] good day" — where "a good day" is the object of the wish (the accusative case). For a masculine noun in that role, gut takes the ending -en: guten.
-Don't try to master German's ending system now — it's a later chapter. Just bank two things: (1) German adjectives take endings that shift with gender, number, and case; (2) the greeting is really "(I wish you a) good day," which is why it's guten. You'll see the contrast next: Gute Nacht, with a different ending, because Nacht is feminine.
+Like every Germanic and Romance adjective, German gut agrees with its noun — but German adjectives agree in more dimensions than Spanish or French: not just gender and number, but case (the noun's job in the sentence). Guten Tag is a frozen piece of a fuller phrase meaning "I wish you a good day." In that fuller thought, "a good day" is the object of the wish (the accusative case). For a masculine noun in that role, gut takes the ending -en: guten.
+Don't try to master German's ending system now — it's a later chapter. Just bank two things: (1) German adjectives take endings that shift with gender, number, and case; (2) the greeting is really "(I wish you a) good day," which is why it's guten. A later bedtime greeting will give you a gentle contrast with a feminine noun and a different ending.
 
 Guided Practice.
 [pause 1 second]
@@ -204,7 +202,7 @@ Morgen = MOR-gen — the g is a hard g; the German r is soft and guttural.
 
 The word, taken apart.
 der Morgen — "the morning" (masculine). Root: Proto-Germanic murganaz — the same root as English morning, morn, and the -morrow in tomorrow ("to-morrow" = "at [the] morning [to come]"). No Latin detour; German Morgen and English morning are the same Germanic word, barely changed.
-A small false-friend warning for later: German Morgen also means "tomorrow" on its own (bis morgen = "until tomorrow"). Context tells them apart. English kept the two senses in separate words (morning vs tomorrow); German lets Morgen do both.
+A small false-friend warning for later: German Morgen can also mean "tomorrow." A later farewell will reuse it with that meaning. Context tells the two senses apart; English keeps them in separate words (morning vs tomorrow), while German lets Morgen do both jobs.
 
 Grammar Lens.
 Morgen is masculine (der Morgen) — so, like Tag, it will take guten in the greeting.
@@ -233,7 +231,7 @@ Guten Tag, Morgen.
 
 The word, taken apart — by assembling it.
 Guten Morgen = gut ("good") + Morgen ("morning") = "good morning." Morgen is masculine, exactly like Tag, so gut takes the same -en: guten — no new agreement to learn. Said GOO-ten MOR-gen.
-Used in the morning (roughly until midday); after that, German switches to Guten Tag, then Guten Abend in the evening — the same day-parts you're building.
+Used in the morning (roughly until midday); after that, German switches to Guten Tag. You will build the evening greeting next, from the same familiar pattern.
 
 Guided Practice.
 [pause 1 second]
@@ -265,7 +263,7 @@ der Abend — "the evening" (masculine). Root: Proto-Germanic ābanþs — the s
 Contrast worth banking across all four languages: "evening" has a different root in each branch — Germanic ābanþs (German Abend, English eve), vs Latin sērus "late" (French soir) and Latin tardus "late" (Spanish tarde). The Romance pair named it after lateness; the Germanic pair named it after the evening-down of the day.
 
 Grammar Lens.
-Abend is masculine (der Abend) — so, again, guten in the greeting. Three masculine day-parts in a row (Tag, Morgen, Abend) all take guten; the feminine Nacht, next, will break the streak.
+Abend is masculine (der Abend) — so, again, guten in the greeting. Three masculine day-parts in a row (Tag, Morgen, Abend) all take guten. The next day-part is feminine, so it will gently show you a different ending without adding a new rule to memorize now.
 
 Guided Practice.
 [pause 1 second]
@@ -407,4 +405,4 @@ Run Guten Morgen becomes Guten Tag becomes Guten Abend becomes Gute Nacht withou
 
 Wrap-up Recall.
 [pause 3 seconds]
-Which German greeting uses gute, not guten, and why? (Gute Nacht — Nacht is feminine.) Next chapter: introducing yourself — ich heiße… — and German's formal/informal "you," du vs Sie.
+Which German greeting uses gute, not guten, and why? (Gute Nacht — Nacht is feminine.) Next chapter, you will learn to introduce yourself and then build the friendly and respectful ways to address someone.

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -1006,6 +1006,20 @@ describe("the real corpus", () => {
     expect(of("veinte")).toBeUndefined();
   });
 
+  it("keeps German Chapter 1 free of untaught target-language previews", () => {
+    const { lessons } = loadEverything();
+    const german = measureContinuity(lessons).forwardReferences.filter(
+      (reference) => reference.language === "german",
+    );
+
+    // #12350 removes ten previews from the opening chapter. The learner now
+    // meets each German form in its owning lesson instead of seeing evening,
+    // night, farewell, and Chapter 2 pronoun vocabulary early. The remaining
+    // track-wide debt is explicit and may fall, never grow.
+    expect(german.length).toBeLessThanOrEqual(45);
+    expect(german.filter((reference) => reference.lessonId.startsWith("GE-C01-"))).toEqual([]);
+  });
+
   it("keeps the windows expanding, which is the whole point", () => {
     let previous = 0;
     for (const window of REINFORCEMENT_WINDOWS) {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -966,7 +966,13 @@ describe("corpus regression", () => {
       // All eight Chapter-17 lessons remain voice-first.
       // +6, and it is the same six lessons that leave `sight` below.
       // +8, the eight chapter 4-5 lessons that drop their inline script sections.
-      voice: 2461, // Marwadi's final four-skill courtesy checkpoint is voice-first.
+      // +1 voice / -1 sight: GE-C01-guten-tag no longer prints an untaught fuller
+      // German sentence. Its spoken greeting lesson is now honestly voice-first.
+      voice: 2462, // German's cleaned opener adds one voice-first lesson; Marwadi's final courtesy checkpoint is voice-first too.
+      /* Superseded merge-side totals:
+      voice: 2463, // +2: Arabic marḥaban and the full greeting become genuinely voice-first. // Italian's legacy opener now exposes its pen dependency.
+      voice: 2460, // Italian and Portuguese legacy openers now expose their pen dependencies.
+      */
       // -3 sight / +3 voice: TA-C02-en, -enna and -peyar dropped their "The letters in
       // this word" sections once TA-W08 and TA-W09 gave those glyphs a home in the
       // strand. Verified against the GENERATED manifest, not the source — all three now
@@ -986,7 +992,7 @@ describe("corpus regression", () => {
       // -poy-varugiren, -naalai, -mindum-sandippom and TA-C05-pesu, -velai-sey, -vaazh,
       // -naan-tamizh-pesugiren all flip ["script-block"] -> ["no-visual-dependency"]
       // with an empty detachableSegments, verified against the GENERATED manifest.
-      sight: 589, // Urdu's honest script-bearing migrations add two sight lessons after Arabic removes three greeting blocks.
+      sight: 588, // German removes one visual dependency from the combined Urdu baseline.
       /* Historical cumulative sight ledger retained below.
       sight: 590, // HL-C259: +1 -- GU-C01-practice, see drivableLessons // HL-C251: +1 -- RU-C01-practice, see drivableLessons // merge with main (round 4): +4 -- HL-C231..C240 landed on main while this tranche was in flight // HL-C200: +35 telugu pre-A1 lessons, +7 chapters (chapters 46-52) // HL: +35 -- Sanskrit chapters 24-30, 35 pre-A1 vocabulary lessons // HL-C181: +5 -- chapter 277, the spine closes at 33/33 // HL-C175: +5 -- chapter 272, reading between the lines // HL-C166: +11 -- Sanskrit chapters 19 and 20 // HL-C157 // +5: vocabulary wave 5's honest cousin-script citations in a handful of lessons // +1: HL-C88 slices 5-6 // +18: vocabulary wave 6 // HL-C113 step 7: +2 -- 214 (question marks) and 215 (the accent) cannot be taught by voice // HL-C128 step 2: +1 -- ch223 // HL-C128 step 3: +1 // HL-C128 step 5: +1 // HL-C127: +2 -- ch243 and ch244 turn on written accents, which cannot be heard // kannada pre-A1 tranche: +35 lessons, +7 chapters (chapters 46-52) // malayalam pre-A1 tranche: 35 lessons over 7 chapters -- voice +34 and sight +1 sum to 35; the prefix figures follow from the per-chapter walk // latin pre-A1 tranche: +20 lessons, +4 chapters (chapters 44-47)
       */
@@ -1007,7 +1013,7 @@ describe("corpus regression", () => {
       // drivablePrefixTotal, fullyDrivableChapters and unstartableChapters ALL hold —
       // this tranche adds lessons and removes no inline section, so nothing flips.
       pen: 366, // Marwadi adds two writing lessons and one word lesson with a writing block.
-      drivableLessons: 2461, // Marwadi's final courtesy checkpoint is independently drivable.
+      drivableLessons: 2462, // German adds one hands-free opener; Marwadi's courtesy checkpoint remains drivable.
       /* Superseded merge-side totals:
       pen: 360, // +8: seven Arabic writing micro-lessons plus salām's one-shape opening trace. // +2: Italian's opener trace and guided copy.
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.


### PR DESCRIPTION
## Summary
- remove all ten untaught German forms from Chapter 1 prose and practice
- keep the useful register, agreement, and etymology explanations while deferring German spellings to their owning lessons
- ratchet German forward-language debt from 55 to at most 45 and keep Chapter 1 at zero
- regenerate narration, modality, book, and gentle-ramp artifacts

## Learner impact
The German book now starts one form at a time: a pre-A1 learner does not have to read, pronounce, or remember evening, night, farewell, or Chapter 2 pronoun forms before those lessons teach them. Every edited lesson remains capped at four minutes.

The prose cleanup also makes one Chapter 1 greeting lesson genuinely voice-first, moving German drivable coverage from 88% to 89%.

## Validation
- `npm test -- --run tests/continuity.test.ts tests/gentle-ramp.test.ts tests/levels.test.ts tests/ramp.test.ts tests/narration.test.ts tests/modality.test.ts tests/modality-manifest.test.ts` (234 passed)
- `npm run check:books`
- `npm run check:narration`
- `npm run check:modality`
- `npm run check:gentle-snapshots`
- `npm run check:progress`
- `npm run build`
- `bash data/scripts/build_all_books.sh german` (exit 0; missing/overfull/underfull all zero)

## Stack
Depends on #12349. Please review and merge #12349 first; this PR can then be retargeted to `main` and auto-merge enabled.

Closes #12350
Part of #12206