### PR TITLE
feat(human-languages): inventory Russian pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/russian/CHANGELOG.md
+++ b/code/learning/human-languages/russian/CHANGELOG.md
@@ -530,6 +530,18 @@ Ch. 2 plan the roadmap already set out.
 
 ## [Unreleased]
 
+### Added — project-defined pre-A1 four-skill task shapes
+
+- Made the Russian pre-A1 bridge executable as separate reading, listening,
+  writing, and speaking papers with exact items, timing, replay, aids, scoring,
+  and an independent 60/100 floor for every skill.
+- Kept the writing evidence honest: delayed recall, heard-word Cyrillic
+  transcription, and bounded independent production are scored; visible
+  tracing and copying remain lesson supports and cannot earn exam credit.
+- This inventory is not a readiness claim. Two full mocks, rubrics, answer
+  keys, calibration, curriculum task coverage, and book-only human validation
+  remain required before even project pre-A1 readiness can be claimed.
+
 ### Added — Chapter 14, eleven letters sorted into three kinds (HL-C219)
 
 `scriptLessons` 5 → 16, `taughtGlyphs` 18 → 30, `neverTaughtGlyphs` **37 → 25**.

--- a/code/learning/human-languages/russian/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/russian/task-shapes/pre-a1.json
@@ -1,0 +1,261 @@
+{
+  "version": 1,
+  "language": "russian",
+  "level": "pre-A1",
+  "target": {
+    "name": "Coding Adventures Russian pre-A1 Assessment — project-defined bridge",
+    "basis": "project-defined"
+  },
+  "sources": [
+    {
+      "id": "ca-hl16-assessment-policy",
+      "title": "HL16 — Exam-ready books and the gentle writing ramp",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-hl18-task-shapes",
+      "title": "HL18 — Four-skill task shapes",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-russian-assessment",
+      "title": "Coding Adventures Russian Assessment Specification",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/russian/assessment-spec.md",
+      "published": "2026-08-21",
+      "accessed": "2026-08-21"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 32,
+    "speakingMinutes": 8,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 0,
+    "deliveryModes": ["paper", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.6,
+      "listening": 0.6,
+      "writing": 0.6,
+      "speaking": 0.6
+    },
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-reading-signs-and-words",
+          "promptModes": ["written-cyrillic"],
+          "promptGenres": ["single-word sign", "single-word label"],
+          "responseModes": ["selection", "word-to-meaning match"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["meaning selection", "Cyrillic recognition"] },
+          "aids": { "allowed": [], "forbidden": ["romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-reading-phrases-and-notices",
+          "promptModes": ["written-cyrillic"],
+          "promptGenres": ["short phrase", "short notice", "memorized greeting"],
+          "responseModes": ["selection", "situation match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["phrase recognition", "situation match"] },
+          "aids": { "allowed": [], "forbidden": ["romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-reading-personal-details",
+          "promptModes": ["written-cyrillic", "written-icon-supported-instruction"],
+          "promptGenres": ["personal detail", "short form field"],
+          "responseModes": ["selection", "detail match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 30, "criteria": ["personal-detail recognition", "accurate selection"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["romanization", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-listening-sounds-and-words",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["isolated sound", "known word"],
+          "responseModes": ["selection", "picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound recognition", "word recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-listening-greeting-responses",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["memorized greeting", "courtesy exchange"],
+          "responseModes": ["selection", "situation match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["communicative-function recognition", "appropriate response selection"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-listening-personal-details",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["isolated personal detail", "short personal statement"],
+          "responseModes": ["selection", "picture match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["gist recognition", "personal-detail recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 12,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-recall",
+          "promptModes": ["briefly-visible-written-model"],
+          "promptGenres": ["known word"],
+          "responseModes": ["delayed handwritten recall"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 20, "criteria": ["recognizable Cyrillic letter sequence", "letter formation", "legibility"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "romanization", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded-speech"],
+          "promptGenres": ["known word or greeting chunk"],
+          "responseModes": ["handwritten dictation", "Cyrillic transcription"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-Cyrillic mapping", "word boundary", "legibility"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "romanization", "dictionary", "copyable model"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["written-icon-supported-instruction"],
+          "promptGenres": ["personal label", "greeting choice"],
+          "responseModes": ["independent handwritten word or memorized chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task completion", "independent retrieval", "Cyrillic orthographic control", "legibility"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["copyable answer model", "romanization", "dictionary", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 8,
+      "parts": [
+        {
+          "id": "prea1-speaking-greeting-and-identity",
+          "promptModes": ["live-speech"],
+          "promptGenres": ["greeting exchange", "identity prompt"],
+          "responseModes": ["spoken memorized chunk", "short identity response"],
+          "items": 2,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task completion", "intelligibility", "appropriate greeting response", "identity supplied"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one repeat request"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-speaking-familiar-questions",
+          "promptModes": ["live-speech", "picture cue"],
+          "promptGenres": ["familiar one-turn question", "personal prompt"],
+          "responseModes": ["short personal response"],
+          "items": 3,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 40, "criteria": ["question recognition", "relevant response", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        },
+        {
+          "id": "prea1-speaking-short-request",
+          "promptModes": ["live-speech", "picture cue"],
+          "promptGenres": ["familiar request situation"],
+          "responseModes": ["short spoken request"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["request completed", "appropriate courtesy", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "romanization"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-russian-assessment"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/russian-task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/russian-task-shapes.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { loadTaskShapeInventory } from "../src/loader.js";
+
+describe("Russian task-shape inventories", () => {
+  it("makes the project-defined pre-A1 four-skill bridge executable", () => {
+    const inventory = loadTaskShapeInventory("russian", "pre-A1");
+
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Russian pre-A1 Assessment — project-defined bridge",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual([
+      "reading",
+      "listening",
+      "writing",
+      "speaking",
+    ]);
+    expect(inventory.administration).toMatchObject({
+      writtenMinutes: 32,
+      speakingMinutes: 8,
+      speakingPreparationMinutes: 0,
+    });
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([10, 10, 12, 8]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.items))).toEqual([
+      [6, 4, 4],
+      [6, 4, 4],
+      [2, 4, 2],
+      [2, 3, 1],
+    ]);
+
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0),
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(paperPoints.reduce((sum, points) => sum + points, 0)).toBe(
+      inventory.passRule.maximumPoints,
+    );
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([
+      0.6,
+      0.6,
+      0.6,
+      0.6,
+    ]);
+  });
+
+  it("keeps scored Cyrillic writing productive without copyable supports", () => {
+    const inventory = loadTaskShapeInventory("russian", "pre-A1");
+    const writing = inventory.sections.find((section) => section.skill === "writing");
+
+    expect(writing?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-recall",
+      "prea1-writing-dictation",
+      "prea1-writing-bounded-production",
+    ]);
+    expect(writing?.parts.map((part) => part.responseModes)).toEqual([
+      ["delayed handwritten recall"],
+      ["handwritten dictation", "Cyrillic transcription"],
+      ["independent handwritten word or memorized chunk"],
+    ]);
+    expect(writing?.parts.every((part) =>
+      part.aids.forbidden.some((aid) => /model|tracing/i.test(aid)),
+    )).toBe(true);
+  });
+});


### PR DESCRIPTION
## Outcome

Russian's project-defined pre-A1 bridge now has an executable, sourced four-skill task inventory matching the merged assessment contract.

- Reading: 10 minutes; 6 Cyrillic sign/word matches, 4 phrase/notice matches, 4 personal-detail selections
- Listening: 10 minutes; 6 sound/word recognitions, 4 greeting-response choices, 4 personal-detail selections; two plays
- Writing: 12 minutes; 2 delayed recalls, 4 heard-word Cyrillic transcriptions, 2 bounded independent responses
- Speaking: 8 minutes; greeting + identity, 3 familiar questions, 1 short request; one slow repetition
- Scoring: four separate 100-point papers, each requiring 60/100; no compensation

Visible tracing and copying remain gentle teaching supports. They are forbidden as scoring aids, so merely touching a writing stage cannot masquerade as exam evidence.

This inventory does not claim mock readiness or learner-proven readiness. Two complete mocks, rubrics, answer keys, curriculum coverage, calibration, and book-only human validation remain backlog.

## Validation

- `npx vitest run --maxWorkers=1` — **80 files, 945 tests passed**
- focused task-shape/schema/backlog suite — **4 files, 68 tests passed**
- book, figure, modality, narration, progress, and gentle-snapshot checks — passed
- `git diff --check` — passed

Closes #12455