### PR TITLE
feat(human-languages): inventory Urdu pre-A1 task shapes

### DIFF
--- a/code/learning/human-languages/urdu/CHANGELOG.md
+++ b/code/learning/human-languages/urdu/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased — project-defined pre-A1 four-skill task shapes
+
+- Made the Urdu pre-A1 bridge executable as independent reading, listening,
+  writing, and speaking papers with exact timing, items, replay, aids, scoring,
+  and a 60/100 floor on every skill.
+- Kept writing productive and script-aware: scored work covers delayed recall,
+  dictation, and bounded independent Urdu-script responses with right-to-left
+  order, joins, non-joins, dots, and word-boundary control. Roman Urdu and
+  Devanagari cannot substitute for an Urdu-script response.
+- Kept the construct typographically fair: ordinary legible handwriting is
+  enough, Nastaliq calligraphic imitation is not scored, approved Naskh remains
+  an accessibility presentation, and unwritten short vowels are not errors.
+- This project rung is not an external qualification. Mocks, rubrics, keys,
+  calibration, curriculum coverage, and book-only validation remain required.
+
 ## 2026-08-21 — Contract the seven-rung Urdu assessment ladder (#12444)
 
 - Defined pre-A1 through C2 as project-owned four-skill assessments with

--- a/code/learning/human-languages/urdu/task-shapes/pre-a1.json
+++ b/code/learning/human-languages/urdu/task-shapes/pre-a1.json
@@ -1,0 +1,236 @@
+{
+  "version": 1,
+  "language": "urdu",
+  "level": "pre-A1",
+  "target": { "name": "Coding Adventures Urdu pre-A1 Assessment — project-defined equivalent", "basis": "project-defined" },
+  "sources": [
+    { "id": "ca-hl16", "title": "HL16 — Exam-ready books and the gentle writing ramp", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL16-exam-ready-books-and-writing-ramp.md", "published": "2026-08-20", "accessed": "2026-08-21" },
+    { "id": "ca-hl18", "title": "HL18 — Four-skill task shapes", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/HL18-four-skill-task-shapes.md", "published": "2026-08-20", "accessed": "2026-08-21" },
+    { "id": "ca-urdu-assessment", "title": "Coding Adventures Urdu Assessment Specification", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/urdu/assessment-spec.md", "published": "2026-08-21", "accessed": "2026-08-21" },
+    { "id": "ca-urdu-pronunciation", "title": "Coding Adventures Urdu Pronunciation and Script Reference", "url": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/urdu/pronunciation-reference.md", "published": "not stated", "accessed": "2026-08-21" }
+  ],
+  "administration": {
+    "writtenMinutes": 32,
+    "speakingMinutes": 8,
+    "speakingGroupMaximum": 1,
+    "speakingPreparationMinutes": 0,
+    "deliveryModes": ["paper or equivalent locked digital form", "recorded-audio", "live-interlocutor"]
+  },
+  "passRule": {
+    "maximumPoints": 400,
+    "passPoints": 240,
+    "requiresEverySectionAttempted": true,
+    "independentSkillThresholds": { "reading": 0.6, "listening": 0.6, "writing": 0.6, "speaking": 0.6 },
+    "note": "Each skill is a separate 100-point paper and must independently reach 60/100; the 240-point headline sum cannot compensate for a failed paper. This project-defined assessment is not an external qualification."
+  },
+  "sections": [
+    {
+      "skill": "reading",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-reading-letters-and-words",
+          "promptModes": ["written Urdu script in approved Nastaliq or accessibility Naskh", "optional nonverbal picture cue"],
+          "promptGenres": ["taught letter family", "single-word sign", "single-word label"],
+          "responseModes": ["selection", "word-to-meaning match", "label-to-picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 40, "criteria": ["answer-key match", "letter and word recognition", "joining-form recognition"] },
+          "aids": { "allowed": ["nonverbal picture cue", "approved Nastaliq or Naskh accessibility presentation"], "forbidden": ["Roman Urdu", "Devanagari substitution", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-reading-phrases-and-notices",
+          "promptModes": ["written Urdu script in approved Nastaliq or accessibility Naskh", "optional nonverbal situation cue"],
+          "promptGenres": ["memorized phrase", "short notice", "greeting exchange"],
+          "responseModes": ["selection", "situation match", "choose the next turn"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 30, "criteria": ["answer-key match", "phrase recognition", "communicative-function recognition"] },
+          "aids": { "allowed": ["nonverbal situation cue", "approved Nastaliq or Naskh accessibility presentation"], "forbidden": ["Roman Urdu", "Devanagari substitution", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-reading-personal-details",
+          "promptModes": ["written Urdu script in approved Nastaliq or accessibility Naskh", "written-icon-supported instruction"],
+          "promptGenres": ["personal detail", "short form field"],
+          "responseModes": ["selection", "detail match"],
+          "items": 4,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": null,
+          "scoring": { "maxRawPoints": 30, "criteria": ["personal-detail recognition", "accurate selection"] },
+          "aids": { "allowed": ["nonverbal picture cue", "approved Nastaliq or Naskh accessibility presentation"], "forbidden": ["Roman Urdu", "Devanagari substitution", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": ["replay is not applicable to written input", "response length is not applicable to selection and matching"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "listening",
+      "minutes": 10,
+      "parts": [
+        {
+          "id": "prea1-listening-sounds-and-words",
+          "promptModes": ["recorded contemporary standard Urdu at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["isolated sound", "known word"],
+          "responseModes": ["selection", "picture match"],
+          "items": 6,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound recognition", "word recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "Roman Urdu", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-listening-greeting-responses",
+          "promptModes": ["recorded contemporary standard Urdu at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["memorized greeting", "courtesy exchange"],
+          "responseModes": ["selection", "situation match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["communicative-function recognition", "appropriate response selection"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "Roman Urdu", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-listening-personal-details",
+          "promptModes": ["recorded contemporary standard Urdu at 70-90 words per minute", "eight-second inter-item pause"],
+          "promptGenres": ["isolated personal detail", "short personal statement"],
+          "responseModes": ["selection", "picture match"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": null,
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 30, "criteria": ["gist recognition", "personal-detail recognition"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "Roman Urdu", "dictionary", "translation tool"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "writing",
+      "minutes": 12,
+      "parts": [
+        {
+          "id": "prea1-writing-delayed-recall",
+          "promptModes": ["briefly-visible Urdu-script model in approved Nastaliq or accessibility Naskh"],
+          "promptGenres": ["known word"],
+          "responseModes": ["delayed handwritten Urdu-script recall"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 20, "criteria": ["right-to-left letter sequence", "joining, non-joining, and dot control", "legibility without calligraphic imitation"] },
+          "aids": { "allowed": ["ten-second initial model view"], "forbidden": ["visible model during response", "Roman Urdu", "Devanagari substitution", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-writing-dictation",
+          "promptModes": ["recorded contemporary standard Urdu at 70-90 words per minute"],
+          "promptGenres": ["known one-word item"],
+          "responseModes": ["handwritten dictation", "Urdu-script transcription"],
+          "items": 4,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 5, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 1, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 2,
+          "scoring": { "maxRawPoints": 40, "criteria": ["sound-to-script mapping", "right-to-left sequence", "joining, non-joining, and dot control", "readable word boundaries"] },
+          "aids": { "allowed": [], "forbidden": ["transcript", "Roman Urdu", "Devanagari substitution", "dictionary", "copyable model", "tracing guide"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-writing-bounded-production",
+          "promptModes": ["written support-language or nonverbal instruction"],
+          "promptGenres": ["personal label", "greeting response"],
+          "responseModes": ["independent handwritten Urdu word or memorized chunk"],
+          "items": 2,
+          "stimulusLength": { "unit": "words", "minimum": 1, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "words", "minimum": 1, "maximum": 5, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 0,
+          "scoring": { "maxRawPoints": 40, "criteria": ["task fulfilment", "independent retrieval", "Urdu orthographic control", "legible right-to-left joins, non-joins, dots, and word boundaries"] },
+          "aids": { "allowed": ["nonverbal picture cue", "Unicode normalization of equivalent Urdu grapheme sequences for typed responses after submission"], "forbidden": ["copyable answer model", "Roman Urdu", "Devanagari substitution", "dictionary", "spell-checker", "tracing guide"], "notPublished": [] },
+          "notPublished": ["unwritten short vowels and optional diacritics receive neither bonus nor penalty unless the item explicitly tests a meaning-changing contrast", "ordinary legible handwriting is sufficient; Nastaliq calligraphic ligatures and slope are not scored"],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        }
+      ],
+      "variants": []
+    },
+    {
+      "skill": "speaking",
+      "minutes": 8,
+      "parts": [
+        {
+          "id": "prea1-speaking-greeting-and-identity",
+          "promptModes": ["trained live Urdu interlocutor"],
+          "promptGenres": ["greeting exchange", "identity prompt"],
+          "responseModes": ["spoken memorized Urdu chunk", "short identity response"],
+          "items": 2,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["task fulfilment", "intelligibility", "appropriate greeting response", "identity supplied"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one repeat request"], "forbidden": ["written answer script", "Roman Urdu", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-familiar-questions",
+          "promptModes": ["trained live Urdu interlocutor", "optional picture cue"],
+          "promptGenres": ["familiar one-turn question", "personal prompt"],
+          "responseModes": ["short personal Urdu response"],
+          "items": 3,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 40, "criteria": ["question recognition", "relevant response", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "Roman Urdu", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        },
+        {
+          "id": "prea1-speaking-short-request",
+          "promptModes": ["trained live Urdu interlocutor", "nonverbal situation cue"],
+          "promptGenres": ["familiar request situation"],
+          "responseModes": ["short spoken Urdu request"],
+          "items": 1,
+          "stimulusLength": { "unit": "seconds", "minimum": 2, "maximum": 8, "approximate": false },
+          "responseLength": { "unit": "seconds", "minimum": 2, "maximum": 15, "approximate": false },
+          "interaction": "individual",
+          "replayCount": 1,
+          "scoring": { "maxRawPoints": 30, "criteria": ["request completed", "appropriate courtesy", "intelligibility"] },
+          "aids": { "allowed": ["nonverbal picture cue", "one slow repetition"], "forbidden": ["written answer script", "Roman Urdu", "translation"], "notPublished": [] },
+          "notPublished": [],
+          "sourceIds": ["ca-hl16", "ca-hl18", "ca-urdu-assessment", "ca-urdu-pronunciation"]
+        }
+      ],
+      "variants": []
+    }
+  ]
+}

--- a/code/packages/typescript/human-language-data/tests/urdu-task-shapes.test.ts
+++ b/code/packages/typescript/human-language-data/tests/urdu-task-shapes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { loadTaskShapeInventory } from "../src/loader.js";
+
+describe("Urdu task-shape inventories", () => {
+  it("makes the project-defined pre-A1 four-skill envelope executable", () => {
+    const inventory = loadTaskShapeInventory("urdu", "pre-A1");
+    expect(inventory.target).toEqual({
+      name: "Coding Adventures Urdu pre-A1 Assessment — project-defined equivalent",
+      basis: "project-defined",
+    });
+    expect(inventory.sections.map((section) => section.skill)).toEqual(["reading", "listening", "writing", "speaking"]);
+    expect(inventory.administration).toMatchObject({ writtenMinutes: 32, speakingMinutes: 8, speakingPreparationMinutes: 0 });
+    expect(inventory.sections.map((section) => section.minutes)).toEqual([10, 10, 12, 8]);
+    expect(inventory.sections.map((section) => section.parts.map((part) => part.items))).toEqual([
+      [6, 4, 4], [6, 4, 4], [2, 4, 2], [2, 3, 1],
+    ]);
+    const paperPoints = inventory.sections.map((section) =>
+      section.parts.reduce((sum, part) => sum + (part.scoring.maxRawPoints ?? 0), 0),
+    );
+    expect(paperPoints).toEqual([100, 100, 100, 100]);
+    expect(inventory.passRule).toMatchObject({ maximumPoints: 400, passPoints: 240 });
+    expect(Object.values(inventory.passRule.independentSkillThresholds)).toEqual([0.6, 0.6, 0.6, 0.6]);
+  });
+
+  it("keeps scored Urdu writing productive and script-aware", () => {
+    const inventory = loadTaskShapeInventory("urdu", "pre-A1");
+    const writing = inventory.sections.find((section) => section.skill === "writing");
+    const criteria = writing?.parts.flatMap((part) => part.scoring.criteria).join(" ") ?? "";
+    const boundaries = writing?.parts.flatMap((part) => [
+      ...part.aids.allowed,
+      ...part.aids.forbidden,
+      ...part.notPublished,
+    ]).join(" ") ?? "";
+    expect(writing?.parts.map((part) => part.id)).toEqual([
+      "prea1-writing-delayed-recall", "prea1-writing-dictation", "prea1-writing-bounded-production",
+    ]);
+    expect(writing?.parts.every((part) => part.aids.forbidden.some((aid) => /model|tracing/i.test(aid)))).toBe(true);
+    expect(criteria).toMatch(/right-to-left/);
+    expect(criteria).toMatch(/joining, non-joining, and dot control/);
+    expect(criteria).toMatch(/word boundaries/);
+    expect(boundaries).toMatch(/Roman Urdu/);
+    expect(boundaries).toMatch(/Unicode normalization/);
+    expect(boundaries).toMatch(/short vowels/);
+    expect(boundaries).toMatch(/calligraphic ligatures/);
+  });
+});


### PR DESCRIPTION
## Summary
- add an executable, project-defined Urdu pre-A1 assessment envelope across reading, listening, writing, and speaking
- pin exact timing, item counts, replay behavior, aids, scoring, and independent 60/100 skill floors
- make writing productive with delayed recall, dictation, and bounded independent Urdu-script production
- preserve Urdu-specific RTL, joining/non-joining, dot, word-boundary, Nastaliq/Naskh accessibility, optional-short-vowel, Unicode-normalization, and no-Roman-Urdu boundaries

## Boundaries
- this is not an external qualification
- ordinary legible Urdu is the construct; Nastaliq calligraphic imitation is not scored
- mocks, rubrics, keys, calibration, curriculum coverage, and book-only validation remain separate backlog work

## Validation
- `npm run build`
- `npm run generate:progress`
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `npx vitest run --maxWorkers=1` (80 files, 945 tests)
- after final rebase: 4 focused files / 41 tests plus all six artifact checks
- `git diff --check`

Closes #12462