### PR TITLE
Human languages: model non-CEFR external exam capstones

### DIFF
--- a/code/packages/typescript/human-language-data/src/assessment.ts
+++ b/code/packages/typescript/human-language-data/src/assessment.ts
@@ -28,6 +28,33 @@ export interface AssessmentPolicy {
 export interface AssessmentContract {
   version: number;
   language: string;
+  externalCapstones: Array<{
+    id: string;
+    target: {
+      name: string;
+      basis: "external";
+      source: string;
+      edition: string;
+      accessed: string;
+    };
+    requiredAfterLevel: CefrLevel;
+    cefrRelation: "not-mapped";
+    skills: Record<AssessmentSkill, {
+      taskInventory: string[];
+      passThreshold: number;
+    }>;
+    additionalComponents: Record<string, {
+      name: string;
+      taskInventory: string[];
+      passThreshold: number;
+    }>;
+    fullMocks: Array<{
+      id: string;
+      timed: boolean;
+      rubric: string;
+      answerKey: string;
+    }>;
+  }>;
   levels: Array<{
     level: CefrLevel;
     target: {
@@ -82,6 +109,23 @@ function exactStrings(value: unknown, expected: readonly string[], where: string
     throw new Error(`assessment: ${where} must contain exactly ${expected.join(", ")}`);
   }
   return [...value] as string[];
+}
+
+function artifactReference(value: unknown, where: string): string {
+  const reference = nonEmpty(value, where);
+  const path = reference.split("#", 1)[0] ?? "";
+  if (
+    path === ""
+    || path.startsWith("/")
+    || path.startsWith("\\")
+    || /^[A-Za-z]:/.test(path)
+    || path.includes("\\")
+    || path.split("/").includes("..")
+    || /^[a-z][a-z0-9+.-]*:/i.test(path)
+  ) {
+    throw new Error(`assessment: ${where} must be a safe relative artifact reference`);
+  }
+  return reference;
 }
 
 export function parseAssessmentPolicy(value: unknown): AssessmentPolicy {
@@ -250,5 +294,113 @@ export function parseAssessmentContract(
   for (const required of policy.levels) {
     if (!seen.has(required)) throw new Error(`assessment: ${expectedLanguage} is missing level ${required}`);
   }
-  return { version: 1, language: expectedLanguage, levels };
+
+  const capstonesRaw = raw.externalCapstones === undefined ? [] : raw.externalCapstones;
+  if (!Array.isArray(capstonesRaw)) {
+    throw new Error(`assessment: ${expectedLanguage}.externalCapstones must be an array`);
+  }
+  const capstoneIds = new Set<string>();
+  const externalCapstones = capstonesRaw.map((entry, index) => {
+    const where = `${expectedLanguage}.externalCapstones[${index}]`;
+    const item = object(entry, where);
+    const id = nonEmpty(item.id, `${where}.id`);
+    if (!/^[a-z][a-z0-9-]*$/.test(id)) {
+      throw new Error(`assessment: ${where}.id must be a lowercase slug`);
+    }
+    if (capstoneIds.has(id)) throw new Error(`assessment: ${expectedLanguage} duplicates capstone '${id}'`);
+    capstoneIds.add(id);
+
+    const target = object(item.target, `${where}.target`);
+    if (target.basis !== "external") {
+      throw new Error(`assessment: ${where}.target.basis must be external`);
+    }
+    if (item.cefrRelation !== "not-mapped") {
+      throw new Error(`assessment: ${where}.cefrRelation must be 'not-mapped'`);
+    }
+
+    const skills = object(item.skills, `${where}.skills`);
+    const parsedSkills = Object.fromEntries(ASSESSMENT_SKILLS.map((skill) => {
+      const skillRaw = object(skills[skill], `${where}.skills.${skill}`);
+      if (!Array.isArray(skillRaw.taskInventory) || skillRaw.taskInventory.length === 0) {
+        throw new Error(`assessment: ${where}.skills.${skill}.taskInventory must be a non-empty array`);
+      }
+      const taskInventory = skillRaw.taskInventory.map((reference, referenceIndex) =>
+        artifactReference(reference, `${where}.skills.${skill}.taskInventory[${referenceIndex}]`)
+      );
+      if (typeof skillRaw.passThreshold !== "number" || skillRaw.passThreshold <= 0 || skillRaw.passThreshold > 1) {
+        throw new Error(`assessment: ${where}.skills.${skill}.passThreshold must be in (0, 1]`);
+      }
+      return [skill, { taskInventory, passThreshold: skillRaw.passThreshold }];
+    })) as AssessmentContract["externalCapstones"][number]["skills"];
+
+    const additionalRaw = item.additionalComponents === undefined
+      ? {}
+      : object(item.additionalComponents, `${where}.additionalComponents`);
+    const additionalComponents = Object.fromEntries(Object.entries(additionalRaw).map(([componentId, component]) => {
+      if (!/^[a-z][a-z0-9-]*$/.test(componentId)) {
+        throw new Error(`assessment: ${where}.additionalComponents key '${componentId}' must be a lowercase slug`);
+      }
+      if (ASSESSMENT_SKILLS.includes(componentId as AssessmentSkill)) {
+        throw new Error(`assessment: ${where}.additionalComponents '${componentId}' duplicates a universal skill`);
+      }
+      const componentRaw = object(component, `${where}.additionalComponents.${componentId}`);
+      if (!Array.isArray(componentRaw.taskInventory) || componentRaw.taskInventory.length === 0) {
+        throw new Error(
+          `assessment: ${where}.additionalComponents.${componentId}.taskInventory must be a non-empty array`,
+        );
+      }
+      const taskInventory = componentRaw.taskInventory.map((reference, referenceIndex) =>
+        artifactReference(
+          reference,
+          `${where}.additionalComponents.${componentId}.taskInventory[${referenceIndex}]`,
+        )
+      );
+      if (
+        typeof componentRaw.passThreshold !== "number"
+        || componentRaw.passThreshold <= 0
+        || componentRaw.passThreshold > 1
+      ) {
+        throw new Error(`assessment: ${where}.additionalComponents.${componentId}.passThreshold must be in (0, 1]`);
+      }
+      return [componentId, {
+        name: nonEmpty(componentRaw.name, `${where}.additionalComponents.${componentId}.name`),
+        taskInventory,
+        passThreshold: componentRaw.passThreshold,
+      }];
+    }));
+
+    if (!Array.isArray(item.fullMocks) || item.fullMocks.length < policy.passEvidence.minimumFullMocksPerLevel) {
+      throw new Error(
+        `assessment: ${where} needs at least ${policy.passEvidence.minimumFullMocksPerLevel} full mocks`,
+      );
+    }
+    const fullMocks = item.fullMocks.map((mock, mockIndex) => {
+      const mockRaw = object(mock, `${where}.fullMocks[${mockIndex}]`);
+      if (mockRaw.timed !== true) throw new Error(`assessment: ${where} mock must be timed`);
+      return {
+        id: nonEmpty(mockRaw.id, `${where}.fullMocks[${mockIndex}].id`),
+        timed: true,
+        rubric: artifactReference(mockRaw.rubric, `${where}.fullMocks[${mockIndex}].rubric`),
+        answerKey: artifactReference(mockRaw.answerKey, `${where}.fullMocks[${mockIndex}].answerKey`),
+      };
+    });
+
+    return {
+      id,
+      target: {
+        name: nonEmpty(target.name, `${where}.target.name`),
+        basis: "external" as const,
+        source: nonEmpty(target.source, `${where}.target.source`),
+        edition: nonEmpty(target.edition, `${where}.target.edition`),
+        accessed: nonEmpty(target.accessed, `${where}.target.accessed`),
+      },
+      requiredAfterLevel: level(item.requiredAfterLevel, `${where}.requiredAfterLevel`),
+      cefrRelation: "not-mapped" as const,
+      skills: parsedSkills,
+      additionalComponents,
+      fullMocks,
+    };
+  });
+
+  return { version: 1, language: expectedLanguage, externalCapstones, levels };
 }

--- a/code/packages/typescript/human-language-data/src/completion-plan.ts
+++ b/code/packages/typescript/human-language-data/src/completion-plan.ts
@@ -38,9 +38,10 @@ import { LEVEL_VOCABULARY, type LevelGateReport } from "./level-gate.js";
 import type { ScriptClosureReport } from "./script-closure.js";
 import type { WritingStageReport } from "./writing-stages.js";
 
-/** The ten families of work. Every item belongs to exactly one. */
+/** The eleven families of work. Every item belongs to exactly one. */
 export type WorkKind =
   | "assessment-contract"
+  | "external-capstone"
   | "task-shape"
   | "writing-stage"
   | "exam-inventory"
@@ -89,15 +90,16 @@ export type WorkKind =
  */
 export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
   "assessment-contract": 1,
-  "task-shape": 2,
-  "writing-stage": 3,
-  "exam-inventory": 4,
-  "script-closure": 5,
-  "exam-point": 6,
-  vocabulary: 7,
-  reinforcement: 8,
-  "atom-budget": 9,
-  "spine-nodes": 10,
+  "external-capstone": 2,
+  "task-shape": 3,
+  "writing-stage": 4,
+  "exam-inventory": 5,
+  "script-closure": 6,
+  "exam-point": 7,
+  vocabulary: 8,
+  reinforcement: 9,
+  "atom-budget": 10,
+  "spine-nodes": 11,
 });
 
 /**
@@ -111,6 +113,7 @@ export const KIND_PRIORITY: Readonly<Record<WorkKind, number>> = Object.freeze({
  */
 export const TRANCHE_SIZE: Readonly<Record<WorkKind, number>> = Object.freeze({
   "assessment-contract": 1,
+  "external-capstone": 1,
   "task-shape": 1,
   "writing-stage": 1,
   "exam-inventory": 1,
@@ -200,6 +203,15 @@ export interface CompletionPlanInput {
   writingStages?: WritingStageReport;
   /** Tracks with a validated `<track>/assessment.json` covering the whole ladder. */
   assessmentContracts?: readonly string[];
+  /** Declared external exams that intentionally have no CEFR equivalence. */
+  externalCapstones?: ReadonlyArray<{
+    language: string;
+    id: string;
+    requiredAfterLevel: CefrLevel;
+    name: string;
+    complete: boolean;
+    missingArtifacts: readonly string[];
+  }>;
   /** Which target inventories are complete. Every other rung becomes an `exam-inventory` item. */
   inventories: readonly InventoryPresence[];
   /** Valid but incomplete source inventories. Their points count; their presence does not close the item. */
@@ -312,6 +324,23 @@ export function buildCompletionPlan(input: CompletionPlanInput): CompletionPlan 
           `the gentle writing stages, scored tasks, rubrics, answer keys and timed full mocks`,
         outstanding: 1,
         tranches: 1,
+      });
+    }
+
+    for (const capstone of input.externalCapstones ?? []) {
+      if (capstone.language !== track.language || capstone.complete) continue;
+      if (levelRank(capstone.requiredAfterLevel) > levelRank(ceiling)) continue;
+      mine.push({
+        id: `external-capstone/${track.language}/${capstone.id}`,
+        kind: "external-capstone",
+        language: track.language,
+        level: capstone.requiredAfterLevel,
+        goal:
+          `complete the non-CEFR-mapped external capstone '${capstone.name}' after ` +
+          `${capstone.requiredAfterLevel}: add ${capstone.missingArtifacts.length} missing task, rubric, or answer-key ` +
+          `artifact(s) without inventing a CEFR equivalence`,
+        outstanding: capstone.missingArtifacts.length,
+        tranches: Math.max(1, capstone.missingArtifacts.length),
       });
     }
 
@@ -575,6 +604,12 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
     (input.assessmentContracts ?? []).filter((language) => trackNames.has(language)),
   );
   const assessmentItems = Math.max(0, input.levelGate.tracks.length - validAssessmentContracts.size);
+  const relevantCapstones = (input.externalCapstones ?? []).filter(
+    (capstone) =>
+      trackNames.has(capstone.language)
+      && levelRank(capstone.requiredAfterLevel) <= levelRank(ceiling),
+  );
+  const incompleteCapstones = relevantCapstones.filter((capstone) => !capstone.complete);
 
   const glyphs = input.scriptClosure.tracks.reduce((sum, track) => sum + track.neverTaughtGlyphs, 0);
   const writingStagePairs = input.writingStages
@@ -610,6 +645,13 @@ function project(input: CompletionPlanInput, ceiling: CefrLevel, items: readonly
       detail:
         `${validAssessmentContracts.size} of ${input.levelGate.tracks.length} track(s) have a validated ` +
         `four-skill, writing-ramp and timed-mock contract`,
+    },
+    {
+      kind: "external-capstone",
+      items: incompleteCapstones.length,
+      detail:
+        `${relevantCapstones.length - incompleteCapstones.length} of ${relevantCapstones.length} declared ` +
+        `non-CEFR-mapped external capstone(s) have every task, rubric and answer-key artifact`,
     },
     {
       kind: "task-shape",

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -22,6 +22,7 @@ import { CEFR_LEVELS, type CefrLevel } from "./levels.js";
 import {
   parseAssessmentContract,
   parseAssessmentPolicy,
+  type AssessmentContract,
   type AssessmentPolicy,
 } from "./assessment.js";
 import type { LedgerLetter, LetterLedger } from "./letter-ledger.js";
@@ -102,6 +103,50 @@ export function listAssessmentContracts(root = defaultCurriculumRoot()): string[
     if (!existsSync(path)) continue;
     parseAssessmentContract(JSON.parse(readFileSync(path, "utf8")), track.id, policy);
     out.push(track.id);
+  }
+  return out;
+}
+
+export interface ExternalExamCapstoneStatus {
+  language: string;
+  id: string;
+  requiredAfterLevel: CefrLevel;
+  name: string;
+  complete: boolean;
+  missingArtifacts: string[];
+}
+
+/** Declared non-CEFR-mapped external capstones and whether their artifacts exist. */
+export function listExternalExamCapstones(root = defaultCurriculumRoot()): ExternalExamCapstoneStatus[] {
+  const policy = loadAssessmentPolicy(root);
+  const registry = loadLanguageRegistry(root);
+  const out: ExternalExamCapstoneStatus[] = [];
+  for (const track of registry.languages) {
+    const contractPath = join(root, track.id, "assessment.json");
+    if (!existsSync(contractPath)) continue;
+    const contract: AssessmentContract = parseAssessmentContract(
+      JSON.parse(readFileSync(contractPath, "utf8")),
+      track.id,
+      policy,
+    );
+    for (const capstone of contract.externalCapstones) {
+      const references = [
+        ...Object.values(capstone.skills).flatMap((skill) => skill.taskInventory),
+        ...Object.values(capstone.additionalComponents).flatMap((component) => component.taskInventory),
+        ...capstone.fullMocks.flatMap((mock) => [mock.rubric, mock.answerKey]),
+      ];
+      const missingArtifacts = [...new Set(references
+        .map((reference) => reference.split("#", 1)[0]!)
+        .filter((reference) => !existsSync(join(root, track.id, reference))))];
+      out.push({
+        language: track.id,
+        id: capstone.id,
+        requiredAfterLevel: capstone.requiredAfterLevel,
+        name: capstone.target.name,
+        complete: missingArtifacts.length === 0,
+        missingArtifacts,
+      });
+    }
   }
   return out;
 }

--- a/code/packages/typescript/human-language-data/src/plan-cli.ts
+++ b/code/packages/typescript/human-language-data/src/plan-cli.ts
@@ -13,6 +13,7 @@ import { pathToFileURL } from "node:url";
 import {
   defaultCurriculumRoot as defaultRoot,
   listAssessmentContracts,
+  listExternalExamCapstones,
   loadAssessmentPolicy,
   listExamInventories,
   loadChapterPolicy,
@@ -176,6 +177,7 @@ export function runCompletionPlan(args = process.argv.slice(2)): number {
     scriptClosure: report.scriptClosure,
     writingStages: report.writingStages,
     assessmentContracts: listAssessmentContracts(options.root),
+    externalCapstones: listExternalExamCapstones(options.root),
     inventories: readable,
     partialInventories: partial,
     taskShapes: listTaskShapeInventories(options.root).flatMap<InventoryPresence>((entry) => {

--- a/code/packages/typescript/human-language-data/tests/external-capstone-plan.test.ts
+++ b/code/packages/typescript/human-language-data/tests/external-capstone-plan.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildCompletionPlan, CERTIFIABLE_LEVELS, TASK_SHAPE_LEVELS } from "../src/completion-plan.js";
+import { LEVEL_VOCABULARY } from "../src/level-gate.js";
+
+function build(complete: boolean) {
+  const language = "persian";
+  return buildCompletionPlan({
+    levelGate: {
+      vocabularyTargets: LEVEL_VOCABULARY,
+      tracks: [{ language, touches: null, attained: null, inProgressAt: "pre-A1", blockers: [], vocabulary: 0 }],
+      summary: {
+        tracksOverstating: 0,
+        tracksWithAnyLevel: 0,
+        attainedByLevel: { "pre-A1": 0, A1: 0, A2: 0, B1: 0, B2: 0, C1: 0, C2: 0 },
+      },
+    },
+    scriptClosure: {
+      tracks: [],
+      violations: [],
+      unknownScriptTracks: [],
+      summary: {
+        tracksWithScript: 0,
+        tracksTeachingNothing: 0,
+        violations: 0,
+        exposureOnly: 0,
+        exposureExemptedGlyphs: 0,
+        headwordsWithoutRomanization: 0,
+        tracksWithUnknownScript: 0,
+      },
+    },
+    assessmentContracts: [language],
+    taskShapes: TASK_SHAPE_LEVELS.map((level) => ({ language, level })),
+    inventories: CERTIFIABLE_LEVELS.map((level) => ({ language, level })),
+    externalCapstones: [{
+      language,
+      id: "samfa-academic",
+      requiredAfterLevel: "C2",
+      name: "SAMFA Academic",
+      complete,
+      missingArtifacts: complete ? [] : ["capstones/samfa.json", "mocks/samfa/rubric.md"],
+    }],
+  });
+}
+
+describe("external capstone planning", () => {
+  it("keeps a declared capstone open until every referenced artifact exists", () => {
+    const plan = build(false);
+    expect(plan.head[0]).toMatchObject({
+      id: "external-capstone/persian/samfa-academic",
+      kind: "external-capstone",
+      level: "C2",
+      outstanding: 2,
+    });
+    expect(plan.head[0]?.goal).toContain("without inventing a CEFR equivalence");
+    expect(plan.projection.find((entry) => entry.kind === "external-capstone")?.items).toBe(1);
+  });
+
+  it("retires the work item only when the capstone artifacts are complete", () => {
+    const plan = build(true);
+    expect(plan.head.some((item) => item.kind === "external-capstone")).toBe(false);
+    expect(plan.projection.find((entry) => entry.kind === "external-capstone")?.items).toBe(0);
+  });
+});

--- a/code/packages/typescript/human-language-data/tests/external-capstones.test.ts
+++ b/code/packages/typescript/human-language-data/tests/external-capstones.test.ts
@@ -1,0 +1,131 @@
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  defaultCurriculumRoot,
+  listExternalExamCapstones,
+  loadAssessmentPolicy,
+} from "../src/loader.js";
+import { parseAssessmentContract } from "../src/assessment.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function contractWith(capstone: Record<string, unknown>) {
+  const policy = loadAssessmentPolicy();
+  const skill = { taskInventory: ["task-shapes/level.json"], passThreshold: 0.6 };
+  return {
+    policy,
+    value: {
+      version: 1,
+      language: "alpha",
+      externalCapstones: [capstone],
+      levels: policy.levels.map((level, levelIndex) => ({
+        level,
+        target: { name: `Alpha ${level}`, basis: "project-defined", source: "assessment-spec.md" },
+        skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+        writingStages: policy.writingStages
+          .filter((stage) => policy.levels.indexOf(stage.firstRequiredAt) <= levelIndex)
+          .map((stage) => stage.id),
+        fullMocks: [
+          { id: `${level}-1`, timed: true, rubric: "rubric.md", answerKey: "one.md" },
+          { id: `${level}-2`, timed: true, rubric: "rubric.md", answerKey: "two.md" },
+        ],
+      })),
+    },
+  };
+}
+
+function validCapstone() {
+  const skill = { taskInventory: ["capstones/provider.json"], passThreshold: 0.5 };
+  return {
+    id: "provider-academic",
+    target: {
+      name: "Provider Academic Exam",
+      basis: "external",
+      source: "https://provider.example/spec",
+      edition: "2026",
+      accessed: "2026-08-21",
+    },
+    requiredAfterLevel: "C2",
+    cefrRelation: "not-mapped",
+    skills: { reading: skill, listening: skill, writing: skill, speaking: skill },
+    fullMocks: [
+      { id: "provider-1", timed: true, rubric: "mocks/provider/rubric.md", answerKey: "mocks/provider/one.md" },
+      { id: "provider-2", timed: true, rubric: "mocks/provider/rubric.md", answerKey: "mocks/provider/two.md" },
+    ],
+  };
+}
+
+describe("non-CEFR-mapped external exam capstones", () => {
+  it("parses a four-skill capstone without turning its dependency level into an equivalence", () => {
+    const { policy, value } = contractWith(validCapstone());
+    const parsed = parseAssessmentContract(value, "alpha", policy);
+    expect(parsed.externalCapstones[0]).toMatchObject({
+      id: "provider-academic",
+      requiredAfterLevel: "C2",
+      cefrRelation: "not-mapped",
+      target: { basis: "external" },
+    });
+    expect(Object.values(parsed.externalCapstones[0]!.skills).map((skill) => skill.passThreshold)).toEqual([
+      0.5,
+      0.5,
+      0.5,
+      0.5,
+    ]);
+  });
+
+  it("rejects an invented CEFR relation", () => {
+    const capstone = validCapstone();
+    capstone.cefrRelation = "C2";
+    const { policy, value } = contractWith(capstone);
+    expect(() => parseAssessmentContract(value, "alpha", policy)).toThrow(/cefrRelation must be 'not-mapped'/);
+  });
+
+  it("rejects a missing universal skill and an unsafe artifact path", () => {
+    const missing = validCapstone();
+    delete (missing.skills as Partial<typeof missing.skills>).speaking;
+    const one = contractWith(missing);
+    expect(() => parseAssessmentContract(one.value, "alpha", one.policy)).toThrow(/skills\.speaking must be an object/);
+
+    const unsafe = validCapstone();
+    unsafe.skills.reading.taskInventory = ["../outside.json"];
+    const two = contractWith(unsafe);
+    expect(() => parseAssessmentContract(two.value, "alpha", two.policy)).toThrow(/safe relative artifact reference/);
+  });
+
+  it("keeps a declaration incomplete until every referenced artifact exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "hl-external-capstone-"));
+    temporaryRoots.push(root);
+    mkdirSync(join(root, "core"), { recursive: true });
+    mkdirSync(join(root, "alpha", "capstones"), { recursive: true });
+    mkdirSync(join(root, "alpha", "mocks", "provider"), { recursive: true });
+    copyFileSync(
+      join(defaultCurriculumRoot(), "core", "assessment-policy.json"),
+      join(root, "core", "assessment-policy.json"),
+    );
+    writeFileSync(
+      join(root, "core", "languages.json"),
+      JSON.stringify({ version: 1, languages: [{ id: "alpha" }] }),
+    );
+    const { value } = contractWith(validCapstone());
+    writeFileSync(join(root, "alpha", "assessment.json"), JSON.stringify(value));
+    writeFileSync(join(root, "alpha", "capstones", "provider.json"), "{}");
+    writeFileSync(join(root, "alpha", "mocks", "provider", "rubric.md"), "# Rubric\n");
+
+    expect(listExternalExamCapstones(root)[0]).toMatchObject({
+      language: "alpha",
+      id: "provider-academic",
+      complete: false,
+      missingArtifacts: ["mocks/provider/one.md", "mocks/provider/two.md"],
+    });
+
+    writeFileSync(join(root, "alpha", "mocks", "provider", "one.md"), "# Key one\n");
+    writeFileSync(join(root, "alpha", "mocks", "provider", "two.md"), "# Key two\n");
+    expect(listExternalExamCapstones(root)[0]).toMatchObject({ complete: true, missingArtifacts: [] });
+  });
+});

--- a/code/specs/HL16-exam-ready-books-and-writing-ramp.md
+++ b/code/specs/HL16-exam-ready-books-and-writing-ramp.md
@@ -129,6 +129,21 @@ The label shown to learners is “Coding Adventures <Language> <Level>
 Assessment — project-defined equivalent,” never the name of an official
 qualification the project does not award.
 
+### 4.3 External capstones without a CEFR mapping
+
+An external provider may publish a real proficiency exam without publishing a
+defensible mapping from that exam to A1–C2. The complete book must still prepare
+the learner for that exam when it is an appropriate destination, but the
+contract must not force it into a CEFR rung by editorial guesswork.
+
+Such an exam is declared in the optional root-level `externalCapstones` array.
+Each declaration has a stable lowercase id, an external target and dated source,
+`cefrRelation: not-mapped`, the curriculum level after which the capstone is
+attempted, four independently thresholded skill inventories, any additional
+provider components, and at least two timed mocks with rubrics and answer keys.
+The level is a dependency boundary, not an equivalence claim. Missing referenced
+artifacts remain a computed `external-capstone` work item until they exist.
+
 ## 5. Writing is a full strand, beginning on the first page
 
 Writing has two coupled ramps:


### PR DESCRIPTION
## Summary

- add an optional, fail-closed externalCapstones contract for real provider exams that have no defensible CEFR mapping
- keep the curriculum dependency level separate from equivalence through an exact cefrRelation: not-mapped invariant
- require all four independently thresholded skills, provider components, dated source metadata, two timed mocks, safe artifact paths, rubrics, and answer keys
- derive planner debt from missing capstone artifacts and keep existing contracts backward-compatible
- document the policy in HL16 so Persian SAMFA can be modeled honestly as an end-of-book capstone

## Validation

- npx tsc
- npx vitest run tests/external-capstones.test.ts tests/external-capstone-plan.test.ts tests/assessment.test.ts tests/completion-plan.test.ts --maxWorkers=1 (46 passed)
- npm run plan
- npx vitest run --maxWorkers=1 (74 files, 918 tests passed on current main)
- npm run check:books
- npm run check:figures
- npm run check:modality
- npm run check:narration
- npm run check:progress
- npm run check:gentle-snapshots
- git diff --check

Closes #12438
Part of #12206