### PR TITLE
human-languages: model required exam components

### DIFF
--- a/code/packages/typescript/human-language-data/src/assessment.ts
+++ b/code/packages/typescript/human-language-data/src/assessment.ts
@@ -39,6 +39,11 @@ export interface AssessmentContract {
       taskInventory: string[];
       passThreshold: number;
     }>;
+    additionalComponents: Record<string, {
+      name: string;
+      taskInventory: string[];
+      passThreshold: number;
+    }>;
     writingStages: string[];
     fullMocks: Array<{
       id: string;
@@ -158,6 +163,51 @@ export function parseAssessmentContract(
       }
       return [skill, { taskInventory: [...skillRaw.taskInventory], passThreshold: skillRaw.passThreshold }];
     })) as AssessmentContract["levels"][number]["skills"];
+    const additionalRaw = item.additionalComponents === undefined
+      ? {}
+      : object(item.additionalComponents, `${expectedLanguage}.${current}.additionalComponents`);
+    const additionalComponents = Object.fromEntries(Object.entries(additionalRaw).map(([id, component]) => {
+      if (!/^[a-z][a-z0-9-]*$/.test(id)) {
+        throw new Error(
+          `assessment: ${expectedLanguage}.${current}.additionalComponents key '${id}' must be a lowercase slug`,
+        );
+      }
+      if (ASSESSMENT_SKILLS.includes(id as AssessmentSkill)) {
+        throw new Error(
+          `assessment: ${expectedLanguage}.${current}.additionalComponents '${id}' duplicates a universal skill`,
+        );
+      }
+      const componentRaw = object(
+        component,
+        `${expectedLanguage}.${current}.additionalComponents.${id}`,
+      );
+      if (
+        !Array.isArray(componentRaw.taskInventory)
+        || componentRaw.taskInventory.length === 0
+        || componentRaw.taskInventory.some((task) => typeof task !== "string" || task.trim() === "")
+      ) {
+        throw new Error(
+          `assessment: ${expectedLanguage}.${current}.additionalComponents.${id}.taskInventory must be a non-empty string array`,
+        );
+      }
+      if (
+        typeof componentRaw.passThreshold !== "number"
+        || componentRaw.passThreshold <= 0
+        || componentRaw.passThreshold > 1
+      ) {
+        throw new Error(
+          `assessment: ${expectedLanguage}.${current}.additionalComponents.${id}.passThreshold must be in (0, 1]`,
+        );
+      }
+      return [id, {
+        name: nonEmpty(
+          componentRaw.name,
+          `${expectedLanguage}.${current}.additionalComponents.${id}.name`,
+        ),
+        taskInventory: [...componentRaw.taskInventory],
+        passThreshold: componentRaw.passThreshold,
+      }];
+    }));
     if (!Array.isArray(item.writingStages) || item.writingStages.some((stage) => typeof stage !== "string")) {
       throw new Error(`assessment: ${expectedLanguage}.${current}.writingStages must be a string array`);
     }
@@ -192,6 +242,7 @@ export function parseAssessmentContract(
         source: nonEmpty(target.source, `${expectedLanguage}.${current}.target.source`),
       },
       skills: parsedSkills,
+      additionalComponents,
       writingStages: [...item.writingStages] as string[],
       fullMocks,
     };

--- a/code/packages/typescript/human-language-data/tests/assessment.test.ts
+++ b/code/packages/typescript/human-language-data/tests/assessment.test.ts
@@ -118,7 +118,86 @@ describe("track assessment contracts", () => {
         ],
       })),
     };
-    expect(parseAssessmentContract(value, "alpha", policy).levels).toHaveLength(7);
+    const parsed = parseAssessmentContract(value, "alpha", policy);
+    expect(parsed.levels).toHaveLength(7);
+    expect(parsed.levels.every((level) => Object.keys(level.additionalComponents).length === 0)).toBe(true);
+  });
+
+  it("parses independently required provider components beyond the four-skill floor", () => {
+    const skill = { taskInventory: ["tasks.json"], passThreshold: 0.66 };
+    const value = {
+      version: 1,
+      language: "alpha",
+      levels: policy.levels.map((current, levelIndex) => ({
+        level: current,
+        target: { name: `Alpha ${current}`, basis: "external", source: "assessment-spec.md" },
+        skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+        additionalComponents: {
+          "lexis-grammar": {
+            name: "Lexis. Grammar",
+            taskInventory: [`task-shapes/${current}.json#lexis-grammar`],
+            passThreshold: 0.66,
+          },
+        },
+        writingStages: policy.writingStages
+          .filter((stage) => policy.levels.indexOf(stage.firstRequiredAt) <= levelIndex)
+          .map((stage) => stage.id),
+        fullMocks: [
+          { id: `${current}-mock-1`, timed: true, rubric: "rubric.md", answerKey: "answers-1.md" },
+          { id: `${current}-mock-2`, timed: true, rubric: "rubric.md", answerKey: "answers-2.md" },
+        ],
+      })),
+    };
+    const parsed = parseAssessmentContract(value, "alpha", policy);
+    expect(parsed.levels[0]?.additionalComponents["lexis-grammar"]).toEqual({
+      name: "Lexis. Grammar",
+      taskInventory: ["task-shapes/pre-A1.json#lexis-grammar"],
+      passThreshold: 0.66,
+    });
+  });
+
+  it("rejects additional components that shadow a universal skill", () => {
+    const skill = { taskInventory: ["tasks.json"], passThreshold: 0.6 };
+    const one = {
+      version: 1,
+      language: "alpha",
+      levels: [{
+        level: "pre-A1",
+        target: { name: "Alpha checkpoint", basis: "external", source: "alpha.md" },
+        skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+        additionalComponents: {
+          reading: { name: "Second reading", taskInventory: ["extra.json"], passThreshold: 0.6 },
+        },
+        writingStages: ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription"],
+        fullMocks: [
+          { id: "mock-1", timed: true, rubric: "rubric.md", answerKey: "answers-1.md" },
+          { id: "mock-2", timed: true, rubric: "rubric.md", answerKey: "answers-2.md" },
+        ],
+      }],
+    };
+    expect(() => parseAssessmentContract(one, "alpha", policy)).toThrow(/duplicates a universal skill/);
+  });
+
+  it("rejects a declared provider component without a task inventory", () => {
+    const skill = { taskInventory: ["tasks.json"], passThreshold: 0.6 };
+    const one = {
+      version: 1,
+      language: "alpha",
+      levels: [{
+        level: "pre-A1",
+        target: { name: "Alpha checkpoint", basis: "external", source: "alpha.md" },
+        skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+        additionalComponents: {
+          "lexis-grammar": { name: "Lexis. Grammar", taskInventory: [], passThreshold: 0.66 },
+        },
+        writingStages: ["observe-trace", "guided-copy", "delayed-copy", "dictation-transcription"],
+        fullMocks: [
+          { id: "mock-1", timed: true, rubric: "rubric.md", answerKey: "answers-1.md" },
+          { id: "mock-2", timed: true, rubric: "rubric.md", answerKey: "answers-2.md" },
+        ],
+      }],
+    };
+    expect(() => parseAssessmentContract(one, "alpha", policy)).toThrow(/taskInventory must be a non-empty string array/);
   });
 
   it("requires all four independently scored skills", () => {

--- a/code/specs/HL16-exam-ready-books-and-writing-ramp.md
+++ b/code/specs/HL16-exam-ready-books-and-writing-ramp.md
@@ -79,7 +79,17 @@ contract contains every level and, at each level:
 5. an independent pass threshold for each skill;
 6. the writing stages required at that level;
 7. at least two complete timed mocks;
-8. a rubric and answer key for every mock.
+8. a rubric and answer key for every mock;
+9. every compulsory provider-specific component beyond the four-skill floor.
+
+An external exam may require a separately passed component that is not itself
+one of the four universal skills—for example, TORFL's `Lexis. Grammar`
+subtest. Declare each such part in the level's optional `additionalComponents`
+object, keyed by a lowercase slug. Every declared component has a learner-facing
+name, non-empty task-inventory references, and its own pass threshold. A slug may
+not shadow `reading`, `listening`, `writing`, or `speaking`. Omission means the
+level has no known additional required component; it must never be used to hide
+one that the named provider actually requires.
 
 “No widely-sat ladder” is no longer a terminal answer. It selects the
 project-defined path. The equivalent must be published and reviewable; it may


### PR DESCRIPTION
## Summary

- extend HL16 assessment levels with optional, independently thresholded provider-specific components beyond the universal four-skill floor
- validate lowercase non-shadowing component slugs, learner-facing names, non-empty task inventories, and pass thresholds
- preserve backward compatibility by parsing existing contracts with an empty component map
- document the contract rule in HL16 and cover valid, missing-inventory, and universal-skill-shadowing cases

## Stack

Depends on #12404 for the merge-friendly contract-discovery seam. Russian #12408 will be rebased onto this PR and will be its first real consumer for TORFL `Lexis. Grammar`.

## Validation

- `npx vitest run --maxWorkers=1` — 49 files, 856 tests passed
- focused parser/planner run — 3 files, 52 tests passed before the final negative-case addition
- `npm run check:books`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `git diff --check`

Closes #12407