### PR TITLE
feat(human-languages): define Japanese pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/japanese/CHANGELOG.md
+++ b/code/learning/human-languages/japanese/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Japanese curriculum track are recorded here.
 
 ## [Unreleased]
 
+### Added — pre-A1 four-skill task shapes (#12363)
+
+- Made the project-defined rung below JLPT/JF A1 executable as four independently
+  scored reading, listening, writing, and speaking sections.
+- Kept writing productive: delayed kana recall, dictation/transcription, and one
+  bounded independent response earn points; tracing and visible copying do not.
+- Recorded exact project-owned timing and length bounds without inventing an
+  external “JLPT N6” or implying that chapter coverage proves readiness.
+
 ### Added — pre-A1-to-C2 four-skill assessment contract (#12361)
 
 - Replaced the old unofficial one-level-per-JLPT mapping with the official CEFR

--- a/code/learning/human-languages/japanese/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/japanese/task-shapes/pre-a1.json
@@ -1,0 +1,178 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "level": "pre-A1",
+  "target": {
+    "name": "Coding Adventures Japanese pre-A1 Assessment — project-defined JLPT/JF Standard precursor",
+    "basis": "project-defined"
+  },
+  "sources": [
+    {
+      "id": "ca-hl16-assessment-policy",
+      "title": "HL16 — Exam-ready books and the gentle writing ramp",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "ca-hl18-task-shapes",
+      "title": "HL18 — Four-skill task shapes",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "ca-japanese-assessment",
+      "title": "Coding Adventures Japanese Assessment Specification",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/japanese/assessment-spec.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "jf-standard-overview",
+      "title": "JF Standard for Japanese-Language Education — Overview",
+      "url": "https://www.jfstandard.jpf.go.jp/summaryen/ja/render.do",
+      "published": "current web edition",
+      "accessed": "2026-08-20"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 20,
+    "speakingMinutes": 5,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 1,
+    "deliveryModes": ["paper", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 100,
+    "passPoints": 60,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.6,
+      "listening": 0.6,
+      "writing": 0.6,
+      "speaking": 0.6
+    },
+    "note": "Each skill is worth 25 points and must independently reach 60%; the overall 60-point floor cannot compensate for a failed skill. This project-defined precursor is below the official JLPT and JF Standard A1 ladders."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 5,
+      "parts": [
+        {
+          "id": "prea1-reading-kana-and-doorway-words",
+          "promptModes": ["written-japanese-script"],
+          "promptGenres": ["single known word", "memorized greeting", "classroom cue"],
+          "responseModes": ["selection", "word-to-meaning match"],
+          "items": 5,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 25, "criteria": ["meaning selection", "kana recognition", "whole-word recognition"] },
+          "aids": { "allowed": [], "forbidden": ["romaji", "dictionary", "furigana over already-assessed kana"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment", "jf-standard-overview"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 5,
+      "parts": [
+        {
+          "id": "prea1-listening-greetings-and-one-turn-details",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["greeting exchange", "yes-no response", "isolated identity detail", "classroom cue"],
+          "responseModes": ["selection", "picture match"],
+          "items": 5,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 25, "criteria": ["gist recognition", "detail recognition", "appropriate response selection"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "romaji", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment", "jf-standard-overview"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-kana-recall",
+          "promptModes": ["briefly-visible-written-model"],
+          "promptGenres": ["known kana word"],
+          "responseModes": ["delayed handwritten recall"],
+          "items": 1,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 5, "criteria": ["recognizable kana sequence", "mark placement", "legibility"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "romaji", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["known word", "memorized greeting chunk"],
+          "responseModes": ["handwritten dictation", "Japanese-script transcription"],
+          "items": 2,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 10, "criteria": ["mora-to-script mapping", "kana order", "mark placement", "legibility"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "romaji", "dictionary", "copyable model"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["written-icon-supported-instruction"],
+          "promptGenres": ["personal label", "greeting choice", "yes-no response"],
+          "responseModes": ["independent handwritten word or memorized chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 10, "criteria": ["task completion", "independent retrieval", "orthographic control", "legibility"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["copyable answer model", "romaji", "dictionary", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment", "jf-standard-overview"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 5,
+      "parts": [
+        {
+          "id": "prea1-speaking-doorway-exchange",
+          "promptModes": ["live-speech", "picture cue"],
+          "promptGenres": ["greeting exchange", "one-step identity prompt", "yes-no prompt", "memorized request"],
+          "responseModes": ["spoken memorized chunk", "short personal response"],
+          "items": 5,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 25, "criteria": ["task completion", "intelligibility", "mora timing", "appropriate greeting or response"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repeat request"], "forbidden": ["written answer script", "romaji"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-japanese-assessment", "jf-standard-overview"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -155,6 +155,27 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(inventory.passRule.note).toContain("not an official HSK level");
   });
 
+  it("loads the project-defined Japanese pre-A1 precursor without inventing a JLPT level", () => {
+    const inventory = loadTaskShapeInventory("japanese", "pre-A1");
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Japanese pre-A1 Assessment — project-defined JLPT/JF Standard precursor",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual([
+      "reading",
+      "listening",
+      "writing",
+      "speaking",
+    ]);
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+    expect(inventory.sections.find((section) => section.skill === "writing")?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-kana-recall",
+      "prea1-writing-dictation",
+      "prea1-writing-bounded-production",
+    ]);
+    expect(inventory.passRule.note).toContain("below the official JLPT");
+  });
+
   it("loads the official Spanish A1 performance target and its grouped pass rule", () => {
     const inventory = loadTaskShapeInventory("spanish", "A1");
     expect(inventory.target).toEqual({ name: "DELE A1", basis: "external" });
@@ -326,6 +347,7 @@ describe("four-skill task-shape inventories (HL18)", () => {
       { language: "marwadi", level: "A1" },
       { language: "gujarati", level: "pre-A1" },
       { language: "chinese", level: "pre-A1" },
+      { language: "japanese", level: "pre-A1" },
     ]));
     expect(new Set(present.map((item) => `${item.language}/${item.level}`)).size).toBe(present.length);
     expect(present).toEqual([...present].sort((left, right) => {
@@ -354,6 +376,8 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(backlog.some((item) => item.id === "task-shape/arabic/A2")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/chinese/pre-A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/chinese/A1")).toBe(true);
+    expect(backlog.some((item) => item.id === "task-shape/japanese/pre-A1")).toBe(false);
+    expect(backlog.some((item) => item.id === "task-shape/japanese/A1")).toBe(true);
   });
 
   it("rejects a missing skill instead of treating it as exam-ready", () => {


### PR DESCRIPTION
## Summary
- rescue the Japanese pre-A1 inventory from its obsolete feature history as one Japanese-only commit
- define four independently scored project-owned papers below the official JLPT/JF A1 ladder
- require delayed kana recall, dictation/transcription, and bounded independent writing while giving tracing and visible copying no pass credit
- preserve the append-safe inventory discovery and derived backlog math from parent #12427

## Validation
- TypeScript build
- 82 focused task-shape, assessment, integration, and planner tests
- 913 full serial tests across 72 files
- books, figures, modality, narration, progress, and gentle-snapshot drift checks

Depends on #12427. Retarget to main and enable auto-merge after its parent lands.

Closes #12363
Closes #12428
Part of #12206