### PR TITLE
feat(human-languages): complete Chinese pre-A1 writing ramp

### DIFF
--- a/code/learning/human-languages/chinese/CHANGELOG.md
+++ b/code/learning/human-languages/chinese/CHANGELOG.md
@@ -5,6 +5,15 @@ tracks: one entry per authored tranche, describing what was added and why.
 
 ## [Unreleased]
 
+### Changed — complete the pre-A1 writing-stage runway (#12449)
+
+- Made the existing first-character practice an explicit model-visible guided
+  copy rather than leaving the learner to infer how much support was allowed.
+- Turned the already component-safe **你** assembly into a ten-second delayed
+  copy with half-by-half repair.
+- Added sound-only dictation of **好** only after **女** and **子** are secure,
+  without adding a new character or extending any lesson past five minutes.
+
 ### Added — project-defined pre-A1 four-skill task shapes (#12369)
 
 - Turned the Chinese assessment contract's pre-A1 target into bounded reading,

--- a/code/learning/human-languages/chinese/book/chapters/ch02-components.tex
+++ b/code/learning/human-languages/chinese/book/chapters/ch02-components.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6caa25387e298904
+% canonical-source-hash: fnv1a64:5432e6ff10c3a520
 % canonical-lessons: ZH-W01-ren, ZH-W01-ren-radical, ZH-W01-er, ZH-W01-ni-build, ZH-W01-nu, ZH-W01-zi, ZH-W01-hao-build
 
 \chapter{Reading the Greeting — One Piece at a Time}
@@ -43,12 +43,10 @@ Write it in this order, and the order is not a suggestion:
 
 The pitch is \textbf{second tone}: \emph{rén} rises, like the end of an English question.
 
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \zh{人} — left stroke first, then right. Say \emph{rén} as you finish it.
-  \item \emph{Say it:} \textbf{rén}, rising
-\end{itemize}
+\subsection*{Your turn — copy with the model visible}
+Keep \textbf{\zh{人}} visible. Point to the left stroke, then the right. Copy the character once immediately below the model: left stroke first, then right. Say \emph{rén} as you finish it, and compare the meeting point at the top before moving on.
+
+This is guided copy, not a memory test. One careful copy is enough.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which stroke goes first — the one leaning left, or the one leaning right? (The \textbf{left}.)
@@ -180,12 +178,8 @@ Stop and take the measure of what just happened, because it is the reason this b
 You have not been shown a picture and asked to remember it. You were given two pieces, one at a time, and then shown that a character is what you get when they share a square. \textbf{The next character works the same way, and so does the one after that.} There are only a few hundred components in common use, and they recombine — which is what makes several thousand characters a climb rather than a cliff.
 \end{grammarlens}
 
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \zh{你} — left half first, complete, then the right half
-  \item \emph{Read it:} cover the right half. What does the left half alone tell you?
-\end{itemize}
+\subsection*{Your turn — look, cover, rebuild}
+Copy \textbf{\zh{你}} once while the model is visible: complete \textbf{\zh{亻}}, then complete \textbf{\zh{尔}}. Point to the meaning half and the sound half. Now cover every model, wait ten seconds, and rebuild the character from memory. Uncover and compare the two halves separately; correct only the half that stalled.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Two pieces, one block, and a character you can take apart again whenever you need to. Which half would you look at to guess the pronunciation?
@@ -305,12 +299,10 @@ You will find it said that \zh{好} means \emph{good} \textbf{because} a woman w
 Use the pairing as a \textbf{memory hook}, which it genuinely is. Do not file it as a fact about why the word means what it means.
 \end{grammarlens}
 
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \zh{好} — the whole left half first, then the whole right half
-  \item \emph{Notice:} the crossing bar on the left half no longer sweeps all the way across. Why not?
-\end{itemize}
+\subsection*{Your turn — from the spoken word to the page}
+Copy \textbf{\zh{好}} once while looking: finish \textbf{\zh{女}}, then \textbf{\zh{子}}. Notice that the crossing bar on the left stops before the right half.
+
+Now close the page. Have a person or screen reader say \emph{hǎo} with no character visible. Wait ten seconds, write \textbf{\zh{好}} from the spoken cue, then uncover it. Compare the left half and right half separately. If one half stalled, revisit only its three-stroke lesson before trying the dictation again.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Six strokes, two pieces, and you built both pieces yourself. What is the one claim in this lesson you should NOT repeat as fact?

--- a/code/learning/human-languages/chinese/lessons/ZH-W01-hao-build.md
+++ b/code/learning/human-languages/chinese/lessons/ZH-W01-hao-build.md
@@ -73,12 +73,17 @@ not, and this is one of the second kind.
 Use the pairing as a **memory hook**, which it genuinely is. Do not file it as a
 fact about why the word means what it means.
 
-## Guided Practice
+## Guided Practice — from the spoken word to the page
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-HAO-BUILD-01] -->
+<!-- hl-writing-stage: dictation-transcription -->
 
-- [YOU WRITE: 好 — the whole left half first, then the whole right half]
-- [YOU NOTICE: the crossing bar on the left half no longer sweeps all the way
-  across. Why not?]
+Copy **好** once while looking: finish **女**, then **子**. Notice that the
+crossing bar on the left stops before the right half.
+
+Now close the page. Have a person or screen reader say *hǎo* with no character
+visible. Wait ten seconds, write **好** from the spoken cue, then uncover it.
+Compare the left half and right half separately. If one half stalled, revisit
+only its three-stroke lesson before trying the dictation again.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-HAO-BUILD-01, ZH-SCRIPT-NU-01, ZH-SCRIPT-ZI-01, ZH-SCRIPT-NI-BUILD-01] -->

--- a/code/learning/human-languages/chinese/lessons/ZH-W01-ni-build.md
+++ b/code/learning/human-languages/chinese/lessons/ZH-W01-ni-build.md
@@ -80,11 +80,14 @@ after that.** There are only a few hundred components in common use, and they
 recombine — which is what makes several thousand characters a climb rather than
 a cliff.
 
-## Guided Practice
+## Guided Practice — look, cover, rebuild
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-NI-BUILD-01] -->
+<!-- hl-writing-stage: delayed-copy -->
 
-- [YOU WRITE: 你 — left half first, complete, then the right half]
-- [YOU READ: cover the right half. What does the left half alone tell you?]
+Copy **你** once while the model is visible: complete **亻**, then complete
+**尔**. Point to the meaning half and the sound half. Now cover every model,
+wait ten seconds, and rebuild the character from memory. Uncover and compare
+the two halves separately; correct only the half that stalled.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-NI-BUILD-01, ZH-SCRIPT-REN-RADICAL-01] -->

--- a/code/learning/human-languages/chinese/lessons/ZH-W01-ren.md
+++ b/code/learning/human-languages/chinese/lessons/ZH-W01-ren.md
@@ -68,11 +68,15 @@ with fifteen.
 
 The pitch is **second tone**: *rén* rises, like the end of an English question.
 
-## Guided Practice
+## Guided Practice — copy with the model visible
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-REN-01] -->
+<!-- hl-writing-stage: guided-copy -->
 
-- [YOU WRITE: 人 — left stroke first, then right. Say *rén* as you finish it.]
-- [YOU SAY: **rén**, rising]
+Keep **人** visible. Point to the left stroke, then the right. Copy the character
+once immediately below the model: left stroke first, then right. Say *rén* as
+you finish it, and compare the meeting point at the top before moving on.
+
+This is guided copy, not a memory test. One careful copy is enough.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[ZH-SCRIPT-REN-01] -->

--- a/code/learning/human-languages/chinese/narration/ch02.json
+++ b/code/learning/human-languages/chinese/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Reading the Greeting — One Piece at a Time",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:64ef4a9e6f25106d",
+  "sourceHash": "fnv1a64:f6536c2a08dff0b2",
   "lessons": [
     {
       "id": "ZH-W01-ren",
@@ -21,7 +21,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:d901b02da46ba1d0",
+      "sourceHash": "fnv1a64:61937c2eaec8d499",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -30,10 +30,9 @@
           "your eyes, because the lesson points at something written down"
         ],
         "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
+          "Script — the shape"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -103,25 +102,15 @@
         {
           "index": 2,
           "type": "guided-production",
-          "title": "Guided Practice",
+          "title": "Guided Practice — copy with the model visible",
           "segments": [
             {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "人 — left stroke first, then right. Say rén as you finish it.",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: 人 — left stroke first, then right. Say *rén* as you finish it.]"
+              "kind": "speech",
+              "text": "Keep 人 visible. Point to the left stroke, then the right. Copy the character once immediately below the model: left stroke first, then right. Say rén as you finish it, and compare the meeting point at the top before moving on."
             },
             {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "rén, rising",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **rén**, rising]"
+              "kind": "speech",
+              "text": "This is guided copy, not a memory test. One careful copy is enough."
             }
           ]
         },
@@ -471,7 +460,7 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:328329e181918529",
+      "sourceHash": "fnv1a64:f4f2811fa6744a06",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -480,10 +469,9 @@
           "your eyes, because the lesson points at something written down"
         ],
         "waitUntilStopped": [
-          "Script — the assembly",
-          "Guided Practice"
+          "Script — the assembly"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the assembly until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -576,25 +564,11 @@
         {
           "index": 3,
           "type": "guided-production",
-          "title": "Guided Practice",
+          "title": "Guided Practice — look, cover, rebuild",
           "segments": [
             {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "你 (nǐ) — left half first, complete, then the right half",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: 你 — left half first, complete, then the right half]"
-            },
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "cover the right half. What does the left half alone tell you?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: cover the right half. What does the left half alone tell you?]"
+              "kind": "speech",
+              "text": "Copy 你 (nǐ) once while the model is visible: complete 亻 (rén (as a component)), then complete 尔 (ěr). Point to the meaning half and the sound half. Now cover every model, wait ten seconds, and rebuild the character from memory. Uncover and compare the two halves separately; correct only the half that stalled."
             }
           ]
         },
@@ -950,7 +924,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:05834146103e3854",
+      "sourceHash": "fnv1a64:2b4ee5a1c588bbd7",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -958,10 +932,9 @@
           "your eyes, for letter shapes on the page"
         ],
         "waitUntilStopped": [
-          "Script — the assembly",
-          "Guided Practice"
+          "Script — the assembly"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — the assembly until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -1034,25 +1007,15 @@
         {
           "index": 3,
           "type": "guided-production",
-          "title": "Guided Practice",
+          "title": "Guided Practice — from the spoken word to the page",
           "segments": [
             {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "好 (hǎo) — the whole left half first, then the whole right half",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: 好 — the whole left half first, then the whole right half]"
+              "kind": "speech",
+              "text": "Copy 好 (hǎo) once while looking: finish 女 (nǚ), then 子 (zǐ). Notice that the crossing bar on the left stops before the right half."
             },
             {
-              "kind": "prompt",
-              "action": "NOTICE",
-              "instruction": "the crossing bar on the left half no longer sweeps all the way across. Why not?",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU NOTICE: the crossing bar on the left half no longer sweeps all the way across. Why not?]"
+              "kind": "speech",
+              "text": "Now close the page. Have a person or screen reader say hǎo with no character visible. Wait ten seconds, write 好 from the spoken cue, then uncover it. Compare the left half and right half separately. If one half stalled, revisit only its three-stroke lesson before trying the dictation again."
             }
           ]
         },

--- a/code/learning/human-languages/chinese/narration/ch02.txt
+++ b/code/learning/human-languages/chinese/narration/ch02.txt
@@ -5,7 +5,7 @@ Mandarin Chinese, chapter 2: Reading the Greeting — One Piece at a Time.
 Lesson 1 of 7.
 人 (rén) — two strokes, and a person walking.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -23,10 +23,9 @@ the right stroke, starting near the top of the first and pressing down to the lo
 Left before right. Almost every character you meet will obey it, and it is worth meeting here — on a character with two strokes — rather than later on one with fifteen.
 The pitch is second tone: rén rises, like the end of an English question.
 
-Guided Practice.
-[once you have stopped driving — write: 人 — left stroke first, then right. Say rén as you finish it.]
-[your turn — say: rén, rising]
-[pause 8 seconds for the answer]
+Guided Practice — copy with the model visible.
+Keep 人 visible. Point to the left stroke, then the right. Copy the character once immediately below the model: left stroke first, then right. Say rén as you finish it, and compare the meeting point at the top before moving on.
+This is guided copy, not a memory test. One careful copy is enough.
 
 Wrap-up Recall.
 Which stroke goes first — the one leaning left, or the one leaning right? (The left.)
@@ -100,7 +99,7 @@ When a component is inside a character for its SOUND rather than its meaning, wh
 Lesson 4 of 7.
 Putting two pieces together — and reading the result.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the assembly until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 3 seconds]
@@ -124,10 +123,8 @@ What you've built.
 Stop and take the measure of what just happened, because it is the reason this book teaches script this way.
 You have not been shown a picture and asked to remember it. You were given two pieces, one at a time, and then shown that a character is what you get when they share a square. The next character works the same way, and so does the one after that. There are only a few hundred components in common use, and they recombine — which is what makes several thousand characters a climb rather than a cliff.
 
-Guided Practice.
-[once you have stopped driving — write: 你 (nǐ) — left half first, complete, then the right half]
-[your turn — read: cover the right half. What does the left half alone tell you?]
-[pause 8 seconds for the answer]
+Guided Practice — look, cover, rebuild.
+Copy 你 (nǐ) once while the model is visible: complete 亻 (rén (as a component)), then complete 尔 (ěr). Point to the meaning half and the sound half. Now cover every model, wait ten seconds, and rebuild the character from memory. Uncover and compare the two halves separately; correct only the half that stalled.
 
 Wrap-up Recall.
 Two pieces, one block, and a character you can take apart again whenever you need to. Which half would you look at to guess the pronunciation?
@@ -203,7 +200,7 @@ What does the three-stroke character with the hooked vertical and a bar across t
 Lesson 7 of 7.
 Two pieces again — and a warning about the story.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — the assembly until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 3 seconds]
@@ -222,10 +219,9 @@ You will find it said that 好 (hǎo) means good because a woman with a child is
 Treat that as a story, not as evidence. It is memorable, it is repeated everywhere, and there is no agreement among specialists that it is what happened — competing accounts read the woman as the sound half in an older pronunciation, or read the pair as a woman caring for a child. This book will hand you an etymology when there is a source behind it and tell you plainly when there is not, and this is one of the second kind.
 Use the pairing as a memory hook, which it genuinely is. Do not file it as a fact about why the word means what it means.
 
-Guided Practice.
-[once you have stopped driving — write: 好 (hǎo) — the whole left half first, then the whole right half]
-[your turn — notice: the crossing bar on the left half no longer sweeps all the way across. Why not?]
-[pause 8 seconds for the answer]
+Guided Practice — from the spoken word to the page.
+Copy 好 (hǎo) once while looking: finish 女 (nǚ), then 子 (zǐ). Notice that the crossing bar on the left stops before the right half.
+Now close the page. Have a person or screen reader say hǎo with no character visible. Wait ten seconds, write 好 from the spoken cue, then uncover it. Compare the left half and right half separately. If one half stalled, revisit only its three-stroke lesson before trying the dictation again.
 
 Wrap-up Recall.
 Six strokes, two pieces, and you built both pieces yourself. What is the one claim in this lesson you should NOT repeat as fact?

--- a/code/learning/human-languages/core/generated-book-hashes/chinese.json
+++ b/code/learning/human-languages/core/generated-book-hashes/chinese.json
@@ -20,7 +20,7 @@
     {
       "language": "chinese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:6caa25387e298904",
+      "sourceHash": "fnv1a64:5432e6ff10c3a520",
       "lessonIds": [
         "ZH-W01-ren",
         "ZH-W01-ren-radical",

--- a/code/learning/human-languages/core/generated-narration-hashes/chinese.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/chinese.json
@@ -26,7 +26,7 @@
     {
       "language": "chinese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:64ef4a9e6f25106d",
+      "sourceHash": "fnv1a64:f6536c2a08dff0b2",
       "lessonIds": [
         "ZH-W01-ren",
         "ZH-W01-ren-radical",
@@ -40,8 +40,8 @@
       "drivablePrefix": 0,
       "text": "chinese/narration/ch02.txt",
       "json": "chinese/narration/ch02.json",
-      "textHash": "fnv1a64:7b28ae4919b294f2",
-      "jsonHash": "fnv1a64:57153004a2405256"
+      "textHash": "fnv1a64:7e9cb98a749101fa",
+      "jsonHash": "fnv1a64:93ca57d2525688df"
     },
     {
       "language": "chinese",

--- a/code/learning/human-languages/core/lesson-modality/chinese.json
+++ b/code/learning/human-languages/core/lesson-modality/chinese.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:f8e4fa839b4556ad",
+  "sourceHash": "fnv1a64:950b0fa38dcae706",
   "summary": {
     "totalLessons": 63,
     "voice": 30,
@@ -370,7 +370,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:d901b02da46ba1d0",
+      "sourceHash": "fnv1a64:61937c2eaec8d499",
       "detachableSegments": [
         "Script — the shape"
       ],
@@ -441,7 +441,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:328329e181918529",
+      "sourceHash": "fnv1a64:f4f2811fa6744a06",
       "detachableSegments": [
         "Script — the assembly"
       ],
@@ -510,7 +510,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:05834146103e3854",
+      "sourceHash": "fnv1a64:2b4ee5a1c588bbd7",
       "detachableSegments": [
         "Script — the assembly"
       ],

--- a/code/packages/typescript/human-language-data/tests/corpus/chinese.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/chinese.test.ts
@@ -1,4 +1,20 @@
-import { it } from "vitest";
-import { expectLanguageContinuity, expectLanguageModality } from "./assert-language-corpus.js";
+import { expect, it } from "vitest";
+import {
+  expectLanguageContinuity,
+  expectLanguageModality,
+  languageWritingStages,
+} from "./assert-language-corpus.js";
 it("pins Chinese continuity", () => expectLanguageContinuity("chinese"));
 it("pins Chinese modality", () => expectLanguageModality("chinese"));
+
+it("pins Chinese's complete pre-A1 writing ramp", () => {
+  const chinese = languageWritingStages("chinese");
+  expect(chinese.defects).toEqual([]);
+  expect(chinese.levels[0]).toMatchObject({ level: "pre-A1", complete: true, missingStages: [] });
+  expect(chinese.validEvidence.map((entry) => entry.stage)).toEqual([
+    "observe-trace",
+    "guided-copy",
+    "delayed-copy",
+    "dictation-transcription",
+  ]);
+});


### PR DESCRIPTION
﻿## Summary

- turn the existing ? practice into explicit model-visible guided copy
- fade support to a ten-second delayed reconstruction of ?, repairing only the half that stalls
- add sound-only dictation of ? after ? and ? are already secure
- pin the cumulative pre-A1 sequence as observe/trace -> guided copy -> delayed copy -> dictation/transcription
- regenerate Chapter 2 book and narration outputs plus the Chinese modality ledger

## Gentle-ramp boundary

This tranche adds no character, stroke, level claim, or lesson. It makes the existing support fade executable inside the current <=5-minute lessons, and keeps the component-first order intact.

## Validation

- `npm run build`
- focused writing/book/narration/modality/script/integration suite - 8 files, 209 tests
- `npx vitest run --maxWorkers=1` - 76 files, 936 tests
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `git diff --check`

Closes #12449
