### PR TITLE
feat(human-languages): inventory French DILF tasks

### DIFF
--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -13,6 +13,20 @@
 
 ## [Unreleased]
 
+### Added — sourced DILF A1.1 four-skill task shapes (HL18)
+
+- Inventory the official 25-minute listening, 25-minute reading, 10-minute
+  individual speaking, and 15-minute writing sections, including all seventeen
+  activity families published by France Éducation international.
+- Preserve the real 35/15/35/15 weighting and the grouped pass rule: 50/100
+  overall plus 35/70 across the two oral tests. DILF publishes no independent
+  four-skill floors, so the inventory records them as unknown rather than
+  manufacturing four tidy percentages.
+- Record item counts, text and response lengths, audio speed and length, replay
+  counts, aids, and part-level score allocations as explicitly unpublished.
+  The separate assessment contract keeps the book's stricter 60%-per-skill
+  two-mock readiness margin.
+
 ### Added — DILF/DELF/DALF assessment contract through C2 (HL16)
 
 - Name the official external target at every rung: DILF A1.1 as the closest
@@ -22,9 +36,9 @@
   both timed mocks. A strong receptive score may not hide weak writing.
 - Require the complete gentle writing sequence from tracing through timed
   independent production, without lengthening any lesson beyond five minutes.
-- Keep readiness honest: only French A1 has a task-shape inventory today; all
-  other inventories, mocks, rubrics, answer keys, calibration, and book-only
-  human validation remain named dependencies.
+- Keep readiness honest: only French pre-A1 and A1 have task-shape inventories
+  today; later inventories, mocks, rubrics, answer keys, calibration, and
+  book-only human validation remain named dependencies.
 
 ### Added — Chapter 32, asking a question (HL-C229)
 

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -26,10 +26,10 @@ The track's [assessment contract](assessment-spec.md) targets DILF A1.1 as the
 closest official pre-A1 runway, DELF *tout public* at A1–B2, and DALF at C1–C2.
 The machine-readable [contract](assessment.json) requires all four skills, the
 complete gentle writing ramp, and two timed mocks at every rung. This names the
-destination; it does not claim that the current book is exam-ready. French A1
-already has a sourced [task-shape inventory](task-shapes/a1.json). The other
-inventories, mocks, rubrics, answer keys, calibration, and book-only human
-validation remain explicit backlog.
+destination; it does not claim that the current book is exam-ready. French now
+has sourced task-shape inventories for [DILF A1.1](task-shapes/pre-a1.json) and
+[DELF A1](task-shapes/a1.json). The later inventories, mocks, rubrics, answer
+keys, calibration, and book-only human validation remain explicit backlog.
 
 ## Progress
 

--- a/code/learning/human-languages/french/assessment-spec.md
+++ b/code/learning/human-languages/french/assessment-spec.md
@@ -196,8 +196,8 @@ register and implication across unfamiliar domains.
 
 Every rung still requires:
 
-1. a dated four-skill task-shape inventory (French A1 is the only one already
-   present);
+1. a dated four-skill task-shape inventory (French pre-A1/DILF and A1/DELF are
+   present; A2 through C2 remain backlog);
 2. two original, complete, timed mock forms;
 3. official-grid-aligned rubrics and task-specific scoring notes;
 4. answer keys, acceptable variants, and rater training samples;

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -20,6 +20,11 @@ seven-rung machine-readable contract. Lessons stay at five minutes or less and
 writing grows one action at a time; full mocks keep authentic continuous timing.
 The contract is a target, not present-tense readiness evidence.
 
+The first two external performance envelopes are now inventoried without
+inventing unpublished measurements: [DILF A1.1](task-shapes/pre-a1.json) and
+[DELF A1](task-shapes/a1.json). A2 through C2 remain finite research items on the
+generated completion plan.
+
 ## Authored
 
 - **Ch. 1 — Greetings**: salut → bien → bon/bonne → **le/la/les** (gender) →

--- a/code/learning/human-languages/french/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/french/task-shapes/pre-a1.json
@@ -1,0 +1,332 @@
+{
+  "version": 1,
+  "language": "french",
+  "level": "pre-A1",
+  "target": {
+    "name": "DILF A1.1",
+    "basis": "external"
+  },
+  "sources": [
+    {
+      "id": "fei-dilf-overview",
+      "title": "DILF",
+      "url": "https://www.france-education-international.fr/diplome/dilf?langue=en",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "fei-dilf-examples",
+      "title": "Exemples de sujets - DILF",
+      "url": "https://www.france-education-international.fr/diplome/dilf/exemples-sujets",
+      "published": "not stated",
+      "accessed": "2026-08-20"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 65,
+    "speakingMinutes": 10,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": null,
+    "deliveryModes": [
+      "paper and recorded audio at an approved examination centre",
+      "individual live speaking with assessors"
+    ]
+  },
+  "passRule": {
+    "maximumPoints": 100,
+    "passPoints": 50,
+    "requiresEverySectionAttempted": false,
+    "independentSkillThresholds": {
+      "reading": null,
+      "listening": null,
+      "writing": null,
+      "speaking": null
+    },
+    "note": "France Education international requires at least 50/100 overall and at least 35/70 across the two oral tests together. It does not publish an independent floor for each of the four skills. Null thresholds preserve that boundary; the curriculum's separate two-mock readiness rule remains stricter at 60% per skill."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 25,
+      "parts": [
+        {
+          "id": "reading-understand-information",
+          "promptModes": ["written text", "image when supplied"],
+          "promptGenres": ["very short practical information"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "stimulus length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "reading-understand-simple-instructions",
+          "promptModes": ["written text", "image when supplied"],
+          "promptGenres": ["simple practical instruction"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "stimulus length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "reading-understand-basic-details",
+          "promptModes": ["written text", "image when supplied"],
+          "promptGenres": ["basic personal or practical details"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "stimulus length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "reading-understand-numerical-information",
+          "promptModes": ["written text", "image when supplied"],
+          "promptGenres": ["price", "date", "telephone number", "other numerical information"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "stimulus length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "reading-identify-text-purpose",
+          "promptModes": ["written text", "image when supplied"],
+          "promptGenres": ["simple everyday text with a practical purpose"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "stimulus length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 25,
+      "parts": [
+        {
+          "id": "listening-public-announcement",
+          "promptModes": ["recorded audio", "exam booklet", "image when supplied"],
+          "promptGenres": ["simple public announcement"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "clip duration", "speech rate", "response length", "replay count", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "listening-direction-and-instruction",
+          "promptModes": ["recorded audio", "exam booklet", "image when supplied"],
+          "promptGenres": ["simple direction", "simple practical instruction"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "clip duration", "speech rate", "response length", "replay count", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "listening-numerical-information",
+          "promptModes": ["recorded audio", "exam booklet", "image when supplied"],
+          "promptGenres": ["price", "date", "telephone number", "other numerical information"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "clip duration", "speech rate", "response length", "replay count", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "listening-time-information",
+          "promptModes": ["recorded audio", "exam booklet", "image when supplied"],
+          "promptGenres": ["time and schedule information"],
+          "responseModes": ["selected response", "matching", "short written response"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official answer-key match"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "clip duration", "speech rate", "response length", "replay count", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 15,
+      "parts": [
+        {
+          "id": "writing-copy-contact-detail",
+          "promptModes": ["written model in exam booklet"],
+          "promptGenres": ["address", "telephone number"],
+          "responseModes": ["handwritten copy"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-writing grid or answer key"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "model length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "writing-record-number-price-date",
+          "promptModes": ["exam booklet and supervisor instructions"],
+          "promptGenres": ["number", "price", "date"],
+          "responseModes": ["handwritten numerical information"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-writing grid or answer key"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["item count", "prompt mode within the live form", "stimulus length", "response length", "replay count", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "writing-complete-form",
+          "promptModes": ["written form in exam booklet"],
+          "promptGenres": ["simple practical form"],
+          "responseModes": ["handwritten form completion"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-writing grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["field count", "form length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "writing-leave-simple-message",
+          "promptModes": ["written situation and instruction in exam booklet"],
+          "promptGenres": ["simple practical or personal message"],
+          "responseModes": ["independent handwritten message"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-writing grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["prompt length", "response length", "part-level point allocation", "replay is not applicable to written input"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "speaking-price-transaction",
+          "promptModes": ["live assessor", "visual material when supplied"],
+          "promptGenres": ["ask for and give a price"],
+          "responseModes": ["short spoken transaction"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-speaking grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["turn count", "prompt length", "response length", "repetition policy", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "speaking-present-person-or-place",
+          "promptModes": ["live assessor", "visual material when supplied"],
+          "promptGenres": ["introduce people", "describe a place"],
+          "responseModes": ["short spoken presentation or description"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-speaking grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["turn count", "prompt length", "response length", "repetition policy", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "speaking-express-need-or-request-information",
+          "promptModes": ["live assessor", "visual material when supplied"],
+          "promptGenres": ["express a need", "make an appointment", "request information"],
+          "responseModes": ["short spoken request and interaction"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-speaking grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["turn count", "prompt length", "response length", "repetition policy", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        },
+        {
+          "id": "speaking-describe-health-problem",
+          "promptModes": ["live assessor", "visual material when supplied"],
+          "promptGenres": ["describe the nature of a health problem"],
+          "responseModes": ["short spoken description and interaction"],
+          "items": null,
+          "stimulusLength": null,
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": null, "criteria": ["official production-speaking grid"] },
+          "aids": { "allowed": [], "forbidden": [], "notPublished": ["complete aid policy"] },
+          "notPublished": ["turn count", "prompt length", "response length", "repetition policy", "part-level point allocation"],
+          "sourceIds": ["fei-dilf-overview", "fei-dilf-examples"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -128,6 +128,37 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(speaking?.parts.map((part) => part.scoring.maxRawPoints)).toEqual([4, 4, 4]);
   });
 
+  it("loads DILF as French's sourced pre-A1 target without inventing per-skill floors", () => {
+    const inventory = loadTaskShapeInventory("french", "pre-A1");
+    expect(inventory.target).toEqual({ name: "DILF A1.1", basis: "external" });
+    expect(inventory.sections.map((section) => section.skill)).toEqual([
+      "reading",
+      "listening",
+      "writing",
+      "speaking",
+    ]);
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([25, 25, 15, 10]);
+    expect(inventory.sections.flatMap((section) => section.parts)).toHaveLength(17);
+    expect(inventory.administration).toMatchObject({
+      writtenMinutes: 65,
+      speakingMinutes: 10,
+      speakingGroupMaximum: 1,
+      speakingPreparationMinutes: null,
+    });
+    expect(inventory.passRule).toMatchObject({
+      maximumPoints: 100,
+      passPoints: 50,
+      requiresEverySectionAttempted: false,
+    });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([null, null, null, null]);
+    expect(inventory.sections.find((section) => section.skill === "speaking")?.parts.map((part) => part.id)).toEqual([
+      "speaking-price-transaction",
+      "speaking-present-person-or-place",
+      "speaking-express-need-or-request-information",
+      "speaking-describe-health-problem",
+    ]);
+  });
+
   it("loads the official German A1 performance target", () => {
     const inventory = loadTaskShapeInventory("german", "A1");
     expect(inventory.target).toEqual({
@@ -153,13 +184,14 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(present).toEqual([
       { language: "spanish", level: "A1" },
       { language: "latin", level: "A1" },
+      { language: "french", level: "pre-A1" },
       { language: "french", level: "A1" },
       { language: "german", level: "A1" },
       { language: "arabic", level: "A1" },
       { language: "marwadi", level: "pre-A1" },
     ]);
-    expect(backlog).toHaveLength(registry.languages.length * 7 - 6);
-    expect(backlog.filter((item) => item.level === "pre-A1")).toHaveLength(registry.languages.length - 1);
+    expect(backlog).toHaveLength(registry.languages.length * 7 - 7);
+    expect(backlog.filter((item) => item.level === "pre-A1")).toHaveLength(registry.languages.length - 2);
     expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 5);
     expect(backlog.some((item) => item.id === "task-shape/marwadi/pre-A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/spanish/pre-A1")).toBe(true);
@@ -167,6 +199,7 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(backlog.some((item) => item.id === "task-shape/spanish/A2")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/latin/A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/latin/A2")).toBe(true);
+    expect(backlog.some((item) => item.id === "task-shape/french/pre-A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/french/A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/french/A2")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/german/A1")).toBe(false);


### PR DESCRIPTION
Closes #12382. Adds the 17 published DILF A1.1 activity families with exact section durations and official skill weights; models the published grouped pass rule without inventing per-skill thresholds, while retaining the curriculum's stricter local mastery gate; records source gaps explicitly; and advances the task-shape plan from 6/161 to 7/161, making the French pre-A1 writing-stage slice next. Validated with TypeScript build, 29 focused tests, all 49 test files / 850 tests, all five generated-data checks, and git diff --check.