### PR TITLE
feat(human-languages): inventory Persian pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/persian/CHANGELOG.md
+++ b/code/learning/human-languages/persian/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased — project-defined pre-A1 four-skill task shapes
+
+- Made the Persian pre-A1 bridge executable as independent reading, listening,
+  writing, and speaking papers with exact timing, items, replay, aids, scoring,
+  and a 60/100 floor on every skill.
+- Kept writing productive and script-aware: scored work covers delayed recall,
+  dictation, and bounded independent responses with right-to-left order,
+  joining, dots, spacing, and ZWNJ control. Unicode-equivalent Arabic yeh/kaf
+  forms are normalized, readable variants receive credit, and short vowels are
+  not required unless explicitly tested.
+- This project rung has no claimed CEFR mapping to SAMFA. Mocks, rubrics, keys,
+  calibration, curriculum coverage, and book-only validation remain required.
+
 ## Unreleased — writing begins with one alef in lesson one
 
 - Rewrote the opening `salâm` lesson as a schema-v2, four-atom introduction:

--- a/code/learning/human-languages/persian/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/persian/task-shapes/pre-a1.json
@@ -1,0 +1,236 @@
+{
+  "version": 1,
+  "language": "persian",
+  "level": "pre-A1",
+  "target": { "name": "Coding Adventures Persian pre-A1 Assessment — project-defined equivalent", "basis": "project-defined" },
+  "sources": [
+    { "id": "ca-hl16", "title": "HL16 — Exam-ready books and the gentle writing ramp", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md", "published": "2026-08-20", "accessed": "2026-08-21" },
+    { "id": "ca-hl18", "title": "HL18 — Four-skill task shapes", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md", "published": "2026-08-20", "accessed": "2026-08-21" },
+    { "id": "ca-persian-assessment", "title": "Coding Adventures Persian Assessment Specification", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/persian/assessment-spec.md", "published": "2026-08-21", "accessed": "2026-08-21" },
+    { "id": "ca-persian-pronunciation", "title": "Coding Adventures Persian Pronunciation Reference", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/persian/pronunciation-reference.md", "published": "not stated", "accessed": "2026-08-21" }
+  ],
+  "administration": {
+    "writtenMinutes": 32,
+    "speakingMinutes": 8,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 0,
+    "deliveryModes": ["paper or equivalent locked digital form", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": { "reading": 0.6, "listening": 0.6, "writing": 0.6, "speaking": 0.6 },
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper. This project-defined rung has no claimed CEFR mapping to SAMFA."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-reading-letters-and-words",
+          "promptModes": ["written Persian script", "optional nonverbal picture cue"],
+          "promptGenres": ["taught letter family", "single-word sign", "single-word label"],
+          "responseModes": ["selection", "word-to-meaning match", "label-to-picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 40, "criteria": ["answer-key match", "letter and word recognition", "joining-form recognition"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["romanization", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment"]
+        },
+        {
+          "id": "prea1-reading-phrases-and-signs",
+          "promptModes": ["written Persian script", "optional nonverbal situation cue"],
+          "promptGenres": ["memorized phrase", "short sign", "greeting exchange"],
+          "responseModes": ["selection", "situation match", "choose the next turn"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 30, "criteria": ["answer-key match", "phrase recognition", "communicative-function recognition"] },
+          "aids": { "allowed": ["nonverbal situation cue"], "forbidden": ["romanization", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment"]
+        },
+        {
+          "id": "prea1-reading-personal-details",
+          "promptModes": ["written Persian script", "written-icon-supported instruction"],
+          "promptGenres": ["personal detail", "short form field"],
+          "responseModes": ["selection", "detail match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 30, "criteria": ["personal-detail recognition", "accurate selection"] },
+          "aids": { "allowed": ["nonverbal picture cue"], "forbidden": ["romanization", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-listening-sounds-and-words",
+          "promptModes": ["recorded Iranian Persian at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["isolated sound", "known word"],
+          "responseModes": ["selection", "picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound recognition", "word recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        },
+        {
+          "id": "prea1-listening-greeting-responses",
+          "promptModes": ["recorded Iranian Persian at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["memorized greeting", "courtesy exchange"],
+          "responseModes": ["selection", "situation match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["communicative-function recognition", "appropriate response selection"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        },
+        {
+          "id": "prea1-listening-personal-details",
+          "promptModes": ["recorded Iranian Persian at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["isolated personal detail", "short personal statement"],
+          "responseModes": ["selection", "picture match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["gist recognition", "personal-detail recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 12,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-recall",
+          "promptModes": ["briefly-visible Persian-script model"],
+          "promptGenres": ["known word"],
+          "responseModes": ["delayed handwritten recall"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 20, "criteria": ["right-to-left letter sequence", "joining and dot control", "legibility"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "romanization", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded Iranian Persian at 70-90 words per minute"],
+          "promptGenres": ["known one-word item"],
+          "responseModes": ["handwritten dictation", "Persian-script transcription"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-script mapping", "right-to-left sequence", "joining and dot control", "readable spacing"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "romanization", "dictionary", "copyable model", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["written support-language or nonverbal instruction"],
+          "promptGenres": ["personal label", "greeting response"],
+          "responseModes": ["independent handwritten Persian word or memorized chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task fulfilment", "independent retrieval", "Persian orthographic control", "readable consistent spacing or ZWNJ"] },
+          "aids": { "allowed": ["nonverbal picture cue", "Unicode normalization of Arabic yeh and kaf to Iranian Persian forms after submission"], "forbidden": ["copyable answer model", "romanization", "dictionary", "spell-checker", "tracing guide"], "notPublished": [] },
+          "notPublished": ["short vowels are not required unless the item explicitly supplies and tests them"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 8,
+      "parts": [
+        {
+          "id": "prea1-speaking-greeting-and-identity",
+          "promptModes": ["trained live Persian interlocutor"],
+          "promptGenres": ["greeting exchange", "identity prompt"],
+          "responseModes": ["spoken memorized Persian chunk", "short identity response"],
+          "items": 2,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task fulfilment", "intelligibility", "appropriate greeting response", "identity supplied"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one repeat request"], "forbidden": ["written answer script", "romanization", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-familiar-questions",
+          "promptModes": ["trained live Persian interlocutor", "optional picture cue"],
+          "promptGenres": ["familiar one-turn question", "personal prompt"],
+          "responseModes": ["short personal Persian response"],
+          "items": 3,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 40, "criteria": ["question recognition", "relevant response", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "romanization", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-short-request",
+          "promptModes": ["trained live Persian interlocutor", "nonverbal situation cue"],
+          "promptGenres": ["familiar request situation"],
+          "responseModes": ["short spoken Persian request"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["request completed", "appropriate courtesy", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "romanization", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-persian-assessment", "ca-persian-pronunciation"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/persian-task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/persian-task-shapes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { loadTaskShapeInventory } from "../src/loader.js";
+
+describe("Persian task-shape inventories", () => {
+  it("makes the project-defined pre-A1 four-skill envelope executable", () => {
+    const inventory = loadTaskShapeInventory("persian", "pre-A1");
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Persian pre-A1 Assessment — project-defined equivalent",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual(["reading", "listening", "writing", "speaking"]);
+    expect(inventory.administration).toMatchObject({ writtenMinutes: 32, speakingMinutes: 8, speakingPreparationMinutes: 0 });
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([10, 10, 12, 8]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.items))).toEqual([
+      [6, 4, 4], [6, 4, 4], [2, 4, 2], [2, 3, 1],
+    ]);
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0),
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+  });
+
+  it("keeps scored Persian writing productive and script-aware", () => {
+    const inventory = loadTaskShapeInventory("persian", "pre-A1");
+    const writing = inventory.sections.find((section) => section.skill === "writing");
+    const criteria = writing?.parts.flatMap((part) => part.scoring.criteria).join(" ") ?? "";
+    expect(writing?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-recall", "prea1-writing-dictation", "prea1-writing-bounded-production",
+    ]);
+    expect(writing?.parts.every((part) => part.aids.forbidden.some((aid) => /model|tracing/i.test(aid)))).toBe(true);
+    expect(criteria).toMatch(/right-to-left/);
+    expect(criteria).toMatch(/joining and dot control/);
+    expect(criteria).toMatch(/ZWNJ/);
+    expect(writing?.parts.at(-1)?.aids.allowed.join(" ")).toMatch(/Iranian Persian forms/);
+    expect(writing?.parts.at(-1)?.notPublished.join(" ")).toMatch(/short vowels are not required/);
+  });
+});


### PR DESCRIPTION
## Summary
- add an executable, project-defined Persian pre-A1 assessment envelope across reading, listening, writing, and speaking
- pin exact timing, item counts, replay behavior, aids, scoring, and independent 60/100 skill floors
- make writing productive from the first rung with delayed recall, dictation, bounded independent Persian-script production, and explicit RTL/joining/dot/spacing/ZWNJ criteria
- document Unicode-equivalent yeh/kaf normalization and the limited role of short vowels

## Boundaries
- this does **not** claim a CEFR or SAMFA equivalence
- mocks, rubrics, keys, calibration, curriculum coverage, and book-only validation remain separate backlog work

## Validation
- `npm run generate:progress`
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `npx vitest run --maxWorkers=1` (80 files, 945 tests)
- `git diff --check`

Closes #12459