### PR TITLE
feat(human-languages): teach Marwadi water sign by sign

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1679,6 +1679,12 @@
       "scriptSet": "marwadi-main"
     },
     {
+      "language": "marwadi",
+      "chapter": 4,
+      "output": "marwadi/book/chapters/ch04-paani.tex",
+      "scriptSet": "marwadi-main"
+    },
+    {
       "language": "kannada",
       "chapter": 6,
       "output": "kannada/book/chapters/ch06-dative-case.tex",

--- a/code/learning/human-languages/core/generated-book-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-book-hashes/marwadi.json
@@ -41,6 +41,20 @@
         "MW-C03-practice"
       ],
       "tex": "marwadi/book/chapters/ch03-haan-saa.tex"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:8189dbd0f7189ffa",
+      "lessonIds": [
+        "MW-C04-hear-paani",
+        "MW-W04-pa",
+        "MW-W04-nna",
+        "MW-W04-ii-matra",
+        "MW-C04-paani",
+        "MW-C04-practice"
+      ],
+      "tex": "marwadi/book/chapters/ch04-paani.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
@@ -57,6 +57,25 @@
       "json": "marwadi/narration/ch03.json",
       "textHash": "fnv1a64:94c8ba5505ec69f1",
       "jsonHash": "fnv1a64:5b908f221596e8a3"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:6e3cb93f8705c380",
+      "lessonIds": [
+        "MW-C04-hear-paani",
+        "MW-W04-pa",
+        "MW-W04-nna",
+        "MW-W04-ii-matra",
+        "MW-C04-paani",
+        "MW-C04-practice"
+      ],
+      "voiceLessons": 2,
+      "drivablePrefix": 1,
+      "text": "marwadi/narration/ch04.txt",
+      "json": "marwadi/narration/ch04.json",
+      "textHash": "fnv1a64:4374e9c62f49f671",
+      "jsonHash": "fnv1a64:6c5be8b4f3e96739"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
@@ -1,7 +1,7 @@
 {
   "language": "marwadi",
-  "lessonCount": 16,
-  "atomMeasurableLessons": 16,
+  "lessonCount": 22,
+  "atomMeasurableLessons": 22,
   "atomMeasurementBlindLessons": 0,
   "durationViolations": 0,
   "atomLessonSpikes": 0,
@@ -16,7 +16,7 @@
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 0,
-  "atomsTaught": 21,
+  "atomsTaught": 27,
   "atomsNeverRevisited": 1,
   "reinforcementWindowMisses": 0,
   "reinforcementMissesByWindow": {
@@ -26,7 +26,7 @@
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 11,
+  "writingPracticeLessons": 15,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [],

--- a/code/learning/human-languages/core/lesson-modality/marwadi.json
+++ b/code/learning/human-languages/core/lesson-modality/marwadi.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:e0cdd04ce231169b",
+  "sourceHash": "fnv1a64:b18361b6781c6db4",
   "summary": {
-    "totalLessons": 16,
-    "voice": 5,
+    "totalLessons": 22,
+    "voice": 7,
     "sight": 0,
-    "pen": 11,
-    "drivableLessons": 5,
-    "drivablePercent": 31,
+    "pen": 15,
+    "drivableLessons": 7,
+    "drivablePercent": 32,
     "trackCount": 1,
-    "chapterCount": 3,
-    "drivablePrefixTotal": 0,
+    "chapterCount": 4,
+    "drivablePrefixTotal": 1,
     "fullyDrivableChapters": 0,
     "unstartableChapters": 3,
     "overriddenLessons": 0,
@@ -26,12 +26,12 @@
   "tracks": [
     {
       "language": "marwadi",
-      "lessonCount": 16,
-      "voice": 5,
+      "lessonCount": 22,
+      "voice": 7,
       "sight": 0,
-      "pen": 11,
-      "drivablePercent": 31,
-      "drivablePrefixTotal": 0,
+      "pen": 15,
+      "drivablePercent": 32,
+      "drivablePrefixTotal": 1,
       "modalities": [
         "voice",
         "sight",
@@ -85,6 +85,24 @@
           "firstNonVoiceLesson": "MW-W03-ha",
           "drivable": false,
           "drivableLessonIds": []
+        },
+        {
+          "chapter": 4,
+          "lessonCount": 6,
+          "voice": 2,
+          "sight": 0,
+          "pen": 4,
+          "modalities": [
+            "voice",
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "MW-W04-pa",
+          "drivable": false,
+          "drivableLessonIds": [
+            "MW-C04-hear-paani"
+          ]
         }
       ]
     }
@@ -448,6 +466,141 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:83c3d94261a645d9"
+    },
+    {
+      "id": "MW-C04-hear-paani",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 170,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:aaccc85dd1586ef0"
+    },
+    {
+      "id": "MW-W04-pa",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 180,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:1a062d35651bf9ed",
+      "detachableSegments": [
+        "Script — one new consonant",
+        "Writing — observe, trace, copy"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W04-nna",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 190,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:20444a4aaebcd2a7",
+      "detachableSegments": [
+        "Script — one new consonant",
+        "Writing — observe, trace, copy"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W04-ii-matra",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 200,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7c6e12bac8c4fd11",
+      "detachableSegments": [
+        "Script — one new vowel mark",
+        "Writing — attach only the mark"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-C04-paani",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 210,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dccdb7fa2a7dc1c4",
+      "detachableSegments": [
+        "Writing — guided, then delayed"
+      ]
+    },
+    {
+      "id": "MW-C04-practice",
+      "language": "marwadi",
+      "chapter": 4,
+      "sequence": 220,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6170378362027045"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/marwadi/CHANGELOG.md
+++ b/code/learning/human-languages/marwadi/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-21 — Water by ear, then sign by sign
+
+- Added a six-session Chapter 4 for source-attested **पाणी**, beginning with an
+  audio-only meaning step before any new spelling appears.
+- Isolated **प**, retroflex **ण**, and long-*ī* **ी** in separate two-and-a-half
+  minute writing lessons, while reusing already-secure **ा**.
+- Finished with delayed copy and independently scored listening, speaking,
+  reading, and dictation; a complete request for water remains explicit debt.
+
 ## 2026-08-21 — Enumerate the A1 assessment task shapes
 
 - Added an executable A1 destination for all four skills instead of treating a

--- a/code/learning/human-languages/marwadi/README.md
+++ b/code/learning/human-languages/marwadi/README.md
@@ -14,13 +14,16 @@ ask for the complete greeting from memory. Four more lessons then isolate **आ*
 and **भ**, assemble formal **आभार** (*ābhār*, "thanks; gratitude"), and retrieve
 it without a visible model. Five more isolate **ह** and **ं**, build respectful
 **हां सा** (*hā(n) sā*, "yes"), and retrieve it independently by ear, voice, eye,
-and hand. Every lesson is at most five minutes.
+and hand. Six further sessions teach *pāṇī* ("water") by ear before showing its
+spelling, then isolate **प**, **ण**, and **ी** before assembling and independently
+writing **पाणी**. Every lesson is at most five minutes.
 
 ## What this starter edition can honestly claim
 
-After Chapter 3, a learner can recognise, read, say, copy, and write the polite
+After Chapter 4, a learner can recognise, read, say, copy, and write the polite
 greeting **राम-राम सा**, answer it, and offer formal **आभार** after a kindness.
-They can also answer yes respectfully with **हां सा**. That is a small pre-A1
+They can also answer yes respectfully with **हां सा**, and retrieve **पाणी**
+as the Marwadi word for water in all four skills. That is a small pre-A1
 capability, not completion of pre-A1 and not exam readiness. The curriculum map
 records every untouched spine concept explicitly so the remaining work stays
 measurable.
@@ -42,7 +45,9 @@ Akademi magazine *Jāgtī Jot* as **राम-राम सा। — राम-
 April 2004 issue uses **आभार** in an expression of gratitude, anchoring Chapter
 2's formal word. A scholarly edition identifies *hā(n)-sā* as the polite Marwari
 affirmative, and an April–May 2019 *Jāgtī Jot* dialogue uses **हां सा** in
-context, anchoring Chapter 3 without flattening regional alternatives.
+context, anchoring Chapter 3 without flattening regional alternatives. SIL
+International's community-compiled 2015 dictionary records **पाणी** as water,
+anchoring Chapter 4's Marwadi spelling and its contrast with Hindi **पानी**.
 
 - [Rajasthan Foundation: Rajasthani Language](https://foundation.rajasthan.gov.in/RajasthaniLanguage.aspx)
 - [Rajasthan State Archives: learning Rajasthani (Marwari)](https://rsad.artandculture.rajasthan.gov.in/content/raj/art-and-culture/rajasthan-state-archives-bikaner/en/download.html)
@@ -50,6 +55,8 @@ context, anchoring Chapter 3 without flattening regional alternatives.
 - [Rajasthan Sahitya Akademi, *Jāgtī Jot*, April 2004](https://rsad.artandculture.rajasthan.gov.in/content/dam/doitassets/art-and-culture/Rajasthani-Bhasha-Sahitya-Avm-Sanskriti-Academy-Bikaner/pdf/JJ_All_Pdf/JJ_33_01_01_April_to_April_2004.pdf)
 - [Hess, *Texts and Translations*](https://hasp.ub.uni-heidelberg.de/catalog/view/1151/2059/103085)
 - [Rajasthan Sahitya Akademi, *Jāgtī Jot*, April–May 2019](https://rbssa.artandculture.rajasthan.gov.in/content/dam/doitassets/art-and-culture/Rajasthani-Bhasha-Sahitya-Avm-Sanskriti-Academy-Bikaner/pdf/JJ_All_Pdf/JJ_47_01_02_April_to_May_2019.pdf)
+- [SIL International, *Marwari–English Dictionary* (2015)](https://nepal.sil.org/resources/archives/63768)
+- [Turner, *A Comparative Dictionary of the Indo-Aryan Languages*](https://dsal.uchicago.edu/dictionaries/soas/)
 
 The language-specific path is in [`curriculum.json`](./curriculum.json), the
 five-minute sequence in [`session-map.md`](./session-map.md), and the long-range

--- a/code/learning/human-languages/marwadi/book/book.tex
+++ b/code/learning/human-languages/marwadi/book/book.tex
@@ -17,7 +17,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- sixteen lessons, each no longer than five minutes.\par}
+  {\large Starter edition --- twenty-two lessons, each no longer than five minutes.\par}
   \vspace{2cm}
   {\normalsize Copyright \copyright\ Adhithya Rajasekaran. Licensed under
     \href{https://creativecommons.org/licenses/by-sa/4.0/}%
@@ -41,8 +41,10 @@ book uses Marwadi as its short name and keeps Marwari visible for discoverabilit
 Chapter 1 makes one narrow promise: you will be able to read, say, and write the
 respectful greeting \mw{राम-राम सा}, and answer it. Chapter 2 adds one formal
 gratitude response, \mw{आभार}, through two new signs. Chapter 3 isolates two
-more signs before adding respectful affirmative \mw{हां सा}. These are real
-pre-A1 steps, not a claim that the level is complete.
+more signs before adding respectful affirmative \mw{हां सा}. Chapter 4 first
+teaches \emph{pāṇī}, ``water,'' by ear, then isolates each new sign before the
+learner reads and writes \mw{पाणी}. These are real pre-A1 steps, not a claim
+that the level is complete.
 
 \tableofcontents
 \mainmatter
@@ -50,6 +52,7 @@ pre-A1 steps, not a claim that the level is complete.
 \input{chapters/ch01-ram-ram-sa}
 \input{chapters/ch02-aabhaar}
 \input{chapters/ch03-haan-saa}
+\input{chapters/ch04-paani}
 
 \backmatter
 \input{chapters/appendix-pronunciation}
@@ -66,7 +69,9 @@ language page places Marwari among the major forms of Rajasthani. The lesson
 files carry the direct links. Chapters 1 and 2 are generated from those
 canonical files. Chapter 3 adds a scholarly Marwari text edition that identifies
 \emph{hā(n)-sā} as the polite affirmative and an April--May 2019 \emph{Jāgtī Jot}
-dialogue that uses \mw{हां सा} in context.
+dialogue that uses \mw{हां सा} in context. Chapter 4 uses SIL International's
+2015 \emph{Marwari--English Dictionary} for \mw{पाणी}, ``water,'' and Turner's
+comparative dictionary for its Indo-Aryan history.
 
 \input{chapters/appendix-index}
 \end{document}

--- a/code/learning/human-languages/marwadi/book/chapter-modalities.tex
+++ b/code/learning/human-languages/marwadi/book/chapter-modalities.tex
@@ -48,3 +48,10 @@
     \hlvoicesign{}~\textbf{Hands-free start:} none of the 5 lessons.%
     \par}\medskip
 }
+
+\expandafter\def\csname hlchaptermodality4\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlpensign{}~\textbf{pen} (4)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 6 lessons.%
+    \par}\medskip
+}

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 16
+% canonical-activities: 22
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -107,6 +107,44 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 \raggedright
 \hypertarget{review-MW-C03-practice-yes}{\textbf{3.5}} \emph{Practice — hear a yes, give a yes}\par
 \small From the spoken cue hā(n) sā alone, write the respectful affirmative.
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C04-hear-paani-meaning}{\textbf{4.1}} \emph{Hear \emph{pāṇī} — meaning before spelling}\par
+\small You hear pāṇī with no written cue. What does it mean?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W04-pa-build-paa}{\textbf{4.2}} \emph{\mw{प} — \emph{pa}, the first sign}\par
+\small Write pa, then add the familiar long-ā mark to make pā.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W04-nna-contrast}{\textbf{4.3}} \emph{\mw{ण} — curled-back \emph{ṇa}}\par
+\small Write the sign that carries the curled-back ṇ sound in this Marwadi word.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W04-ii-matra-build}{\textbf{4.4}} \emph{\mw{ी} — the long-\emph{ī} mark}\par
+\small Add the long-ī mark to \mw{ण} and write the result.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C04-paani-build}{\textbf{4.5}} \emph{\mw{पाणी} — join the word you already know by ear}\par
+\small Join \mw{पा} and \mw{णी}, then give the word's meaning.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C04-practice-paani}{\textbf{4.6}} \emph{Practice — hear, say, read, and write water}\par
+\small From the spoken cue pāṇī alone, write the Marwadi word and give its meaning.
 \end{minipage}\par\medskip
 
 \chapter*{Answer Key}
@@ -231,4 +269,48 @@ The first response is the canonical display answer. When a question accepts othe
 \hyperlink{review-MW-C03-practice-yes}{\textbf{3.5}} \emph{Practice — hear a yes, give a yes}\par
 \small \textbf{Answer:} \mw{हां} \mw{सा}\par
 \footnotesize \textbf{Also accepted:} \mw{हां} \mw{सा।}; haan sa; hā(n) sā
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C04-hear-paani-meaning}{\textbf{4.1}} \emph{Hear \emph{pāṇī} — meaning before spelling}\par
+\small \textbf{Answer:} water\par
+\footnotesize \textbf{Also accepted:} drinking water
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W04-pa-build-paa}{\textbf{4.2}} \emph{\mw{प} — \emph{pa}, the first sign}\par
+\small \textbf{Answer:} \mw{पा}\par
+\footnotesize \textbf{Also accepted:} \mw{प} + \mw{ा}; paa; pā
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W04-nna-contrast}{\textbf{4.3}} \emph{\mw{ण} — curled-back \emph{ṇa}}\par
+\small \textbf{Answer:} \mw{ण}\par
+\footnotesize \textbf{Also accepted:} nna; retroflex n
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W04-ii-matra-build}{\textbf{4.4}} \emph{\mw{ी} — the long-\emph{ī} mark}\par
+\small \textbf{Answer:} \mw{णी}\par
+\footnotesize \textbf{Also accepted:} \mw{ण} + \mw{ी}; nnee; ṇī
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C04-paani-build}{\textbf{4.5}} \emph{\mw{पाणी} — join the word you already know by ear}\par
+\small \textbf{Answer:} \mw{पाणी} — water\par
+\footnotesize \textbf{Also accepted:} \mw{पाणी}; paani — water; pāṇī — water
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C04-practice-paani}{\textbf{4.6}} \emph{Practice — hear, say, read, and write water}\par
+\small \textbf{Answer:} \mw{पाणी} — water\par
+\footnotesize \textbf{Also accepted:} \mw{पाणी}; \mw{पाणी} water; pāṇī — water
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 15
-% canonical-index-entries: 15
+% canonical-index-candidates: 19
+% canonical-index-entries: 19
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -52,6 +52,14 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-ram-ram-sa]{Chapter~1, p.~\pageref*{ch:mw-ram-ram-sa}}
 \end{minipage}\par\smallskip
 
+\section*{P}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Paani: Hear Water, Then Write It Sign by Sign}\par
+\footnotesize chapter topic; \hyperref[ch:mw-paani]{Chapter~4, p.~\pageref*{ch:mw-paani}}
+\end{minipage}\par\smallskip
+
 \section*{R}
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -64,6 +72,14 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{Ram, the name repeated in the greeting \mw{राम}-\mw{राम} \mw{सा}, built and written from \mw{र} + \mw{ा} + \mw{म}}\enspace\emph{\mw{राम}}\enspace(rām)\par
 \footnotesize explicit focus: script, writing; \hyperref[ch:mw-ram-ram-sa]{Chapter~1, p.~\pageref*{ch:mw-ram-ram-sa}}
+\end{minipage}\par\smallskip
+
+\section*{T}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ी} — the long-\emph{ī} mark}\par
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-paani]{Chapter~4, p.~\pageref*{ch:mw-paani}}
 \end{minipage}\par\smallskip
 
 \section*{Y}
@@ -80,6 +96,18 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\mw{आ} — long \emph{ā} at the beginning}\par
 \footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-aabhaar]{Chapter~2, p.~\pageref*{ch:mw-aabhaar}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ण} — curled-back \emph{ṇa}}\par
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-paani]{Chapter~4, p.~\pageref*{ch:mw-paani}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{प} — \emph{pa}, the first sign}\par
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-paani]{Chapter~4, p.~\pageref*{ch:mw-paani}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/marwadi/book/chapters/ch04-paani.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/ch04-paani.tex
@@ -1,0 +1,159 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:8189dbd0f7189ffa
+% canonical-lessons: MW-C04-hear-paani, MW-W04-pa, MW-W04-nna, MW-W04-ii-matra, MW-C04-paani, MW-C04-practice
+
+\chapter{Paani: Hear Water, Then Write It Sign by Sign}
+\label{ch:mw-paani}
+\hlchaptermodality{4}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can recognise, hear, say, read, and independently write \mw{पाणी} as the Marwadi word for water.}
+
+A source-attested everyday noun secured by ear before three new signs are isolated, assembled, and retrieved independently in all four skills.
+\end{chapteropening}
+
+\section[pāṇī]{Hear \emph{pāṇī} — meaning before spelling}
+
+\label{lesson:MW-C04-hear-paani}
+
+
+
+\begin{quote}
+Give the Chapter 3 four-skill response once: hear \emph{hā(n) sā} and identify a respectful yes; say it; read \textbf{\mw{हां} \mw{सा}}; then cover and write it. Say \emph{ābhār} for formal thanks. Now set writing aside: today's new word begins with the ear and voice.
+\end{quote}
+
+\subsection*{You'll want to know — one useful word}
+\begin{quote}
+\emph{pāṇī} — water
+\end{quote}
+
+Listen for two long vowels: \emph{pā-ṇī}. The middle sound is made with the tongue curled back a little. Hear the whole word twice, then say it once. Do not try to spell it yet; the next three tiny lessons will give the hand one piece at a time.
+
+\subsection*{Your turn — meaning without letters}
+Imagine two cups: one holds water, one holds tea. Hear \emph{pāṇī} and point to the water. Change the order and do it again. Then say \emph{pāṇī} while imagining water.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Close the page. Say \emph{pāṇī} once, then give its meaning.
+
+Source: \href{https://nepal.sil.org/resources/archives/63768}{SIL International, \emph{Marwari–English Dictionary} (2015)}.
+\end{tcolorbox}
+\section[pa]{\mw{प} — \emph{pa}, the first sign}
+
+\label{lesson:MW-W04-pa}
+
+
+
+\begin{quote}
+Write \textbf{\mw{हां}} from memory, checking the first sign and the dot. With no new spelling in view, say the Marwadi word for water. Then write the familiar long-\emph{ā} mark \textbf{\mw{ा}} once.
+\end{quote}
+
+\subsection*{Script — one new consonant}
+\begin{quote}
+\textbf{\mw{प}} — \emph{pa}
+\end{quote}
+
+Close the lips, release them without a strong puff, and say \emph{pa}. Today the hand meets only \textbf{\mw{प}}; the complete word stays hidden.
+
+\subsection*{Writing — observe, trace, copy}
+1. look at \textbf{\mw{प}} for three seconds 2. finger-trace its left stem, bowl, and headline 3. copy \textbf{\mw{प}} twice 4. say \emph{pa} after each copy
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Hide the model for five seconds. Write \textbf{\mw{प}}, then add \textbf{\mw{ा}} to make \textbf{\mw{पा}}.
+\end{tcolorbox}
+\section[ṇa]{\mw{ण} — curled-back \emph{ṇa}}
+
+\label{lesson:MW-W04-nna}
+
+
+
+\begin{quote}
+Write \textbf{\mw{हां}} as one complete known word. Say \emph{pāṇī} without looking at its spelling, then write \textbf{\mw{पा}} from memory.
+\end{quote}
+
+\subsection*{Script — one new consonant}
+\begin{quote}
+\textbf{\mw{ण}} — \emph{ṇa}
+\end{quote}
+
+Curl the tongue tip slightly back for \emph{ṇ}. Do not replace it with the dental \emph{n} heard in the Hindi cognate. The Marwadi dictionary spelling in this chapter uses \textbf{\mw{ण}}, so the eye, voice, and hand keep that contrast clear from the beginning.
+
+\subsection*{Writing — observe, trace, copy}
+1. look at \textbf{\mw{ण}} for three seconds 2. finger-trace the lower loop, upright, and headline 3. copy \textbf{\mw{ण}} twice 4. say \emph{ṇa} after each copy
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Cover both models. Write \textbf{\mw{प}}, then \textbf{\mw{ण}}, with a clear space between them.
+\end{tcolorbox}
+\section[long ī mark]{\mw{ी} — the long-\emph{ī} mark}
+
+\label{lesson:MW-W04-ii-matra}
+
+
+
+\begin{quote}
+Hear “Will you come?” and answer yes respectfully. Then say \emph{pāṇī}. Write \textbf{\mw{प}}, then \textbf{\mw{ण}}, from memory and name the curled-back sound.
+\end{quote}
+
+\subsection*{Script — one new vowel mark}
+\begin{quote}
+\textbf{\mw{ी}} — long \emph{ī}
+\end{quote}
+
+Like familiar \textbf{\mw{ा}}, this mark cannot stand alone in a word. It attaches to a consonant. Add it to \textbf{\mw{ण}} and read \textbf{\mw{णी}}, \emph{ṇī}.
+
+\subsection*{Writing — attach only the mark}
+1. copy \textbf{\mw{ण}} once 2. look at \textbf{\mw{णी}} 3. add \textbf{\mw{ी}} on the right of your copy 4. compare the joined form, then say \emph{ṇī}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Hide \textbf{\mw{णी}} for five seconds. Write it once, then uncover and compare.
+\end{tcolorbox}
+\section[pāṇī]{\mw{पाणी} — join the word you already know by ear}
+
+\label{lesson:MW-C04-paani}
+
+
+
+\begin{quote}
+Write the first sign of \textbf{\mw{राम}} from memory. Then say the Marwadi word for water and write \textbf{\mw{पा}}, then \textbf{\mw{णी}}, as two separate pieces. Check each piece before going on.
+\end{quote}
+
+\subsection*{The exchange — two familiar pieces}
+\begin{quote}
+\textbf{\mw{पा}} + \textbf{\mw{णी}} $\to$ \textbf{\mw{पाणी}} — \emph{pāṇī} — water
+\end{quote}
+
+Join the pieces without adding or changing a sign. Keep \textbf{\mw{ण}}, the curled-back sound that distinguishes this source-attested Marwadi spelling from its Hindi cognate.
+
+\begin{cousinweb}
+The word belongs to an old Indo-Aryan family. Sanskrit \emph{pānīya} meant something for drinking; related regional forms travelled through Middle Indo-Aryan into modern Marwadi \textbf{\mw{पाणी}}. The history is a memory hook, not a new spelling task.
+\end{cousinweb}
+
+\subsection*{Writing — guided, then delayed}
+1. copy \textbf{\mw{पाणी}} once while saying \emph{pā-ṇī} 2. point to \textbf{\mw{पा}}, then \textbf{\mw{णी}} 3. hide the model for ten seconds 4. write the complete word from memory 5. uncover and compare \textbf{\mw{प}}, \textbf{\mw{ा}}, \textbf{\mw{ण}}, and \textbf{\mw{ी}} separately
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textbf{\mw{पाणी}} once without looking, then write it once with the model covered.
+
+Sources: \href{https://nepal.sil.org/resources/archives/63768}{SIL International, \emph{Marwari–English Dictionary} (2015)} and \href{https://dsal.uchicago.edu/dictionaries/soas/}{Turner, \emph{A Comparative Dictionary of the Indo-Aryan Languages}, entry 8082}.
+\end{tcolorbox}
+\section[Practice]{Practice — hear, say, read, and write water}
+
+\label{lesson:MW-C04-practice}
+
+
+
+\begin{quote}
+Give the older respectful yes in four quick steps: hear it and name its meaning; say it; read \textbf{\mw{हां} \mw{सा}}; then cover and write it. Now say the three meanings in English as you hear \emph{ābhār}, \emph{hā(n) sā}, and \emph{pāṇī}. Write \textbf{\mw{पा}}, then \textbf{\mw{ण}} and \textbf{\mw{ी}} separately from memory.
+\end{quote}
+
+\subsection*{Your turn — four independent checks}
+1. \textbf{Listen:} hear \emph{pāṇī} and identify water, without text. 2. \textbf{Speak:} see a picture or imagine a glass of water and say \emph{pāṇī}, without notes. 3. \textbf{Read:} choose \textbf{\mw{पाणी}} from \textbf{\mw{आभार} · \mw{हां} · \mw{पाणी}} and give its meaning. 4. \textbf{Write:} hear \emph{pāṇī}, wait fifteen seconds, then write \textbf{\mw{पाणी}} with no model.
+
+Score each line separately. Repeat only the missed line; strong speaking does not compensate for a missing \textbf{\mw{ण}} or \textbf{\mw{ी}} in writing.
+
+\begin{grammarlens}[title={What you've built — and what remains}]
+You can retrieve one useful word in all four skills. You cannot yet request water in a complete Marwadi sentence; that needs pronouns, a request form, and register choices taught in later small steps.
+\end{grammarlens}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+If one sign stalled, return only to its two-minute sign lesson before repeating the complete dictation.
+\end{tcolorbox}

--- a/code/learning/human-languages/marwadi/chapters.json
+++ b/code/learning/human-languages/marwadi/chapters.json
@@ -68,6 +68,27 @@
           "MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01"
         ]
       }
+    },
+    {
+      "chapter": 4,
+      "title": "Paani: Hear Water, Then Write It Sign by Sign",
+      "label": "ch:mw-paani",
+      "canDo": "I can recognise, hear, say, read, and independently write पाणी as the Marwadi word for water.",
+      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "payoff": {
+        "lesson": "MW-C04-practice",
+        "kind": "survival-vocabulary",
+        "summary": "A source-attested everyday noun secured by ear before three new signs are isolated, assembled, and retrieved independently in all four skills.",
+        "assesses": [
+          "MW-LEX-PAANI-01",
+          "MW-SCRIPT-PA-01",
+          "MW-SCRIPT-AA-MATRA-01",
+          "MW-SCRIPT-NNA-01",
+          "MW-SCRIPT-II-MATRA-01",
+          "MW-SCRIPT-PAANI-01",
+          "MW-PERFORMANCE-PAANI-FOUR-SKILL-01"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/curriculum.json
+++ b/code/learning/human-languages/marwadi/curriculum.json
@@ -25,6 +25,14 @@
       "before": [],
       "inline": ["MW-EXT-005-POLITE-AFFIRMATIVE"],
       "after": []
+    },
+    {
+      "id": "MW-PATH-004",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": ["MW-C04-hear-paani", "MW-W04-pa", "MW-W04-nna", "MW-W04-ii-matra", "MW-C04-paani", "MW-C04-practice"],
+      "before": [],
+      "inline": ["MW-EXT-006-HEAR-PAANI", "MW-EXT-007-WRITE-PAANI", "MW-EXT-008-RETRIEVE-PAANI"],
+      "after": []
     }
   ],
   "spine": {
@@ -33,7 +41,7 @@
     "SPINE-RESPOND-BASIC": { "segments": ["MW-PATH-003"], "omits": ["RESPONSE-NO", "RESPONSE-YESNO", "RESPONSE-OKAY"], "relocates": {} },
     "SPINE-EXCHANGE-NAMES": { "segments": [], "omits": ["QUESTION-WHAT", "PRONOUN-I", "PRONOUN-ME", "PRONOUN-YOU", "PRONOUN-MY", "WORD-NAME", "WORD-IS", "INTRO-MY-NAME-IS", "INTRO-WHATS-YOUR-NAME", "INTRO-NICE-TO-MEET-YOU"], "relocates": {} },
     "SPINE-CHECK-WELLBEING": { "segments": [], "omits": ["QUESTION-HOW", "STATE-HOW-ARE-YOU", "WORD-GOOD", "WORD-WELL", "WORD-SOSO"], "relocates": {} },
-    "SPINE-POLITE-REQUEST-REPAIR": { "segments": [], "omits": ["COURTESY-PLEASE", "COURTESY-SORRY"], "relocates": {} },
+    "SPINE-POLITE-REQUEST-REPAIR": { "segments": ["MW-PATH-004"], "omits": ["COURTESY-PLEASE", "COURTESY-SORRY"], "relocates": {} },
     "SPINE-TAKE-LEAVE": { "segments": [], "omits": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"], "relocates": {} },
     "SPINE-TIME-OF-DAY": { "segments": [], "omits": ["TIME-DAY", "TIME-MORNING", "TIME-AFTERNOON", "TIME-EVENING", "TIME-NIGHT", "GREETING-DAY", "GREETING-MORNING", "GREETING-AFTERNOON", "GREETING-EVENING"], "relocates": {} },
     "SPINE-ASK-LOCATION": { "segments": [], "omits": ["QUESTION-WHERE"], "relocates": {} },
@@ -107,6 +115,33 @@
       "canDo": "I can recognise, hear, say, and independently write हां सा as a respectful affirmative answer.",
       "prerequisites": ["MW-EXT-004-FORMAL-THANKS"],
       "lessons": ["MW-W03-ha", "MW-W03-anusvara", "MW-C03-haan-saa", "MW-C03-listen-say", "MW-C03-practice"]
+    },
+    {
+      "id": "MW-EXT-006-HEAR-PAANI",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "vocabulary",
+      "canDo": "I can recognise pāṇī by ear, say it, and give its meaning before seeing its spelling.",
+      "prerequisites": ["MW-EXT-005-POLITE-AFFIRMATIVE"],
+      "lessons": ["MW-C04-hear-paani"]
+    },
+    {
+      "id": "MW-EXT-007-WRITE-PAANI",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can recognise and form प, ण, and ी, reuse ा, and assemble पाणी without substituting Hindi न.",
+      "prerequisites": ["MW-EXT-006-HEAR-PAANI"],
+      "lessons": ["MW-W04-pa", "MW-W04-nna", "MW-W04-ii-matra", "MW-C04-paani"]
+    },
+    {
+      "id": "MW-EXT-008-RETRIEVE-PAANI",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can hear, say, read, and independently write पाणी as the Marwadi word for water.",
+      "prerequisites": ["MW-EXT-007-WRITE-PAANI"],
+      "lessons": ["MW-C04-practice"]
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/lessons/MW-C04-hear-paani.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C04-hear-paani.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-C04-hear-paani
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 170
+chapter: 4
+type: listening-speaking
+headword: "pāṇī"
+romanization: pāṇī
+gloss: water, heard before it is written
+concept_tag: NOUN-WATER
+prerequisites: [MW-C03-practice]
+sounds: [long-aa, retroflex-n, long-ii]
+roots: []
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01]
+introduces:
+  knowledge: [MW-LEX-PAANI-01]
+practises:
+  knowledge: [MW-LEX-AABHAAR-01, MW-LEX-HAAN-01, MW-RESPONSE-HAAN-SAA-POLITE-01, MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01, MW-LEX-PAANI-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C02-aabhaar, MW-C03-haan-saa, MW-C03-practice]
+---
+
+# Hear *pāṇī* — meaning before spelling
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-AABHAAR-01, MW-LEX-HAAN-01, MW-RESPONSE-HAAN-SAA-POLITE-01, MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01] -->
+
+[PAUSE 15s] Give the Chapter 3 four-skill response once: hear *hā(n) sā* and
+identify a respectful yes; say it; read **हां सा**; then cover and write it.
+Say *ābhār* for formal thanks. Now set writing aside: today's new word begins
+with the ear and voice.
+
+## You'll want to know — one useful word
+<!-- hl-knowledge: introduces=[MW-LEX-PAANI-01]; assesses=[] -->
+
+> *pāṇī* — water
+
+Listen for two long vowels: *pā-ṇī*. The middle sound is made with the tongue
+curled back a little. Hear the whole word twice, then say it once. Do not try to
+spell it yet; the next three tiny lessons will give the hand one piece at a time.
+
+## Guided Practice — meaning without letters
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PAANI-01] -->
+
+Imagine two cups: one holds water, one holds tea. Hear *pāṇī* and point to the
+water. Change the order and do it again. Then say *pāṇī* while imagining water.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PAANI-01] -->
+<!-- hl-activity: {"id":"MW-C04-hear-paani-meaning","kind":"text","assesses":["MW-LEX-PAANI-01"],"prompt":"You hear pāṇī with no written cue. What does it mean?","answer":"water","accepted":["drinking water"],"feedback":{"correct":"Right: pāṇī means water.","incorrect":"The sound pāṇī names water."},"response_seconds":8} -->
+
+Close the page. Say *pāṇī* once, then give its meaning.
+
+Source: [SIL International, *Marwari–English Dictionary* (2015)](https://nepal.sil.org/resources/archives/63768).

--- a/code/learning/human-languages/marwadi/lessons/MW-C04-paani.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C04-paani.md
@@ -1,0 +1,74 @@
+---
+schema_version: 2
+id: MW-C04-paani
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 210
+chapter: 4
+type: vocabulary
+headword: "पाणी"
+romanization: pāṇī
+gloss: water
+concept_tag: NOUN-WATER
+prerequisites: [MW-W04-ii-matra]
+sounds: [unaspirated-p, long-aa, retroflex-n, long-ii]
+roots: [SANSKRIT-PA-DRINK]
+etymology_hook: Marwadi पाणी continues an old Indo-Aryan family descending from Sanskrit पानीय, something for drinking.
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01]
+introduces:
+  knowledge: [MW-SCRIPT-PAANI-01]
+practises:
+  knowledge: [MW-SCRIPT-RA-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01, MW-SCRIPT-PAANI-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C04-hear-paani, MW-W04-pa, MW-W04-nna, MW-W04-ii-matra]
+---
+
+# पाणी — join the word you already know by ear
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-RA-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01] -->
+
+[PAUSE 10s] Write the first sign of **राम** from memory. Then say the Marwadi
+word for water and write **पा**, then **णी**, as two separate pieces. Check each
+piece before going on.
+
+## The exchange — two familiar pieces
+<!-- hl-knowledge: introduces=[MW-SCRIPT-PAANI-01]; assesses=[] -->
+
+> **पा** + **णी** → **पाणी** — *pāṇī* — water
+
+Join the pieces without adding or changing a sign. Keep **ण**, the curled-back
+sound that distinguishes this source-attested Marwadi spelling from its Hindi
+cognate.
+
+## Pāṇī taken apart — a small word history
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PAANI-01, MW-SCRIPT-PAANI-01] -->
+
+The word belongs to an old Indo-Aryan family. Sanskrit *pānīya*
+meant something for drinking; related regional forms travelled through Middle
+Indo-Aryan into modern Marwadi **पाणी**. The history is a memory hook, not a
+new spelling task.
+
+## Writing — guided, then delayed
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-PAANI-01, MW-LEX-PAANI-01] -->
+<!-- hl-writing-stage: delayed-copy -->
+
+1. copy **पाणी** once while saying *pā-ṇī*
+2. point to **पा**, then **णी**
+3. hide the model for ten seconds
+4. write the complete word from memory
+5. uncover and compare **प**, **ा**, **ण**, and **ी** separately
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-PAANI-01, MW-LEX-PAANI-01] -->
+<!-- hl-activity: {"id":"MW-C04-paani-build","kind":"text","assesses":["MW-SCRIPT-PAANI-01","MW-LEX-PAANI-01"],"prompt":"Join पा and णी, then give the word's meaning.","answer":"पाणी — water","accepted":["पाणी","paani — water","pāṇī — water"],"feedback":{"correct":"Right: पा + णी makes पाणी, water.","incorrect":"Join the two taught pieces: पा + णी = पाणी, water."},"response_seconds":12} -->
+
+Say **पाणी** once without looking, then write it once with the model covered.
+
+Sources: [SIL International, *Marwari–English Dictionary* (2015)](https://nepal.sil.org/resources/archives/63768) and [Turner, *A Comparative Dictionary of the Indo-Aryan Languages*, entry 8082](https://dsal.uchicago.edu/dictionaries/soas/).

--- a/code/learning/human-languages/marwadi/lessons/MW-C04-practice.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C04-practice.md
@@ -1,0 +1,64 @@
+---
+schema_version: 2
+id: MW-C04-practice
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 220
+chapter: 4
+type: practice-mix
+headword: "पाणी"
+romanization: pāṇī
+gloss: water
+prerequisites: [MW-C04-paani]
+sounds: [unaspirated-p, long-aa, retroflex-n, long-ii]
+roots: [SANSKRIT-PA-DRINK]
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01, MW-SCRIPT-PAANI-01]
+introduces:
+  knowledge: [MW-PERFORMANCE-PAANI-FOUR-SKILL-01]
+practises:
+  knowledge: [MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01, MW-LEX-AABHAAR-01, MW-LEX-HAAN-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01, MW-SCRIPT-PAANI-01, MW-PERFORMANCE-PAANI-FOUR-SKILL-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C02-aabhaar, MW-C03-haan-saa, MW-C04-hear-paani, MW-W04-pa, MW-W04-nna, MW-W04-ii-matra, MW-C04-paani]
+---
+
+# Practice — hear, say, read, and write water
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-PERFORMANCE-HAAN-SAA-FOUR-SKILL-01, MW-LEX-AABHAAR-01, MW-LEX-HAAN-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01] -->
+
+[PAUSE 20s] Give the older respectful yes in four quick steps: hear it and name
+its meaning; say it; read **हां सा**; then cover and write it. Now say the three
+meanings in English as you hear *ābhār*, *hā(n) sā*, and *pāṇī*. Write **पा**,
+then **ण** and **ी** separately from memory.
+
+## Guided Practice — four independent checks
+<!-- hl-knowledge: introduces=[MW-PERFORMANCE-PAANI-FOUR-SKILL-01]; assesses=[MW-LEX-PAANI-01, MW-SCRIPT-PAANI-01] -->
+
+1. **Listen:** hear *pāṇī* and identify water, without text.
+2. **Speak:** see a picture or imagine a glass of water and say *pāṇī*, without notes.
+3. **Read:** choose **पाणी** from **आभार · हां · पाणी** and give its meaning.
+4. **Write:** hear *pāṇī*, wait fifteen seconds, then write **पाणी** with no model.
+
+Score each line separately. Repeat only the missed line; strong speaking does
+not compensate for a missing **ण** or **ी** in writing.
+
+## What you've built — and what remains
+<!-- hl-knowledge: introduces=[]; assesses=[MW-PERFORMANCE-PAANI-FOUR-SKILL-01] -->
+
+You can retrieve one useful word in all four skills. You cannot yet request
+water in a complete Marwadi sentence; that needs pronouns, a request form, and
+register choices taught in later small steps.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PAANI-01, MW-SCRIPT-PAANI-01, MW-PERFORMANCE-PAANI-FOUR-SKILL-01] -->
+<!-- hl-writing-stage: dictation-transcription -->
+<!-- hl-activity: {"id":"MW-C04-practice-paani","kind":"text","assesses":["MW-LEX-PAANI-01","MW-SCRIPT-PAANI-01","MW-PERFORMANCE-PAANI-FOUR-SKILL-01"],"prompt":"From the spoken cue pāṇī alone, write the Marwadi word and give its meaning.","answer":"पाणी — water","accepted":["पाणी","पाणी water","pāṇī — water"],"feedback":{"correct":"पाणी — water, recalled from sound without a visible model.","incorrect":"Write पा, then णी: पाणी. It means water."},"response_seconds":15} -->
+
+If one sign stalled, return only to its two-minute sign lesson before repeating
+the complete dictation.

--- a/code/learning/human-languages/marwadi/lessons/MW-W04-ii-matra.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W04-ii-matra.md
@@ -1,0 +1,60 @@
+---
+schema_version: 2
+id: MW-W04-ii-matra
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 200
+delivery: script
+chapter: 4
+type: writing
+headword: "ी"
+romanization: long ī mark
+gloss: the Devanagari dependent vowel mark for long ii
+prerequisites: [MW-W04-nna]
+sounds: [long-ii]
+roots: []
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-LEX-PAANI-01, MW-SCRIPT-NNA-01]
+introduces:
+  knowledge: [MW-SCRIPT-II-MATRA-01]
+practises:
+  knowledge: [MW-RESPONSE-HAAN-SAA-POLITE-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C04-hear-paani, MW-W04-pa, MW-W04-nna]
+---
+
+# ी — the long-*ī* mark
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-RESPONSE-HAAN-SAA-POLITE-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-NNA-01] -->
+
+[PAUSE 8s] Hear “Will you come?” and answer yes respectfully. Then say *pāṇī*.
+Write **प**, then **ण**, from memory and name the curled-back sound.
+
+## Script — one new vowel mark
+<!-- hl-knowledge: introduces=[MW-SCRIPT-II-MATRA-01]; assesses=[] -->
+
+> **ी** — long *ī*
+
+Like familiar **ा**, this mark cannot stand alone in a word. It attaches to a
+consonant. Add it to **ण** and read **णी**, *ṇī*.
+
+## Writing — attach only the mark
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01] -->
+<!-- hl-writing-stage: guided-copy -->
+
+1. copy **ण** once
+2. look at **णी**
+3. add **ी** on the right of your copy
+4. compare the joined form, then say *ṇī*
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-NNA-01, MW-SCRIPT-II-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W04-ii-matra-build","kind":"text","assesses":["MW-SCRIPT-NNA-01","MW-SCRIPT-II-MATRA-01"],"prompt":"Add the long-ī mark to ण and write the result.","answer":"णी","accepted":["ण + ी","nnee","ṇī"],"feedback":{"correct":"Yes: ण + ी makes णी, ṇī.","incorrect":"Attach ी on the right of ण: णी."},"response_seconds":10} -->
+
+Hide **णी** for five seconds. Write it once, then uncover and compare.

--- a/code/learning/human-languages/marwadi/lessons/MW-W04-nna.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W04-nna.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-W04-nna
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 190
+delivery: script
+chapter: 4
+type: writing
+headword: "ण"
+romanization: ṇa
+gloss: the Devanagari retroflex consonant nna
+prerequisites: [MW-W04-pa]
+sounds: [retroflex-n]
+roots: []
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-LEX-PAANI-01, MW-SCRIPT-PA-01]
+introduces:
+  knowledge: [MW-SCRIPT-NNA-01]
+practises:
+  knowledge: [MW-SCRIPT-HAAN-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-NNA-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C04-hear-paani, MW-W04-pa, MW-W01-aa-matra]
+---
+
+# ण — curled-back *ṇa*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-HAAN-01, MW-LEX-PAANI-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01] -->
+
+[PAUSE 8s] Write **हां** as one complete known word. Say *pāṇī* without looking
+at its spelling, then write **पा** from memory.
+
+## Script — one new consonant
+<!-- hl-knowledge: introduces=[MW-SCRIPT-NNA-01]; assesses=[] -->
+
+> **ण** — *ṇa*
+
+Curl the tongue tip slightly back for *ṇ*. Do not replace it with the dental
+*n* heard in the Hindi cognate. The Marwadi dictionary spelling in this chapter
+uses **ण**, so the eye, voice, and hand keep that contrast clear from the beginning.
+
+## Writing — observe, trace, copy
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-NNA-01] -->
+<!-- hl-writing-stage: observe-trace -->
+
+1. look at **ण** for three seconds
+2. finger-trace the lower loop, upright, and headline
+3. copy **ण** twice
+4. say *ṇa* after each copy
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-PA-01, MW-SCRIPT-NNA-01] -->
+<!-- hl-activity: {"id":"MW-W04-nna-contrast","kind":"text","assesses":["MW-SCRIPT-NNA-01"],"prompt":"Write the sign that carries the curled-back ṇ sound in this Marwadi word.","answer":"ण","accepted":["nna","retroflex n"],"feedback":{"correct":"Right: ण carries the curled-back ṇ sound.","incorrect":"Use the curled-back sign taught here: ण."},"response_seconds":8} -->
+
+Cover both models. Write **प**, then **ण**, with a clear space between them.

--- a/code/learning/human-languages/marwadi/lessons/MW-W04-pa.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W04-pa.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-W04-pa
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 180
+delivery: script
+chapter: 4
+type: writing
+headword: "प"
+romanization: pa
+gloss: the Devanagari consonant pa
+prerequisites: [MW-C04-hear-paani]
+sounds: [unaspirated-p]
+roots: []
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-LEX-PAANI-01, MW-SCRIPT-AA-MATRA-01]
+introduces:
+  knowledge: [MW-SCRIPT-PA-01]
+practises:
+  knowledge: [MW-SCRIPT-HA-01, MW-SCRIPT-ANUSVARA-01, MW-LEX-PAANI-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-PA-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C04-hear-paani, MW-W01-aa-matra]
+---
+
+# प — *pa*, the first sign
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-HA-01, MW-SCRIPT-ANUSVARA-01, MW-LEX-PAANI-01, MW-SCRIPT-AA-MATRA-01] -->
+
+[PAUSE 8s] Write **हां** from memory, checking the first sign and the dot. With
+no new spelling in view, say the Marwadi word for water. Then write the familiar
+long-*ā* mark **ा** once.
+
+## Script — one new consonant
+<!-- hl-knowledge: introduces=[MW-SCRIPT-PA-01]; assesses=[] -->
+
+> **प** — *pa*
+
+Close the lips, release them without a strong puff, and say *pa*. Today the hand
+meets only **प**; the complete word stays hidden.
+
+## Writing — observe, trace, copy
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-PA-01] -->
+<!-- hl-writing-stage: observe-trace -->
+
+1. look at **प** for three seconds
+2. finger-trace its left stem, bowl, and headline
+3. copy **प** twice
+4. say *pa* after each copy
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W04-pa-build-paa","kind":"text","assesses":["MW-SCRIPT-PA-01","MW-SCRIPT-AA-MATRA-01"],"prompt":"Write pa, then add the familiar long-ā mark to make pā.","answer":"पा","accepted":["प + ा","paa","pā"],"feedback":{"correct":"Yes: प + ा makes पा, pā.","incorrect":"Write प, then attach ा on its right: पा."},"response_seconds":10} -->
+
+Hide the model for five seconds. Write **प**, then add **ा** to make **पा**.

--- a/code/learning/human-languages/marwadi/narration/ch04.json
+++ b/code/learning/human-languages/marwadi/narration/ch04.json
@@ -1,0 +1,695 @@
+{
+  "version": 1,
+  "language": "marwadi",
+  "chapter": 4,
+  "title": "Paani: Hear Water, Then Write It Sign by Sign",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:6e3cb93f8705c380",
+  "lessons": [
+    {
+      "id": "MW-C04-hear-paani",
+      "sequence": 170,
+      "title": "Hear pāṇī — meaning before spelling",
+      "headword": "pāṇī",
+      "romanization": "pāṇī",
+      "gloss": "water, heard before it is written",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:aaccc85dd1586ef0",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the Chapter 3 four-skill response once: hear hā(n) sā and identify a respectful yes; say it; read हां सा; then cover and write it. Say ābhār for formal thanks. Now set writing aside: today's new word begins with the ear and voice."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know — one useful word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "pāṇī — water."
+            },
+            {
+              "kind": "speech",
+              "text": "Listen for two long vowels: pā-ṇī. The middle sound is made with the tongue curled back a little. Hear the whole word twice, then say it once. Do not try to spell it yet; the next three tiny lessons will give the hand one piece at a time."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice — meaning without letters",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Imagine two cups: one holds water, one holds tea. Hear pāṇī and point to the water. Change the order and do it again. Then say pāṇī while imagining water."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Close the page. Say pāṇī once, then give its meaning."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: SIL International, Marwari–English Dictionary (2015)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C04-hear-paani-meaning",
+              "prompt": "You hear pāṇī with no written cue. What does it mean?",
+              "assesses": [
+                "MW-LEX-PAANI-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "water",
+                "drinking water"
+              ],
+              "feedback": {
+                "correct": "Right: pāṇī means water.",
+                "incorrect": "The sound pāṇī names water."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W04-pa",
+      "sequence": 180,
+      "title": "प — pa, the first sign",
+      "headword": "प",
+      "romanization": "pa",
+      "gloss": "the Devanagari consonant pa",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:1a062d35651bf9ed",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — one new consonant"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new consonant until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 8,
+              "perItem": false,
+              "source": "[PAUSE 8s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write हां from memory, checking the first sign and the dot. With no new spelling in view, say the Marwadi word for water. Then write the familiar long-ā mark ा once."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one new consonant",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "प — pa."
+            },
+            {
+              "kind": "speech",
+              "text": "Close the lips, release them without a strong puff, and say pa. Today the hand meets only प; the complete word stays hidden."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "writing",
+          "title": "Writing — observe, trace, copy",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "look at प (pa) for three seconds."
+            },
+            {
+              "kind": "speech",
+              "text": "finger-trace its left stem, bowl, and headline."
+            },
+            {
+              "kind": "speech",
+              "text": "copy प (pa) twice."
+            },
+            {
+              "kind": "speech",
+              "text": "say pa after each copy."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hide the model for five seconds. Write प (pa), then add ा to make पा."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W04-pa-build-paa",
+              "prompt": "Write pa, then add the familiar long-ā mark to make pā.",
+              "assesses": [
+                "MW-SCRIPT-PA-01",
+                "MW-SCRIPT-AA-MATRA-01"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "पा",
+                "प + ा",
+                "paa",
+                "pā"
+              ],
+              "feedback": {
+                "correct": "Yes: प + ा makes पा, pā.",
+                "incorrect": "Write प, then attach ा on its right: पा."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W04-nna",
+      "sequence": 190,
+      "title": "ण — curled-back ṇa",
+      "headword": "ण",
+      "romanization": "ṇa",
+      "gloss": "the Devanagari retroflex consonant nna",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:20444a4aaebcd2a7",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — one new consonant"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new consonant until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 8,
+              "perItem": false,
+              "source": "[PAUSE 8s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write हां as one complete known word. Say pāṇī without looking at its spelling, then write पा from memory."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one new consonant",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ण — ṇa."
+            },
+            {
+              "kind": "speech",
+              "text": "Curl the tongue tip slightly back for ṇ. Do not replace it with the dental n heard in the Hindi cognate. The Marwadi dictionary spelling in this chapter uses ण (ṇa), so the eye, voice, and hand keep that contrast clear from the beginning."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "writing",
+          "title": "Writing — observe, trace, copy",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "look at ण (ṇa) for three seconds."
+            },
+            {
+              "kind": "speech",
+              "text": "finger-trace the lower loop, upright, and headline."
+            },
+            {
+              "kind": "speech",
+              "text": "copy ण (ṇa) twice."
+            },
+            {
+              "kind": "speech",
+              "text": "say ṇa after each copy."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover both models. Write प, then ण (ṇa), with a clear space between them."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W04-nna-contrast",
+              "prompt": "Write the sign that carries the curled-back ṇ sound in this Marwadi word.",
+              "assesses": [
+                "MW-SCRIPT-NNA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "ण",
+                "nna",
+                "retroflex n"
+              ],
+              "feedback": {
+                "correct": "Right: ण carries the curled-back ṇ sound.",
+                "incorrect": "Use the curled-back sign taught here: ण."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W04-ii-matra",
+      "sequence": 200,
+      "title": "ी (long ī mark) — the long-ī mark",
+      "headword": "ी",
+      "romanization": "long ī mark",
+      "gloss": "the Devanagari dependent vowel mark for long ii",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:7c6e12bac8c4fd11",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — one new vowel mark"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new vowel mark until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 8,
+              "perItem": false,
+              "source": "[PAUSE 8s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Hear “Will you come?” and answer yes respectfully. Then say pāṇī. Write प (pa), then ण (ṇa), from memory and name the curled-back sound."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one new vowel mark",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ी (long ī mark) — long ī."
+            },
+            {
+              "kind": "speech",
+              "text": "Like familiar ा, this mark cannot stand alone in a word. It attaches to a consonant. Add it to ण (ṇa) and read णी, ṇī."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "writing",
+          "title": "Writing — attach only the mark",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "copy ण (ṇa) once."
+            },
+            {
+              "kind": "speech",
+              "text": "look at णी."
+            },
+            {
+              "kind": "speech",
+              "text": "add ी (long ī mark) on the right of your copy."
+            },
+            {
+              "kind": "speech",
+              "text": "compare the joined form, then say ṇī."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hide णी for five seconds. Write it once, then uncover and compare."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W04-ii-matra-build",
+              "prompt": "Add the long-ī mark to ण (ṇa) and write the result.",
+              "assesses": [
+                "MW-SCRIPT-NNA-01",
+                "MW-SCRIPT-II-MATRA-01"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "णी",
+                "ण + ी",
+                "nnee",
+                "ṇī"
+              ],
+              "feedback": {
+                "correct": "Yes: ण + ी makes णी, ṇī.",
+                "incorrect": "Attach ी on the right of ण: णी."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C04-paani",
+      "sequence": 210,
+      "title": "पाणी (pāṇī) — join the word you already know by ear",
+      "headword": "पाणी",
+      "romanization": "pāṇī",
+      "gloss": "water",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-block"
+      ],
+      "sourceHash": "fnv1a64:dccdb7fa2a7dc1c4",
+      "notice": {
+        "modality": "pen",
+        "needs": [],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 10,
+              "perItem": false,
+              "source": "[PAUSE 10s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write the first sign of राम from memory. Then say the Marwadi word for water and write पा, then णी, as two separate pieces. Check each piece before going on."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "The exchange — two familiar pieces",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पा + णी becomes पाणी — pāṇī — water."
+            },
+            {
+              "kind": "speech",
+              "text": "Join the pieces without adding or changing a sign. Keep ण (ṇa), the curled-back sound that distinguishes this source-attested Marwadi spelling from its Hindi cognate."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "Pāṇī taken apart — a small word history",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The word belongs to an old Indo-Aryan family. Sanskrit pānīya meant something for drinking; related regional forms travelled through Middle Indo-Aryan into modern Marwadi पाणी (pāṇī). The history is a memory hook, not a new spelling task."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "writing",
+          "title": "Writing — guided, then delayed",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "copy पाणी (pāṇī) once while saying pā-ṇī."
+            },
+            {
+              "kind": "speech",
+              "text": "point to पा, then णी."
+            },
+            {
+              "kind": "speech",
+              "text": "hide the model for ten seconds."
+            },
+            {
+              "kind": "speech",
+              "text": "write the complete word from memory."
+            },
+            {
+              "kind": "speech",
+              "text": "uncover and compare प, ा, ण (ṇa), and ी (long ī mark) separately."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say पाणी (pāṇī) once without looking, then write it once with the model covered."
+            },
+            {
+              "kind": "speech",
+              "text": "Sources: SIL International, Marwari–English Dictionary (2015) and Turner, A Comparative Dictionary of the Indo-Aryan Languages, entry 8082."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C04-paani-build",
+              "prompt": "Join पा and णी, then give the word's meaning.",
+              "assesses": [
+                "MW-SCRIPT-PAANI-01",
+                "MW-LEX-PAANI-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "पाणी — water",
+                "पाणी",
+                "paani — water",
+                "pāṇī — water"
+              ],
+              "feedback": {
+                "correct": "Right: पा + णी makes पाणी, water.",
+                "incorrect": "Join the two taught pieces: पा + णी = पाणी, water."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C04-practice",
+      "sequence": 220,
+      "title": "Practice — hear, say, read, and write water",
+      "headword": "पाणी",
+      "romanization": "pāṇī",
+      "gloss": "water",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6170378362027045",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 20,
+              "perItem": false,
+              "source": "[PAUSE 20s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the older respectful yes in four quick steps: hear it and name its meaning; say it; read हां सा; then cover and write it. Now say the three meanings in English as you hear ābhār, hā(n) sā, and pāṇī. Write पा, then ण (ṇa) and ी (long ī mark) separately from memory."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "guided-production",
+          "title": "Guided Practice — four independent checks",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Listen: hear pāṇī and identify water, without text."
+            },
+            {
+              "kind": "speech",
+              "text": "Speak: see a picture or imagine a glass of water and say pāṇī, without notes."
+            },
+            {
+              "kind": "speech",
+              "text": "Read: choose पाणी (pāṇī) from आभार, हां, पाणी (pāṇī) and give its meaning."
+            },
+            {
+              "kind": "speech",
+              "text": "Write: hear pāṇī, wait fifteen seconds, then write पाणी with no model."
+            },
+            {
+              "kind": "speech",
+              "text": "Score each line separately. Repeat only the missed line; strong speaking does not compensate for a missing ण (ṇa) or ी (long ī mark) in writing."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "notice",
+          "title": "What you've built — and what remains",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You can retrieve one useful word in all four skills. You cannot yet request water in a complete Marwadi sentence; that needs pronouns, a request form, and register choices taught in later small steps."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "If one sign stalled, return only to its two-minute sign lesson before repeating the complete dictation."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C04-practice-paani",
+              "prompt": "From the spoken cue pāṇī alone, write the Marwadi word and give its meaning.",
+              "assesses": [
+                "MW-LEX-PAANI-01",
+                "MW-SCRIPT-PAANI-01",
+                "MW-PERFORMANCE-PAANI-FOUR-SKILL-01"
+              ],
+              "responseSeconds": 15,
+              "acceptedResponses": [
+                "पाणी — water",
+                "पाणी",
+                "पाणी water",
+                "pāṇī — water"
+              ],
+              "feedback": {
+                "correct": "पाणी — water, recalled from sound without a visible model.",
+                "incorrect": "Write पा, then णी: पाणी. It means water."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/marwadi/narration/ch04.txt
+++ b/code/learning/human-languages/marwadi/narration/ch04.txt
@@ -1,0 +1,151 @@
+Marwadi (Marwari), chapter 4: Paani: Hear Water, Then Write It Sign by Sign.
+6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 6.
+Hear pāṇī — meaning before spelling.
+
+Warm-up.
+[pause 15 seconds]
+Give the Chapter 3 four-skill response once: hear hā(n) sā and identify a respectful yes; say it; read हां सा; then cover and write it. Say ābhār for formal thanks. Now set writing aside: today's new word begins with the ear and voice.
+
+You'll want to know — one useful word.
+pāṇī — water.
+Listen for two long vowels: pā-ṇī. The middle sound is made with the tongue curled back a little. Hear the whole word twice, then say it once. Do not try to spell it yet; the next three tiny lessons will give the hand one piece at a time.
+
+Guided Practice — meaning without letters.
+Imagine two cups: one holds water, one holds tea. Hear pāṇī and point to the water. Change the order and do it again. Then say pāṇī while imagining water.
+
+Wrap-up recall.
+Close the page. Say pāṇī once, then give its meaning.
+Source: SIL International, Marwari–English Dictionary (2015).
+[question — say your answer, then pause 8 seconds]
+You hear pāṇī with no written cue. What does it mean?
+
+
+Lesson 2 of 6.
+प — pa, the first sign.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new consonant until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 8 seconds]
+Write हां from memory, checking the first sign and the dot. With no new spelling in view, say the Marwadi word for water. Then write the familiar long-ā mark ा once.
+
+Script — one new consonant.
+प — pa.
+Close the lips, release them without a strong puff, and say pa. Today the hand meets only प; the complete word stays hidden.
+
+Writing — observe, trace, copy.
+look at प (pa) for three seconds.
+finger-trace its left stem, bowl, and headline.
+copy प (pa) twice.
+say pa after each copy.
+
+Wrap-up recall.
+Hide the model for five seconds. Write प (pa), then add ा to make पा.
+[question — say your answer, then pause 10 seconds]
+Write pa, then add the familiar long-ā mark to make pā.
+
+
+Lesson 3 of 6.
+ण — curled-back ṇa.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new consonant until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 8 seconds]
+Write हां as one complete known word. Say pāṇī without looking at its spelling, then write पा from memory.
+
+Script — one new consonant.
+ण — ṇa.
+Curl the tongue tip slightly back for ṇ. Do not replace it with the dental n heard in the Hindi cognate. The Marwadi dictionary spelling in this chapter uses ण (ṇa), so the eye, voice, and hand keep that contrast clear from the beginning.
+
+Writing — observe, trace, copy.
+look at ण (ṇa) for three seconds.
+finger-trace the lower loop, upright, and headline.
+copy ण (ṇa) twice.
+say ṇa after each copy.
+
+Wrap-up recall.
+Cover both models. Write प, then ण (ṇa), with a clear space between them.
+[question — say your answer, then pause 8 seconds]
+Write the sign that carries the curled-back ṇ sound in this Marwadi word.
+
+
+Lesson 4 of 6.
+ी (long ī mark) — the long-ī mark.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one new vowel mark until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 8 seconds]
+Hear “Will you come?” and answer yes respectfully. Then say pāṇī. Write प (pa), then ण (ṇa), from memory and name the curled-back sound.
+
+Script — one new vowel mark.
+ी (long ī mark) — long ī.
+Like familiar ा, this mark cannot stand alone in a word. It attaches to a consonant. Add it to ण (ṇa) and read णी, ṇī.
+
+Writing — attach only the mark.
+copy ण (ṇa) once.
+look at णी.
+add ी (long ī mark) on the right of your copy.
+compare the joined form, then say ṇī.
+
+Wrap-up recall.
+Hide णी for five seconds. Write it once, then uncover and compare.
+[question — say your answer, then pause 10 seconds]
+Add the long-ī mark to ण (ṇa) and write the result.
+
+
+Lesson 5 of 6.
+पाणी (pāṇī) — join the word you already know by ear.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+
+Warm-up.
+[pause 10 seconds]
+Write the first sign of राम from memory. Then say the Marwadi word for water and write पा, then णी, as two separate pieces. Check each piece before going on.
+
+The exchange — two familiar pieces.
+पा + णी becomes पाणी — pāṇī — water.
+Join the pieces without adding or changing a sign. Keep ण (ṇa), the curled-back sound that distinguishes this source-attested Marwadi spelling from its Hindi cognate.
+
+Pāṇī taken apart — a small word history.
+The word belongs to an old Indo-Aryan family. Sanskrit pānīya meant something for drinking; related regional forms travelled through Middle Indo-Aryan into modern Marwadi पाणी (pāṇī). The history is a memory hook, not a new spelling task.
+
+Writing — guided, then delayed.
+copy पाणी (pāṇī) once while saying pā-ṇī.
+point to पा, then णी.
+hide the model for ten seconds.
+write the complete word from memory.
+uncover and compare प, ा, ण (ṇa), and ी (long ī mark) separately.
+
+Wrap-up recall.
+Say पाणी (pāṇī) once without looking, then write it once with the model covered.
+Sources: SIL International, Marwari–English Dictionary (2015) and Turner, A Comparative Dictionary of the Indo-Aryan Languages, entry 8082.
+[question — say your answer, then pause 12 seconds]
+Join पा and णी, then give the word's meaning.
+
+
+Lesson 6 of 6.
+Practice — hear, say, read, and write water.
+
+Warm-up.
+[pause 20 seconds]
+Give the older respectful yes in four quick steps: hear it and name its meaning; say it; read हां सा; then cover and write it. Now say the three meanings in English as you hear ābhār, hā(n) sā, and pāṇī. Write पा, then ण (ṇa) and ी (long ī mark) separately from memory.
+
+Guided Practice — four independent checks.
+Listen: hear pāṇī and identify water, without text.
+Speak: see a picture or imagine a glass of water and say pāṇī, without notes.
+Read: choose पाणी (pāṇī) from आभार, हां, पाणी (pāṇī) and give its meaning.
+Write: hear pāṇī, wait fifteen seconds, then write पाणी with no model.
+Score each line separately. Repeat only the missed line; strong speaking does not compensate for a missing ण (ṇa) or ी (long ī mark) in writing.
+
+What you've built — and what remains.
+You can retrieve one useful word in all four skills. You cannot yet request water in a complete Marwadi sentence; that needs pronouns, a request form, and register choices taught in later small steps.
+
+Wrap-up recall.
+If one sign stalled, return only to its two-minute sign lesson before repeating the complete dictation.
+[question — say your answer, then pause 15 seconds]
+From the spoken cue pāṇī alone, write the Marwadi word and give its meaning.

--- a/code/learning/human-languages/marwadi/roadmap.md
+++ b/code/learning/human-languages/marwadi/roadmap.md
@@ -29,6 +29,9 @@ Chapter 1 teaches **राम-राम सा** through seven lessons. Chapter 
 **आभार** through four more sessions: independent **आ**, then **भ**, then the
 whole word, then a hidden-model four-skill response. Chapter 3 adds polite
 **हां सा** through two sign-sized steps, assembly, ear/voice retrieval, and an
-independent four-skill check. The next independent content tranche should add
-the contrasting no response before a complete yes/no exchange; okay, casual
-gratitude, and a you're-welcome response remain explicit debt.
+independent four-skill check. Chapter 4 adds **पाणी**, "water": meaning is
+secured by ear first, then **प**, **ण**, and **ी** arrive one at a time before
+delayed copy and dictation. The next independent content tranche should add the
+contrasting no response before a complete yes/no exchange; okay, casual
+gratitude, a you're-welcome response, and a full request for water remain
+explicit debt.

--- a/code/learning/human-languages/marwadi/session-map.md
+++ b/code/learning/human-languages/marwadi/session-map.md
@@ -22,6 +22,12 @@ memory demand at a time.
 | S14 | `MW-C03-haan-saa`: **हां सा** | build it from **ह + ा + ं**, then known **सा** | delayed copy of one response |
 | S15 | `MW-C03-listen-say` | distinguish *hā(n) sā* from *ābhār* by ear | hidden-model recall of **हां** |
 | S16 | `MW-C03-practice` | hear/read a yes cue and answer respectfully | dictation and independent phrase recall |
+| S17 | `MW-C04-hear-paani`: *pāṇī* | identify water from sound alone | none; meaning precedes spelling |
+| S18 | `MW-W04-pa`: **प** | write **पा** with familiar **ा** | observe, trace, copy one sign |
+| S19 | `MW-W04-nna`: **ण** | distinguish curled-back **ण** from Hindi **न** | observe, trace, copy one sign |
+| S20 | `MW-W04-ii-matra`: **ी** | attach **ी** to **ण** and read **णी** | guided copy of one vowel mark |
+| S21 | `MW-C04-paani`: **पाणी** | join **पा + णी** and give the meaning | delayed copy of one word |
+| S22 | `MW-C04-practice` | retrieve water by ear, voice, eye, and meaning | dictation and independent word recall |
 
 Reviews use expanding spacing: repeat S7 the next day, after three days, after
 one week, and after two weeks. A failed written recall sends the learner back to

--- a/code/learning/human-languages/progress/marwadi.md
+++ b/code/learning/human-languages/progress/marwadi.md
@@ -2,8 +2,8 @@
 
 - Track: [Marwadi (Marwari)](../marwadi/README.md)
 - Family / script: Indo-Aryan / Devanagari
-- Canonical lessons: 16
-- Mapped lessons: 16
-- Book progress: 3 chapters; through Ch. 3; 3 generated
+- Canonical lessons: 22
+- Mapped lessons: 22
+- Book progress: 4 chapters; through Ch. 4; 4 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
@@ -27,13 +27,18 @@ it("pins Marwadi's complete pre-A1 writing ramp", () => {
     "guided-copy",
     "delayed-copy",
     "dictation-transcription",
+    "observe-trace",
+    "observe-trace",
+    "guided-copy",
+    "delayed-copy",
+    "dictation-transcription",
   ]);
 });
 
 it("pins Marwadi-owned chapters and objective activities", () => {
   const lessons = loadTrackLessons("marwadi");
   expect(new Set(lessons.map((lesson) => Number(lesson.frontmatter.chapter)))).toEqual(
-    new Set([1, 2, 3]),
+    new Set([1, 2, 3, 4]),
   );
   expect(
     lessons
@@ -48,6 +53,9 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-C03-haan-saa-build",
     "MW-C03-listen-say-choice",
     "MW-C03-practice-yes",
+    "MW-C04-hear-paani-meaning",
+    "MW-C04-paani-build",
+    "MW-C04-practice-paani",
     "MW-W01-aa-matra-change",
     "MW-W01-ra-read",
     "MW-W01-raam-build",
@@ -57,5 +65,8 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-W02-bha-sound",
     "MW-W03-anusvara-add",
     "MW-W03-ha-read",
+    "MW-W04-ii-matra-build",
+    "MW-W04-nna-contrast",
+    "MW-W04-pa-build-paa",
   ]);
 });


### PR DESCRIPTION
﻿## Summary

- teach source-attested Marwadi **????** (*p???*, "water") by ear before showing its spelling
- isolate **?**, retroflex **?**, and long-*?* **?** in separate <= 2.5-minute writing steps, reusing already-known **?**
- finish with delayed copy, dictation, and independently scored listening, speaking, reading, and writing
- add exact spaced retrieval for older Chapter 1 and 3 atoms as the longer track opens their next windows
- regenerate the standalone book chapter, answer key, index, narration, modality ledger, progress card, and gentle-ramp snapshot

## Curriculum boundary

This teaches one survival word; it does **not** claim a complete request for water or B1 travel competence. The path remains pre-A1 request preparation, and the full request form stays explicit debt.

## Sources

- SIL International, *Marwari-English Dictionary* (2015): https://nepal.sil.org/resources/archives/63768
- Turner, *A Comparative Dictionary of the Indo-Aryan Languages*, entry 8082: https://dsal.uchicago.edu/dictionaries/soas/

## Validation

- `npm run build`
- `npx vitest run --maxWorkers=1` - 75 files, 929 tests
- post-rebase focused/corpus regression - 12 files, 259 tests
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `git diff --check`

Closes #12446
