### PR TITLE
feat(human-languages): define Gujarati pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/gujarati/CHANGELOG.md
+++ b/code/learning/human-languages/gujarati/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added — project-defined pre-A1 four-skill task shapes (HL18)
+
+- Made the pre-A1 target executable as reading, listening, writing, and
+  speaking papers with exact prompts, responses, timing, replay, aids, and
+  scoring boundaries.
+- Kept the assessment contract's point model literal: four separate 100-point
+  papers, a 60-point floor on each, and no aggregate compensation.
+- Writing assesses delayed recall, dictation/transcription, and bounded
+  independent production. Tracing and visible copying remain gentle lesson
+  supports and cannot earn exam credit.
+- The inventory is not a readiness claim. Curriculum task coverage, two full
+  mocks, rubrics, answer keys, calibration, and book-only human validation are
+  still required.
+
 ### Added — pre-A1-to-C2 assessment contract (HL16)
 
 - Added a clearly labelled project-defined Gujarati assessment ladder at

--- a/code/learning/human-languages/gujarati/README.md
+++ b/code/learning/human-languages/gujarati/README.md
@@ -31,9 +31,12 @@ Assessment](assessment-spec.md) from pre-A1 through C2. Its machine-readable
 [contract](assessment.json) requires separate passes in reading, listening,
 writing, and speaking, the full gentle writing ladder, and two timed mocks at
 every rung. This names the destination; it does not claim that the current book
-or the future certificate is externally accredited. Task inventories, mocks,
-rubrics, answer keys, calibration, and book-only human validation remain
-explicit backlog.
+or the future certificate is externally accredited. The pre-A1
+[four-skill task inventory](task-shapes/pre-a1.json) now makes that first rung
+executable, including independent writing from memory; it is an assessment
+blueprint, not proof that the current lessons teach every task. A1–C2
+inventories, mocks, rubrics, answer keys, calibration, and book-only human
+validation remain explicit backlog.
 
 ## Progress
 

--- a/code/learning/human-languages/gujarati/roadmap.md
+++ b/code/learning/human-languages/gujarati/roadmap.md
@@ -20,6 +20,10 @@ four-skill pass rule, and validation boundary, and [assessment.json](assessment.
 for the machine-readable seven-rung contract. Lessons stay at five minutes or
 less and writing grows one action at a time; full mocks keep continuous target
 timing. The contract records a target, not present-tense readiness evidence.
+The project-defined pre-A1 [task-shape inventory](task-shapes/pre-a1.json)
+specifies the first executable reading, listening, writing, and speaking papers.
+Its presence closes inventory debt only: curriculum coverage, mocks, scoring
+materials, and human pass evidence remain separate gates.
 
 ## Authored
 

--- a/code/learning/human-languages/gujarati/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/gujarati/task-shapes/pre-a1.json
@@ -1,0 +1,276 @@
+{
+  "version": 1,
+  "language": "gujarati",
+  "level": "pre-A1",
+  "target": {
+    "name": "Coding Adventures Gujarati pre-A1 Assessment — project-defined equivalent",
+    "basis": "project-defined"
+  },
+  "sources": [
+    {
+      "id": "ca-hl16-assessment-policy",
+      "title": "HL16 — Exam-ready books and the gentle writing ramp",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "ca-hl18-task-shapes",
+      "title": "HL18 — Four-skill task shapes",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    },
+    {
+      "id": "ca-gujarati-assessment",
+      "title": "Coding Adventures Gujarati Assessment Specification",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/gujarati/assessment-spec.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-20"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 32,
+    "speakingMinutes": 8,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 0,
+    "deliveryModes": ["paper", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.6,
+      "listening": 0.6,
+      "writing": 0.6,
+      "speaking": 0.6
+    },
+    "note": "Each skill is a separate 100-point paper and must reach 60 points. The 240-point aggregate floor cannot compensate for any failed skill."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-reading-script-and-word-match",
+          "promptModes": ["written-gujarati"],
+          "promptGenres": ["single Gujarati glyph", "known word", "everyday label"],
+          "responseModes": ["selection", "glyph-or-word-to-meaning match"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["Gujarati script recognition", "word recognition"] },
+          "aids": { "allowed": ["nonverbal picture choices"], "forbidden": ["romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-reading-phrases-and-notices",
+          "promptModes": ["written-gujarati", "icon-supported-written-prompt"],
+          "promptGenres": ["memorized greeting", "short everyday notice"],
+          "responseModes": ["selection", "phrase-to-situation match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["phrase recognition", "situation match"] },
+          "aids": { "allowed": ["nonverbal situation picture"], "forbidden": ["romanization", "translation", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-reading-personal-details",
+          "promptModes": ["written-gujarati", "simple-form-layout"],
+          "promptGenres": ["name label", "one-line personal detail"],
+          "responseModes": ["selection", "detail match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["personal-detail recognition", "accurate selection"] },
+          "aids": { "allowed": ["nonverbal form icons"], "forbidden": ["romanization", "translation", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-listening-sound-and-word-recognition",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["Gujarati sound", "known word"],
+          "responseModes": ["selection", "picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 1, "maximum": 4, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound recognition", "word recognition"] },
+          "aids": { "allowed": ["nonverbal picture choices"], "forbidden": ["transcript", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-listening-greeting-response",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["greeting", "farewell", "courtesy exchange"],
+          "responseModes": ["selection", "response-to-prompt match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["communicative-function recognition", "appropriate response selection"] },
+          "aids": { "allowed": ["nonverbal situation picture"], "forbidden": ["transcript", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-listening-personal-details",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["name", "identity statement", "familiar personal detail"],
+          "responseModes": ["selection", "detail match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["gist recognition", "personal-detail recognition"] },
+          "aids": { "allowed": ["nonverbal picture choices"], "forbidden": ["transcript", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 12,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-recall",
+          "promptModes": ["briefly-visible-written-model"],
+          "promptGenres": ["known Gujarati word", "known greeting chunk"],
+          "responseModes": ["delayed handwritten recall"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 20, "criteria": ["recognizable Gujarati letter sequence", "matra placement", "word boundary", "legibility"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["known Gujarati word"],
+          "responseModes": ["handwritten Gujarati dictation", "Gujarati-script transcription"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 1, "maximum": 4, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-script mapping", "matra placement", "orthographic control", "legibility"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["icon-supported-written-instruction"],
+          "promptGenres": ["personal label", "greeting response"],
+          "responseModes": ["independent handwritten word", "independent handwritten memorized chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task completion", "independent retrieval", "Gujarati orthographic control", "legibility"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["copyable answer model", "romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 8,
+      "parts": [
+        {
+          "id": "prea1-speaking-return-greeting",
+          "promptModes": ["live-speech"],
+          "promptGenres": ["greeting", "farewell"],
+          "responseModes": ["spoken memorized chunk"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 1, "maximum": 10, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 20, "criteria": ["appropriate response", "intelligibility"] },
+          "aids": { "allowed": ["one slow repetition"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-speaking-identify-self",
+          "promptModes": ["live-speech", "nonverbal picture cue"],
+          "promptGenres": ["name prompt", "identity prompt"],
+          "responseModes": ["short personal response"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 20, "criteria": ["task completion", "intelligibility", "personal information"] },
+          "aids": { "allowed": ["one slow repetition", "nonverbal picture cue"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-speaking-familiar-questions",
+          "promptModes": ["live-speech"],
+          "promptGenres": ["familiar one-turn personal question"],
+          "responseModes": ["one-word response", "short memorized response"],
+          "items": 3,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 1, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["question recognition", "relevant response", "intelligibility"] },
+          "aids": { "allowed": ["one slow repetition per question"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        },
+        {
+          "id": "prea1-speaking-short-request",
+          "promptModes": ["nonverbal picture cue", "live-speech"],
+          "promptGenres": ["one-step everyday need", "polite request situation"],
+          "responseModes": ["spoken short request"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["request completed", "appropriate courtesy", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-gujarati-assessment"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -3,6 +3,35 @@ import { loadLanguageRegistry, loadTaskShapeInventory, listTaskShapeInventories 
 import { buildTaskShapeBacklog, parseTaskShapeInventory } from "../src/task-shapes.js";
 
 describe("four-skill task-shape inventories (HL18)", () => {
+  it("loads the project-defined Gujarati pre-A1 floor with four separate 100-point papers", () => {
+    const inventory = loadTaskShapeInventory("gujarati", "pre-A1");
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Gujarati pre-A1 Assessment — project-defined equivalent",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual([
+      "reading",
+      "listening",
+      "writing",
+      "speaking",
+    ]);
+    expect(inventory.administration).toMatchObject({
+      writtenMinutes: 32,
+      speakingMinutes: 8,
+      speakingPreparationMinutes: 0,
+    });
+    expect(inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0)
+    )).toEqual([100, 100, 100, 100]);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+    expect(inventory.sections.find((section) => section.skill === "writing")?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-recall",
+      "prea1-writing-dictation",
+      "prea1-writing-bounded-production",
+    ]);
+  });
+
   it("loads the project-defined Marwadi pre-A1 floor with independent productive writing", () => {
     const inventory = loadTaskShapeInventory("marwadi", "pre-A1");
     expect(inventory.target).toEqual({
@@ -189,11 +218,13 @@ describe("four-skill task-shape inventories (HL18)", () => {
       { language: "german", level: "A1" },
       { language: "arabic", level: "A1" },
       { language: "marwadi", level: "pre-A1" },
+      { language: "gujarati", level: "pre-A1" },
     ]);
-    expect(backlog).toHaveLength(registry.languages.length * 7 - 7);
-    expect(backlog.filter((item) => item.level === "pre-A1")).toHaveLength(registry.languages.length - 2);
+    expect(backlog).toHaveLength(registry.languages.length * 7 - 8);
+    expect(backlog.filter((item) => item.level === "pre-A1")).toHaveLength(registry.languages.length - 3);
     expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 5);
     expect(backlog.some((item) => item.id === "task-shape/marwadi/pre-A1")).toBe(false);
+    expect(backlog.some((item) => item.id === "task-shape/gujarati/pre-A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/spanish/pre-A1")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/spanish/A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/spanish/A2")).toBe(true);


### PR DESCRIPTION
## Summary

- make the project-defined Gujarati pre-A1 assessment executable as 13 task parts across reading, listening, writing, and speaking
- pin the contract's exact 32-minute written and 8-minute speaking administration
- keep four separate 100-point papers, independent 60% skill floors, and a 240-point aggregate that cannot compensate for a failed skill
- assess delayed recall, dictation/transcription, and bounded independent writing while keeping tracing and visible copying instructional only
- document that task-inventory coverage is not curriculum coverage, mock readiness, or learner-pass evidence

## Planner effect

- sourced four-skill task shapes: 6/161 -> 7/161 on the current parent baseline
- Gujarati's next queue head becomes its missing pre-A1 writing-stage runway
- newly discovered Marwadi point-scale mismatch is logged separately in #12392

## Validation

- `npm run build`
- focused assessment/task-shape/completion-plan suites — 51 tests passed
- `npx vitest run --maxWorkers=1` — 49 files, 850 tests passed in 420.80s
- all five generated-artifact checks
- `git diff --check`

Closes #12391
Depends on #12390
Parent program: #12206