### PR TITLE
feat(human-languages): complete Marathi pre-A1 writing ramp

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes/marathi.json
+++ b/code/learning/human-languages/core/generated-book-hashes/marathi.json
@@ -98,10 +98,12 @@
     {
       "language": "marathi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:823201992120effc",
+      "sourceHash": "fnv1a64:5b52f1a9896b6c93",
       "lessonIds": [
         "MR-W01-ha",
         "MR-W01-o-matra",
+        "MR-W01-ho-delayed-copy",
+        "MR-W01-ho-dictation",
         "MR-W01-na",
         "MR-W01-aa-matra",
         "MR-W01-ii-matra",

--- a/code/learning/human-languages/core/generated-narration-hashes/marathi.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/marathi.json
@@ -237,10 +237,12 @@
     {
       "language": "marathi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:da1616ad5a472c41",
+      "sourceHash": "fnv1a64:3ae68a8a3a71295b",
       "lessonIds": [
         "MR-W01-ha",
         "MR-W01-o-matra",
+        "MR-W01-ho-delayed-copy",
+        "MR-W01-ho-dictation",
         "MR-W01-na",
         "MR-W01-aa-matra",
         "MR-W01-ii-matra",
@@ -255,8 +257,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch14.txt",
       "json": "marathi/narration/ch14.json",
-      "textHash": "fnv1a64:887fa0efc572a4d2",
-      "jsonHash": "fnv1a64:038600c3072b41e7"
+      "textHash": "fnv1a64:805b1adec8665211",
+      "jsonHash": "fnv1a64:b774834cc05b3d09"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marathi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marathi.json
@@ -1,8 +1,8 @@
 {
   "language": "marathi",
-  "lessonCount": 73,
+  "lessonCount": 75,
   "atomMeasurableLessons": 40,
-  "atomMeasurementBlindLessons": 33,
+  "atomMeasurementBlindLessons": 35,
   "durationViolations": 0,
   "atomLessonSpikes": 1,
   "atomChapterSpikes": 0,
@@ -18,15 +18,15 @@
   "forwardReferences": 3,
   "atomsTaught": 79,
   "atomsNeverRevisited": 3,
-  "reinforcementWindowMisses": 98,
+  "reinforcementWindowMisses": 103,
   "reinforcementMissesByWindow": {
     "R1": 6,
     "R2": 48,
-    "R3": 44,
+    "R3": 49,
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 52,
+  "writingPracticeLessons": 54,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [
@@ -61,14 +61,14 @@
     {
       "language": "marathi",
       "kind": "reinforcement",
-      "count": 98,
+      "count": 103,
       "unit": "missed window(s)",
       "detail": "add retrieval at the expanding R1-R4 intervals"
     },
     {
       "language": "marathi",
       "kind": "measurement-blind",
-      "count": 33,
+      "count": 35,
       "unit": "lesson(s)",
       "detail": "migrate undeclared lesson knowledge so gentleness can be measured"
     }

--- a/code/learning/human-languages/core/lesson-modality/marathi.json
+++ b/code/learning/human-languages/core/lesson-modality/marathi.json
@@ -7,14 +7,14 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:b8680b4902bd51b9",
+  "sourceHash": "fnv1a64:ff6ea3cd33ed21d5",
   "summary": {
-    "totalLessons": 73,
+    "totalLessons": 75,
     "voice": 21,
     "sight": 41,
-    "pen": 11,
+    "pen": 13,
     "drivableLessons": 21,
-    "drivablePercent": 29,
+    "drivablePercent": 28,
     "trackCount": 1,
     "chapterCount": 14,
     "drivablePrefixTotal": 8,
@@ -26,11 +26,11 @@
   "tracks": [
     {
       "language": "marathi",
-      "lessonCount": 73,
+      "lessonCount": 75,
       "voice": 21,
       "sight": 41,
-      "pen": 11,
-      "drivablePercent": 29,
+      "pen": 13,
+      "drivablePercent": 28,
       "drivablePrefixTotal": 8,
       "modalities": [
         "voice",
@@ -237,10 +237,10 @@
         },
         {
           "chapter": 14,
-          "lessonCount": 11,
+          "lessonCount": 13,
           "voice": 0,
           "sight": 0,
-          "pen": 11,
+          "pen": 13,
           "modalities": [
             "sight",
             "pen"
@@ -1504,6 +1504,7 @@
       "drivable": false,
       "reasons": [
         "writing-type",
+        "writing-block",
         "script-block",
         "sight-cue"
       ],
@@ -1512,9 +1513,10 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:0cf74f292b342665",
+      "sourceHash": "fnv1a64:1ba26806e71f743e",
       "detachableSegments": [
-        "Script"
+        "Script",
+        "Writing — notice and trace one consonant"
       ],
       "delivery": "script"
     },
@@ -1528,6 +1530,7 @@
       "drivable": false,
       "reasons": [
         "writing-type",
+        "writing-block",
         "script-block"
       ],
       "coreModality": "pen",
@@ -1535,9 +1538,58 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:2ae6f15f4e484fcf",
+      "sourceHash": "fnv1a64:c6ba4ce949efabee",
       "detachableSegments": [
-        "Script"
+        "Script",
+        "Writing — one supported copy"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MR-W01-ho-delayed-copy",
+      "language": "marathi",
+      "chapter": 14,
+      "sequence": 815,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:3b16799d2e8b32e9",
+      "detachableSegments": [
+        "Writing — delayed copy"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MR-W01-ho-dictation",
+      "language": "marathi",
+      "chapter": 14,
+      "sequence": 817,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "writing-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:10fa9ba2c3351bac",
+      "detachableSegments": [
+        "Writing — short dictation"
       ],
       "delivery": "script"
     },
@@ -1558,7 +1610,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:f94d7ae350fe5366",
+      "sourceHash": "fnv1a64:ec4d9f8ba18dec9c",
       "detachableSegments": [
         "Script"
       ],

--- a/code/learning/human-languages/marathi/CHANGELOG.md
+++ b/code/learning/human-languages/marathi/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased — complete the pre-A1 writing runway with one word
+
+- Move familiar **हो** through four explicit <=3-minute stages: trace only
+  **ह**, guided-copy the two-piece word, hide it for delayed copy, then write
+  it from a heard cue with no visible or romanized answer model.
+- Add no glyphs in the independent stages and preserve the one-new-shape ceiling
+  in the supported stages, so writing difficulty rises without a script jump.
+- Put the two new steps into the actual curriculum, book, and narration before
+  the next consonant rather than claiming writing-stage credit from metadata.
+- Record the five Chapter 11 R3 reviews that become measurable when the track
+  grows; #12467 will first reconcile declared and learner-visible order, then
+  place those reviews at honest durable distances instead of hiding the debt.
+- This proves instruction, not assessment readiness; timed production, mocks,
+  calibration, and book-only learner evidence remain separate work.
+
 ## 2026-08-21 — Enumerate the pre-A1 assessment task shapes (#12430)
 
 - Turned the project-defined pre-A1 contract into executable reading,

--- a/code/learning/human-languages/marathi/book/chapter-modalities.tex
+++ b/code/learning/human-languages/marathi/book/chapter-modalities.tex
@@ -121,7 +121,7 @@
 
 \expandafter\def\csname hlchaptermodality14\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlpensign{}~\textbf{pen} (11)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 11 lessons.%
+    \textbf{Modes:} \hlpensign{}~\textbf{pen} (13)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 13 lessons.%
     \par}\medskip
 }

--- a/code/learning/human-languages/marathi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/marathi/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 1
+% canonical-activities: 5
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -15,6 +15,32 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 \small Did Marathi don preserve an ancient final n?
 \end{minipage}\par\medskip
 
+\section*{Chapter 14}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MR-W01-ha-observe-check}{\textbf{14.1}} \emph{\mr{ह} — the consonant ha}\par
+\small Trace the visible Devanagari consonant once, then name its built-in vowel.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MR-W01-o-matra-guided-copy-check}{\textbf{14.2}} \emph{\mr{ो} — the vowel sign that replaces the inherent a}\par
+\small Copy the visible Marathi word for yes once, then name its two pieces.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MR-W01-ho-delayed-copy-check}{\textbf{14.3}} \emph{\mr{हो} — look, hide, write, compare}\par
+\small After hiding the model for five seconds, write the Marathi word for yes and then compare it.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MR-W01-ho-dictation-answer}{\textbf{14.4}} \emph{One heard answer — write what you know}\par
+\small From the heard cue ho alone, write the known Marathi word for yes.
+\end{minipage}\par\medskip
+
 \chapter*{Answer Key}
 \addcontentsline{toc}{chapter}{Answer Key}
 \markboth{Answer Key}{Answer Key}
@@ -28,4 +54,32 @@ The first response is the canonical display answer. When a question accepts othe
 \hyperlink{review-MR-C06-number-differences-don-ending}{\textbf{6.1}} \emph{Why Marathi \emph{two} rhymes with \emph{three}}\par
 \small \textbf{Answer:} no\par
 \footnotesize \textbf{Also accepted:} no it copied three; it copied the pattern of three
+\end{minipage}\par\medskip
+
+\section*{Chapter 14}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MR-W01-ha-observe-check}{\textbf{14.1}} \emph{\mr{ह} — the consonant ha}\par
+\small \textbf{Answer:} \mr{ह} — ha, with inherent a\par
+\footnotesize \textbf{Also accepted:} \mr{ह}; ha; a; inherent a
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MR-W01-o-matra-guided-copy-check}{\textbf{14.2}} \emph{\mr{ो} — the vowel sign that replaces the inherent a}\par
+\small \textbf{Answer:} \mr{हो} — \mr{ह} plus \mr{ो}\par
+\footnotesize \textbf{Also accepted:} \mr{हो}; \mr{ह} + \mr{ो}; \mr{ह} plus \mr{ो}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MR-W01-ho-delayed-copy-check}{\textbf{14.3}} \emph{\mr{हो} — look, hide, write, compare}\par
+\small \textbf{Answer:} \mr{हो}\par
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MR-W01-ho-dictation-answer}{\textbf{14.4}} \emph{One heard answer — write what you know}\par
+\small \textbf{Answer:} \mr{हो}\par
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/marathi/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/marathi/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 82
-% canonical-index-entries: 82
+% canonical-index-candidates: 84
+% canonical-index-entries: 84
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -246,6 +246,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{One heard answer — write what you know}\par
+\footnotesize script and writing topic; explicit focus: writing; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{one to five — nearly Hindi's, with two tells in the spelling and one in the sound}\enspace\emph{\mr{एक} \mr{दोन} \mr{तीन} \mr{चार} \mr{पाच}}\enspace(ek don tīn chār pāch)\par
 \footnotesize \hyperref[ch:numbers-one-to-five]{Chapter~6, p.~\pageref*{ch:numbers-one-to-five}}
 \end{minipage}\par\smallskip
@@ -331,7 +337,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\mr{ो} — the vowel sign that replaces the inherent a}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -528,6 +534,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\mr{हो} — look, hide, write, compare}\par
+\footnotesize script and writing topic; explicit focus: writing; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\mr{ह} — the consonant ha}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
+\footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mr-script-first]{Chapter~14, p.~\pageref*{ch:mr-script-first}}
 \end{minipage}\par\smallskip

--- a/code/learning/human-languages/marathi/book/chapters/ch14-script-first.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch14-script-first.tex
@@ -1,13 +1,13 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:823201992120effc
-% canonical-lessons: MR-W01-ha, MR-W01-o-matra, MR-W01-na, MR-W01-aa-matra, MR-W01-ii-matra, MR-W01-ma, MR-W01-sa, MR-W01-ka, MR-W01-virama, MR-W01-ra, MR-W01-namaskar-read
+% canonical-source-hash: fnv1a64:5b52f1a9896b6c93
+% canonical-lessons: MR-W01-ha, MR-W01-o-matra, MR-W01-ho-delayed-copy, MR-W01-ho-dictation, MR-W01-na, MR-W01-aa-matra, MR-W01-ii-matra, MR-W01-ma, MR-W01-sa, MR-W01-ka, MR-W01-virama, MR-W01-ra, MR-W01-namaskar-read
 
 \chapter{Hanging From the Head-Line, One Piece at a Time}
 \label{ch:mr-script-first}
 \hlchaptermodality{14}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can write ten Devanagari pieces from memory — six consonants, three vowel signs and the virama — and read the words for yes, no and the greeting by assembling them from those pieces, including the greeting's conjunct.}
+\textbf{By the end of this chapter:} \emph{I can move one familiar word from tracing through guided copy, delayed copy and dictation; write ten Devanagari pieces from memory; and read yes, no and the greeting by assembling them from those pieces, including the greeting's conjunct.}
 
 The greeting assembled from seven pieces the reader can each write from memory, including the conjunct, and introducing nothing new at all.
 \end{chapteropening}
@@ -37,12 +37,8 @@ That is not \emph{h}. It is \textbf{ha} — the consonant \emph{h} with an \text
 
 Now look at the top of the shape. There is a \textbf{horizontal bar} running across it, and it is not decoration. It is the \textbf{shirorekhā}, the head-line, and in running Devanagari it joins up across a whole word so the writing appears to hang from a washing line. It is the single most recognisable thing about this script — and Gujarati, its sister, is written by \textbf{erasing} exactly this line.
 
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \mr{ह}
-  \item \emph{Read it:} every piece this chapter has given you so far, in order
-\end{itemize}
+\subsection*{Writing — notice and trace one consonant}
+Keep \textbf{\mr{ह}} visible. Finger-trace it once, then trace one printed model once with a pencil. Say \emph{ha} only after your hand stops. Do not copy the word for \textquotedblleft{}yes\textquotedblright{} yet; its vowel sign comes next.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What vowel does a bare consonant carry? (\textbf{a} — the inherent vowel, and nobody writes it.) What is the bar across the top called, and what does it do in a whole word? (The \textbf{shirorekhā}; it \textbf{joins up} across the word.)
@@ -78,17 +74,49 @@ Put it on the consonant you have:
 
 One consonant and one mark, and a word you could already say became a word you can \textbf{read}. Nothing was memorised as a picture.
 
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \mr{ो}
-  \item \emph{Read it:} every piece this chapter has given you so far, in order
-\end{itemize}
+\subsection*{Writing — one supported copy}
+Keep \textbf{\mr{हो}} visible. Copy it once: first \textbf{\mr{ह}}, then its attached \textbf{\mr{ो}} sign. Point to both pieces in your copy and read \emph{ho}. You may look back after each piece; memory is not the task yet.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What does a mātrā do to the inherent vowel? (\textbf{Replaces} it.) What word did those two pieces make? (\textbf{\mr{हो}} — \emph{ho}, \textquotedblleft{}yes\textquotedblright{}.)
 
 Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[ho]{\mr{हो} — look, hide, write, compare}
+
+\label{lesson:MR-W01-ho-delayed-copy}
+
+
+
+\begin{quote}
+Look at \textbf{\mr{हो}} for five seconds. Point first to \textbf{\mr{ह}}, then to attached \textbf{\mr{ो}}. Do not copy it while the model is visible.
+\end{quote}
+
+\subsection*{Writing — delayed copy}
+1. cover \textbf{\mr{हो}} 2. wait five seconds 3. write it once from memory 4. uncover the model and compare the two pieces
+
+If one piece differs, circle it and repair only that place. Repair is part of the exercise, not a failure. There is no tracing and no romanized answer model.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read your repaired word as \emph{ho}. Stop after one memory attempt.
+\end{tcolorbox}
+\section[ho]{One heard answer — write what you know}
+
+\label{lesson:MR-W01-ho-dictation}
+
+
+
+\begin{quote}
+Cover the answer lower on this page. You will hear one familiar answer. No new Marathi and no new Devanagari shape is hiding in this lesson.
+\end{quote}
+
+\subsection*{Writing — short dictation}
+{[}YOU HEAR: \emph{ho} — \textquotedblleft{}yes\textquotedblright{}{]}
+
+Write the Devanagari word from sound alone. Do not use a visible model, romanization, or tracing guide. Now uncover and compare: \textbf{\mr{हो}}. Check \textbf{\mr{ह}} first and attached \textbf{\mr{ो}} second. Repair one place if needed.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Writing from sound completes this tiny runway. It is not a mock assessment; later lessons must grow from one known word to forms, messages, and timed tasks.
 \end{tcolorbox}
 \section[na]{\mr{न} — the consonant na}
 

--- a/code/learning/human-languages/marathi/chapters.json
+++ b/code/learning/human-languages/marathi/chapters.json
@@ -283,7 +283,7 @@
       "chapter": 14,
       "title": "Hanging From the Head-Line, One Piece at a Time",
       "label": "ch:mr-script-first",
-      "canDo": "I can write ten Devanagari pieces from memory — six consonants, three vowel signs and the virama — and read the words for yes, no and the greeting by assembling them from those pieces, including the greeting's conjunct.",
+      "canDo": "I can move one familiar word from tracing through guided copy, delayed copy and dictation; write ten Devanagari pieces from memory; and read yes, no and the greeting by assembling them from those pieces, including the greeting's conjunct.",
       "spineNodes": [
         "SPINE-MEET-GREET"
       ],

--- a/code/learning/human-languages/marathi/curriculum.json
+++ b/code/learning/human-languages/marathi/curriculum.json
@@ -9,6 +9,8 @@
         "MR-C01-namaskar",
         "MR-W01-ha",
         "MR-W01-o-matra",
+        "MR-W01-ho-delayed-copy",
+        "MR-W01-ho-dictation",
         "MR-W01-na",
         "MR-W01-aa-matra",
         "MR-W01-ii-matra",
@@ -789,6 +791,8 @@
       "lessons": [
         "MR-W01-ha",
         "MR-W01-o-matra",
+        "MR-W01-ho-delayed-copy",
+        "MR-W01-ho-dictation",
         "MR-W01-na",
         "MR-W01-aa-matra",
         "MR-W01-ii-matra",

--- a/code/learning/human-languages/marathi/lessons/MR-W01-ha.md
+++ b/code/learning/human-languages/marathi/lessons/MR-W01-ha.md
@@ -14,7 +14,7 @@ sounds: []
 roots: []
 etymology_hook: "Devanagari hangs its letters from a head-line, the shirorekha; Gujarati is the same script with that line erased."
 duration:
-  max_seconds: 200
+  max_seconds: 180
 requires:
   knowledge: []
 introduces:
@@ -59,14 +59,17 @@ Devanagari it joins up across a whole word so the writing appears to hang from a
 washing line. It is the single most recognisable thing about this script — and
 Gujarati, its sister, is written by **erasing** exactly this line.
 
-## Guided Practice
+## Writing — notice and trace one consonant
 <!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01] -->
+<!-- hl-writing-stage: observe-trace -->
 
-- [YOU WRITE: ह]
-- [YOU READ: every piece this chapter has given you so far, in order]
+Keep **ह** visible. Finger-trace it once, then trace one printed model once
+with a pencil. Say *ha* only after your hand stops. Do not copy the word for
+"yes" yet; its vowel sign comes next.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01] -->
+<!-- hl-activity: {"id":"MR-W01-ha-observe-check","kind":"text","assesses":["MR-SCRIPT-HA-01"],"prompt":"Trace the visible Devanagari consonant once, then name its built-in vowel.","answer":"ह — ha, with inherent a","accepted":["ह","ha","a","inherent a"],"feedback":{"correct":"Right: ह is ha; the a is already present.","incorrect":"Keep ह visible, trace it once, and remember that a bare Devanagari consonant carries a."},"response_seconds":15} -->
 
 [PAUSE 3s] What vowel does a bare consonant carry? (**a** — the inherent vowel, and nobody
 writes it.) What is the bar across the top called, and what does it do in a whole

--- a/code/learning/human-languages/marathi/lessons/MR-W01-ho-delayed-copy.md
+++ b/code/learning/human-languages/marathi/lessons/MR-W01-ho-delayed-copy.md
@@ -1,0 +1,55 @@
+---
+schema_version: 2
+id: MR-W01-ho-delayed-copy
+spine_node: SPINE-MEET-GREET
+sequence: 815
+delivery: script
+chapter: 14
+type: writing
+headword: हो
+romanization: "ho"
+gloss: "look, hide, write, compare, and repair yes"
+prerequisites: [MR-W01-o-matra]
+sounds: []
+roots: []
+duration:
+  max_seconds: 120
+requires:
+  knowledge: [MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-marathi
+reviews_of: [MR-W01-ha, MR-W01-o-matra]
+---
+
+# हो — look, hide, write, compare
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+
+Look at **हो** for five seconds. Point first to **ह**, then to attached **ो**.
+Do not copy it while the model is visible.
+
+## Writing — delayed copy
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-writing-stage: delayed-copy -->
+
+1. cover **हो**
+2. wait five seconds
+3. write it once from memory
+4. uncover the model and compare the two pieces
+
+If one piece differs, circle it and repair only that place. Repair is part of
+the exercise, not a failure. There is no tracing and no romanized answer model.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-activity: {"id":"MR-W01-ho-delayed-copy-check","kind":"text","assesses":["MR-SCRIPT-HA-01","MR-SCRIPT-O-MATRA-01"],"prompt":"After hiding the model for five seconds, write the Marathi word for yes and then compare it.","answer":"हो","accepted":[],"feedback":{"correct":"Yes: हो, one consonant and its attached o sign.","incorrect":"Uncover the model, repair only the differing piece, and try once more tomorrow."},"response_seconds":18} -->
+
+Read your repaired word as *ho*. Stop after one memory attempt.

--- a/code/learning/human-languages/marathi/lessons/MR-W01-ho-dictation.md
+++ b/code/learning/human-languages/marathi/lessons/MR-W01-ho-dictation.md
@@ -1,0 +1,54 @@
+---
+schema_version: 2
+id: MR-W01-ho-dictation
+spine_node: SPINE-MEET-GREET
+sequence: 817
+delivery: script
+chapter: 14
+type: writing
+headword: हो
+romanization: "ho"
+gloss: "write yes from a heard cue with no visible model"
+prerequisites: [MR-W01-ho-delayed-copy]
+sounds: []
+roots: []
+duration:
+  max_seconds: 120
+requires:
+  knowledge: [MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01]
+introduces:
+  knowledge: []
+practises:
+  knowledge: [MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01]
+skills: [listening, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-marathi
+reviews_of: [MR-W01-o-matra, MR-W01-ho-delayed-copy]
+---
+
+# One heard answer — write what you know
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+
+Cover the answer lower on this page. You will hear one familiar answer. No new
+Marathi and no new Devanagari shape is hiding in this lesson.
+
+## Writing — short dictation
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-writing-stage: dictation-transcription -->
+
+[YOU HEAR: *ho* — "yes"]
+
+Write the Devanagari word from sound alone. Do not use a visible model,
+romanization, or tracing guide. Now uncover and compare: **हो**. Check **ह**
+first and attached **ो** second. Repair one place if needed.
+
+## Wrap-up recall
+<!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-activity: {"id":"MR-W01-ho-dictation-answer","kind":"text","assesses":["MR-SCRIPT-HA-01","MR-SCRIPT-O-MATRA-01"],"prompt":"From the heard cue ho alone, write the known Marathi word for yes.","answer":"हो","accepted":[],"feedback":{"correct":"हो — ह with attached o sign ो.","incorrect":"The word has two pieces: ह, then attached ो: हो."},"response_seconds":18} -->
+
+Writing from sound completes this tiny runway. It is not a mock assessment;
+later lessons must grow from one known word to forms, messages, and timed tasks.

--- a/code/learning/human-languages/marathi/lessons/MR-W01-na.md
+++ b/code/learning/human-languages/marathi/lessons/MR-W01-na.md
@@ -9,7 +9,7 @@ type: writing
 headword: न
 romanization: "na"
 gloss: "the consonant na"
-prerequisites: [MR-W01-o-matra]
+prerequisites: [MR-W01-ho-dictation]
 sounds: []
 roots: []
 etymology_hook: "Devanagari hangs its letters from a head-line, the shirorekha; Gujarati is the same script with that line erased."
@@ -26,7 +26,7 @@ modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral
 variety: standard
-reviews_of: [MR-W01-o-matra]
+reviews_of: [MR-W01-ho-dictation]
 ---
 # न — the consonant na
 

--- a/code/learning/human-languages/marathi/lessons/MR-W01-o-matra.md
+++ b/code/learning/human-languages/marathi/lessons/MR-W01-o-matra.md
@@ -14,7 +14,7 @@ sounds: []
 roots: []
 etymology_hook: "Devanagari hangs its letters from a head-line, the shirorekha; Gujarati is the same script with that line erased."
 duration:
-  max_seconds: 200
+  max_seconds: 180
 requires:
   knowledge: [MR-SCRIPT-HA-01]
 introduces:
@@ -57,14 +57,17 @@ lesson in Marathi.
 One consonant and one mark, and a word you could already say became a word you can
 **read**. Nothing was memorised as a picture.
 
-## Guided Practice
+## Writing — one supported copy
 <!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-writing-stage: guided-copy -->
 
-- [YOU WRITE: ो]
-- [YOU READ: every piece this chapter has given you so far, in order]
+Keep **हो** visible. Copy it once: first **ह**, then its attached **ो** sign.
+Point to both pieces in your copy and read *ho*. You may look back after each
+piece; memory is not the task yet.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[MR-SCRIPT-HA-01, MR-SCRIPT-O-MATRA-01] -->
+<!-- hl-activity: {"id":"MR-W01-o-matra-guided-copy-check","kind":"text","assesses":["MR-SCRIPT-HA-01","MR-SCRIPT-O-MATRA-01"],"prompt":"Copy the visible Marathi word for yes once, then name its two pieces.","answer":"हो — ह plus ो","accepted":["हो","ह + ो","ह plus ो"],"feedback":{"correct":"Good: one supported copy, built from ह and attached ो.","incorrect":"Keep the model visible and copy only two pieces: ह, then ो."},"response_seconds":18} -->
 
 [PAUSE 3s] What does a mātrā do to the inherent vowel? (**Replaces** it.) What word did
 those two pieces make? (**हो** — *ho*, "yes".)

--- a/code/learning/human-languages/marathi/narration/ch14.json
+++ b/code/learning/human-languages/marathi/narration/ch14.json
@@ -4,7 +4,7 @@
   "chapter": 14,
   "title": "Hanging From the Head-Line, One Piece at a Time",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:da1616ad5a472c41",
+  "sourceHash": "fnv1a64:3ae68a8a3a71295b",
   "lessons": [
     {
       "id": "MR-W01-ha",
@@ -18,10 +18,11 @@
       "derivedModality": "pen",
       "modalityReasons": [
         "writing-type",
+        "writing-block",
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:0cf74f292b342665",
+      "sourceHash": "fnv1a64:1ba26806e71f743e",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -30,10 +31,9 @@
           "your eyes, because the lesson points at something written down"
         ],
         "waitUntilStopped": [
-          "Script",
-          "Guided Practice"
+          "Script"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -86,26 +86,12 @@
         },
         {
           "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
+          "type": "writing",
+          "title": "Writing — notice and trace one consonant",
           "segments": [
             {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ह (ha)",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ह]"
-            },
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "every piece this chapter has given you so far, in order",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: every piece this chapter has given you so far, in order]"
+              "kind": "speech",
+              "text": "Keep ह visible. Finger-trace it once, then trace one printed model once with a pencil. Say ha only after your hand stops. Do not copy the word for \"yes\" yet; its vowel sign comes next."
             }
           ]
         },
@@ -127,6 +113,27 @@
             {
               "kind": "speech",
               "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MR-W01-ha-observe-check",
+              "prompt": "Trace the visible Devanagari consonant once, then name its built-in vowel.",
+              "assesses": [
+                "MR-SCRIPT-HA-01"
+              ],
+              "responseSeconds": 15,
+              "acceptedResponses": [
+                "ह — ha, with inherent a",
+                "ह",
+                "ha",
+                "a",
+                "inherent a"
+              ],
+              "feedback": {
+                "correct": "Right: ह is ha; the a is already present.",
+                "incorrect": "Keep ह visible, trace it once, and remember that a bare Devanagari consonant carries a."
+              }
             }
           ]
         }
@@ -144,9 +151,10 @@
       "derivedModality": "pen",
       "modalityReasons": [
         "writing-type",
+        "writing-block",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2ae6f15f4e484fcf",
+      "sourceHash": "fnv1a64:c6ba4ce949efabee",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -154,10 +162,9 @@
           "your eyes, for letter shapes on the page"
         ],
         "waitUntilStopped": [
-          "Script",
-          "Guided Practice"
+          "Script"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -200,7 +207,7 @@
             },
             {
               "kind": "speech",
-              "text": "ह (ha) + ो (-o) becomes हो."
+              "text": "ह (ha) + ो (-o) becomes हो (ho)."
             },
             {
               "kind": "speech",
@@ -214,26 +221,12 @@
         },
         {
           "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
+          "type": "writing",
+          "title": "Writing — one supported copy",
           "segments": [
             {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ो (-o)",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ो]"
-            },
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "every piece this chapter has given you so far, in order",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: every piece this chapter has given you so far, in order]"
+              "kind": "speech",
+              "text": "Keep हो visible. Copy it once: first ह (ha), then its attached ो (-o) sign. Point to both pieces in your copy and read ho. You may look back after each piece; memory is not the task yet."
             }
           ]
         },
@@ -255,6 +248,208 @@
             {
               "kind": "speech",
               "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MR-W01-o-matra-guided-copy-check",
+              "prompt": "Copy the visible Marathi word for yes once, then name its two pieces.",
+              "assesses": [
+                "MR-SCRIPT-HA-01",
+                "MR-SCRIPT-O-MATRA-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "हो — ह plus ो",
+                "हो",
+                "ह + ो",
+                "ह plus ो"
+              ],
+              "feedback": {
+                "correct": "Good: one supported copy, built from ह and attached ो.",
+                "incorrect": "Keep the model visible and copy only two pieces: ह, then ो."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MR-W01-ho-delayed-copy",
+      "sequence": 815,
+      "title": "हो (ho) — look, hide, write, compare",
+      "headword": "हो",
+      "romanization": "ho",
+      "gloss": "look, hide, write, compare, and repair yes",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:3b16799d2e8b32e9",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look at हो (ho) for five seconds. Point first to ह (ha), then to attached ो (-o). Do not copy it while the model is visible."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "writing",
+          "title": "Writing — delayed copy",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "cover हो (ho)."
+            },
+            {
+              "kind": "speech",
+              "text": "wait five seconds."
+            },
+            {
+              "kind": "speech",
+              "text": "write it once from memory."
+            },
+            {
+              "kind": "speech",
+              "text": "uncover the model and compare the two pieces."
+            },
+            {
+              "kind": "speech",
+              "text": "If one piece differs, circle it and repair only that place. Repair is part of the exercise, not a failure. There is no tracing and no romanized answer model."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read your repaired word as ho. Stop after one memory attempt."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MR-W01-ho-delayed-copy-check",
+              "prompt": "After hiding the model for five seconds, write the Marathi word for yes and then compare it.",
+              "assesses": [
+                "MR-SCRIPT-HA-01",
+                "MR-SCRIPT-O-MATRA-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "हो"
+              ],
+              "feedback": {
+                "correct": "Yes: हो, one consonant and its attached o sign.",
+                "incorrect": "Uncover the model, repair only the differing piece, and try once more tomorrow."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MR-W01-ho-dictation",
+      "sequence": 817,
+      "title": "One heard answer — write what you know",
+      "headword": "हो",
+      "romanization": "ho",
+      "gloss": "write yes from a heard cue with no visible model",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "writing-block"
+      ],
+      "sourceHash": "fnv1a64:10fa9ba2c3351bac",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on"
+        ],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the answer lower on this page. You will hear one familiar answer. No new Marathi and no new Devanagari shape is hiding in this lesson."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "writing",
+          "title": "Writing — short dictation",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "HEAR",
+              "instruction": "ho — \"yes\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU HEAR: *ho* — \"yes\"]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write the Devanagari word from sound alone. Do not use a visible model, romanization, or tracing guide. Now uncover and compare: हो (ho). Check ह (ha) first and attached ो (-o) second. Repair one place if needed."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "recall",
+          "title": "Wrap-up recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Writing from sound completes this tiny runway. It is not a mock assessment; later lessons must grow from one known word to forms, messages, and timed tasks."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MR-W01-ho-dictation-answer",
+              "prompt": "From the heard cue ho alone, write the known Marathi word for yes.",
+              "assesses": [
+                "MR-SCRIPT-HA-01",
+                "MR-SCRIPT-O-MATRA-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "हो"
+              ],
+              "feedback": {
+                "correct": "हो — ह with attached o sign ो.",
+                "incorrect": "The word has two pieces: ह, then attached ो: हो."
+              }
             }
           ]
         }
@@ -274,7 +469,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f94d7ae350fe5366",
+      "sourceHash": "fnv1a64:ec4d9f8ba18dec9c",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -580,7 +775,7 @@
             },
             {
               "kind": "speech",
-              "text": "हो नाही."
+              "text": "हो (ho) नाही."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/marathi/narration/ch14.txt
+++ b/code/learning/human-languages/marathi/narration/ch14.txt
@@ -1,11 +1,11 @@
 Marathi, chapter 14: Hanging From the Head-Line, One Piece at a Time.
-11 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+13 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 11.
+Lesson 1 of 13.
 ह — the consonant ha.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -19,21 +19,21 @@ Here is the first consonant:
 That is not h. It is ha — the consonant h with an a already inside it, the a of English about. Nobody wrote that vowel. A bare consonant in this script is understood to carry it, and it is called the inherent vowel.
 Now look at the top of the shape. There is a horizontal bar running across it, and it is not decoration. It is the shirorekhā, the head-line, and in running Devanagari it joins up across a whole word so the writing appears to hang from a washing line. It is the single most recognisable thing about this script — and Gujarati, its sister, is written by erasing exactly this line.
 
-Guided Practice.
-[once you have stopped driving — write: ह (ha)]
-[your turn — read: every piece this chapter has given you so far, in order]
-[pause 8 seconds for the answer]
+Writing — notice and trace one consonant.
+Keep ह visible. Finger-trace it once, then trace one printed model once with a pencil. Say ha only after your hand stops. Do not copy the word for "yes" yet; its vowel sign comes next.
 
 Wrap-up Recall.
 [pause 3 seconds]
 What vowel does a bare consonant carry? (a — the inherent vowel, and nobody writes it.) What is the bar across the top called, and what does it do in a whole word? (The shirorekhā; it joins up across the word.)
 Source: Unicode Devanagari chart.
+[question — say your answer, then pause 15 seconds]
+Trace the visible Devanagari consonant once, then name its built-in vowel.
 
 
-Lesson 2 of 11.
+Lesson 2 of 13.
 ो (-o) — the vowel sign that replaces the inherent a.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -44,22 +44,62 @@ The inherent a is a default. To get a different vowel you replace it, with a mar
 ो (-o).
 On its own it is meaningless. Attached to a consonant it swaps the inherent short a for o, the vowel of English go — and notice how it attaches: a stroke to the right, plus a small mark riding on the head-line itself.
 Put it on the consonant you have:
-ह (ha) + ो (-o) becomes हो.
+ह (ha) + ो (-o) becomes हो (ho).
 ho. That is a word: it is yes, and you have been saying it since your first lesson in Marathi.
 One consonant and one mark, and a word you could already say became a word you can read. Nothing was memorised as a picture.
 
-Guided Practice.
-[once you have stopped driving — write: ो (-o)]
-[your turn — read: every piece this chapter has given you so far, in order]
-[pause 8 seconds for the answer]
+Writing — one supported copy.
+Keep हो visible. Copy it once: first ह (ha), then its attached ो (-o) sign. Point to both pieces in your copy and read ho. You may look back after each piece; memory is not the task yet.
 
 Wrap-up Recall.
 [pause 3 seconds]
 What does a mātrā do to the inherent vowel? (Replaces it.) What word did those two pieces make? (हो — ho, "yes".)
 Source: Unicode Devanagari chart.
+[question — say your answer, then pause 18 seconds]
+Copy the visible Marathi word for yes once, then name its two pieces.
 
 
-Lesson 3 of 11.
+Lesson 3 of 13.
+हो (ho) — look, hide, write, compare.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+
+Warm-up.
+Look at हो (ho) for five seconds. Point first to ह (ha), then to attached ो (-o). Do not copy it while the model is visible.
+
+Writing — delayed copy.
+cover हो (ho).
+wait five seconds.
+write it once from memory.
+uncover the model and compare the two pieces.
+If one piece differs, circle it and repair only that place. Repair is part of the exercise, not a failure. There is no tracing and no romanized answer model.
+
+Wrap-up recall.
+Read your repaired word as ho. Stop after one memory attempt.
+[question — say your answer, then pause 18 seconds]
+After hiding the model for five seconds, write the Marathi word for yes and then compare it.
+
+
+Lesson 4 of 13.
+One heard answer — write what you know.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+
+Warm-up.
+Cover the answer lower on this page. You will hear one familiar answer. No new Marathi and no new Devanagari shape is hiding in this lesson.
+
+Writing — short dictation.
+[your turn — hear: ho — "yes"]
+[pause 8 seconds for the answer]
+Write the Devanagari word from sound alone. Do not use a visible model, romanization, or tracing guide. Now uncover and compare: हो (ho). Check ह (ha) first and attached ो (-o) second. Repair one place if needed.
+
+Wrap-up recall.
+Writing from sound completes this tiny runway. It is not a mock assessment; later lessons must grow from one known word to forms, messages, and timed tasks.
+[question — say your answer, then pause 18 seconds]
+From the heard cue ho alone, write the known Marathi word for yes.
+
+
+Lesson 5 of 13.
 न — the consonant na.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -85,7 +125,7 @@ What vowel is inside न (na) when nothing is attached? (a.) And how many new ru
 Source: Unicode Devanagari chart.
 
 
-Lesson 4 of 11.
+Lesson 6 of 13.
 ा (-ā) — a second vowel sign, and the simplest one in the script.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -112,7 +152,7 @@ Where does this mātrā sit? (To the right of the consonant.) Does it add a beat
 Source: Unicode Devanagari chart.
 
 
-Lesson 5 of 11.
+Lesson 7 of 13.
 ी (-ī) — a mātrā that leans the other way.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -130,7 +170,7 @@ And now put that beside a piece you already built:
 ना + ही becomes नाही.
 nā-hī — no.
 You can now read both answers to a yes-or-no question:
-हो नाही.
+हो (ho) नाही.
 Two consonants and three vowel signs. That is the arithmetic of an abugida: consonants and mātrās multiply, so a small number of pieces reaches a large number of syllables very fast.
 
 Guided Practice.
@@ -144,7 +184,7 @@ What is नाही? (No.) How many pieces is it built from? (Four — two cons
 Source: Unicode Devanagari chart.
 
 
-Lesson 6 of 11.
+Lesson 8 of 13.
 म — the consonant ma.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -171,7 +211,7 @@ Say the three consonants you hold, each with its inherent vowel. (ha, na, ma.)
 Source: Unicode Devanagari chart.
 
 
-Lesson 7 of 11.
+Lesson 9 of 13.
 स — the consonant sa.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -196,7 +236,7 @@ What is the inherent vowel in स? (a — sa.)
 Source: Unicode Devanagari chart.
 
 
-Lesson 8 of 11.
+Lesson 10 of 13.
 क — the consonant ka.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -222,7 +262,7 @@ Is क (ka) the k of kit or of skip? (Of skip — no puff of air.) And does the 
 Source: Unicode Devanagari chart.
 
 
-Lesson 9 of 11.
+Lesson 11 of 13.
 ् ((virama)) — the mark that DELETES the inherent vowel and glues two consonants together.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -251,7 +291,7 @@ What does the virama do? (Removes the inherent vowel.) What usually happens to a
 Source: Unicode Devanagari chart.
 
 
-Lesson 10 of 11.
+Lesson 12 of 13.
 र (ra) — the last consonant of the greeting.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -276,7 +316,7 @@ How is र (ra) made? (A light tap of the tongue, not an English r.)
 Source: Unicode Devanagari chart.
 
 
-Lesson 11 of 11.
+Lesson 13 of 13.
 नमस्कार (namaskār) — seven pieces, all of them already yours.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script and Guided Practice until you have stopped, and I will say so again when we reach it.

--- a/code/learning/human-languages/progress/marathi.md
+++ b/code/learning/human-languages/progress/marathi.md
@@ -2,8 +2,8 @@
 
 - Track: [Marathi](../marathi/README.md)
 - Family / script: Indo-Aryan / Devanagari
-- Canonical lessons: 73
-- Mapped lessons: 68
+- Canonical lessons: 75
+- Mapped lessons: 70
 - Book progress: 14 chapters; through Ch. 14; 9 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.


### PR DESCRIPTION
## Summary

- turn the familiar word **हो** into a four-step pre-A1 writing runway: observe/trace, guided copy, delayed copy, and sound-to-script dictation
- keep every step at three minutes or less, introduce no new glyphs during independent recall, and place both new lessons in the real curriculum/book/narration before the next consonant
- regenerate Marathi book, narration, modality, progress, and gentle-ramp evidence
- disclose the five Chapter 11 R3 misses that become newly measurable as the track grows; #12467 owns the ordering repair and genuine durable reviews

## Evidence

- focused: 11 test files, 229 tests passed
- final rebased base: 93 test files, 957 tests passed with `--maxWorkers=1`
- `check:books`
- `check:figures`
- `check:modality`
- `check:narration`
- `check:progress`
- `check:gentle-snapshots`
- `git diff --check`

## Scope boundary

This proves the four instructional writing stages at pre-A1. It does not claim timed exam readiness; timed production, full mocks, calibration, and book-only human validation remain backlog work.

Closes #12466