### PR TITLE
feat(human-languages): restore Malayalam spaced writing ramp

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -5823,7 +5823,7 @@
     {
       "language": "malayalam",
       "chapter": 2,
-      "sourceHash": "fnv1a64:da4d2f30bce7d386",
+      "sourceHash": "fnv1a64:6928ba9fa0a57b17",
       "lessonIds": [
         "ML-C02-peru",
         "ML-C02-enre",
@@ -5833,33 +5833,35 @@
         "ML-C02-entu",
         "ML-C02-ninre-peru-entaanu",
         "ML-C02-santosham",
+        "ML-W02-santosham-guided-copy",
         "ML-C02-practice"
       ],
-      "voiceLessons": 4,
+      "voiceLessons": 3,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch02.txt",
       "json": "malayalam/narration/ch02.json",
-      "textHash": "fnv1a64:8556d0d39744d548",
-      "jsonHash": "fnv1a64:edbbe2b388e8c07b"
+      "textHash": "fnv1a64:fcac8a1bf395115a",
+      "jsonHash": "fnv1a64:5d8c0351fb248940"
     },
     {
       "language": "malayalam",
       "chapter": 3,
-      "sourceHash": "fnv1a64:5236bd3259a983df",
+      "sourceHash": "fnv1a64:c73a9560fa68161c",
       "lessonIds": [
         "ML-C03-engane",
         "ML-C03-sukhamaano",
         "ML-C03-njaan",
         "ML-C03-sukham",
         "ML-C03-saaramilla",
-        "ML-C03-practice"
+        "ML-C03-practice",
+        "ML-W03-santosham-delayed-copy"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch03.txt",
       "json": "malayalam/narration/ch03.json",
-      "textHash": "fnv1a64:19f0c90b6391e61a",
-      "jsonHash": "fnv1a64:77dad064c2d252c5"
+      "textHash": "fnv1a64:b762a40c6767a192",
+      "jsonHash": "fnv1a64:ec60b51d1ced9e15"
     },
     {
       "language": "malayalam",

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/malayalam.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/malayalam.json
@@ -1,14 +1,14 @@
 {
   "language": "malayalam",
-  "lessonCount": 247,
-  "atomMeasurableLessons": 216,
-  "atomMeasurementBlindLessons": 31,
+  "lessonCount": 249,
+  "atomMeasurableLessons": 217,
+  "atomMeasurementBlindLessons": 32,
   "durationViolations": 0,
   "atomLessonSpikes": 1,
   "atomChapterSpikes": 0,
-  "glyphLessonSpikes": 4,
+  "glyphLessonSpikes": 3,
   "scriptSystemSpikes": 0,
-  "scriptClosureViolations": 42,
+  "scriptClosureViolations": 40,
   "neverTaughtGlyphs": 18,
   "orderDefects": 0,
   "lessonsWithoutSequence": 0,
@@ -16,17 +16,17 @@
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 17,
-  "atomsTaught": 281,
+  "atomsTaught": 283,
   "atomsNeverRevisited": 51,
-  "reinforcementWindowMisses": 789,
+  "reinforcementWindowMisses": 794,
   "reinforcementMissesByWindow": {
-    "R1": 83,
+    "R1": 84,
     "R2": 261,
-    "R3": 247,
-    "R4": 198
+    "R3": 249,
+    "R4": 200
   },
   "payoffSurprises": 7,
-  "writingPracticeLessons": 57,
+  "writingPracticeLessons": 60,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
@@ -54,14 +54,14 @@
     {
       "language": "malayalam",
       "kind": "glyph-step",
-      "count": 4,
+      "count": 3,
       "unit": "lesson/system spike(s)",
       "detail": "split new glyphs and writing systems across gentler steps"
     },
     {
       "language": "malayalam",
       "kind": "reinforcement",
-      "count": 789,
+      "count": 794,
       "unit": "missed window(s)",
       "detail": "add retrieval at the expanding R1-R4 intervals"
     },
@@ -75,7 +75,7 @@
     {
       "language": "malayalam",
       "kind": "measurement-blind",
-      "count": 31,
+      "count": 32,
       "unit": "lesson(s)",
       "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
     }

--- a/code/learning/human-languages/core/lesson-modality/malayalam.json
+++ b/code/learning/human-languages/core/lesson-modality/malayalam.json
@@ -7,14 +7,14 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:2aa3d495ce57eafa",
+  "sourceHash": "fnv1a64:e5f168764350268e",
   "summary": {
-    "totalLessons": 247,
-    "voice": 182,
+    "totalLessons": 249,
+    "voice": 181,
     "sight": 41,
-    "pen": 24,
-    "drivableLessons": 182,
-    "drivablePercent": 74,
+    "pen": 27,
+    "drivableLessons": 181,
+    "drivablePercent": 73,
     "trackCount": 1,
     "chapterCount": 66,
     "drivablePrefixTotal": 172,
@@ -26,11 +26,11 @@
   "tracks": [
     {
       "language": "malayalam",
-      "lessonCount": 247,
-      "voice": 182,
+      "lessonCount": 249,
+      "voice": 181,
       "sight": 41,
-      "pen": 24,
-      "drivablePercent": 74,
+      "pen": 27,
+      "drivablePercent": 73,
       "drivablePrefixTotal": 172,
       "modalities": [
         "voice",
@@ -54,13 +54,14 @@
         },
         {
           "chapter": 2,
-          "lessonCount": 9,
-          "voice": 4,
+          "lessonCount": 10,
+          "voice": 3,
           "sight": 5,
-          "pen": 0,
+          "pen": 2,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "ML-C02-peru",
@@ -69,13 +70,14 @@
         },
         {
           "chapter": 3,
-          "lessonCount": 6,
+          "lessonCount": 7,
           "voice": 1,
           "sight": 5,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "ML-C03-engane",
@@ -1509,25 +1511,55 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4a79c6125d8f596e"
+      "sourceHash": "fnv1a64:e9d348626eb61ca9"
+    },
+    {
+      "id": "ML-W02-santosham-guided-copy",
+      "language": "malayalam",
+      "chapter": 2,
+      "sequence": 145,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:302aa3f33ad582a2",
+      "detachableSegments": [
+        "Script — notice before moving",
+        "Writing — trace two visible shapes",
+        "Writing — one guided copy"
+      ],
+      "delivery": "script"
     },
     {
       "id": "ML-C02-practice",
       "language": "malayalam",
       "chapter": 2,
       "sequence": 150,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a842043a35b2edf7"
+      "sourceHash": "fnv1a64:114795962eddf610",
+      "detachableSegments": [
+        "Writing check — keep the model visible"
+      ]
     },
     {
       "id": "ML-C03-engane",
@@ -1651,6 +1683,31 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:50faef297aa213bd"
+    },
+    {
+      "id": "ML-W03-santosham-delayed-copy",
+      "language": "malayalam",
+      "chapter": 3,
+      "sequence": 215,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:388046eca08ab1d4",
+      "detachableSegments": [
+        "Writing — one try after a delay"
+      ],
+      "delivery": "script"
     },
     {
       "id": "ML-C04-pokuka",

--- a/code/learning/human-languages/malayalam/CHANGELOG.md
+++ b/code/learning/human-languages/malayalam/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-20 — A spaced സന്തോഷം writing ramp
+
+- Reduced the Chapter 2 script step to the two genuinely new shapes in the
+  usable one-word expression, deferring an untaught fuller phrase.
+- Added a two-minute model-visible copy and a two-minute delayed copy eight
+  lessons later, while keeping the chapter checkpoint within five minutes.
+- Made the sequence explicit cumulative writing evidence: observe and trace,
+  guided copy, then delayed copy, with no invalid stage claims.
+- Wired both writing lessons into the local script extension, introduced each
+  evidence atom before assessing it, and kept the delayed-copy close as a typed
+  recall block so the complete schema gate can validate the ramp.
+
 ## Unreleased -- Chapters 60-66: a third thirty-five
 
 Malayalam stood at 119 headwords against the 300 the pre-A1 vocabulary floor asks

--- a/code/learning/human-languages/malayalam/book/chapter-modalities.tex
+++ b/code/learning/human-languages/malayalam/book/chapter-modalities.tex
@@ -37,15 +37,15 @@
 
 \expandafter\def\csname hlchaptermodality2\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (4) \quad \hlsightsign{}~\textbf{eyes} (5)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 9 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (3) \quad \hlsightsign{}~\textbf{eyes} (5) \quad \hlpensign{}~\textbf{pen} (2)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 8 of 10 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality3\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (5)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 6 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (5) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 6 of 7 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/malayalam/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 308
-% canonical-index-entries: 308
+% canonical-index-candidates: 310
+% canonical-index-entries: 310
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -1896,6 +1896,18 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ml{സ} — one character, met inside words you already say}\par
 \footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:ml-dog-and-cat]{Chapter~21, p.~\pageref*{ch:ml-dog-and-cat}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സന്തോഷം} — copy one known word with help}\par
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:introductions]{Chapter~2, p.~\pageref*{ch:introductions}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സന്തോഷം} — one delayed copy}\par
+\footnotesize script and writing topic; explicit focus: writing; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/malayalam/chapters.json
+++ b/code/learning/human-languages/malayalam/chapters.json
@@ -33,8 +33,10 @@
         "lesson": "ML-C02-practice",
         "kind": "task",
         "summary": "Complete ML-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Malayalam, give my name, and understand the other person's name.",
-        "assesses": [],
-        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+        "assesses": [
+          "ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02"
+        ],
+        "note": "The checkpoint now directly assesses the chapter's first typed writing atom with a model-visible copy. The legacy spoken lessons still have no typed knowledge atoms, so their representativeness remains authored until migration."
       }
     },
     {

--- a/code/learning/human-languages/malayalam/curriculum.json
+++ b/code/learning/human-languages/malayalam/curriculum.json
@@ -91,10 +91,14 @@
         "ML-C02-nii-ningal",
         "ML-C02-entu",
         "ML-C02-ninre-peru-entaanu",
-        "ML-C02-santosham"
+        "ML-C02-santosham",
+        "ML-W02-santosham-guided-copy",
+        "ML-W03-santosham-delayed-copy"
       ],
       "before": [],
-      "inline": [],
+      "inline": [
+        "ML-EXT-005-SANTOSHAM-WRITING"
+      ],
       "after": []
     },
     {
@@ -1288,6 +1292,18 @@
     }
   },
   "extensions": [
+    {
+      "id": "ML-EXT-005-SANTOSHAM-WRITING",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can move from noticing two shapes in a known Malayalam word to one guided copy and one delayed copy without a sudden writing jump.",
+      "prerequisites": [],
+      "lessons": [
+        "ML-W02-santosham-guided-copy",
+        "ML-W03-santosham-delayed-copy"
+      ]
+    },
     {
       "id": "ML-EXT-100-SCRIPT-RECOGNITION",
       "stage": "pre-A1",

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-practice.md
@@ -6,11 +6,11 @@ type: practice
 headword: (dialogue)
 gloss: Chapter 2 recap — the introduction exchange
 concept_tag: REVIEW
-prerequisites: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
+prerequisites: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu, ML-C02-santosham, ML-W02-santosham-guided-copy]
 sounds: []
 roots: []
-est_minutes: 4
-reviews_of: [ML-C02-peru, ML-C02-enre, ML-C02-aanu, ML-C02-enre-peru-aanu, ML-C02-nii-ningal, ML-C02-entu, ML-C02-ninre-peru-entaanu, ML-C02-santosham]
+est_minutes: 5
+reviews_of: [ML-C02-peru, ML-C02-enre, ML-C02-aanu, ML-C02-enre-peru-aanu, ML-C02-nii-ningal, ML-C02-entu, ML-C02-ninre-peru-entaanu, ML-C02-santosham, ML-W02-santosham-guided-copy]
 ---
 
 # Chapter 2 — the introduction, whole
@@ -27,7 +27,7 @@ reviews_of: [ML-C02-peru, ML-C02-enre, ML-C02-aanu, ML-C02-enre-peru-aanu, ML-C0
 Every atom traced:
 
 - **pēru** ← Dravidian *\*pēr* (*not* *name*; twin of Tamil *peyar*)
-- **enṟe** ← *ñāṉ* ("I")
+- **enṟe** — the native Dravidian possessive "my"
 - **āṇŭ** ← the verb *āka* ("to be") — Malayalam's **copula**
 - **entŭ** ← Dravidian question-stem *\*yā-/\*e-*
 - **santōṣam** ← **Sanskrit** (borrowed even in native-loving Malayalam)
@@ -43,10 +43,18 @@ closest of sisters.
 - [YOU SAY: your own introduction — "enṟe pēru … āṇŭ"]
 - [YOU SAY: ask it back — "ninṟe pēru entāṇŭ?"]
 
+## Writing check — keep the model visible
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+
+Keep the dialogue table open. Copy **സന്തോഷം** once from its visible row,
+then compare your two new shapes, **ഷ** and **ോ**, with the model. This is
+supported checkpoint writing, not spelling from memory.
+
 ## Wrap-up Recall
 
 [PAUSE 3s] Give your name, ask someone else's, say you're pleased. (*Enṟe pēru
 … āṇŭ. / Ninṟe pēru entāṇŭ? / Santōṣam.*) What grammatical word does Malayalam
 have that Tamil, Kannada, and Telugu lack? (A copula — *āṇŭ*, "is.")
 
-Next chapter: *sukhamāṇō?* ("are you well?") — the responding cycle.
+Next chapter begins the responding cycle, one short question and answer at a
+time.

--- a/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C02-santosham.md
@@ -20,10 +20,23 @@ reviews_of: [ML-C02-enre-peru-aanu, ML-C02-ninre-peru-entaanu]
 
 [PAUSE 2s] The warm close — a Sanskrit word even in native-loving Malayalam.
 
-## The phrase
+## The word you can use
 
-The full form is **നിങ്ങളെ കണ്ടതിൽ സന്തോഷം** (*niṅṅaḷe kaṇḍatil santōṣam*) —
-"joy at having seen you."
+**സന്തോഷം** (*santōṣam*) literally means "joy." At the end of a short
+introduction, it can stand by itself for "pleased to meet you." A fuller phrase
+exists, but it needs words and grammar you have not learned yet; the one-word
+version is complete and useful now.
+
+## Two new shapes to notice
+
+Keep **സന്തോഷം** visible. Most of its shapes have already appeared in this
+chapter. Point to just two new ones:
+
+- **ഷ** carries the *ṣa* sound near the end.
+- **ോ** is the long *ō* vowel sign attached to the consonant before it.
+
+Look, point, and say the whole word once. The next two-minute lesson will let
+your hand copy it with the model still present.
 
 ## The word, taken apart
 

--- a/code/learning/human-languages/malayalam/lessons/ML-W02-santosham-guided-copy.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-W02-santosham-guided-copy.md
@@ -1,0 +1,70 @@
+---
+schema_version: 2
+id: ML-W02-santosham-guided-copy
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 145
+delivery: script
+chapter: 2
+type: writing
+headword: "സന്തോഷം"
+gloss: copy the known word for joy once with the model visible
+romanization: "santōṣam"
+prerequisites: [ML-C02-santosham]
+sounds: [anusvara]
+roots: [santosha-sanskrit]
+duration:
+  max_seconds: 120
+requires:
+  knowledge: []
+introduces:
+  knowledge: [ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02]
+practises:
+  knowledge: [ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [ML-C02-santosham]
+---
+
+# സന്തോഷം — copy one known word with help
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+Point to **സന്തോഷം** and say *santōṣam* once. Keep the model on the page.
+Find **ഷ** near the end, then find the long *ō* sign **ോ** on the consonant
+before it. Those are the two shapes you will work with.
+
+## Script — notice before moving
+<!-- hl-knowledge: introduces=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02]; assesses=[] -->
+
+Look at **ഷ** and **ോ** without writing. Say *ṣa* and *ō*. The first action is
+observe and trace: your finger follows a visible model, so memory is not yet
+doing the work.
+
+## Writing — trace two visible shapes
+<!-- hl-knowledge: introduces=[ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02]; assesses=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02] -->
+<!-- hl-writing-stage: observe-trace -->
+
+Trace **ഷ** once and **ോ** once with your finger while both models remain
+visible. Stop after those two shapes. The next action is a guided copy: the
+whole word stays in view while your hand makes its own copy.
+
+## Writing — one guided copy
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+<!-- hl-writing-stage: guided-copy -->
+
+Follow **സന്തോഷം** from left to right with your finger. Then copy the whole
+word once directly below the visible model. Look back as often as you need.
+
+This is shape familiarity, not a stroke-order test. Write large and slowly. Do
+not hide the model, do not spell from memory, and do not add a second word.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+
+Compare your copy with **സന്തോഷം** while both remain visible. Check only the
+two shapes you noticed: **ഷ** and **ോ**. Repair one shape if you want, then
+stop and say *santōṣam* once more.

--- a/code/learning/human-languages/malayalam/lessons/ML-W03-santosham-delayed-copy.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-W03-santosham-delayed-copy.md
@@ -1,0 +1,53 @@
+---
+schema_version: 2
+id: ML-W03-santosham-delayed-copy
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 215
+delivery: script
+chapter: 3
+type: writing
+headword: "സന്തോഷം"
+gloss: write the known word for joy once after a short delay
+romanization: "santōṣam"
+prerequisites: [ML-W02-santosham-guided-copy]
+sounds: [anusvara]
+roots: [santosha-sanskrit]
+duration:
+  max_seconds: 120
+requires:
+  knowledge: [ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [ML-C02-santosham, ML-W02-santosham-guided-copy]
+---
+
+# സന്തോഷം — one delayed copy
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+
+Look at **സന്തോഷം** for five seconds and say *santōṣam*. Find **ഷ** and the
+long *ō* sign **ോ** once more. Then cover the model with your hand or a small
+piece of paper.
+
+## Writing — one try after a delay
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+<!-- hl-writing-stage: delayed-copy -->
+
+Write **സന്തോഷം** once while the model is covered. This is a gentle retrieval,
+not a speed test. If one shape will not come, uncover the model, look, cover it
+again, and finish.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[ML-SCRIPT-OBSERVE-TRACE-SANTOSHAM-02, ML-SCRIPT-GUIDED-COPY-SANTOSHAM-02] -->
+
+Uncover **സന്തോഷം** and compare it with your copy. Repair only one shape if
+needed. Say *santōṣam* once, then stop: one known word, one spaced writing
+revisit.

--- a/code/learning/human-languages/malayalam/narration/ch02.json
+++ b/code/learning/human-languages/malayalam/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:da4d2f30bce7d386",
+  "sourceHash": "fnv1a64:6928ba9fa0a57b17",
   "lessons": [
     {
       "id": "ML-C02-peru",
@@ -891,7 +891,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4a79c6125d8f596e",
+      "sourceHash": "fnv1a64:e9d348626eb61ca9",
       "notice": null,
       "blocks": [
         {
@@ -914,16 +914,39 @@
         {
           "index": 1,
           "type": "unknown",
-          "title": "The phrase",
+          "title": "The word you can use",
           "segments": [
             {
               "kind": "speech",
-              "text": "The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — \"joy at having seen you.\""
+              "text": "സന്തോഷം (santōṣam) literally means \"joy.\" At the end of a short introduction, it can stand by itself for \"pleased to meet you.\" A fuller phrase exists, but it needs words and grammar you have not learned yet; the one-word version is complete and useful now."
             }
           ]
         },
         {
           "index": 2,
+          "type": "unknown",
+          "title": "Two new shapes to notice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Keep സന്തോഷം (santōṣam) visible. Most of its shapes have already appeared in this chapter. Point to just two new ones:"
+            },
+            {
+              "kind": "speech",
+              "text": "ഷ carries the ṣa sound near the end."
+            },
+            {
+              "kind": "speech",
+              "text": "ോ is the long ō vowel sign attached to the consonant before it."
+            },
+            {
+              "kind": "speech",
+              "text": "Look, point, and say the whole word once. The next two-minute lesson will let your hand copy it with the model still present."
+            }
+          ]
+        },
+        {
+          "index": 3,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -934,7 +957,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -965,7 +988,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -984,6 +1007,97 @@
       ]
     },
     {
+      "id": "ML-W02-santosham-guided-copy",
+      "sequence": 145,
+      "title": "സന്തോഷം (santōṣam) — copy one known word with help",
+      "headword": "സന്തോഷം",
+      "romanization": "santōṣam",
+      "gloss": "copy the known word for joy once with the model visible",
+      "script": "malayalam",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:302aa3f33ad582a2",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — notice before moving"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — notice before moving until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Point to സന്തോഷം and say santōṣam once. Keep the model on the page. Find ഷ near the end, then find the long ō sign ോ on the consonant before it. Those are the two shapes you will work with."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — notice before moving",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look at ഷ and ോ without writing. Say ṣa and ō. The first action is observe and trace: your finger follows a visible model, so memory is not yet doing the work."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "writing",
+          "title": "Writing — trace two visible shapes",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Trace ഷ once and ോ once with your finger while both models remain visible. Stop after those two shapes. The next action is a guided copy: the whole word stays in view while your hand makes its own copy."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "writing",
+          "title": "Writing — one guided copy",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Follow സന്തോഷം (santōṣam) from left to right with your finger. Then copy the whole word once directly below the visible model. Look back as often as you need."
+            },
+            {
+              "kind": "speech",
+              "text": "This is shape familiarity, not a stroke-order test. Write large and slowly. Do not hide the model, do not spell from memory, and do not add a second word."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Compare your copy with സന്തോഷം while both remain visible. Check only the two shapes you noticed: ഷ and ോ. Repair one shape if you want, then stop and say santōṣam once more."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "ML-C02-practice",
       "sequence": 150,
       "title": "Chapter 2 — the introduction, whole",
@@ -991,13 +1105,18 @@
       "romanization": "",
       "gloss": "Chapter 2 recap — the introduction exchange",
       "script": "malayalam",
-      "modality": "voice",
-      "derivedModality": "voice",
+      "modality": "pen",
+      "derivedModality": "pen",
       "modalityReasons": [
-        "no-visual-dependency"
+        "writing-block"
       ],
-      "sourceHash": "fnv1a64:a842043a35b2edf7",
-      "notice": null,
+      "sourceHash": "fnv1a64:114795962eddf610",
+      "notice": {
+        "modality": "pen",
+        "needs": [],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
       "blocks": [
         {
           "index": 0,
@@ -1029,7 +1148,7 @@
             },
             {
               "kind": "speech",
-              "text": "enṟe from ñāṉ (\"I\")."
+              "text": "enṟe — the native Dravidian possessive \"my\"."
             },
             {
               "kind": "speech",
@@ -1091,6 +1210,17 @@
         },
         {
           "index": 2,
+          "type": "writing",
+          "title": "Writing check — keep the model visible",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Keep the dialogue table open. Copy സന്തോഷം (santōṣam) once from its visible row, then compare your two new shapes, ഷ and ോ, with the model. This is supported checkpoint writing, not spelling from memory."
+            }
+          ]
+        },
+        {
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1106,7 +1236,7 @@
             },
             {
               "kind": "speech",
-              "text": "Next chapter: sukhamāṇō? (\"are you well?\") — the responding cycle."
+              "text": "Next chapter begins the responding cycle, one short question and answer at a time."
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch02.txt
+++ b/code/learning/human-languages/malayalam/narration/ch02.txt
@@ -1,8 +1,8 @@
 Malayalam, chapter 2: Introducing Yourself.
-9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+10 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 9.
+Lesson 1 of 10.
 പേര് (pēru) — "name," the native Dravidian word.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -32,7 +32,7 @@ Wrap-up Recall.
 Is പേര് native or borrowed, and what Tamil word is its twin? (Native Dravidian, pēr; Tamil peyar.)
 
 
-Lesson 2 of 9.
+Lesson 2 of 10.
 എന്റെ (enṟe) — "my".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -62,7 +62,7 @@ Wrap-up Recall.
 What does എന്റെ (enṟe) mean? ("My.") Is it native Dravidian or an Indo-European loan? (Native Dravidian.)
 
 
-Lesson 3 of 9.
+Lesson 3 of 10.
 ആണ് (āṇŭ) — "is," where Malayalam breaks with its sisters.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -96,7 +96,7 @@ Wrap-up Recall.
 What is ആണ്, and how does Malayalam differ from Tamil here? (The copula "is," from āka; Malayalam has a word for "is" where Tamil uses none.)
 
 
-Lesson 4 of 9.
+Lesson 4 of 10.
 എന്റെ പേര് … ആണ് (enṟe pēru … āṇŭ) — "my name is…"
 
 Warm-up.
@@ -123,7 +123,7 @@ Wrap-up Recall.
 Give your name in Malayalam. (Enṟe pēru … āṇŭ.) What word does Malayalam add that Tamil omits? (The copula āṇŭ, "is.")
 
 
-Lesson 5 of 9.
+Lesson 5 of 10.
 നീ / നിങ്ങൾ (nī / niṅṅaḷ) — "you," familiar and respectful.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -154,7 +154,7 @@ Wrap-up Recall.
 How does Malayalam make "you" respectful, and which Tamil word is niṅṅaḷ's twin? (By the plural; Tamil nīṅgaḷ.)
 
 
-Lesson 6 of 9.
+Lesson 6 of 10.
 എന്ത് (entŭ) — "what".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -184,7 +184,7 @@ Wrap-up Recall.
 What Dravidian stem heads എന്ത്? (yā-/e-, same as Tamil eṉṉa, Telugu ēmiṭi.)
 
 
-Lesson 7 of 9.
+Lesson 7 of 10.
 നിന്റെ പേര് എന്താണ്? (ninṟe pēru entāṇŭ?) — "what's your name?"
 
 Warm-up.
@@ -212,15 +212,21 @@ Wrap-up Recall.
 What two words fuse into എന്താണ്, and how does this differ from the Tamil question? (entŭ "what" + āṇŭ "is"; Tamil's question has no verb, Malayalam's carries the copula.)
 
 
-Lesson 8 of 9.
+Lesson 8 of 10.
 സന്തോഷം (santōṣam) — "joy," and "pleased to meet you".
 
 Warm-up.
 [pause 2 seconds]
 The warm close — a Sanskrit word even in native-loving Malayalam.
 
-The phrase.
-The full form is നിങ്ങളെ കണ്ടതിൽ സന്തോഷം (niṅṅaḷe kaṇḍatil santōṣam) — "joy at having seen you."
+The word you can use.
+സന്തോഷം (santōṣam) literally means "joy." At the end of a short introduction, it can stand by itself for "pleased to meet you." A fuller phrase exists, but it needs words and grammar you have not learned yet; the one-word version is complete and useful now.
+
+Two new shapes to notice.
+Keep സന്തോഷം (santōṣam) visible. Most of its shapes have already appeared in this chapter. Point to just two new ones:
+ഷ carries the ṣa sound near the end.
+ോ is the long ō vowel sign attached to the consonant before it.
+Look, point, and say the whole word once. The next two-minute lesson will let your hand copy it with the model still present.
 
 The word, taken apart.
 സന്തോഷം (santōṣam, "joy") is Sanskrit — the same loan Kannada and Telugu use. So even Malayalam, the great keeper of native words (recall nandi for "thanks" in Chapter 1), reaches for Sanskrit here. The loanwords spread selectively, word by word — which is exactly what these cognate notes trace: native for "name" and "thanks," Sanskrit for "pleased."
@@ -237,8 +243,32 @@ Wrap-up Recall.
 Is സന്തോഷം (santōṣam) native or Sanskrit, and what does that show about how Malayalam borrows? (Sanskrit; it borrows selectively — native for some words, Sanskrit for others.)
 
 
-Lesson 9 of 9.
+Lesson 9 of 10.
+സന്തോഷം (santōṣam) — copy one known word with help.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — notice before moving until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+Point to സന്തോഷം and say santōṣam once. Keep the model on the page. Find ഷ near the end, then find the long ō sign ോ on the consonant before it. Those are the two shapes you will work with.
+
+Script — notice before moving.
+Look at ഷ and ോ without writing. Say ṣa and ō. The first action is observe and trace: your finger follows a visible model, so memory is not yet doing the work.
+
+Writing — trace two visible shapes.
+Trace ഷ once and ോ once with your finger while both models remain visible. Stop after those two shapes. The next action is a guided copy: the whole word stays in view while your hand makes its own copy.
+
+Writing — one guided copy.
+Follow സന്തോഷം (santōṣam) from left to right with your finger. Then copy the whole word once directly below the visible model. Look back as often as you need.
+This is shape familiarity, not a stroke-order test. Write large and slowly. Do not hide the model, do not spell from memory, and do not add a second word.
+
+Wrap-up recall.
+Compare your copy with സന്തോഷം while both remain visible. Check only the two shapes you noticed: ഷ and ോ. Repair one shape if you want, then stop and say santōṣam once more.
+
+
+Lesson 10 of 10.
 Chapter 2 — the introduction, whole.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
 
 The dialogue.
 [a table of 4 rows, read aloud]
@@ -248,7 +278,7 @@ The dialogue.
 സന്തോഷം. (santōṣam) means Pleased to meet you.
 Every atom traced:
 pēru from Dravidian pēr (not name; twin of Tamil peyar).
-enṟe from ñāṉ ("I").
+enṟe — the native Dravidian possessive "my".
 āṇŭ from the verb āka ("to be") — Malayalam's copula.
 entŭ from Dravidian question-stem yā-/e-.
 santōṣam from Sanskrit (borrowed even in native-loving Malayalam).
@@ -263,7 +293,10 @@ Guided Practice.
 [your turn — say: ask it back — "ninṟe pēru entāṇŭ?"]
 [pause 8 seconds for the answer]
 
+Writing check — keep the model visible.
+Keep the dialogue table open. Copy സന്തോഷം (santōṣam) once from its visible row, then compare your two new shapes, ഷ and ോ, with the model. This is supported checkpoint writing, not spelling from memory.
+
 Wrap-up Recall.
 [pause 3 seconds]
 Give your name, ask someone else's, say you're pleased. (Enṟe pēru … āṇŭ. / Ninṟe pēru entāṇŭ? / Santōṣam.) What grammatical word does Malayalam have that Tamil, Kannada, and Telugu lack? (A copula — āṇŭ, "is.")
-Next chapter: sukhamāṇō? ("are you well?") — the responding cycle.
+Next chapter begins the responding cycle, one short question and answer at a time.

--- a/code/learning/human-languages/malayalam/narration/ch03.json
+++ b/code/learning/human-languages/malayalam/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "How Are You?",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:5236bd3259a983df",
+  "sourceHash": "fnv1a64:c73a9560fa68161c",
   "lessons": [
     {
       "id": "ML-C03-engane",
@@ -846,6 +846,67 @@
             {
               "kind": "speech",
               "text": "A friend asks sukhamāṇō? — give a full, polite reply, and answer their thanks. (Sukhamāṇŭ, nandi — and to thanks, sāramilla.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ML-W03-santosham-delayed-copy",
+      "sequence": 215,
+      "title": "സന്തോഷം (santōṣam) — one delayed copy",
+      "headword": "സന്തോഷം",
+      "romanization": "santōṣam",
+      "gloss": "write the known word for joy once after a short delay",
+      "script": "malayalam",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:388046eca08ab1d4",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look at സന്തോഷം for five seconds and say santōṣam. Find ഷ and the long ō sign ോ once more. Then cover the model with your hand or a small piece of paper."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "writing",
+          "title": "Writing — one try after a delay",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Write സന്തോഷം (santōṣam) once while the model is covered. This is a gentle retrieval, not a speed test. If one shape will not come, uncover the model, look, cover it again, and finish."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Uncover സന്തോഷം and compare it with your copy. Repair only one shape if needed. Say santōṣam once, then stop: one known word, one spaced writing revisit."
             }
           ]
         }

--- a/code/learning/human-languages/malayalam/narration/ch03.txt
+++ b/code/learning/human-languages/malayalam/narration/ch03.txt
@@ -1,8 +1,8 @@
 Malayalam, chapter 3: How Are You?.
-6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 6.
+Lesson 1 of 7.
 എങ്ങനെ (eṅṅane) — "how," another of the e- questions.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -32,7 +32,7 @@ Wrap-up Recall.
 What base do Malayalam's question-words share, and which Tamil cousin heads its own? (The interrogative e-; Tamil's eppaḍi.)
 
 
-Lesson 2 of 6.
+Lesson 2 of 7.
 സുഖമാണോ? (sukhamāṇō?) — "how are you?"
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -64,7 +64,7 @@ Wrap-up Recall.
 What does sukhamāṇō? literally ask, and what are its Sanskrit and Dravidian pieces? ("Is [it] well?"; Sanskrit sukha "well-being" + the native copula āṇŭ + the question -ō.)
 
 
-Lesson 3 of 6.
+Lesson 3 of 7.
 ഞാൻ (ñān) — "I," the Dravidian first person.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -99,7 +99,7 @@ Wrap-up Recall.
 What is ñān's possessive, and why must Malayalam say "I" where Tamil can drop it? (Enṟe, "my"; Malayalam verbs don't change for person, so the pronoun is needed.)
 
 
-Lesson 4 of 6.
+Lesson 4 of 7.
 സുഖം (sukhaṁ) — "well-being," and how to answer.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -133,7 +133,7 @@ Wrap-up Recall.
 Give the reply to sukhamāṇō?, and say where sukham comes from. (Sukhamāṇŭ; Sanskrit sukha, "well-being" — the su- that is Greek eu-.)
 
 
-Lesson 5 of 6.
+Lesson 5 of 7.
 സാരമില്ല (sāramilla) — "it doesn't matter".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -165,7 +165,7 @@ Wrap-up Recall.
 What does sāramilla literally say, and which of its two words is Sanskrit? ("There's no matter / it doesn't matter"; sāraṁ "substance" is Sanskrit, illa "not" is native Dravidian.)
 
 
-Lesson 6 of 6.
+Lesson 6 of 7.
 Chapter 3 — The how-are-you exchange.
 
 Warm-up.
@@ -201,3 +201,18 @@ the question-marker -ō — turns any statement into a yes/no question.
 Wrap-up Recall.
 [pause 3 seconds]
 A friend asks sukhamāṇō? — give a full, polite reply, and answer their thanks. (Sukhamāṇŭ, nandi — and to thanks, sāramilla.)
+
+
+Lesson 7 of 7.
+സന്തോഷം (santōṣam) — one delayed copy.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+
+Warm-up.
+Look at സന്തോഷം for five seconds and say santōṣam. Find ഷ and the long ō sign ോ once more. Then cover the model with your hand or a small piece of paper.
+
+Writing — one try after a delay.
+Write സന്തോഷം (santōṣam) once while the model is covered. This is a gentle retrieval, not a speed test. If one shape will not come, uncover the model, look, cover it again, and finish.
+
+Wrap-up recall.
+Uncover സന്തോഷം and compare it with your copy. Repair only one shape if needed. Say santōṣam once, then stop: one known word, one spaced writing revisit.

--- a/code/learning/human-languages/progress/malayalam.md
+++ b/code/learning/human-languages/progress/malayalam.md
@@ -2,8 +2,8 @@
 
 - Track: [Malayalam](../malayalam/README.md)
 - Family / script: Dravidian / Malayalam
-- Canonical lessons: 247
-- Mapped lessons: 243
+- Canonical lessons: 249
+- Mapped lessons: 245
 - Book progress: 66 chapters; through Ch. 66; 61 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/corpus/malayalam.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/malayalam.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import { measureContinuity } from "../../src/continuity.js";
-import { defaultCurriculumRoot, loadTrackLessons } from "../../src/loader.js";
+import { defaultCurriculumRoot, loadChapterPolicy, loadTrackLessons } from "../../src/loader.js";
+import { measureRamp } from "../../src/ramp.js";
 import { expectLanguageContinuity, expectLanguageModality } from "./assert-language-corpus.js";
 it("pins Malayalam continuity", () => expectLanguageContinuity("malayalam"));
 it("pins Malayalam modality", () => expectLanguageModality("malayalam"));
@@ -16,4 +17,9 @@ it("keeps Malayalam's opening free of genuine future farewells and pronouns", ()
         !(reference.lessonId === "ML-C01-athe" && reference.word === "അത്"),
     ),
   ).toEqual([]);
+});
+it("keeps the santosham payoff inside the three-glyph lesson budget", () => {
+  const root = defaultCurriculumRoot();
+  const report = measureRamp(loadTrackLessons("malayalam", root), loadChapterPolicy(root)).script;
+  expect(report.lessons.find((lesson) => lesson.lessonId === "ML-C02-santosham")).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- restore the Malayalam santosham writing ramp that previously merged only into an obsolete feature stack
- keep the useful one-word payoff and add model-visible guided copy, supported checkpoint writing, and delayed copy within five-minute lessons
- regenerate the Malayalam-only narration, modality, progress, and gentle-ramp shards under the current repository architecture
- add a language-owned regression proving the payoff stays inside the three-glyph lesson budget

## Validation
- TypeScript build
- 223 focused lesson, writing, modality, ramp, narration, and integration tests
- 911 full serial tests across 72 files
- books, figures, modality, narration, progress, and gentle-snapshot drift checks
- Malayalam book build: exit 0; missing, overfull, and underfull all zero

Closes #12422
Part of #12206

Supersedes the main-branch publication gap left by #12358.