### PR TITLE
feat(human-languages): contract Gujarati assessment ladder

### DIFF
--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added — pre-A1-to-C2 assessment contract (HL16)
+
+- Added a clearly labelled project-defined Gujarati assessment ladder at
+  pre-A1, A1, A2, B1, B2, C1, and C2 rather than implying an external
+  qualification exists.
+- Every rung requires independent reading, listening, writing, and speaking
+  passes at 60%, with no stronger skill compensating for a weaker one.
+- The contract carries writing from observe/trace and copying through delayed
+  recall, dictation, connected composition, and timed exam production.
+- Two timed mocks, rubrics, answer keys, calibration, and book-only human
+  validation remain explicit dependencies, so the track cannot mistake a named
+  destination for pass-readiness evidence.
+
 ### Fixed — three false forward-review claims
 
 - `GU-C02-anand` now records the earlier name statement that its warm-up and

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -24,6 +24,17 @@ you can read straight through.
 - The language of **Gandhi**, grounded throughout against English + Sanskrit +
   the other Indo-Aryan tracks.
 
+## Assessment destination
+
+The complete book targets the project-defined [Coding Adventures Gujarati
+Assessment](assessment-spec.md) from pre-A1 through C2. Its machine-readable
+[contract](assessment.json) requires separate passes in reading, listening,
+writing, and speaking, the full gentle writing ladder, and two timed mocks at
+every rung. This names the destination; it does not claim that the current book
+or the future certificate is externally accredited. Task inventories, mocks,
+rubrics, answer keys, calibration, and book-only human validation remain
+explicit backlog.
+
 ## Progress
 
 - **Chapter 1 — Greetings** ([`lessons/GU-C01-*`](./lessons/)): namaste, ābhār,

--- a/code/learning/human-languages/gujarati/assessment-spec.md
+++ b/code/learning/human-languages/gujarati/assessment-spec.md
@@ -1,0 +1,183 @@
+# Coding Adventures Gujarati Assessment
+
+**Version:** 1.0 target contract, 2026-08-20
+
+**Basis:** project-defined CEFR-aligned equivalent
+
+**Status:** target specified; task inventories, mocks, calibration, and human
+validation are still backlog
+
+This specification names the assessment that the complete Gujarati book must
+eventually prepare a book-only learner to pass. It is not an external
+qualification, and it does not claim that the current book is exam-ready. The
+learner-facing name at each rung is **Coding Adventures Gujarati <Level>
+Assessment — project-defined equivalent**.
+
+The checked-in [`assessment.json`](assessment.json) is the machine-readable
+contract. Its paths name required future artifacts. A path is a dependency, not
+evidence that a task inventory, rubric, answer key, or mock already exists. All
+of those assets, two timed mock passes, and a book-only human pilot must land
+before a readiness claim is permitted.
+
+## Evidence and scope
+
+The proficiency backbone is the Council of Europe's 2020 CEFR Companion Volume,
+including its pre-A1 descriptors and its separate scales for reception,
+production, interaction, mediation, and written production. CEFR is a framework
+for describing proficiency and developing transparent examinations; it is not
+a Gujarati awarding body. The Council of Europe also states that it does not
+verify or validate an examination's claimed link to CEFR. Every target here is
+therefore labelled `project-defined`.
+
+The assessed variety is contemporary standard Gujarati written in Gujarati
+script. The current track's taught forms define the initial model. Documented
+regional forms receive credit when used consistently and when they satisfy the
+task; a trained Gujarati reviewer adjudicates unfamiliar forms. Hindi or English
+replacement is not silently accepted as Gujarati, while natural code-switching
+is assessed only when a task explicitly licenses it.
+
+Sources checked 2026-08-20:
+
+- [CEFR Companion Volume and language versions](https://www.coe.int/en/web/common-european-framework-reference-languages/cefr-companion-volume-and-its-language-versions)
+- [Council of Europe CEFR descriptors](https://www.coe.int/en/web/common-european-framework-reference-languages/cefr-descriptors)
+- [Council of Europe guidance on tests and examinations](https://www.coe.int/en/web/common-european-framework-reference-languages/tests-and-examinations)
+- [Council of Europe introduction and certification caveat](https://www.coe.int/en/web/common-european-framework-reference-languages/introduction-and-context)
+
+## Pass rule
+
+Reading, listening, writing, and speaking are separate 100-point papers. A
+candidate must score at least **60/100 on every paper in the same
+administration**. There is no aggregate compensation: 90 in reading cannot hide
+59 in writing. An unattempted required part scores zero. A complete pass also
+requires both published timed mocks at the rung to have been passed under the
+same independent thresholds before the book may call the learner mock ready.
+
+Writing and speaking use four equally weighted analytic dimensions:
+
+1. task fulfilment and relevant content;
+2. comprehensibility, organisation, and interaction;
+3. range and control of Gujarati vocabulary and grammar;
+4. Gujarati orthographic control for writing, or pronunciation and fluency for
+   speaking.
+
+Each dimension is scored 0–5, then scaled to the paper's points. A response that
+is not meaningfully in Gujarati cannot earn task-fulfilment credit. Documented
+regional vocabulary, morphology, pronunciation, and spelling variants are not
+errors merely because they differ from the standard-variety model.
+
+The 60% threshold is a transparent provisional project standard, not validation
+evidence. Before release, at least eight qualified Gujarati educators or
+linguists must perform a modified Angoff review; two raters must double-score at
+least 50 writing and 50 speaking samples per rung; and a book-only pilot must
+report every skill separately. The contract is versioned if standard setting
+changes the threshold or task envelope.
+
+## Administration rules
+
+- Listening recordings use Gujarati speakers. Words-per-minute bands below are
+  form-assembly targets, not a claim that Gujarati has one natural speaking rate.
+- Pre-A1 and A1 directions may also be supplied in a declared support language,
+  so misunderstanding directions is not confused with Gujarati proficiency.
+  From A2 onward directions are in Gujarati, with one unscored example.
+- No dictionary, grammar reference, spell-checker, translator, or generative
+  assistant is allowed. Ordinary accessibility accommodations may change
+  presentation or response mode without changing the construct; every change is
+  recorded.
+- Listening pause and replay rules are fixed below. A technical restart replaces
+  the affected recording; it is not an extra candidate-selected replay.
+- Speaking is recorded and independently scored by two trained raters. A third
+  rater adjudicates when scaled totals differ by more than 10 points or when the
+  first two raters disagree about a documented regional form.
+- Full mocks use unseen prompts and the target timing. Five-minute lessons build
+  the skills gently; full assessments keep continuous timing because they are
+  evidence, not instruction.
+
+## Level envelopes
+
+The later `task-shapes/<level>.json` inventories must make every part below
+executable without expanding its input, response, timing, replay, interaction,
+or aid boundary.
+
+### pre-A1
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 10 | 6 script/word matches, 4 short phrase or notice matches, and 4 personal-detail selections; no text over 8 words |
+| listening | 10 | 6 sound/word recognitions, 4 greeting-response choices, and 4 personal-detail selections; 70–90 wpm, two plays, 8-second inter-item pauses |
+| writing | 12 | 2 delayed-copy items, 4 one-word dictation items, and 2 independently produced personal or greeting responses; no visible answer model during scoring |
+| speaking | 8 | return a greeting, state a name or chosen identity, answer 3 familiar one-turn questions, and make 1 short request; the interlocutor may repeat once slowly |
+
+Writing instruction proves observe/trace, guided copy, delayed copy, and
+dictation/transcription in the learning record. Only delayed recall, dictation,
+and independent production earn paper points; tracing and visible copying are
+instructional supports, not pass evidence.
+
+### A1
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 20 | 3 parts and 18–22 items across signs, forms, messages, and personal descriptions; 250–350 source words total, no text over 90 words |
+| listening | 18 | 3 parts and 15–18 items across announcements, short exchanges, and a personal account; 90–110 wpm, two plays |
+| writing | 20 | complete a practical form, then write a 30–40 word message for a named reader and purpose |
+| speaking | 10 | personal interview, 1-minute prepared description, and a simple transactional role-play; 5 minutes preparation |
+
+### A2
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 30 | 3 parts and 22–26 items across notices, correspondence, and two connected everyday texts; 550–750 source words total |
+| listening | 25 | 3 parts and 18–22 items across announcements, conversations, and one 2–3 minute account; 110–130 wpm, two plays |
+| writing | 30 | a 25–35 word functional response and a 70–90 word connected message or description |
+| speaking | 12 | interview, 2-minute picture or topic account, and a role-play requiring information exchange; 5 minutes preparation |
+
+### B1
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 45 | 4 parts and 26–32 items across correspondence, public information, narrative, and an informational article; 1,100–1,400 source words total |
+| listening | 35 | 4 parts and 22–28 items across transactions, interviews, narrative, and a short talk; 130–150 wpm, two plays for short items and one replay for each long item |
+| writing | 45 | a 50–70 word functional text and a 130–170 word connected narrative, description, or opinion for a named audience |
+| speaking | 15 | interview, 3-minute prepared account, collaborative planning task, and follow-up discussion; 10 minutes preparation |
+
+### B2
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 60 | 4 parts and 30–36 items across argument, reporting, instructions, and literary or cultural prose; 1,800–2,300 source words total |
+| listening | 45 | 4 parts and 24–30 items using multiple speakers and at least two regional voices; 150–170 wpm, long recordings played once after one orienting preview |
+| writing | 60 | a 100–130 word interaction text and a 220–280 word report, article, narrative, or reasoned argument in the required register |
+| speaking | 18 | 4-minute presentation, collaborative problem-solving, and defended discussion with follow-up questions; 10 minutes preparation |
+
+### C1
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 75 | 4 parts and 32–40 items across dense public, professional, academic, and literary texts; 2,800–3,500 source words total, including implicit stance |
+| listening | 50 | 4 parts and 26–32 items across unscripted discussion, lecture, interview, and narrative; 160–185 wpm with natural variation, recordings played once |
+| writing | 75 | synthesize two short sources in 180–220 words, then produce a 300–380 word audience-aware argument, report, or critical response |
+| speaking | 22 | 5-minute source-based presentation, collaborative synthesis, and sustained challenge and defence; 15 minutes preparation with paper notes only |
+
+### C2
+
+| paper | minutes | required task envelope |
+|---|---:|---|
+| reading | 90 | 4 parts and 34–42 items across stylistically varied specialist, public, and literary texts; 4,000–5,000 source words, including ambiguity and intertextual stance |
+| listening | 60 | 4 parts and 28–34 items across rapid multiparty interaction, extended argument, narrative, and culturally dense media; natural 165–200 wpm variation, recordings played once |
+| writing | 90 | synthesize and reframe multiple sources for one audience in 220–280 words, then produce a precise 420–520 word extended text in a contrasting genre or register |
+| speaking | 25 | 6-minute synthesis or mediation presentation, multiparty negotiation, and sustained defence requiring reformulation for a second audience; 15 minutes preparation with paper notes only |
+
+## Required artifacts and readiness language
+
+For each rung, implementation must add:
+
+1. the four-skill JSON task inventory named by `assessment.json`;
+2. two complete timed mock forms with fresh input and prompts;
+3. a shared analytic rubric plus task-specific scoring notes;
+4. one answer key per mock, including acceptable regional alternatives;
+5. rater training samples, double-scoring evidence, and adjudication records;
+6. the pre-registered book-only human-validation report.
+
+Until items 1–4 exist, reports may say **target contracted** only. After a
+learner passes both mocks they may say **mock ready**. Only the pre-registered
+human study can support **learner proven**, and its result must never be inferred
+from corpus coverage.

--- a/code/learning/human-languages/gujarati/assessment.json
+++ b/code/learning/human-languages/gujarati/assessment.json
@@ -1,0 +1,139 @@
+{
+  "version": 1,
+  "language": "gujarati",
+  "levels": [
+    {
+      "level": "pre-A1",
+      "target": {
+        "name": "Coding Adventures Gujarati pre-A1 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#pre-a1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/pre-a1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/pre-a1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/pre-a1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/pre-a1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription"],
+      "fullMocks": [
+        { "id": "pre-a1-mock-1", "timed": true, "rubric": "mocks/pre-a1/rubric.md", "answerKey": "mocks/pre-a1/mock-1-answer-key.md" },
+        { "id": "pre-a1-mock-2", "timed": true, "rubric": "mocks/pre-a1/rubric.md", "answerKey": "mocks/pre-a1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "A1",
+      "target": {
+        "name": "Coding Adventures Gujarati A1 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#a1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/a1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/a1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/a1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/a1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "a1-mock-1", "timed": true, "rubric": "mocks/a1/rubric.md", "answerKey": "mocks/a1/mock-1-answer-key.md" },
+        { "id": "a1-mock-2", "timed": true, "rubric": "mocks/a1/rubric.md", "answerKey": "mocks/a1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "A2",
+      "target": {
+        "name": "Coding Adventures Gujarati A2 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#a2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/a2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/a2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/a2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/a2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "a2-mock-1", "timed": true, "rubric": "mocks/a2/rubric.md", "answerKey": "mocks/a2/mock-1-answer-key.md" },
+        { "id": "a2-mock-2", "timed": true, "rubric": "mocks/a2/rubric.md", "answerKey": "mocks/a2/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "B1",
+      "target": {
+        "name": "Coding Adventures Gujarati B1 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#b1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/b1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/b1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/b1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/b1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "b1-mock-1", "timed": true, "rubric": "mocks/b1/rubric.md", "answerKey": "mocks/b1/mock-1-answer-key.md" },
+        { "id": "b1-mock-2", "timed": true, "rubric": "mocks/b1/rubric.md", "answerKey": "mocks/b1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "B2",
+      "target": {
+        "name": "Coding Adventures Gujarati B2 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#b2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/b2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/b2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/b2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/b2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "b2-mock-1", "timed": true, "rubric": "mocks/b2/rubric.md", "answerKey": "mocks/b2/mock-1-answer-key.md" },
+        { "id": "b2-mock-2", "timed": true, "rubric": "mocks/b2/rubric.md", "answerKey": "mocks/b2/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "C1",
+      "target": {
+        "name": "Coding Adventures Gujarati C1 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#c1"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/c1.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/c1.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/c1.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/c1.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "c1-mock-1", "timed": true, "rubric": "mocks/c1/rubric.md", "answerKey": "mocks/c1/mock-1-answer-key.md" },
+        { "id": "c1-mock-2", "timed": true, "rubric": "mocks/c1/rubric.md", "answerKey": "mocks/c1/mock-2-answer-key.md" }
+      ]
+    },
+    {
+      "level": "C2",
+      "target": {
+        "name": "Coding Adventures Gujarati C2 Assessment — project-defined equivalent",
+        "basis": "project-defined",
+        "source": "assessment-spec.md#c2"
+      },
+      "skills": {
+        "reading": { "taskInventory": ["task-shapes/c2.json#reading"], "passThreshold": 0.6 },
+        "listening": { "taskInventory": ["task-shapes/c2.json#listening"], "passThreshold": 0.6 },
+        "writing": { "taskInventory": ["task-shapes/c2.json#writing"], "passThreshold": 0.6 },
+        "speaking": { "taskInventory": ["task-shapes/c2.json#speaking"], "passThreshold": 0.6 }
+      },
+      "writingStages": ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription", "controlled-composition", "connected-composition", "timed-assessment-production"],
+      "fullMocks": [
+        { "id": "c2-mock-1", "timed": true, "rubric": "mocks/c2/rubric.md", "answerKey": "mocks/c2/mock-1-answer-key.md" },
+        { "id": "c2-mock-2", "timed": true, "rubric": "mocks/c2/rubric.md", "answerKey": "mocks/c2/mock-2-answer-key.md" }
+      ]
+    }
+  ]
+}

--- a/code/learning/human-languages/gujarati/roadmap.md
+++ b/code/learning/human-languages/gujarati/roadmap.md
@@ -11,6 +11,16 @@ Gujarati's distinctives — the **headless script** (no *shirorekhā*), the **th
 genders** (*-o / -ī / -ũ*), its **own copula** *chhe*, and the **Perso-Arabic
 trade layer**. The script is taught **inline**, never as a gated reading course.
 
+## Assessment destination
+
+The complete book must prepare a book-only learner for the project-defined
+Gujarati assessment ladder from pre-A1 through C2. See
+[assessment-spec.md](assessment-spec.md) for the level envelopes, independent
+four-skill pass rule, and validation boundary, and [assessment.json](assessment.json)
+for the machine-readable seven-rung contract. Lessons stay at five minutes or
+less and writing grows one action at a time; full mocks keep continuous target
+timing. The contract records a target, not present-tense readiness evidence.
+
 ## Authored
 
 - **Ch. 1 — Greetings**: namaste → ābhār → hā/nā → sārũ → āvjo → practice.

--- a/code/packages/typescript/human-language-data/tests/assessment.test.ts
+++ b/code/packages/typescript/human-language-data/tests/assessment.test.ts
@@ -37,8 +37,8 @@ describe("assessment policy (HL16)", () => {
     })).toThrow(/maxLessonMinutes must be 5/);
   });
 
-  it("loads the complete French and Marwadi contracts and keeps the other tracks queued", () => {
-    expect(listAssessmentContracts()).toEqual(["french", "marwadi"]);
+  it("loads the complete French, Gujarati, and Marwadi contracts and keeps the other tracks queued", () => {
+    expect(listAssessmentContracts()).toEqual(["french", "marwadi", "gujarati"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- define a clearly labelled project-defined Gujarati assessment ladder from pre-A1 through C2
- require independent 60% passes in reading, listening, writing, and speaking with no aggregate compensation
- require the cumulative gentle writing runway, two timed mocks, rubrics, answer keys, calibration, and book-only human validation at every rung
- distinguish `target contracted`, `mock ready`, and `learner proven` so a named destination cannot be mistaken for present readiness
- document level-specific four-skill timing and task envelopes for the future task inventories

## Evidence boundary

The Council of Europe CEFR Companion Volume supplies the proficiency descriptors and assessment-development framework. This is not an external Gujarati qualification, and the specification says so explicitly; its pass threshold and task envelopes are provisional project rules that require standard setting and human validation.

## Planner effect

- validated assessment contracts: 2/23 -> 3/23
- Gujarati's next enumerable item becomes the pre-A1 four-skill task-shape inventory
- 20 track contracts remain after this tranche; Japanese and Chinese are already represented by open stacks

## Validation

- `npm run build`
- `npx vitest run --maxWorkers=1` — 49 files, 849 tests passed in 425.62s
- all five generated-artifact checks
- focused assessment and completion-plan suites — 33 tests passed
- `git diff --check`

Closes #12389
Parent: #12206