### PR TITLE
human-languages: inventory Marwadi A1 task shapes

### DIFF
--- a/code/learning/human-languages/marwadi/CHANGELOG.md
+++ b/code/learning/human-languages/marwadi/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-21 — Enumerate the A1 assessment task shapes
+
+- Added an executable A1 destination for all four skills instead of treating a
+  level label as evidence of exam readiness.
+- Bounded the 20-item reading and 17-item two-play listening papers, including
+  the published source-word and speech-rate envelopes.
+- Made writing progress from a practical form to a 30–40 word message for a
+  named reader and purpose, then pinned the interview, prepared description,
+  and transactional speaking phases.
+- Preserved four independent 100-point papers with a 60% threshold in every
+  skill and no aggregate compensation.
+
 ## 2026-08-21 — Align the pre-A1 assessment inventory
 
 - Aligned the four paper durations with the published pre-A1 assessment

--- a/code/learning/human-languages/marwadi/task-shapes/a1.json
+++ b/code/learning/human-languages/marwadi/task-shapes/a1.json
@@ -1,0 +1,246 @@
+{
+  "version": 1,
+  "language": "marwadi",
+  "level": "A1",
+  "target": {
+    "name": "Coding Adventures Marwadi A1 Assessment — project-defined equivalent",
+    "basis": "project-defined"
+  },
+  "sources": [
+    {
+      "id": "ca-hl16-assessment-policy",
+      "title": "HL16 — Exam-ready books and the gentle writing ramp",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-hl18-task-shapes",
+      "title": "HL18 — Four-skill task shapes",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-marwadi-assessment",
+      "title": "Coding Adventures Marwadi Assessment Specification",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/marwadi/assessment-spec.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 58,
+    "speakingMinutes": 10,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 5,
+    "deliveryModes": ["paper", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.6,
+      "listening": 0.6,
+      "writing": 0.6,
+      "speaking": 0.6
+    },
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 20,
+      "parts": [
+        {
+          "id": "a1-reading-signs-and-forms",
+          "promptModes": ["written-devanagari", "written-icon-supported-instruction"],
+          "promptGenres": ["sign and label set; no source over 90 words", "practical form extract; no source over 90 words"],
+          "responseModes": ["selection", "detail match"],
+          "items": 7,
+          "stimulusLength": { "unit": "words", "minimum": 70, "maximum": 90, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 35, "criteria": ["meaning selection", "practical-detail recognition", "script recognition"] },
+          "aids": { "allowed": ["marking on the question paper"], "forbidden": ["romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-reading-short-messages",
+          "promptModes": ["written-devanagari"],
+          "promptGenres": ["short personal message set; no source over 90 words", "short public notice set; no source over 90 words"],
+          "responseModes": ["selection", "short detail match"],
+          "items": 7,
+          "stimulusLength": { "unit": "words", "minimum": 90, "maximum": 120, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 35, "criteria": ["gist recognition", "detail recognition", "communicative-purpose recognition"] },
+          "aids": { "allowed": ["marking on the question paper"], "forbidden": ["romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-reading-personal-descriptions",
+          "promptModes": ["written-devanagari"],
+          "promptGenres": ["personal description set; no source over 90 words", "everyday profile set; no source over 90 words"],
+          "responseModes": ["selection", "person-to-detail match"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 90, "maximum": 140, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["person-detail association", "explicit-information recognition", "simple inference"] },
+          "aids": { "allowed": ["marking on the question paper"], "forbidden": ["romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 18,
+      "parts": [
+        {
+          "id": "a1-listening-announcements",
+          "promptModes": ["recorded Marwari at 90-110 words per minute"],
+          "promptGenres": ["short public announcement", "practical recorded notice"],
+          "responseModes": ["selection", "picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 60, "maximum": 90, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 35, "criteria": ["gist recognition", "time-place-detail recognition"] },
+          "aids": { "allowed": ["nonverbal picture cue", "notes on the question paper"], "forbidden": ["transcript", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-listening-short-exchanges",
+          "promptModes": ["recorded Marwari at 90-110 words per minute"],
+          "promptGenres": ["short everyday exchange", "simple transaction"],
+          "responseModes": ["selection", "speaker-intention match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 90, "maximum": 120, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 35, "criteria": ["exchange gist", "speaker intention", "specific detail"] },
+          "aids": { "allowed": ["nonverbal picture cue", "notes on the question paper"], "forbidden": ["transcript", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-listening-personal-account",
+          "promptModes": ["recorded Marwari at 90-110 words per minute"],
+          "promptGenres": ["short personal account", "familiar daily-routine description"],
+          "responseModes": ["selection", "sequence match"],
+          "items": 5,
+          "stimulusLength": { "unit": "seconds", "minimum": 120, "maximum": 180, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["account gist", "event sequence", "personal detail"] },
+          "aids": { "allowed": ["nonverbal picture cue", "notes on the question paper"], "forbidden": ["transcript", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 20,
+      "parts": [
+        {
+          "id": "a1-writing-practical-form",
+          "promptModes": ["written-devanagari", "written support-language instruction"],
+          "promptGenres": ["practical personal-information form"],
+          "responseModes": ["handwritten form completion in Devanagari"],
+          "items": 1,
+          "stimulusLength": { "unit": "words", "minimum": 40, "maximum": 70, "approximate": false },
+          "responseLength": { "unit": "items", "minimum": 6, "maximum": 8, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task fulfilment", "requested content", "Marwari control", "orthographic control"] },
+          "aids": { "allowed": ["unscored example field"], "forbidden": ["copyable answer model", "romanization", "dictionary", "translator", "spell-checker"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-writing-reader-purpose-message",
+          "promptModes": ["written-devanagari", "written support-language instruction"],
+          "promptGenres": ["named-reader everyday message", "purpose-led personal note"],
+          "responseModes": ["independent handwritten message in Devanagari"],
+          "items": 1,
+          "stimulusLength": { "unit": "words", "minimum": 25, "maximum": 50, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 30, "maximum": 40, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 60, "criteria": ["task fulfilment and relevant content", "comprehensibility and organisation", "Marwari vocabulary and grammar", "orthographic control"] },
+          "aids": { "allowed": ["unscored task example"], "forbidden": ["copyable answer model", "romanization", "dictionary", "translator", "spell-checker"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "a1-speaking-personal-interview",
+          "promptModes": ["live-speech"],
+          "promptGenres": ["familiar personal interview"],
+          "responseModes": ["short spoken personal responses"],
+          "items": 5,
+          "stimulusLength": { "unit": "seconds", "minimum": 10, "maximum": 45, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 60, "maximum": 120, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task fulfilment and relevant content", "interaction", "Marwari vocabulary and grammar", "pronunciation and fluency"] },
+          "aids": { "allowed": [], "forbidden": ["written answer script", "romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-speaking-prepared-description",
+          "promptModes": ["written-devanagari", "nonverbal picture cue"],
+          "promptGenres": ["familiar person, place, object, or routine"],
+          "responseModes": ["one-minute prepared spoken description"],
+          "items": 1,
+          "stimulusLength": { "unit": "words", "minimum": 10, "maximum": 30, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 60, "maximum": 60, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task fulfilment and relevant content", "organisation", "Marwari vocabulary and grammar", "pronunciation and fluency"] },
+          "aids": { "allowed": ["examiner-provided prompt card", "paper notes made during preparation"], "forbidden": ["written answer script", "romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        },
+        {
+          "id": "a1-speaking-transactional-role-play",
+          "promptModes": ["live-speech", "nonverbal situation cue"],
+          "promptGenres": ["simple everyday transaction"],
+          "responseModes": ["spoken transactional role-play"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 10, "maximum": 30, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 60, "maximum": 120, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task fulfilment and relevant content", "interaction and repair", "Marwari vocabulary and grammar", "pronunciation and fluency"] },
+          "aids": { "allowed": ["examiner-provided situation cue"], "forbidden": ["written answer script", "romanization", "dictionary", "translator"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-marwadi-assessment"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/task-shapes.test.ts
@@ -87,6 +87,53 @@ describe("four-skill task-shape inventories (HL18)", () => {
     expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
   });
 
+  it("loads the project-defined Marwadi A1 destination as an executable four-paper envelope", () => {
+    const inventory = loadTaskShapeInventory("marwadi", "A1");
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Marwadi A1 Assessment — project-defined equivalent",
+      basis: "project-defined",
+    });
+    expect(inventory.administration).toMatchObject({
+      writtenMinutes: 58,
+      speakingMinutes: 10,
+      speakingPreparationMinutes: 5,
+    });
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([20, 18, 20, 10]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.id))).toEqual([
+      ["a1-reading-signs-and-forms", "a1-reading-short-messages", "a1-reading-personal-descriptions"],
+      ["a1-listening-announcements", "a1-listening-short-exchanges", "a1-listening-personal-account"],
+      ["a1-writing-practical-form", "a1-writing-reader-purpose-message"],
+      ["a1-speaking-personal-interview", "a1-speaking-prepared-description", "a1-speaking-transactional-role-play"],
+    ]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.items))).toEqual([
+      [7, 7, 6],
+      [6, 6, 5],
+      [1, 1],
+      [5, 1, 1],
+    ]);
+
+    const [reading, listening, writing] = inventory.sections;
+    expect(reading?.parts.reduce((sum, part) => sum + (part.stimulusLength?.minimum ?? 0), 0)).toBe(250);
+    expect(reading?.parts.reduce((sum, part) => sum + (part.stimulusLength?.maximum ?? 0), 0)).toBe(350);
+    expect(reading?.parts.every((part) =>
+      part.promptGenres.every((genre) => genre.includes("no source over 90 words"))
+    )).toBe(true);
+    expect(listening?.parts.every((part) =>
+      part.promptModes.includes("recorded Marwari at 90-110 words per minute") && part.replayCount === 2
+    )).toBe(true);
+    expect(writing?.parts.map((part) => part.responseLength)).toEqual([
+      { unit: "items", minimum: 6, maximum: 8, approximate: false },
+      { unit: "words", minimum: 30, maximum: 40, approximate: false },
+    ]);
+
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0)
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+  });
+
   it("loads the official Spanish A1 performance target and its grouped pass rule", () => {
     const inventory = loadTaskShapeInventory("spanish", "A1");
     expect(inventory.target).toEqual({ name: "DELE A1", basis: "external" });
@@ -253,12 +300,14 @@ describe("four-skill task-shape inventories (HL18)", () => {
       { language: "german", level: "A1" },
       { language: "arabic", level: "A1" },
       { language: "marwadi", level: "pre-A1" },
+      { language: "marwadi", level: "A1" },
       { language: "gujarati", level: "pre-A1" },
     ]);
-    expect(backlog).toHaveLength(registry.languages.length * 7 - 8);
+    expect(backlog).toHaveLength(registry.languages.length * 7 - 9);
     expect(backlog.filter((item) => item.level === "pre-A1")).toHaveLength(registry.languages.length - 3);
-    expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 5);
+    expect(backlog.filter((item) => item.level === "A1")).toHaveLength(registry.languages.length - 6);
     expect(backlog.some((item) => item.id === "task-shape/marwadi/pre-A1")).toBe(false);
+    expect(backlog.some((item) => item.id === "task-shape/marwadi/A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/gujarati/pre-A1")).toBe(false);
     expect(backlog.some((item) => item.id === "task-shape/spanish/pre-A1")).toBe(true);
     expect(backlog.some((item) => item.id === "task-shape/spanish/A1")).toBe(false);


### PR DESCRIPTION
## Summary
- enumerate a complete project-defined Marwadi A1 reading, listening, writing, and speaking destination
- turn the assessment specification into bounded timings, source/response lengths, item counts, replays, aids, and scoring criteria
- retain four separate 100-point papers with a 60% threshold in every skill and no aggregate compensation
- remove exactly one A1 task-shape item from the round-robin research backlog

## Validation
- npm run build
- npx vitest run tests/task-shapes.test.ts tests/integration.test.ts tests/completion-plan.test.ts (64 passed)
- npx vitest run --maxWorkers=1 (854 passed)
- npm run check:books
- npm run check:figures
- npm run check:modality
- npm run check:narration
- npm run check:progress
- npm run check:gentle-snapshots

## Stack
This PR is based on #12414 so the A1 diff remains reviewable. Retarget to main and enable auto-merge only after #12414 lands.

Closes #12415