### PR TITLE
feat(human-languages): contract Chinese assessment ladder

### DIFF
--- a/code/learning/human-languages/chinese/CHANGELOG.md
+++ b/code/learning/human-languages/chinese/CHANGELOG.md
@@ -5,6 +5,18 @@ tracks: one entry per authored tranche, describing what was added and why.
 
 ## [Unreleased]
 
+### Added — transitional HSK 3.0 four-skill assessment contract (#12367)
+
+- Replaced the stale pre-2021 six-band mapping with a dated GF0025-2021 /
+  HSK 3.0 target that distinguishes the 2026 Levels 1–6 trials from the
+  operational combined Levels 7–9 exam.
+- Labelled every CEFR correspondence project-defined rather than presenting it
+  as an awarding-body claim, and added companion skill papers wherever a live
+  external form does not independently score the curriculum's four skills.
+- Contracted the full pre-A1-to-C2 gentle writing ladder, timed mocks,
+  calibration, and book-only human validation without claiming the current
+  chapters meet the target.
+
 ### Changed — writing now starts with the first lesson
 
 The opening tone lesson now asks for one model-visible pass over the four pinyin

--- a/code/learning/human-languages/chinese/assessment-spec.md
+++ b/code/learning/human-languages/chinese/assessment-spec.md
@@ -1,0 +1,200 @@
+# Coding Adventures Chinese Assessment
+
+**Version:** 1.0 transitional target contract, 2026-08-21
+
+**Basis:** project-defined CEFR ladder aligned to GF0025-2021 and the changing
+HSK 3.0 examination system
+
+**Status:** target specified; task inventories, mocks, calibration, and human
+validation remain backlog
+
+This specification names the assessment that the Mandarin Chinese book must
+eventually prepare a book-only learner to pass. It is deliberately dated because
+the external system is in transition. HSK Levels 7–9 already operate as one
+advanced five-skill exam, while HSK 3.0 Levels 1–6 are still being globally
+trialled in 2026.
+
+The checked-in [assessment.json](assessment.json) is the machine-readable
+contract. Its future paths are requirements, not evidence that the corresponding
+task inventory, rubric, answer key, mock, or validation study exists.
+
+## What is official, and what is not
+
+China's Ministry of Education standard GF0025-2021 defines three broad stages
+and nine levels. It describes listening, speaking, reading, writing, and
+translation, together with syllable, character, vocabulary, and grammar
+benchmarks. It is an official Chinese-proficiency standard.
+
+The official Chinese Test Service describes HSK 3.0 as assessing listening,
+speaking, reading, writing, and—at advanced levels—translation. Its September
+2026 trial requires candidates for Levels 3–6 to register for the corresponding
+speaking paper. The same notice lists no paired speaking paper for Levels 1–2.
+The operational combined Levels 7–9 exam has 98 items over roughly 210 minutes
+and reports listening, reading, writing, translation, and speaking scores.
+
+None of those official sources publishes the CEFR correspondence used by this
+curriculum. The following is therefore project judgement:
+
+| curriculum rung | project external anchor |
+|---|---|
+| A1 | HSK 3.0 Level 1-aligned |
+| A2 | HSK 3.0 Level 2-aligned |
+| B1 | HSK 3.0 Level 3-aligned |
+| B2 | HSK 3.0 Level 4-aligned |
+| C1 | HSK 3.0 Level 6-aligned |
+| C2 | HSK Level 9-aligned |
+
+Level 5 remains a substantial milestone on the road to the C1 target; Levels 7
+and 8 remain substantial milestones on the road to C2. The table does not say
+that an HSK certificate is a CEFR certificate. Every target is labelled
+project-defined, and every future report must preserve that label.
+
+Sources checked 2026-08-21:
+
+- [Ministry of Education announcement for GF0025-2021](https://www.moe.gov.cn/jyb_xwfb/gzdt_gzdt/s5987/202103/t20210329_523304.html)
+- [Ministry of Education explanation of the nine-level standard and HSK transition](https://www.moe.gov.cn/jyb_xwfb/s271/202104/t20210402_524194.html)
+- [Official September 2026 HSK 3.0 trial notice](https://www.chinesetest.cn/notice)
+- [Official HSK Levels 7–9 structure](https://www.chinesetest.cn/HSK/7-9)
+
+## Four-skill pass rule
+
+Reading, listening, writing, and speaking are separate 100-point curriculum
+papers. A candidate must score at least 60/100 on every paper in the same
+administration. A high reading result cannot compensate for failed writing.
+Where the named HSK form has an official pass or level-award rule, the candidate
+must satisfy that external rule as well. The local 60% floor never overwrites an
+official threshold or IRT-based level decision.
+
+Translation or mediation remains mandatory when the external HSK target
+requires it. In this four-skill schema, written translation is scored inside the
+writing paper and oral translation or reformulation inside speaking. It cannot
+be omitted merely because there is no fifth top-level skill key.
+
+Writing and speaking use four equally weighted analytic dimensions:
+
+1. task fulfilment and relevant content;
+2. comprehensibility, organisation, and interaction;
+3. vocabulary, grammar, and register control;
+4. character and punctuation control for writing, or tones, pronunciation, and
+   fluency for speaking.
+
+Pinyin is accepted only when a task explicitly licenses it. A character task
+must state whether handwriting, typed input, or either mode is required. Script
+support that is visible during tracing or copying is learning evidence, not
+independent pass evidence.
+
+Before a “learner proven” claim, both timed mocks at the rung must be passed and
+a preregistered book-only pilot must show every skill passing independently.
+Two trained raters double-score writing and speaking; a third adjudicates
+material disagreement. External-format mocks require a Chinese assessment
+specialist and documented calibration against official sample material or
+candidates with recent official results.
+
+## Administration and transition rules
+
+- Lessons remain five minutes or shorter. Partial mocks build endurance gently;
+  full mocks keep the external target's continuous timing.
+- Standard Mandarin and simplified characters are the initial assessed variety.
+  Tasks state when a documented regional pronunciation or traditional-character
+  response is acceptable.
+- Pre-A1 and A1 directions may include a declared support language. From A2,
+  Chinese directions include one unscored example.
+- No dictionary, translator, handwriting recogniser, pinyin input aid,
+  spell-checker, or generative assistant is allowed unless the task or a recorded
+  accessibility accommodation explicitly permits it.
+- Project mocks use original items; they do not copy protected live HSK items.
+- Every annual target review checks whether Levels 1–6 have left trial status,
+  whether their speaking/writing sections or score rules changed, and whether an
+  official international-framework alignment has been published.
+
+## Gentle writing ladder
+
+Writing begins with one visible contour or stroke path and advances only after
+evidence at each step:
+
+1. observe and trace a visible pinyin contour or character component;
+2. guided-copy one character with formation cues;
+3. look, hide, write, compare, and repair one known character or word;
+4. transcribe a heard syllable or pinyin cue into the required character;
+5. choose and order known material in controlled composition;
+6. write connected text for a named reader and purpose;
+7. produce under the target paper's time and rubric.
+
+A learner is never asked to memorise a page of characters before writing one,
+and recognising a character does not count as producing it.
+
+## Level envelopes
+
+### pre-A1
+
+This project-defined HSK precursor tests a tiny greeting exchange, yes/no,
+identity, and a few classroom cues. Reading and listening inputs are isolated
+known words or one short turn. Writing samples one delayed character or known
+word, short dictation/transcription, and one bounded independent response.
+Speaking covers a greeting, a name, one yes/no response, and one memorised
+request. No response is longer than one short turn.
+
+### A1
+
+External anchor: the current HSK 3.0 Level 1 construct. Because the 2026 trial
+notice does not pair Level 1 with a speaking paper, the complete target adds
+independently scored speaking and productive writing. The candidate handles
+high-frequency personal and survival exchanges, reads short signs/messages,
+writes a small form and short message, and completes a rehearsed role-play.
+
+### A2
+
+External anchor: HSK 3.0 Level 2. The complete target adds or separates any
+productive skill the live form does not independently score. The candidate
+handles routine transactions and personal accounts, writes a short functional
+response plus a connected message, and sustains a simple information-exchange
+role-play.
+
+### B1
+
+External anchor: HSK 3.0 Level 3 with its corresponding speaking component under
+the 2026 trial rules. The complete target requires independently scored
+reception and production even if the external result aggregates them. Writing
+includes functional correspondence and a connected narrative or opinion;
+speaking includes an account, collaborative planning, and follow-up discussion.
+
+### B2
+
+External anchor: HSK 3.0 Level 4 with its corresponding speaking component.
+The candidate reads and listens across reporting, explanation, and argument,
+writes a structured audience-aware report or position, and sustains a
+presentation plus defended discussion with register control.
+
+### C1
+
+External anchor: HSK 3.0 Level 6, with Level 5 retained as an intermediate
+milestone rather than silently skipped. The complete target requires dense
+public, professional, academic, and literary reception; multi-source written
+synthesis; an extended argument; source-based presentation; and sustained
+interaction. Translation or mediation tasks are introduced before the advanced
+external target demands them.
+
+### C2
+
+External anchor: an HSK Levels 7–9 result at Level 9. The complete target
+preserves the live exam's listening, reading, writing, translation, and speaking
+construct, then reports the four curriculum skills independently. Tasks sample
+unfamiliar specialist, public, academic, and literary domains; require precise
+multi-source writing in contrasting genres; and include oral and written
+translation, reformulation, negotiation, and sustained defence.
+
+## Required artifacts and readiness language
+
+Each rung still needs:
+
+1. complete four-skill task-shape inventories with dated external provenance;
+2. two original full timed mock forms;
+3. analytic rubrics and task-specific scoring notes;
+4. answer keys, acceptable variants, and rater-training samples;
+5. calibration and double-scoring evidence;
+6. a preregistered book-only human-validation report.
+
+Until items 1–4 exist, reports may say **target contracted** only. Passing both
+calibrated mocks supports **mock ready**. Only the human study supports
+**learner proven**. HSK alignment, chapter count, vocabulary count, or a level
+label alone supports none of those claims.

--- a/code/learning/human-languages/chinese/assessment.json
+++ b/code/learning/human-languages/chinese/assessment.json
@@ -1,0 +1,139 @@
+{
+  "version": 1,
+  "language": "chinese",
+  "levels": [
+    {
+      "level": "pre-A1",
+      "target": {
+        "name": "Coding Adventures Chinese pre-A1 Assessment — project-defined HSK precursor",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#pre-a1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/pre-a1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/pre-a1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/pre-a1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/pre-a1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription"],
+      "fullMocks": [
+        { "id": "pre-a1-mock-1", "timed": true, "rubric": "mocks/pre-a1/rubric.md", "answerKey": "mocks/pre-a1/mock-1-answer-key.md" },
+        { "id": "pre-a1-mock-2", "timed": true, "rubric": "mocks/pre-a1/rubric.md", "answerKey": "mocks/pre-a1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "A1",
+      "target": {
+        "name": "Coding Adventures Chinese A1 Four-Skill Assessment — HSK 3.0 Level 1-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#a1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/a1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/a1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/a1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/a1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "a1-mock-1", "timed": true, "rubric": "mocks/a1/rubric.md", "answerKey": "mocks/a1/mock-1-answer-key.md" },
+        { "id": "a1-mock-2", "timed": true, "rubric": "mocks/a1/rubric.md", "answerKey": "mocks/a1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "A2",
+      "target": {
+        "name": "Coding Adventures Chinese A2 Four-Skill Assessment — HSK 3.0 Level 2-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#a2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/a2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/a2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/a2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/a2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "a2-mock-1", "timed": true, "rubric": "mocks/a2/rubric.md", "answerKey": "mocks/a2/mock-1-answer-key.md" },
+        { "id": "a2-mock-2", "timed": true, "rubric": "mocks/a2/rubric.md", "answerKey": "mocks/a2/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "B1",
+      "target": {
+        "name": "Coding Adventures Chinese B1 Four-Skill Assessment — HSK 3.0 Level 3-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#b1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/b1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/b1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/b1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/b1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "b1-mock-1", "timed": true, "rubric": "mocks/b1/rubric.md", "answerKey": "mocks/b1/mock-1-answer-key.md" },
+        { "id": "b1-mock-2", "timed": true, "rubric": "mocks/b1/rubric.md", "answerKey": "mocks/b1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "B2",
+      "target": {
+        "name": "Coding Adventures Chinese B2 Four-Skill Assessment — HSK 3.0 Level 4-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#b2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/b2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/b2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/b2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/b2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "b2-mock-1", "timed": true, "rubric": "mocks/b2/rubric.md", "answerKey": "mocks/b2/mock-1-answer-key.md" },
+        { "id": "b2-mock-2", "timed": true, "rubric": "mocks/b2/rubric.md", "answerKey": "mocks/b2/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "C1",
+      "target": {
+        "name": "Coding Adventures Chinese C1 Four-Skill Assessment — HSK 3.0 Level 6-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#c1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/c1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/c1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/c1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/c1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "c1-mock-1", "timed": true, "rubric": "mocks/c1/rubric.md", "answerKey": "mocks/c1/mock-1-answer-key.md" },
+        { "id": "c1-mock-2", "timed": true, "rubric": "mocks/c1/rubric.md", "answerKey": "mocks/c1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "C2",
+      "target": {
+        "name": "Coding Adventures Chinese C2 Four-Skill Assessment — HSK Level 9-aligned project equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#c2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/c2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/c2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/c2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/c2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "c2-mock-1", "timed": true, "rubric": "mocks/c2/rubric.md", "answerKey": "mocks/c2/mock-1-answer-key.md" },
+        { "id": "c2-mock-2", "timed": true, "rubric": "mocks/c2/rubric.md", "answerKey": "mocks/c2/mock-2-answer-key.md" }
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/core/exam-levels.json
+++ b/code/learning/human-languages/core/exam-levels.json
@@ -29,10 +29,17 @@
       "caveat": "Official JLPT score reports add these CEFR reference indications from the December 2025 test, but only for candidates who pass the named JLPT level and only for the language knowledge, reading, and listening competence JLPT tests. JLPT does not test production (speaking and writing) or interaction. The complete four-skill destination therefore pairs the published receptive anchor with a project-defined JF Standard/CEFR-aligned production companion; pre-A1 and C2 are wholly project-defined."
     },
     "chinese": {
-      "exam": "HSK (six-band, pre-2021)",
-      "basis": "published",
-      "mapping": { "A1": "HSK1–2", "A2": "HSK3", "B1": "HSK4", "B2": "HSK5", "C1": "HSK6", "C2": "beyond HSK6" },
-      "caveat": "Hanban's own alignment for the six-band HSK. HSK 3.0 (2021) redefines the bands as nine levels and shifts the correspondence upward; revisit when the Chinese track passes HSK3 material."
+      "exam": "HSK 3.0 / GF0025-2021 plus Coding Adventures four-skill companion",
+      "basis": "editorial",
+      "mapping": {
+        "A1": "HSK 3.0 Level 1-aligned project target",
+        "A2": "HSK 3.0 Level 2-aligned project target",
+        "B1": "HSK 3.0 Level 3-aligned project target",
+        "B2": "HSK 3.0 Level 4-aligned project target",
+        "C1": "HSK 3.0 Level 6-aligned project target",
+        "C2": "HSK 3.0 Level 9-aligned project target"
+      },
+      "caveat": "GF0025-2021 officially defines three stages and nine levels across listening, speaking, reading, writing, and translation, but it does not publish this CEFR correspondence. The mapping is this project's assessment design, not an awarding-body equivalence. HSK 3.0 Levels 1-6 remain in global trial during 2026, while the combined HSK Levels 7-9 exam is operational; every rung therefore preserves dated external anchors and adds project-defined companion papers wherever the live form does not independently score all four curriculum skills."
     },
     "arabic": {
       "exam": "ALPT / ILR / ACTFL",

--- a/code/packages/typescript/human-language-data/tests/assessment.test.ts
+++ b/code/packages/typescript/human-language-data/tests/assessment.test.ts
@@ -53,6 +53,7 @@ describe("assessment policy (HL16)", () => {
       "marwadi",
       "punjabi",
       "gujarati",
+      "chinese",
       "japanese",
     ]));
     expect(new Set(contracts).size).toBe(contracts.length);
@@ -126,6 +127,27 @@ describe("track assessment contracts", () => {
     ]);
     expect(japanese.levels.at(-1)?.writingStages).toEqual(policy.writingStages.map((stage) => stage.id));
     expect(japanese.levels.every((level) => level.fullMocks.length === 2)).toBe(true);
+  });
+
+  it("loads Chinese's seven-rung independent four-skill destination", () => {
+    const chinese = parseAssessmentContract(
+      JSON.parse(readFileSync(join(defaultCurriculumRoot(), "chinese", "assessment.json"), "utf8")),
+      "chinese",
+      policy,
+    );
+    expect(chinese.levels.map((level) => level.level)).toEqual(policy.levels);
+    expect(chinese.levels.every((level) => level.target.basis === "project-defined")).toBe(true);
+    expect(chinese.levels.every((level) =>
+      Object.values(level.skills).every((skill) => skill.passThreshold === 0.6)
+    )).toBe(true);
+    expect(chinese.levels[0]?.writingStages).toEqual([
+      "observe-trace",
+      "guided-copy",
+      "delayed-copy",
+      "dictation-transcription",
+    ]);
+    expect(chinese.levels.at(-1)?.writingStages).toEqual(policy.writingStages.map((stage) => stage.id));
+    expect(chinese.levels.every((level) => level.fullMocks.length === 2)).toBe(true);
   });
 
   it("accepts a complete seven-level contract with independent skills and full mocks", () => {


### PR DESCRIPTION
## Summary

- replace the stale pre-2021 six-band HSK mapping with a dated GF0025-2021 / HSK 3.0 transition model
- add a complete pre-A1-to-C2 Chinese contract with independent reading, listening, writing, and speaking passes
- distinguish the September 2026 Levels 1-6 trial from the operational combined HSK Levels 7-9 exam
- label every CEFR correspondence project-defined and require companion papers wherever a live HSK form does not independently score all four curriculum skills
- preserve translation/mediation inside advanced production rather than dropping it from the four-skill schema

Official sources:
- https://www.moe.gov.cn/jyb_xwfb/gzdt_gzdt/s5987/202103/t20210329_523304.html
- https://www.moe.gov.cn/jyb_xwfb/s271/202104/t20210402_524194.html
- https://www.chinesetest.cn/notice
- https://www.chinesetest.cn/HSK/7-9

Closes #12367
Backlog: #12206

## Validation

- `npm test -- --run tests/assessment.test.ts tests/completion-plan.test.ts` (33 passed)
- `npm run build`
- full `npm test -- --maxWorkers=1` on this sibling stack (852 passed)
- `npm run plan -- --format json --head 8` (20 missing contracts; 11,693 projected finite tranches on this sibling)
- `git diff --check`

## Stack

Base: `codex/japanese-assessment-contract` (#12362). This is a sibling of #12364/#12366 so the Chinese and Japanese execution paths can clear independently. Auto-merge intentionally remains off until the parent lands and this PR is retargeted to `main`.