### PR TITLE
feat(human-languages): complete Japanese pre-A1 writing ramp

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-book-hashes/japanese.json
@@ -21,7 +21,7 @@
     {
       "language": "japanese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:664789ddc7990979",
+      "sourceHash": "fnv1a64:958b71163f0094dc",
       "lessonIds": [
         "JA-W01-i",
         "JA-W01-ha",

--- a/code/learning/human-languages/core/generated-narration-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/japanese.json
@@ -27,7 +27,7 @@
     {
       "language": "japanese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:6f566408e539a412",
+      "sourceHash": "fnv1a64:44f1c780f26d205d",
       "lessonIds": [
         "JA-W01-i",
         "JA-W01-ha",
@@ -44,8 +44,8 @@
       "drivablePrefix": 0,
       "text": "japanese/narration/ch02.txt",
       "json": "japanese/narration/ch02.json",
-      "textHash": "fnv1a64:3e5230985378a580",
-      "jsonHash": "fnv1a64:4a0f57dceb21953d"
+      "textHash": "fnv1a64:e272464eb26f742b",
+      "jsonHash": "fnv1a64:17ec0ae9d3a112d6"
     },
     {
       "language": "japanese",

--- a/code/learning/human-languages/core/lesson-modality/japanese.json
+++ b/code/learning/human-languages/core/lesson-modality/japanese.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:997f89b3166db51b",
+  "sourceHash": "fnv1a64:fb35a9ffdc62b30e",
   "summary": {
     "totalLessons": 29,
     "voice": 1,
@@ -269,7 +269,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:26298eeb3f317c1e",
+      "sourceHash": "fnv1a64:536c9f5fc624cc79",
       "detachableSegments": [
         "Script — the shape"
       ],
@@ -293,7 +293,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:ffb69730dd67576c",
+      "sourceHash": "fnv1a64:319589a1fed4234f",
       "detachableSegments": [
         "Script — the shape"
       ],
@@ -309,14 +309,16 @@
       "drivable": false,
       "reasons": [
         "writing-type",
-        "script-block"
+        "script-block",
+        "sight-cue"
       ],
       "coreModality": "pen",
       "coreReasons": [
-        "writing-type"
+        "writing-type",
+        "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:62d719b3344477a5",
+      "sourceHash": "fnv1a64:66f8ba352205ee5c",
       "detachableSegments": [
         "Script — no new sign at all"
       ],
@@ -339,7 +341,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:9be9028fc8bdc7fa",
+      "sourceHash": "fnv1a64:3794174c4b117901",
       "detachableSegments": [
         "Script — the shape"
       ],

--- a/code/learning/human-languages/japanese/CHANGELOG.md
+++ b/code/learning/human-languages/japanese/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Japanese curriculum track are recorded here.
 
 ## [Unreleased]
 
+### Added — cumulative pre-A1 writing evidence (#12365)
+
+- Turned four already gentle Chapter 2 lessons into an explicit cumulative
+  writing ladder: trace one visible sign, copy one visible sign with cues, hide
+  and recall one two-sign word, then transcribe one heard or romanized mora.
+- Kept every action inside its original one-sign load and below five minutes;
+  the evidence metadata now follows the learner action instead of merely tagging
+  lessons that happen to contain handwriting.
+
 ### Added — pre-A1 four-skill task shapes (#12363)
 
 - Made the project-defined rung below JLPT/JF A1 executable as four independently

--- a/code/learning/human-languages/japanese/book/chapters/ch02-hiragana-eight.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch02-hiragana-eight.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:664789ddc7990979
+% canonical-source-hash: fnv1a64:958b71163f0094dc
 % canonical-lessons: JA-W01-i, JA-W01-ha, JA-W01-hai-read, JA-W01-e, JA-W01-ko, JA-W01-n, JA-W01-ni, JA-W01-chi, JA-W01-wa, JA-W01-konnichiwa-read
 
 \chapter{Eight Signs, and Three Words You Can Read}
@@ -40,9 +40,11 @@ It is read \textbf{i}, the vowel of English \emph{machine} — short, tight, nev
 \subsection*{Your turn}
 \begin{itemize}
 \raggedright
-  \item \emph{Write it:} \ja{い} — long stroke first, then the short tick
+  \item \emph{Trace it:} follow the visible \ja{い} once — long stroke first, then the short tick
   \item \emph{Say it:} \textbf{i}, one clean beat
 \end{itemize}
+
+Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 How many beats does one hiragana sign take? (\textbf{One.})
@@ -75,9 +77,11 @@ Read \textbf{ha}, breathed rather than hard: the \emph{h} of English \emph{hat},
 \subsection*{Your turn}
 \begin{itemize}
 \raggedright
-  \item \emph{Write it:} \ja{は} — vertical, crossbar, loop
+  \item \emph{Copy:} keep \ja{は} visible and write it once — vertical, crossbar, loop
   \item \emph{Say it:} \textbf{ha}, one beat, breath not force
 \end{itemize}
+
+Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which stroke of \ja{は} is written first? (The \textbf{vertical} on the left.)
@@ -91,11 +95,13 @@ Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana cha
 
 
 \begin{quote}
-Both signs are yours. Write them, in this order, and say each beat as you finish it:
+Both signs are yours. Look at them for five seconds:
 
 \begin{quote}
 \ja{は}   \ja{い}
 \end{quote}
+
+Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
 \end{quote}
 
 \subsection*{Script — no new sign at all}
@@ -159,9 +165,12 @@ You have now read both answers to a yes-or-no question, from the signs up. Neith
 \subsection*{Your turn}
 \begin{itemize}
 \raggedright
-  \item \emph{Write it:} \ja{え} — tick first, then the body in one movement
+  \item Cover the printed \textbf{\ja{え}}. Have a partner or recording say \textbf{e} once. If you are working alone, read the romanized cue \emph{e}, cover it, and continue.
+  \item \emph{Write from the heard or romanized cue:} \ja{え} — tick first, then the body in one movement
   \item \emph{Read it:} \ja{いいえ} — three beats, and do not shorten the doubled sign
 \end{itemize}
+
+Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Why is the first sign of that word written twice? (Because it is \textbf{two beats}, not one held longer.)

--- a/code/learning/human-languages/japanese/lessons/JA-W01-e.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-e.md
@@ -65,9 +65,16 @@ of them was memorised as a picture.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-LEX-IIE] -->
+<!-- hl-writing-stage: dictation-transcription -->
 
-- [YOU WRITE: え — tick first, then the body in one movement]
+- Cover the printed **え**. Have a partner or recording say **e** once. If you
+  are working alone, read the romanized cue *e*, cover it, and continue.
+- [YOU WRITE FROM THE HEARD OR ROMANIZED CUE: え — tick first, then the body in
+  one movement]
 - [YOU READ: いいえ — three beats, and do not shorten the doubled sign]
+
+Uncover the model only after your one transcription attempt. Compare, repair
+one stroke if needed, and stop.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-LEX-IIE] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-ha.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-ha.md
@@ -59,9 +59,13 @@ after you have met the sign it *sounds* like.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HA-01, JA-SCRIPT-I-01] -->
+<!-- hl-writing-stage: guided-copy -->
 
-- [YOU WRITE: は — vertical, crossbar, loop]
+- [YOU COPY: keep は visible and write it once — vertical, crossbar, loop]
 - [YOU SAY: **ha**, one beat, breath not force]
+
+Look back at the model between strokes if you need to. This is one guided copy,
+not a memory test.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HA-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-hai-read.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-hai-read.md
@@ -33,11 +33,15 @@ reviews_of: [JA-W01-ha, JA-W01-i, JA-C01-hai]
 
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HA-01, JA-SCRIPT-I-01] -->
+<!-- hl-writing-stage: delayed-copy -->
 
-[PAUSE 3s] Both signs are yours. Write them, in this order, and say each beat as
-you finish it:
+[PAUSE 3s] Both signs are yours. Look at them for five seconds:
 
 > は   い
+
+Cover the model. Write the two signs in that order and say each beat as you
+finish it. Uncover the model, compare once, and repair at most one stroke. This
+short look-hide-write-check cycle is the whole delayed-copy step.
 
 ## Script — no new sign at all
 <!-- hl-knowledge: introduces=[JA-SCRIPT-HAI-READ-01]; assesses=[JA-SCRIPT-HA-01, JA-SCRIPT-I-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-i.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-i.md
@@ -63,9 +63,13 @@ information and when it does not, and this is the second kind.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-I-01] -->
+<!-- hl-writing-stage: observe-trace -->
 
-- [YOU WRITE: い — long stroke first, then the short tick]
+- [YOU TRACE: follow the visible い once — long stroke first, then the short tick]
 - [YOU SAY: **i**, one clean beat]
+
+Keep the model visible and stop after one traced sign. Copying without the model
+comes later; today your hand is only learning the direction of two strokes.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-I-01, JA-SCRIPT-HIRAGANA-MORA] -->

--- a/code/learning/human-languages/japanese/narration/ch02.json
+++ b/code/learning/human-languages/japanese/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Eight Signs, and Three Words You Can Read",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6f566408e539a412",
+  "sourceHash": "fnv1a64:44f1c780f26d205d",
   "lessons": [
     {
       "id": "JA-W01-i",
@@ -20,7 +20,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:26298eeb3f317c1e",
+      "sourceHash": "fnv1a64:536c9f5fc624cc79",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -93,12 +93,12 @@
           "segments": [
             {
               "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "い — long stroke first, then the short tick",
+              "action": "TRACE",
+              "instruction": "follow the visible い once — long stroke first, then the short tick",
               "spoken": false,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU WRITE: い — long stroke first, then the short tick]"
+              "source": "[YOU TRACE: follow the visible い once — long stroke first, then the short tick]"
             },
             {
               "kind": "prompt",
@@ -108,6 +108,10 @@
               "scored": false,
               "responseSeconds": 8,
               "source": "[YOU SAY: **i**, one clean beat]"
+            },
+            {
+              "kind": "speech",
+              "text": "Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes."
             }
           ]
         },
@@ -163,7 +167,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:ffb69730dd67576c",
+      "sourceHash": "fnv1a64:319589a1fed4234f",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -172,10 +176,9 @@
           "your eyes, because the lesson points at something written down"
         ],
         "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
+          "Script — the shape"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -237,12 +240,12 @@
           "segments": [
             {
               "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "は (ha) — vertical, crossbar, loop",
-              "spoken": false,
+              "action": "COPY",
+              "instruction": "keep は (ha) visible and write it once — vertical, crossbar, loop",
+              "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU WRITE: は — vertical, crossbar, loop]"
+              "source": "[YOU COPY: keep は visible and write it once — vertical, crossbar, loop]"
             },
             {
               "kind": "prompt",
@@ -252,6 +255,10 @@
               "scored": false,
               "responseSeconds": 8,
               "source": "[YOU SAY: **ha**, one beat, breath not force]"
+            },
+            {
+              "kind": "speech",
+              "text": "Look back at the model between strokes if you need to. This is one guided copy, not a memory test."
             }
           ]
         },
@@ -304,20 +311,22 @@
       "derivedModality": "pen",
       "modalityReasons": [
         "writing-type",
-        "script-block"
+        "script-block",
+        "sight-cue"
       ],
-      "sourceHash": "fnv1a64:62d719b3344477a5",
+      "sourceHash": "fnv1a64:66f8ba352205ee5c",
       "notice": {
         "modality": "pen",
         "needs": [
           "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
         ],
         "waitUntilStopped": [
           "Script — no new sign at all",
           "Guided Practice"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -333,11 +342,15 @@
             },
             {
               "kind": "speech",
-              "text": "Both signs are yours. Write them, in this order, and say each beat as you finish it:"
+              "text": "Both signs are yours. Look at them for five seconds:"
             },
             {
               "kind": "speech",
               "text": "は (ha) い (i)."
+            },
+            {
+              "kind": "speech",
+              "text": "Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step."
             }
           ]
         },
@@ -444,7 +457,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9be9028fc8bdc7fa",
+      "sourceHash": "fnv1a64:3794174c4b117901",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -531,13 +544,17 @@
           "title": "Guided Practice",
           "segments": [
             {
+              "kind": "speech",
+              "text": "Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue."
+            },
+            {
               "kind": "prompt",
-              "action": "WRITE",
+              "action": "WRITE FROM THE HEARD OR ROMANIZED CUE",
               "instruction": "え — tick first, then the body in one movement",
               "spoken": false,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU WRITE: え — tick first, then the body in one movement]"
+              "source": "[YOU WRITE FROM THE HEARD OR ROMANIZED CUE: え — tick first, then the body in one movement]"
             },
             {
               "kind": "prompt",
@@ -547,6 +564,10 @@
               "scored": false,
               "responseSeconds": 8,
               "source": "[YOU READ: いいえ — three beats, and do not shorten the doubled sign]"
+            },
+            {
+              "kind": "speech",
+              "text": "Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop."
             }
           ]
         },

--- a/code/learning/human-languages/japanese/narration/ch02.txt
+++ b/code/learning/human-languages/japanese/narration/ch02.txt
@@ -21,9 +21,10 @@ It is read i, the vowel of English machine — short, tight, never the eye of En
 Where the shape came from, and why it does not help you. Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen for their sound, not their meaning, so unlike a Chinese component there is nothing inside い to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind.
 
 Guided Practice.
-[once you have stopped driving — write: い — long stroke first, then the short tick]
+[once you have stopped driving — trace: follow the visible い once — long stroke first, then the short tick]
 [your turn — say: i, one clean beat]
 [pause 8 seconds for the answer]
+Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
 
 Wrap-up Recall.
 How many beats does one hiragana sign take? (One.)
@@ -35,7 +36,7 @@ How many strokes does the hiragana sign for 'i' have?
 Lesson 2 of 10.
 は (ha) — three strokes.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -51,9 +52,11 @@ Read ha, breathed rather than hard: the h of English hat, then the open a of fat
 It has a second reading, and you have already used it. Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it sounds like.
 
 Guided Practice.
-[once you have stopped driving — write: は (ha) — vertical, crossbar, loop]
+[your turn — copy: keep は (ha) visible and write it once — vertical, crossbar, loop]
+[pause 8 seconds for the answer]
 [your turn — say: ha, one beat, breath not force]
 [pause 8 seconds for the answer]
+Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
 
 Wrap-up Recall.
 Which stroke of は (ha) is written first? (The vertical on the left.)
@@ -65,12 +68,13 @@ How many strokes does the hiragana sign read 'ha' have?
 Lesson 3 of 10.
 Two signs, side by side — and a word appears.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 3 seconds]
-Both signs are yours. Write them, in this order, and say each beat as you finish it:
+Both signs are yours. Look at them for five seconds:
 は (ha) い (i).
+Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
 
 Script — no new sign at all.
 Now write them touching:
@@ -114,9 +118,11 @@ i-i-e. Three beats — and note that the first sign is written twice, because Ja
 You have now read both answers to a yes-or-no question, from the signs up. Neither of them was memorised as a picture.
 
 Guided Practice.
-[once you have stopped driving — write: え — tick first, then the body in one movement]
+Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue.
+[once you have stopped driving — write from the heard or romanized cue: え — tick first, then the body in one movement]
 [your turn — read: いいえ — three beats, and do not shorten the doubled sign]
 [pause 8 seconds for the answer]
+Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
 
 Wrap-up Recall.
 Why is the first sign of that word written twice? (Because it is two beats, not one held longer.)

--- a/code/packages/typescript/human-language-data/tests/corpus/japanese.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/japanese.test.ts
@@ -1,4 +1,20 @@
-import { it } from "vitest";
-import { expectLanguageContinuity, expectLanguageModality } from "./assert-language-corpus.js";
+import { expect, it } from "vitest";
+import {
+  expectLanguageContinuity,
+  expectLanguageModality,
+  languageWritingStages,
+} from "./assert-language-corpus.js";
 it("pins Japanese continuity", () => expectLanguageContinuity("japanese"));
 it("pins Japanese modality", () => expectLanguageModality("japanese"));
+
+it("pins Japanese's complete pre-A1 writing ramp", () => {
+  const japanese = languageWritingStages("japanese");
+  expect(japanese.defects).toEqual([]);
+  expect(japanese.levels[0]).toMatchObject({ level: "pre-A1", complete: true, missingStages: [] });
+  expect(japanese.validEvidence.map((entry) => entry.stage)).toEqual([
+    "observe-trace",
+    "guided-copy",
+    "delayed-copy",
+    "dictation-transcription",
+  ]);
+});


### PR DESCRIPTION
## Summary

- make four existing one-sign/one-word Japanese lessons carry the cumulative pre-A1 writing ladder
- keep observe/trace, guided copy, delayed copy, and dictation/transcription as distinct learner actions in strict sequence
- avoid new glyph load: the ramp stays on one visible sign, one visible sign, one known two-sign word, and one heard/romanized mora
- regenerate the Japanese book, narration, modality manifest, and corpus hashes

Closes #12365
Parent task inventory: #12364
Backlog: #12206

## Validation

- focused integration/writing/gentle-ramp/modality tests (91 passed before snapshot repin; 21 passed after repin)
- full `npm test -- --maxWorkers=1` on the composed stack (853 passed)
- TypeScript build
- all five generated-artifact checks
- `npm run plan -- --format json --head 5` (Japanese pre-A1 writing complete; 846 cumulative writing gaps; 11,665 projected finite tranches)
- `git diff --check`

## Stack

Base: `codex/japanese-pre-a1-task-shapes` (#12364). Auto-merge intentionally remains off until its parents land and this PR is retargeted to `main`.