### PR TITLE
human-languages: reconcile Marwadi paper scoring

### DIFF
--- a/code/learning/human-languages/marwadi/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/marwadi/task-shapes/pre-a1.json
@@ -37,8 +37,8 @@
     "deliveryModes": ["paper", "recorded-audio", "live-interlocutor"]
   },
   "passRule": {
-    "maximumPoints": 100,
-    "passPoints": 60,
+    "maximumPoints": 400,
+    "passPoints": 240,
     "requiresEverySectionAttempted": true,
     "independentSkillThresholds": {
       "reading": 0.6,
@@ -46,7 +46,7 @@
       "writing": 0.6,
       "speaking": 0.6
     },
-    "note": "Each skill is worth 25 points and must independently reach 60%; the overall 60-point floor cannot compensate for a failed skill."
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper."
   },
   "sections": [
     {
@@ -63,7 +63,7 @@
           "responseLength": null,
           "interaction": "individual",
           "replayCount": 0,
-          "scoring": { "maxRawPoints": 25, "criteria": ["meaning selection", "script recognition"] },
+          "scoring": { "maxRawPoints": 100, "criteria": ["meaning selection", "script recognition"] },
           "aids": { "allowed": [], "forbidden": ["romanization", "dictionary"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
@@ -85,7 +85,7 @@
           "responseLength": null,
           "interaction": "individual",
           "replayCount": 2,
-          "scoring": { "maxRawPoints": 25, "criteria": ["gist recognition", "detail recognition"] },
+          "scoring": { "maxRawPoints": 100, "criteria": ["gist recognition", "detail recognition"] },
           "aids": { "allowed": [], "forbidden": ["transcript", "dictionary"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
@@ -107,7 +107,7 @@
           "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
           "interaction": "individual",
           "replayCount": 0,
-          "scoring": { "maxRawPoints": 5, "criteria": ["recognizable letter sequence", "matra placement", "legibility"] },
+          "scoring": { "maxRawPoints": 20, "criteria": ["recognizable letter sequence", "matra placement", "legibility"] },
           "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "romanization"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
@@ -122,7 +122,7 @@
           "responseLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
           "interaction": "individual",
           "replayCount": 2,
-          "scoring": { "maxRawPoints": 10, "criteria": ["sound-to-script mapping", "word boundary", "legibility"] },
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-script mapping", "word boundary", "legibility"] },
           "aids": { "allowed": [], "forbidden": ["transcript", "romanization", "dictionary"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
@@ -137,7 +137,7 @@
           "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
           "interaction": "individual",
           "replayCount": 0,
-          "scoring": { "maxRawPoints": 10, "criteria": ["task completion", "independent retrieval", "orthographic control", "legibility"] },
+          "scoring": { "maxRawPoints": 40, "criteria": ["task completion", "independent retrieval", "orthographic control", "legibility"] },
           "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["copyable answer model", "romanization", "dictionary"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
@@ -159,7 +159,7 @@
           "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
           "interaction": "individual",
           "replayCount": 1,
-          "scoring": { "maxRawPoints": 25, "criteria": ["task completion", "intelligibility", "appropriate greeting response"] },
+          "scoring": { "maxRawPoints": 100, "criteria": ["task completion", "intelligibility", "appropriate greeting response"] },
           "aids": { "allowed": ["nonverbal picture cue", "one repeat request"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
           "notPublished": [],
           "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]

--- a/code/packages/typescript/human-language-data/src/task-shapes.ts
+++ b/code/packages/typescript/human-language-data/src/task-shapes.ts
@@ -404,6 +404,18 @@ export function parseTaskShapeInventory(value: unknown, expectedLanguage: string
   if (speakingSectionMinutes === undefined || !sameMinutes(speakingSectionMinutes, speakingMinutes)) {
     throw new Error(`task shapes: speaking minutes do not match administration.speakingMinutes`);
   }
+  const hasExplicitVariants = sections.some((section) => section.variants.length > 0);
+  const rawPointCeilings = sections.flatMap((section) =>
+    section.parts.map((part) => part.scoring.maxRawPoints)
+  );
+  if (!hasExplicitVariants && rawPointCeilings.every((points) => points !== null)) {
+    const rawPointTotal = rawPointCeilings.reduce((sum, points) => sum + points, 0);
+    if (rawPointTotal !== maximumPoints) {
+      throw new Error(
+        `task shapes: part maxRawPoints sum to ${rawPointTotal}, not passRule.maximumPoints ${maximumPoints}`,
+      );
+    }
+  }
 
   return {
     version: 1,

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -32,7 +32,7 @@ describe("four-skill task-shape inventories (HL18)", () => {
     ]);
   });
 
-  it("loads the project-defined Marwadi pre-A1 floor with independent productive writing", () => {
+  it("loads the project-defined Marwadi pre-A1 floor as four separate 100-point papers", () => {
     const inventory = loadTaskShapeInventory("marwadi", "pre-A1");
     expect(inventory.target).toEqual({
       name: "Coding Adventures Marwadi pre-A1 Assessment — project-defined equivalent",
@@ -45,6 +45,12 @@ describe("four-skill task-shape inventories (HL18)", () => {
       "speaking",
     ]);
     expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0)
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(paperPoints.reduce((sum, points) => sum + points, 0)).toBe(inventory.passRule.maximumPoints);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
     expect(inventory.sections.find((section) => section.skill === "writing")?.parts.map((part) => part.id)).toEqual([
       "prea1-writing-delayed-recall",
       "prea1-writing-dictation",
@@ -249,6 +255,14 @@ describe("four-skill task-shape inventories (HL18)", () => {
     const value = JSON.parse(JSON.stringify(loadTaskShapeInventory("marwadi", "pre-A1")));
     value.sections = value.sections.filter((section: { skill: string }) => section.skill === "reading");
     expect(() => parseTaskShapeInventory(value, "marwadi")).toThrow(/missing listening section/);
+  });
+
+  it("rejects a fully scored administration whose part ceilings do not reach its declared scale", () => {
+    const value = JSON.parse(JSON.stringify(loadTaskShapeInventory("marwadi", "pre-A1")));
+    value.sections[0].parts[0].scoring.maxRawPoints = 99;
+    expect(() => parseTaskShapeInventory(value, "marwadi")).toThrow(
+      /part maxRawPoints sum to 399, not passRule.maximumPoints 400/,
+    );
   });
 
   it("rejects invented-looking null measurements without an explicit source gap", () => {

--- a/code/specs/HL18-four-skill-task-shapes.md
+++ b/code/specs/HL18-four-skill-task-shapes.md
@@ -83,6 +83,13 @@ independent internal thresholds so a strong reading score cannot hide an
 untaught speaking or writing strand. The source-backed external rule and the
 project's stronger readiness claim remain distinguishable.
 
+When every task part publishes a numeric `maxRawPoints` and the inventory has no
+alternate-form variants, those part ceilings must sum exactly to
+`passRule.maximumPoints`. Four separate 100-point papers therefore declare 400,
+not a fictional 100-point administration with four 25-point sections. The
+headline `passPoints` remains bookkeeping only when independent thresholds are
+present: reaching the sum never compensates for a failed required skill.
+
 ## 5. From exam task to five-minute lessons
 
 A task shape is decomposed backward into microsteps. A 30-word message is not


### PR DESCRIPTION
## Summary

- reconcile Marwadi pre-A1 with its assessment contract as four separate 100-point papers
- scale the existing raw weights without changing any task, item, response, replay, or timing envelope
- declare 400 total / 240 headline points while preserving an independent 60% requirement in every skill, so aggregate points cannot compensate
- make fully numeric, non-variant task inventories fail closed when part ceilings do not sum to the declared administration scale
- document the invariant in HL18 and add positive plus deliberate 399-vs-400 regression coverage

## Follow-up

#12410 tracks the separately discovered 40-minute-spec versus 25-minute-inventory timing mismatch. This scoring PR deliberately does not alter that learner envelope.

## Validation

- `npx vitest run --maxWorkers=1` — 49 files, 853 tests passed
- post-rebase focused run — 3 files, 63 tests passed
- `npm run check:books`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `git diff --check`

Closes #12392