### PR TITLE
fix(human-languages): soften Italian opening previews

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -3501,7 +3501,7 @@
     {
       "language": "italian",
       "chapter": 1,
-      "sourceHash": "fnv1a64:6585a6b1e8e15fe7",
+      "sourceHash": "fnv1a64:f62735b515d964a2",
       "lessonIds": [
         "IT-C01-ciao",
         "IT-W01-ciao-guided-copy",
@@ -3514,12 +3514,12 @@
         "IT-C01-grazie",
         "IT-C01-practice"
       ],
-      "voiceLessons": 7,
+      "voiceLessons": 8,
       "drivablePrefix": 0,
       "text": "italian/narration/ch01.txt",
       "json": "italian/narration/ch01.json",
-      "textHash": "fnv1a64:a3cab2a642418c39",
-      "jsonHash": "fnv1a64:b8705170264b838d"
+      "textHash": "fnv1a64:bb656ecf5aad27da",
+      "jsonHash": "fnv1a64:08fe26246dcc6010"
     },
     {
       "language": "italian",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/italian.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/italian.json
@@ -14,7 +14,7 @@
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
-  "forwardReferences": 44,
+  "forwardReferences": 34,
   "atomsTaught": 200,
   "atomsNeverRevisited": 19,
   "reinforcementWindowMisses": 282,
@@ -26,7 +26,7 @@
     {
       "language": "italian",
       "kind": "forward-language",
-      "count": 44,
+      "count": 34,
       "unit": "use(s)",
       "detail": "teach target-language material before load-bearing use"
     },
@@ -62,7 +62,7 @@
   "next": {
     "language": "italian",
     "kind": "forward-language",
-    "count": 44,
+    "count": 34,
     "unit": "use(s)",
     "detail": "teach target-language material before load-bearing use"
   }

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,13 +7,13 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:1c3ee9e17181a1d6",
+  "sourceHash": "fnv1a64:cd8f34429c23eeeb",
   "summary": {
     "totalLessons": 3416,
-    "voice": 2462,
-    "sight": 588,
+    "voice": 2463,
+    "sight": 587,
     "pen": 366,
-    "drivableLessons": 2462,
+    "drivableLessons": 2463,
     "drivablePercent": 72,
     "trackCount": 23,
     "chapterCount": 1005,
@@ -3643,10 +3643,10 @@
     {
       "language": "italian",
       "lessonCount": 89,
-      "voice": 71,
-      "sight": 16,
+      "voice": 72,
+      "sight": 15,
       "pen": 2,
-      "drivablePercent": 80,
+      "drivablePercent": 81,
       "drivablePrefixTotal": 54,
       "modalities": [
         "voice",
@@ -3657,8 +3657,8 @@
         {
           "chapter": 1,
           "lessonCount": 10,
-          "voice": 7,
-          "sight": 1,
+          "voice": 8,
+          "sight": 0,
           "pen": 2,
           "modalities": [
             "voice",
@@ -33606,7 +33606,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8c20b66619135cdf",
+      "sourceHash": "fnv1a64:7bd946e9a0911e43",
       "detachableSegments": [
         "Writing — follow the greeting you can see"
       ]
@@ -33649,7 +33649,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:2db5c41d4c4ee96c"
+      "sourceHash": "fnv1a64:1a009286963919e4"
     },
     {
       "id": "IT-C01-il-la-lo",
@@ -33667,7 +33667,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4e47245ae0ffffe4"
+      "sourceHash": "fnv1a64:e2fe477a454e308a"
     },
     {
       "id": "IT-C01-giorno",
@@ -33703,7 +33703,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4d06591169ec14c8"
+      "sourceHash": "fnv1a64:f7d36199668fda70"
     },
     {
       "id": "IT-C01-sera",
@@ -33728,18 +33728,18 @@
       "language": "italian",
       "chapter": 1,
       "sequence": 70,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "wide-table"
+        "no-visual-dependency"
       ],
-      "coreModality": "sight",
+      "coreModality": "voice",
       "coreReasons": [
-        "wide-table"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:80c32e88e71504c6"
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6b3f034049e20398"
     },
     {
       "id": "IT-C01-grazie",
@@ -33757,7 +33757,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:45be76e3ae3aa5cf"
+      "sourceHash": "fnv1a64:9564370f405668b5"
     },
     {
       "id": "IT-C01-practice",
@@ -33775,7 +33775,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c887f7af7f33d4a4"
+      "sourceHash": "fnv1a64:30418fbe799afe68"
     },
     {
       "id": "IT-C02-prego",

--- a/code/learning/human-languages/italian/book/chapter-modalities.tex
+++ b/code/learning/human-languages/italian/book/chapter-modalities.tex
@@ -30,7 +30,7 @@
 
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (7) \quad \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (2)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (8) \quad \hlpensign{}~\textbf{pen} (2)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 10 lessons.%
     \par}\medskip
 }

--- a/code/learning/human-languages/italian/lessons/IT-C01-buongiorno.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-buongiorno.md
@@ -29,8 +29,8 @@ reviews_of: [IT-C01-buono, IT-C01-giorno]
 
 Where the casual *ciao* says "I'm your servant," *buongiorno* simply wishes you
 a good day — and it's the **safe, respectful** choice with anyone: shopkeepers,
-strangers, elders. Used through the day until late afternoon, when it gives way
-to *buonasera*.
+strangers, elders. Use it through the day until late afternoon. A later lesson
+will build the corresponding evening greeting.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/italian/lessons/IT-C01-buono.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-buono.md
@@ -17,13 +17,13 @@ reviews_of: [IT-C01-ciao]
 
 ## Warm-up
 
-[PAUSE 2s] The word that starts *buongiorno*, *buonasera*, *buonanotte*. Learn
-it alone first.
+[PAUSE 2s] One small word meaning "good." Learn it alone first; later lessons
+will show how it helps build several greetings.
 
 ## Sounds you'll need
 
 - **buono** = *BWOH-no* (the *uo* is a glide). Before a masculine noun it clips
-  to **buon** (*bwon*) — *buon giorno*.
+  to **buon** (*bwon*).
 
 ## The word, taken apart
 
@@ -35,7 +35,8 @@ made *bonus* into *bueno*; Italian kept it closer, *buono*.
 
 **buono** changes to match its noun's gender and number: *buono* (m.), *buona*
 (f.), *buoni* / *buone* (pl.) — Latin's legacy across the Romance family. Before
-a masculine noun it drops the *-o* to **buon** (*buon giorno*).
+a masculine noun it can drop the *-o* to **buon**. For now, just hear and say
+that small change; the next nouns will give it a job.
 
 ## Guided Practice
 
@@ -45,5 +46,5 @@ a masculine noun it drops the *-o* to **buon** (*buon giorno*).
 
 ## Wrap-up Recall
 
-[PAUSE 3s] What Latin word is **buono** from, and why does it become *buon* in
-*buon giorno*? (*bonus*; it drops *-o* before a masculine noun.)
+[PAUSE 3s] What Latin word is **buono** from, and what short form can it take
+before a masculine noun? (*bonus*; *buon*, with the final *-o* dropped.)

--- a/code/learning/human-languages/italian/lessons/IT-C01-ciao.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-ciao.md
@@ -56,8 +56,9 @@ casual *ciao* is a fossil of "I am your servant."
 
 *ciao* is **informal**, and works both coming and going ("hi" and "bye") — for
 friends, family, peers. To someone you'd show respect, or on a first meeting,
-you reach for *buongiorno* (coming soon). Doubled, *ciao ciao*, it's a breezy
-"bye-bye."
+you reach for a polite daytime greeting instead. You will build that greeting
+from two small pieces later in this chapter. Doubled, *ciao ciao*, it's a
+breezy "bye-bye."
 
 ## Writing — follow the greeting you can see
 <!-- hl-knowledge: introduces=[]; assesses=[IT-PHONO-CIAO-01, IT-PRAGMATIC-CIAO-03] -->

--- a/code/learning/human-languages/italian/lessons/IT-C01-grazie.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-grazie.md
@@ -33,19 +33,16 @@ in**grat**iate. So *grazie* literally wishes someone **grace**.
 
 ## Why it's said this way
 
-The reply is **prego** ("you're welcome") — literally "I pray [it's nothing],"
-from Latin *precari* ("to pray," → English *pray*, *precarious*). You give
-thanks/grace; they wave it off with a prayer.
+Think of **grazie** as offering someone "graces" for what they did. In the next
+chapter, you will learn the short reply people use after hearing it.
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "grazie" (*GRAH-tsyeh*)]
 - [YOU SAY: the cousins — *grace*, *gratitude*, *gratis*]
-- [YOU SAY: the reply — "prego"]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What Latin word is **grazie** from, and three English cousins?
-(*gratia*, "grace"; *grace*, *gratitude*, *gratis*.) The reply to *grazie*?
-(*prego*.)
+(*gratia*, "grace"; *grace*, *gratitude*, *gratis*.)

--- a/code/learning/human-languages/italian/lessons/IT-C01-il-la-lo.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-il-la-lo.md
@@ -24,16 +24,16 @@ gender — a habit inherited from Latin.
 
 **il** and **lo** (masculine "the") and **la** (feminine) ← Latin **ille** /
 **illa** ("that one"), the pointing word worn down to "the." The same *ille/illa*
-gave Spanish *el/la* and French *le/la* — and also Italian **lui** / **lei**
-("he/she"). (English "the" is Germanic, unrelated.)
+gave Spanish *el/la* and French *le/la*. English "the" is Germanic and
+unrelated.
 
 ## Grammar Lens: gender, and two masculine "the"s
 
 Every Italian noun is **masculine or feminine** — Latin's three genders (the
 neuter folding into the masculine) collapsed to two. Learn each noun *with* its
 article. Italian has **two** masculine articles: **lo** before tricky clusters
-(*lo studente*, *lo zio*), **il** everywhere else (*il giorno*); feminine is
-always **la**. Meet *il* at your first noun, next.
+at the start of a noun, **il** in the ordinary pattern; feminine is always
+**la**. Your first noun comes next, so you can practise one real pairing then.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/italian/lessons/IT-C01-notte.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-notte.md
@@ -23,29 +23,22 @@ once.
 ## The word, taken apart
 
 **la notte** (fem.) ← Latin **noctem** (*noct-*) → English **noct**urnal,
-equi**nox**. The change is a **rule**: Latin *-ct-* became Italian **-tt-**
-(*no**tt**e*), where Spanish softened it to *-ch-* (*noche*) and French to *-it-*
-(*nuit*):
-
-| Latin | Italian | Spanish | French | English |
-|---|---|---|---|---|
-| *noctem* | no**tt**e | no**ch**e | nu**it** | night |
-| *lactem* | la**tt**e | le**ch**e | la**it** | (lact-) |
-| *factum* | fa**tt**o | he**ch**o | fa**it** | fact |
-
-Learn the rule once and Italian's double *tt* words light up.
+equi**nox**. Watch just one change today: Latin *-ct-* became Italian **-tt-**,
+so *noc**t**em* became *no**tt**e*. Spanish and French reshaped that same root
+in their own ways. Later words will let you see whether this pattern repeats;
+there is no list to memorize now.
 
 **buonanotte** = *buona* + *notte*, "good night" — the farewell for bed (not an
-evening hello; that's *buonasera*).
+evening hello; use the evening greeting you already learned for that).
 
 ## Guided Practice
 
 [PAUSE 1s]
 - [YOU SAY: "buonanotte"]
-- [YOU SAY: the rule — Latin *-ct-* → Italian *-tt-* (*notte*, *latte*, *fatto*)]
+- [YOU SAY: the one change you saw — Latin *noctem* → Italian *notte*]
 
 ## Wrap-up Recall
 
 [PAUSE 3s] What Latin word gave **notte**, and what regular sound-change does it
-show? (*noctem*; Latin *-ct-* → Italian *-tt-*.) When is *buonanotte* used vs.
-*buonasera*? (Bedtime farewell vs. evening greeting.)
+show? (*noctem*; Latin *-ct-* → Italian *-tt-*.) When is *buonanotte* used?
+(As a bedtime farewell.)

--- a/code/learning/human-languages/italian/lessons/IT-C01-practice.md
+++ b/code/learning/human-languages/italian/lessons/IT-C01-practice.md
@@ -50,5 +50,6 @@ vowel** (*giorno* → *giorni*), not adding *-s*.
 (*ciao*.) What sound-rule turns Latin *noctem* into Italian *notte*? (*-ct-* →
 *-tt-*.)
 
-Next chapter: introducing yourself — *mi chiamo…* ("my name is…") — and Italian's
-*tu* vs. *Lei* (familiar / formal "you").
+Next chapter, you will learn how to introduce yourself and how to address
+someone in a familiar or respectful way. Those new Italian forms can wait for
+their own small lessons.

--- a/code/learning/human-languages/italian/narration/ch01.json
+++ b/code/learning/human-languages/italian/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6585a6b1e8e15fe7",
+  "sourceHash": "fnv1a64:f62735b515d964a2",
   "lessons": [
     {
       "id": "IT-C01-ciao",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "writing-block"
       ],
-      "sourceHash": "fnv1a64:8c20b66619135cdf",
+      "sourceHash": "fnv1a64:7bd946e9a0911e43",
       "notice": {
         "modality": "pen",
         "needs": [],
@@ -73,7 +73,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "ciao is informal, and works both coming and going (\"hi\" and \"bye\") — for friends, family, peers. To someone you'd show respect, or on a first meeting, you reach for buongiorno (coming soon). Doubled, ciao ciao, it's a breezy \"bye-bye.\""
+              "text": "ciao is informal, and works both coming and going (\"hi\" and \"bye\") — for friends, family, peers. To someone you'd show respect, or on a first meeting, you reach for a polite daytime greeting instead. You will build that greeting from two small pieces later in this chapter. Doubled, ciao ciao, it's a breezy \"bye-bye.\""
             }
           ]
         },
@@ -227,7 +227,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2db5c41d4c4ee96c",
+      "sourceHash": "fnv1a64:1a009286963919e4",
       "notice": null,
       "blocks": [
         {
@@ -243,7 +243,7 @@
             },
             {
               "kind": "speech",
-              "text": "The word that starts buongiorno, buonasera, buonanotte. Learn it alone first."
+              "text": "One small word meaning \"good.\" Learn it alone first; later lessons will show how it helps build several greetings."
             }
           ]
         },
@@ -254,7 +254,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "buono = BWOH-no (the uo is a glide). Before a masculine noun it clips to buon (bwon) — buon giorno."
+              "text": "buono = BWOH-no (the uo is a glide). Before a masculine noun it clips to buon (bwon)."
             }
           ]
         },
@@ -276,7 +276,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "buono changes to match its noun's gender and number: buono (m.), buona (f.), buoni / buone (pl.) — Latin's legacy across the Romance family. Before a masculine noun it drops the -o to buon (buon giorno)."
+              "text": "buono changes to match its noun's gender and number: buono (m.), buona (f.), buoni / buone (pl.) — Latin's legacy across the Romance family. Before a masculine noun it can drop the -o to buon. For now, just hear and say that small change; the next nouns will give it a job."
             }
           ]
         },
@@ -324,7 +324,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Latin word is buono from, and why does it become buon in buon giorno? (bonus; it drops -o before a masculine noun.)"
+              "text": "What Latin word is buono from, and what short form can it take before a masculine noun? (bonus; buon, with the final -o dropped.)"
             }
           ]
         }
@@ -343,7 +343,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4e47245ae0ffffe4",
+      "sourceHash": "fnv1a64:e2fe477a454e308a",
       "notice": null,
       "blocks": [
         {
@@ -370,7 +370,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "il and lo (masculine \"the\") and la (feminine) from Latin ille / illa (\"that one\"), the pointing word worn down to \"the.\" The same ille/illa gave Spanish el/la and French le/la — and also Italian lui / lei (\"he/she\"). (English \"the\" is Germanic, unrelated.)"
+              "text": "il and lo (masculine \"the\") and la (feminine) from Latin ille / illa (\"that one\"), the pointing word worn down to \"the.\" The same ille/illa gave Spanish el/la and French le/la. English \"the\" is Germanic and unrelated."
             }
           ]
         },
@@ -381,7 +381,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Every Italian noun is masculine or feminine — Latin's three genders (the neuter folding into the masculine) collapsed to two. Learn each noun with its article. Italian has two masculine articles: lo before tricky clusters (lo studente, lo zio), il everywhere else (il giorno); feminine is always la. Meet il at your first noun, next."
+              "text": "Every Italian noun is masculine or feminine — Latin's three genders (the neuter folding into the masculine) collapsed to two. Learn each noun with its article. Italian has two masculine articles: lo before tricky clusters at the start of a noun, il in the ordinary pattern; feminine is always la. Your first noun comes next, so you can practise one real pairing then."
             }
           ]
         },
@@ -576,7 +576,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4d06591169ec14c8",
+      "sourceHash": "fnv1a64:f7d36199668fda70",
       "notice": null,
       "blocks": [
         {
@@ -618,7 +618,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Where the casual ciao says \"I'm your servant,\" buongiorno simply wishes you a good day — and it's the safe, respectful choice with anyone: shopkeepers, strangers, elders. Used through the day until late afternoon, when it gives way to buonasera."
+              "text": "Where the casual ciao says \"I'm your servant,\" buongiorno simply wishes you a good day — and it's the safe, respectful choice with anyone: shopkeepers, strangers, elders. Use it through the day until late afternoon. A later lesson will build the corresponding evening greeting."
             }
           ]
         },
@@ -785,22 +785,13 @@
       "romanization": "notte / buonanotte",
       "gloss": "night / good night",
       "script": "latin",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "wide-table"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:80c32e88e71504c6",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes for one table that cannot be read aloud"
-        ],
-        "waitUntilStopped": [
-          "The word, taken apart"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The word, taken apart until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:6b3f034049e20398",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -826,29 +817,11 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "la notte (fem.) from Latin noctem (noct-) becomes English nocturnal, equinox. The change is a rule: Latin -ct- became Italian -tt- (notte), where Spanish softened it to -ch- (noche) and French to -it- (nuit):"
-            },
-            {
-              "kind": "table-skipped",
-              "reason": "too-wide",
-              "columns": 5,
-              "rowCount": 3,
-              "headers": [
-                "Latin",
-                "Italian",
-                "Spanish",
-                "French",
-                "English"
-              ],
-              "text": "There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: Latin, Italian, Spanish, French, English. Come back and look at it when you have stopped."
+              "text": "la notte (fem.) from Latin noctem (noct-) becomes English nocturnal, equinox. Watch just one change today: Latin -ct- became Italian -tt-, so noctem became notte. Spanish and French reshaped that same root in their own ways. Later words will let you see whether this pattern repeats; there is no list to memorize now."
             },
             {
               "kind": "speech",
-              "text": "Learn the rule once and Italian's double tt words light up."
-            },
-            {
-              "kind": "speech",
-              "text": "buonanotte = buona + notte, \"good night\" — the farewell for bed (not an evening hello; that's buonasera)."
+              "text": "buonanotte = buona + notte, \"good night\" — the farewell for bed (not an evening hello; use the evening greeting you already learned for that)."
             }
           ]
         },
@@ -875,11 +848,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the rule — Latin -ct- becomes Italian -tt- (notte, latte, fatto)",
+              "instruction": "the one change you saw — Latin noctem becomes Italian notte",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the rule — Latin *-ct-* → Italian *-tt-* (*notte*, *latte*, *fatto*)]"
+              "source": "[YOU SAY: the one change you saw — Latin *noctem* → Italian *notte*]"
             }
           ]
         },
@@ -896,7 +869,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Latin word gave notte, and what regular sound-change does it show? (noctem; Latin -ct- becomes Italian -tt-.) When is buonanotte used vs. buonasera? (Bedtime farewell vs. evening greeting.)"
+              "text": "What Latin word gave notte, and what regular sound-change does it show? (noctem; Latin -ct- becomes Italian -tt-.) When is buonanotte used? (As a bedtime farewell.)"
             }
           ]
         }
@@ -915,7 +888,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:45be76e3ae3aa5cf",
+      "sourceHash": "fnv1a64:9564370f405668b5",
       "notice": null,
       "blocks": [
         {
@@ -964,7 +937,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "The reply is prego (\"you're welcome\") — literally \"I pray [it's nothing],\" from Latin precari (\"to pray,\" becomes English pray, precarious). You give thanks/grace; they wave it off with a prayer."
+              "text": "Think of grazie as offering someone \"graces\" for what they did. In the next chapter, you will learn the short reply people use after hearing it."
             }
           ]
         },
@@ -996,15 +969,6 @@
               "scored": false,
               "responseSeconds": 8,
               "source": "[YOU SAY: the cousins — *grace*, *gratitude*, *gratis*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the reply — \"prego\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the reply — \"prego\"]"
             }
           ]
         },
@@ -1021,7 +985,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Latin word is grazie from, and three English cousins? (gratia, \"grace\"; grace, gratitude, gratis.) The reply to grazie? (prego.)"
+              "text": "What Latin word is grazie from, and three English cousins? (gratia, \"grace\"; grace, gratitude, gratis.)"
             }
           ]
         }
@@ -1040,7 +1004,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c887f7af7f33d4a4",
+      "sourceHash": "fnv1a64:30418fbe799afe68",
       "notice": null,
       "blocks": [
         {
@@ -1151,7 +1115,7 @@
             },
             {
               "kind": "speech",
-              "text": "Next chapter: introducing yourself — mi chiamo… (\"my name is…\") — and Italian's tu vs. Lei (familiar / formal \"you\")."
+              "text": "Next chapter, you will learn how to introduce yourself and how to address someone in a familiar or respectful way. Those new Italian forms can wait for their own small lessons."
             }
           ]
         }

--- a/code/learning/human-languages/italian/narration/ch01.txt
+++ b/code/learning/human-languages/italian/narration/ch01.txt
@@ -18,7 +18,7 @@ The word, taken apart.
 ciao began as the Venetian greeting s-ciào (vostro) — "[I am your] slave / servant," a humble "at your service." That s-ciào is Venetian for schiavo ("slave") from Medieval Latin sclavus. The very same word is English slave — and, astonishingly, Slav: medieval slaves were so often Slavic captives that the ethnic name became the word for "slave" across Europe. So every casual ciao is a fossil of "I am your servant."
 
 Why it's said this way.
-ciao is informal, and works both coming and going ("hi" and "bye") — for friends, family, peers. To someone you'd show respect, or on a first meeting, you reach for buongiorno (coming soon). Doubled, ciao ciao, it's a breezy "bye-bye."
+ciao is informal, and works both coming and going ("hi" and "bye") — for friends, family, peers. To someone you'd show respect, or on a first meeting, you reach for a polite daytime greeting instead. You will build that greeting from two small pieces later in this chapter. Doubled, ciao ciao, it's a breezy "bye-bye."
 
 Writing — follow the greeting you can see.
 Keep ciao visible. Point to ci, the two letters that begin the ch sound, then slide your finger through ao. Trace the whole word once from c to o, and say CHOW.
@@ -59,16 +59,16 @@ buono / buon — "good".
 
 Warm-up.
 [pause 2 seconds]
-The word that starts buongiorno, buonasera, buonanotte. Learn it alone first.
+One small word meaning "good." Learn it alone first; later lessons will show how it helps build several greetings.
 
 Sounds you'll need.
-buono = BWOH-no (the uo is a glide). Before a masculine noun it clips to buon (bwon) — buon giorno.
+buono = BWOH-no (the uo is a glide). Before a masculine noun it clips to buon (bwon).
 
 The word, taken apart.
 buono ("good") from Latin bonus becomes English bonus, bonanza, bonbon, and (via French) bounty. Spanish, another daughter of Latin, made bonus into bueno; Italian kept it closer, buono.
 
 Grammar Lens: it agrees with the noun.
-buono changes to match its noun's gender and number: buono (m.), buona (f.), buoni / buone (pl.) — Latin's legacy across the Romance family. Before a masculine noun it drops the -o to buon (buon giorno).
+buono changes to match its noun's gender and number: buono (m.), buona (f.), buoni / buone (pl.) — Latin's legacy across the Romance family. Before a masculine noun it can drop the -o to buon. For now, just hear and say that small change; the next nouns will give it a job.
 
 Guided Practice.
 [pause 1 second]
@@ -79,7 +79,7 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Latin word is buono from, and why does it become buon in buon giorno? (bonus; it drops -o before a masculine noun.)
+What Latin word is buono from, and what short form can it take before a masculine noun? (bonus; buon, with the final -o dropped.)
 
 
 Lesson 4 of 10.
@@ -90,10 +90,10 @@ Warm-up.
 Before your first noun: the words for "the." Italian splits "the" by gender — a habit inherited from Latin.
 
 The word, taken apart.
-il and lo (masculine "the") and la (feminine) from Latin ille / illa ("that one"), the pointing word worn down to "the." The same ille/illa gave Spanish el/la and French le/la — and also Italian lui / lei ("he/she"). (English "the" is Germanic, unrelated.)
+il and lo (masculine "the") and la (feminine) from Latin ille / illa ("that one"), the pointing word worn down to "the." The same ille/illa gave Spanish el/la and French le/la. English "the" is Germanic and unrelated.
 
 Grammar Lens: gender, and two masculine "the"s.
-Every Italian noun is masculine or feminine — Latin's three genders (the neuter folding into the masculine) collapsed to two. Learn each noun with its article. Italian has two masculine articles: lo before tricky clusters (lo studente, lo zio), il everywhere else (il giorno); feminine is always la. Meet il at your first noun, next.
+Every Italian noun is masculine or feminine — Latin's three genders (the neuter folding into the masculine) collapsed to two. Learn each noun with its article. Italian has two masculine articles: lo before tricky clusters at the start of a noun, il in the ordinary pattern; feminine is always la. Your first noun comes next, so you can practise one real pairing then.
 
 Guided Practice.
 [pause 1 second]
@@ -150,7 +150,7 @@ buon ("good") + giorno ("day").
 buongiorno = "good day," one word.
 
 Why it's said this way.
-Where the casual ciao says "I'm your servant," buongiorno simply wishes you a good day — and it's the safe, respectful choice with anyone: shopkeepers, strangers, elders. Used through the day until late afternoon, when it gives way to buonasera.
+Where the casual ciao says "I'm your servant," buongiorno simply wishes you a good day — and it's the safe, respectful choice with anyone: shopkeepers, strangers, elders. Use it through the day until late afternoon. A later lesson will build the corresponding evening greeting.
 
 Guided Practice.
 [pause 1 second]
@@ -192,28 +192,24 @@ What Latin word gave sera, and why is it buonasera but buon giorno? (sera from s
 Lesson 8 of 10.
 notte / buonanotte — "night," and the -ct- becomes -tt- rule.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The word, taken apart until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 "Night" — and a sound-rule that decodes dozens of Italian words at once.
 
 The word, taken apart.
-la notte (fem.) from Latin noctem (noct-) becomes English nocturnal, equinox. The change is a rule: Latin -ct- became Italian -tt- (notte), where Spanish softened it to -ch- (noche) and French to -it- (nuit):
-There is a table here I cannot read to you — 5 columns and 3 rows, and it has more columns than can be held in the ear at once. Its columns are: Latin, Italian, Spanish, French, English. Come back and look at it when you have stopped.
-Learn the rule once and Italian's double tt words light up.
-buonanotte = buona + notte, "good night" — the farewell for bed (not an evening hello; that's buonasera).
+la notte (fem.) from Latin noctem (noct-) becomes English nocturnal, equinox. Watch just one change today: Latin -ct- became Italian -tt-, so noctem became notte. Spanish and French reshaped that same root in their own ways. Later words will let you see whether this pattern repeats; there is no list to memorize now.
+buonanotte = buona + notte, "good night" — the farewell for bed (not an evening hello; use the evening greeting you already learned for that).
 
 Guided Practice.
 [pause 1 second]
 [your turn — say: "buonanotte"]
 [pause 8 seconds for the answer]
-[your turn — say: the rule — Latin -ct- becomes Italian -tt- (notte, latte, fatto)]
+[your turn — say: the one change you saw — Latin noctem becomes Italian notte]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Latin word gave notte, and what regular sound-change does it show? (noctem; Latin -ct- becomes Italian -tt-.) When is buonanotte used vs. buonasera? (Bedtime farewell vs. evening greeting.)
+What Latin word gave notte, and what regular sound-change does it show? (noctem; Latin -ct- becomes Italian -tt-.) When is buonanotte used? (As a bedtime farewell.)
 
 
 Lesson 9 of 10.
@@ -230,7 +226,7 @@ The word, taken apart.
 grazie ("thanks") from Latin gratiae, plural of gratia ("favour, thanks, grace"). It's the same gratia behind English grace, gratitude, grateful, gratis ("free"), congratulate, and ingratiate. So grazie literally wishes someone grace.
 
 Why it's said this way.
-The reply is prego ("you're welcome") — literally "I pray [it's nothing]," from Latin precari ("to pray," becomes English pray, precarious). You give thanks/grace; they wave it off with a prayer.
+Think of grazie as offering someone "graces" for what they did. In the next chapter, you will learn the short reply people use after hearing it.
 
 Guided Practice.
 [pause 1 second]
@@ -238,12 +234,10 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: the cousins — grace, gratitude, gratis]
 [pause 8 seconds for the answer]
-[your turn — say: the reply — "prego"]
-[pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Latin word is grazie from, and three English cousins? (gratia, "grace"; grace, gratitude, gratis.) The reply to grazie? (prego.)
+What Latin word is grazie from, and three English cousins? (gratia, "grace"; grace, gratitude, gratis.)
 
 
 Lesson 10 of 10.
@@ -276,4 +270,4 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Say all five greetings. Which one once meant "I am your slave"? (ciao.) What sound-rule turns Latin noctem into Italian notte? (-ct- becomes -tt-.)
-Next chapter: introducing yourself — mi chiamo… ("my name is…") — and Italian's tu vs. Lei (familiar / formal "you").
+Next chapter, you will learn how to introduce yourself and how to address someone in a familiar or respectful way. Those new Italian forms can wait for their own small lessons.

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -1020,6 +1020,19 @@ describe("the real corpus", () => {
     expect(german.filter((reference) => reference.lessonId.startsWith("GE-C01-"))).toEqual([]);
   });
 
+  it("keeps Italian Chapter 1 free of untaught target-language previews", () => {
+    const { lessons } = loadEverything();
+    const italian = measureContinuity(lessons).forwardReferences.filter(
+      (reference) => reference.language === "italian",
+    );
+
+    // #12352 removes ten previews from the opening chapter, including a food
+    // word 69 lessons early and an introduction phrase ten lessons early. The
+    // remaining track-wide debt is explicit and may fall, never grow.
+    expect(italian.length).toBeLessThanOrEqual(34);
+    expect(italian.filter((reference) => reference.lessonId.startsWith("IT-C01-"))).toEqual([]);
+  });
+
   it("keeps the windows expanding, which is the whole point", () => {
     let previous = 0;
     for (const window of REINFORCEMENT_WINDOWS) {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -968,7 +968,9 @@ describe("corpus regression", () => {
       // +8, the eight chapter 4-5 lessons that drop their inline script sections.
       // +1 voice / -1 sight: GE-C01-guten-tag no longer prints an untaught fuller
       // German sentence. Its spoken greeting lesson is now honestly voice-first.
-      voice: 2462, // German's cleaned opener adds one voice-first lesson; Marwadi's final courtesy checkpoint is voice-first too.
+      // +1 voice / -1 sight: IT-C01-notte replaces its five-language comparison
+      // table with one spoken Latin-to-Italian change, making it voice-first too.
+      voice: 2463, // Italian adds one voice-first lesson after German; Marwadi's courtesy checkpoint remains voice-first too.
       /* Superseded merge-side totals:
       voice: 2463, // +2: Arabic marḥaban and the full greeting become genuinely voice-first. // Italian's legacy opener now exposes its pen dependency.
       voice: 2460, // Italian and Portuguese legacy openers now expose their pen dependencies.
@@ -992,7 +994,7 @@ describe("corpus regression", () => {
       // -poy-varugiren, -naalai, -mindum-sandippom and TA-C05-pesu, -velai-sey, -vaazh,
       // -naan-tamizh-pesugiren all flip ["script-block"] -> ["no-visual-dependency"]
       // with an empty detachableSegments, verified against the GENERATED manifest.
-      sight: 588, // German removes one visual dependency from the combined Urdu baseline.
+      sight: 587, // Italian removes one more visual dependency after German's opener cleanup.
       /* Historical cumulative sight ledger retained below.
       sight: 590, // HL-C259: +1 -- GU-C01-practice, see drivableLessons // HL-C251: +1 -- RU-C01-practice, see drivableLessons // merge with main (round 4): +4 -- HL-C231..C240 landed on main while this tranche was in flight // HL-C200: +35 telugu pre-A1 lessons, +7 chapters (chapters 46-52) // HL: +35 -- Sanskrit chapters 24-30, 35 pre-A1 vocabulary lessons // HL-C181: +5 -- chapter 277, the spine closes at 33/33 // HL-C175: +5 -- chapter 272, reading between the lines // HL-C166: +11 -- Sanskrit chapters 19 and 20 // HL-C157 // +5: vocabulary wave 5's honest cousin-script citations in a handful of lessons // +1: HL-C88 slices 5-6 // +18: vocabulary wave 6 // HL-C113 step 7: +2 -- 214 (question marks) and 215 (the accent) cannot be taught by voice // HL-C128 step 2: +1 -- ch223 // HL-C128 step 3: +1 // HL-C128 step 5: +1 // HL-C127: +2 -- ch243 and ch244 turn on written accents, which cannot be heard // kannada pre-A1 tranche: +35 lessons, +7 chapters (chapters 46-52) // malayalam pre-A1 tranche: 35 lessons over 7 chapters -- voice +34 and sight +1 sum to 35; the prefix figures follow from the per-chapter walk // latin pre-A1 tranche: +20 lessons, +4 chapters (chapters 44-47)
       */
@@ -1013,7 +1015,7 @@ describe("corpus regression", () => {
       // drivablePrefixTotal, fullyDrivableChapters and unstartableChapters ALL hold —
       // this tranche adds lessons and removes no inline section, so nothing flips.
       pen: 366, // Marwadi adds two writing lessons and one word lesson with a writing block.
-      drivableLessons: 2462, // German adds one hands-free opener; Marwadi's courtesy checkpoint remains drivable.
+      drivableLessons: 2463, // Italian adds one more hands-free opener after German; Marwadi's checkpoint remains drivable.
       /* Superseded merge-side totals:
       pen: 360, // +8: seven Arabic writing micro-lessons plus salām's one-shape opening trace. // +2: Italian's opener trace and guided copy.
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -656,6 +656,8 @@ describe("the whole corpus", () => {
     // singular comparisons. Publishing Chapters 7-18 from the canonical AST
     // also replaces the Chapter-15 and Chapter-16 terminal recap tables with
     // speakable person rows. Chapter 18 removes its remaining refused wide table.
-    expect(refusals).toBe(65); // HL-C113: unchanged -- ch204 has no table for the narrator to refuse // HL-C157: ayer + hablare close A2
+    // #12352 removes Italian Chapter 1's five-language sound-change table: the
+    // pre-A1 lesson now asks the learner to hear one noctem -> notte change.
+    expect(refusals).toBe(64); // HL-C113: unchanged -- ch204 has no table for the narrator to refuse // HL-C157: ayer + hablare close A2
   });
 });


### PR DESCRIPTION
## Summary
- remove all ten untaught Italian forms from Chapter 1 prose and practice
- narrow the night sound-change lesson from a five-language table to one speakable `noctem` → `notte` observation
- remove unmeasured Chapter 2 introduction/register previews as well
- ratchet Italian forward-language debt from 44 to at most 34 and keep Chapter 1 at zero
- regenerate narration, modality, book, and gentle-ramp artifacts

## Learner impact
The Italian book now starts one form at a time. A pre-A1 learner does not meet a food word 69 lessons early, an introduction phrase ten lessons early, or a cluster of unassembled greetings in the first few minutes. Every edited lesson remains capped at four minutes.

The narrower sound-change lesson is fully speakable, so Italian drivable coverage improves from 80% to 81% and the corpus has one fewer narration refusal.

## Validation
- `npm test -- --run tests/continuity.test.ts tests/gentle-ramp.test.ts tests/levels.test.ts tests/ramp.test.ts tests/narration.test.ts tests/modality.test.ts tests/modality-manifest.test.ts` (235 passed)
- `npm run check:books`
- `npm run check:narration`
- `npm run check:modality`
- `npm run check:gentle-snapshots`
- `npm run check:progress`
- `npm run build`
- `bash data/scripts/build_all_books.sh italian` (exit 0; missing/overfull/underfull all zero)

## Stack
Depends on #12351. Please merge the stack in order; this PR can then be retargeted to `main` and auto-merge enabled.

Closes #12352
Part of #12206