### PR TITLE
feat(human-languages): inventory Latin pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/latin/CHANGELOG.md
+++ b/code/learning/human-languages/latin/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added — project-defined pre-A1 four-skill task shapes
+
+- Made the Latin pre-A1 bridge executable as independently scored reading,
+  listening, writing, and speaking papers with exact timing, item counts,
+  replay, aids, and a 60/100 floor on every skill.
+- Kept scored writing productive: delayed recall, short dictation, and bounded
+  independent Latin responses count; tracing and visible copying remain gentle
+  lesson supports. Consistent `u/v` and `i/j` conventions receive credit, and
+  macrons are required only when a prompt explicitly tests quantity.
+- This inventory is project-defined and does not imply ELEX equivalence. Mocks,
+  rubrics, keys, calibration, curriculum coverage, and book-only human
+  validation remain required before readiness can be claimed.
+
 ### Added — pre-A1-to-C2 four-skill assessment contract (#12435)
 
 - Defined seven project-owned Latin assessment rungs with independently passed

--- a/code/learning/human-languages/latin/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/latin/task-shapes/pre-a1.json
@@ -1,0 +1,223 @@
+{
+  "version": 1,
+  "language": "latin",
+  "level": "pre-A1",
+  "target": {
+    "name": "Coding Adventures Latin pre-A1 Assessment — project-defined equivalent",
+    "basis": "project-defined"
+  },
+  "sources": [
+    {
+      "id": "ca-hl16-assessment-policy",
+      "title": "HL16 — Exam-ready books and the gentle writing ramp",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-hl18-task-shapes",
+      "title": "HL18 — Four-skill task shapes",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md",
+      "published": "2026-08-20",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-latin-assessment",
+      "title": "Coding Adventures Latin Assessment Specification",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/latin/assessment-spec.md",
+      "published": "2026-08-21",
+      "accessed": "2026-08-21"
+    },
+    {
+      "id": "ca-latin-pronunciation",
+      "title": "Coding Adventures Latin Pronunciation Reference",
+      "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/latin/pronunciation-reference.md",
+      "published": "not stated",
+      "accessed": "2026-08-21"
+    }
+  ],
+  "administration": {
+    "writtenMinutes": 35,
+    "speakingMinutes": 8,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 0,
+    "deliveryModes": ["paper or equivalent locked digital form", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": {
+      "reading": 0.6,
+      "listening": 0.6,
+      "writing": 0.6,
+      "speaking": 0.6
+    },
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper. This is a project-defined bridge, not an ELEX certificate or equivalence claim."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 15,
+      "parts": [
+        {
+          "id": "prea1-reading-familiar-words-and-labels",
+          "promptModes": ["short written Latin", "optional nonverbal picture cue"],
+          "promptGenres": ["familiar word", "single-word label"],
+          "responseModes": ["selection", "word-to-meaning match", "label-to-picture match"],
+          "items": 8,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 55, "criteria": ["answer-key match", "familiar-word recognition"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["dictionary", "grammar reference", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment"]
+        },
+        {
+          "id": "prea1-reading-memorized-phrases",
+          "promptModes": ["short written Latin", "optional nonverbal situation cue"],
+          "promptGenres": ["memorized phrase", "greeting exchange", "micro-dialogue"],
+          "responseModes": ["selection", "phrase-to-situation match", "choose the next turn"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 45, "criteria": ["answer-key match", "communicative-function recognition"] },
+          "aids": { "allowed": ["nonverbal situation cue"], "forbidden": ["dictionary", "grammar reference", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-listening-sounds-words-and-greetings",
+          "promptModes": ["recorded Latin at 45-65 words per minute", "eight-second inter-item pause", "written or nonverbal answer options"],
+          "promptGenres": ["familiar sound contrast", "known word", "greeting and response"],
+          "responseModes": ["selection", "picture match", "appropriate-response match"],
+          "items": 8,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 100, "criteria": ["answer-key match", "sound and word recognition", "appropriate greeting response"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["transcript", "dictionary", "grammar reference", "translation tool"], "notPublished": [] },
+          "notPublished": ["response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment", "ca-latin-pronunciation"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-recall",
+          "promptModes": ["briefly-visible-written-model"],
+          "promptGenres": ["known Latin word"],
+          "responseModes": ["delayed handwritten recall"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 20, "criteria": ["recognizable letter sequence", "consistent u/v and i/j convention", "legibility"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "dictionary", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded Latin at 45-65 words per minute"],
+          "promptGenres": ["known one- to three-word item"],
+          "responseModes": ["handwritten dictation", "Latin transcription"],
+          "items": 3,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 3, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-letter mapping", "word boundary", "consistent orthographic convention", "macrons only when explicitly tested"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary", "copyable model", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment", "ca-latin-pronunciation"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["written support-language or nonverbal instruction"],
+          "promptGenres": ["personal label", "greeting response"],
+          "responseModes": ["independent handwritten label or memorized Latin chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task fulfilment", "independent retrieval", "comprehensibility", "consistent orthographic convention"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["copyable answer model", "dictionary", "grammar reference", "translation tool", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 8,
+      "parts": [
+        {
+          "id": "prea1-speaking-greeting-and-identity",
+          "promptModes": ["trained live interlocutor"],
+          "promptGenres": ["greeting exchange", "identity prompt"],
+          "responseModes": ["spoken memorized Latin chunk", "short identity response"],
+          "items": 2,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task fulfilment", "intelligibility", "appropriate greeting response", "identity supplied"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one repeat request"], "forbidden": ["written answer script", "dictionary", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment", "ca-latin-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-familiar-questions",
+          "promptModes": ["trained live interlocutor", "optional picture cue"],
+          "promptGenres": ["familiar one-turn question", "personal prompt"],
+          "responseModes": ["short personal Latin response"],
+          "items": 3,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 40, "criteria": ["question recognition", "relevant Latin response", "intelligibility", "consistent pronunciation model"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "dictionary", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment", "ca-latin-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-short-request",
+          "promptModes": ["trained live interlocutor", "nonverbal situation cue"],
+          "promptGenres": ["familiar request situation"],
+          "responseModes": ["short spoken Latin request"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["request completed", "appropriate courtesy", "intelligibility", "documented consistent pronunciation model accepted"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "dictionary", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16-assessment-policy", "ca-hl18-task-shapes", "ca-latin-assessment", "ca-latin-pronunciation"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/latin-prea1-task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/latin-prea1-task-shapes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { loadTaskShapeInventory } from "../src/loader.js";
+
+describe("Latin pre-A1 task-shape inventory", () => {
+  it("makes the project-defined four-skill bridge executable", () => {
+    const inventory = loadTaskShapeInventory("latin", "pre-A1");
+
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Latin pre-A1 Assessment — project-defined equivalent",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual([
+      "reading",
+      "listening",
+      "writing",
+      "speaking",
+    ]);
+    expect(inventory.administration).toMatchObject({
+      writtenMinutes: 35,
+      speakingMinutes: 8,
+      speakingPreparationMinutes: 0,
+    });
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([15, 10, 10, 8]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.items))).toEqual([
+      [8, 6],
+      [8],
+      [2, 3, 2],
+      [2, 3, 1],
+    ]);
+
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0),
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([
+      0.6,
+      0.6,
+      0.6,
+      0.6,
+    ]);
+  });
+
+  it("scores productive writing while preserving Latin convention choices", () => {
+    const inventory = loadTaskShapeInventory("latin", "pre-A1");
+    const writing = inventory.sections.find((section) => section.skill === "writing");
+    const speaking = inventory.sections.find((section) => section.skill === "speaking");
+
+    expect(writing?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-recall",
+      "prea1-writing-dictation",
+      "prea1-writing-bounded-production",
+    ]);
+    expect(writing?.parts.every((part) =>
+      part.aids.forbidden.some((aid) => /model|tracing/i.test(aid)),
+    )).toBe(true);
+    expect(writing?.parts.flatMap((part) => part.scoring.criteria).join(" ")).toMatch(/u\/v and i\/j/);
+    expect(writing?.parts.flatMap((part) => part.scoring.criteria).join(" ")).toMatch(/macrons only when explicitly tested/);
+    expect(speaking?.parts.flatMap((part) => part.scoring.criteria).join(" ")).toMatch(/pronunciation model/);
+  });
+});


### PR DESCRIPTION
## Outcome

Latin now has an executable pre-A1 four-skill task inventory matching its project-defined assessment contract without implying ELEX equivalence.

- Reading: 15 minutes; 8 familiar word/label matches + 6 memorized phrase/micro-dialogue matches; no text over 8 words
- Listening: 10 minutes; 8 sound/word/greeting-response items at 45–65 wpm, two plays, 8-second pauses
- Writing: 10 minutes; 2 delayed recalls, 3 one-to-three-word dictations, 2 independent labels/greeting responses
- Speaking: 8 minutes; greeting + identity, 3 familiar questions, 1 short request; one slow repetition
- Scoring: four independent 100-point papers, 60/100 required on every paper

The inventory preserves Latin-specific fairness: reconstructed Classical is the default listening model, documented consistent alternatives can receive full credit, `u/v` and `i/j` conventions are accepted when consistent, and macrons are mandatory only when a prompt explicitly tests quantity. Tracing and visible copying are lesson supports, never scored evidence.

This is not mock-ready or learner-proven evidence. Mocks, rubrics, keys, calibration, curriculum coverage, and book-only validation remain backlog.

## Validation

- `npx vitest run --maxWorkers=1` — **80 files, 945 tests passed**
- focused task-shape/contract/backlog suite — **4 files, 55 tests passed**
- all six generation checks — passed
- `git diff --check` — passed

Closes #12457