### PR TITLE
Japanese: close the pre-A1 script loop before decoding

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1654,6 +1654,30 @@
       "scriptSet": "japanese-main"
     },
     {
+      "language": "japanese",
+      "chapter": 4,
+      "output": "japanese/book/chapters/ch04-polite-thanks.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "japanese",
+      "chapter": 5,
+      "output": "japanese/book/chapters/ch05-nihongo-kanji.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "japanese",
+      "chapter": 6,
+      "output": "japanese/book/chapters/ch06-koohii-katakana.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "japanese",
+      "chapter": 7,
+      "output": "japanese/book/chapters/ch07-doorway-exchange.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
       "language": "marwadi",
       "chapter": 1,
       "output": "marwadi/book/chapters/ch01-ram-ram-sa.tex",

--- a/code/learning/human-languages/core/generated-book-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-book-hashes/japanese.json
@@ -5,41 +5,36 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:76726ad2b2b0b3b1",
+      "sourceHash": "fnv1a64:72fc5234b7dceb5b",
       "lessonIds": [
+        "JA-W01-i",
+        "JA-W01-ha",
+        "JA-W01-hai-read",
+        "JA-W01-e",
         "JA-C01-hai",
-        "JA-C01-iie",
-        "JA-C01-konnichiwa",
-        "JA-C01-nihongo",
-        "JA-C01-koohii",
-        "JA-C01-arigatou",
-        "JA-C01-gozaimasu",
-        "JA-C01-practice"
+        "JA-C01-iie"
       ],
       "tex": "japanese/book/chapters/ch01-three-scripts.tex"
     },
     {
       "language": "japanese",
       "chapter": 2,
-      "sourceHash": "fnv1a64:958b71163f0094dc",
+      "sourceHash": "fnv1a64:3ea6a6cad1cc95e9",
       "lessonIds": [
-        "JA-W01-i",
-        "JA-W01-ha",
-        "JA-W01-hai-read",
-        "JA-W01-e",
         "JA-W01-ko",
         "JA-W01-n",
         "JA-W01-ni",
         "JA-W01-chi",
         "JA-W01-wa",
-        "JA-W01-konnichiwa-read"
+        "JA-W01-konnichiwa-read",
+        "JA-C01-konnichiwa"
       ],
       "tex": "japanese/book/chapters/ch02-hiragana-eight.tex"
     },
     {
       "language": "japanese",
       "chapter": 3,
-      "sourceHash": "fnv1a64:3ff7e4c4a4bc5425",
+      "sourceHash": "fnv1a64:263995256f27b91e",
       "lessonIds": [
         "JA-W03-a",
         "JA-W03-ri",
@@ -48,12 +43,58 @@
         "JA-W03-to",
         "JA-W03-u",
         "JA-W03-arigatou-read",
+        "JA-C01-arigatou"
+      ],
+      "tex": "japanese/book/chapters/ch03-thanks.tex"
+    },
+    {
+      "language": "japanese",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:9265f112fa74be49",
+      "lessonIds": [
         "JA-W03-sa",
         "JA-W03-ma",
         "JA-W03-su",
+        "JA-C01-gozaimasu",
         "JA-C03-practice"
       ],
-      "tex": "japanese/book/chapters/ch03-thanks.tex"
+      "tex": "japanese/book/chapters/ch04-polite-thanks.tex"
+    },
+    {
+      "language": "japanese",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:2211c70d67acf7a1",
+      "lessonIds": [
+        "JA-W05-nichi-kanji",
+        "JA-W05-hon-kanji",
+        "JA-W05-gen-component",
+        "JA-W05-five-component",
+        "JA-W05-mouth-component",
+        "JA-W05-go-kanji",
+        "JA-C01-nihongo"
+      ],
+      "tex": "japanese/book/chapters/ch05-nihongo-kanji.tex"
+    },
+    {
+      "language": "japanese",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:7adbd5a272c5dded",
+      "lessonIds": [
+        "JA-W06-ko-katakana",
+        "JA-W06-long-mark",
+        "JA-W06-hi-katakana",
+        "JA-C01-koohii"
+      ],
+      "tex": "japanese/book/chapters/ch06-koohii-katakana.tex"
+    },
+    {
+      "language": "japanese",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:c6bb3d2770dc4aaa",
+      "lessonIds": [
+        "JA-C01-practice"
+      ],
+      "tex": "japanese/book/chapters/ch07-doorway-exchange.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-narration-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/japanese.json
@@ -6,51 +6,46 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:9927b0eced7c6fcf",
-      "lessonIds": [
-        "JA-C01-hai",
-        "JA-C01-iie",
-        "JA-C01-konnichiwa",
-        "JA-C01-nihongo",
-        "JA-C01-koohii",
-        "JA-C01-arigatou",
-        "JA-C01-gozaimasu",
-        "JA-C01-practice"
-      ],
-      "voiceLessons": 1,
-      "drivablePrefix": 0,
-      "text": "japanese/narration/ch01.txt",
-      "json": "japanese/narration/ch01.json",
-      "textHash": "fnv1a64:e9d826f7652f1fcf",
-      "jsonHash": "fnv1a64:3425b1b2b383325f"
-    },
-    {
-      "language": "japanese",
-      "chapter": 2,
-      "sourceHash": "fnv1a64:44f1c780f26d205d",
+      "sourceHash": "fnv1a64:fe825b2ffb8c58cd",
       "lessonIds": [
         "JA-W01-i",
         "JA-W01-ha",
         "JA-W01-hai-read",
         "JA-W01-e",
+        "JA-C01-hai",
+        "JA-C01-iie"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "japanese/narration/ch01.txt",
+      "json": "japanese/narration/ch01.json",
+      "textHash": "fnv1a64:b79eb2bcfd6985eb",
+      "jsonHash": "fnv1a64:b87a15a3db84b7ce"
+    },
+    {
+      "language": "japanese",
+      "chapter": 2,
+      "sourceHash": "fnv1a64:4738d9e25fd92f72",
+      "lessonIds": [
         "JA-W01-ko",
         "JA-W01-n",
         "JA-W01-ni",
         "JA-W01-chi",
         "JA-W01-wa",
-        "JA-W01-konnichiwa-read"
+        "JA-W01-konnichiwa-read",
+        "JA-C01-konnichiwa"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "japanese/narration/ch02.txt",
       "json": "japanese/narration/ch02.json",
-      "textHash": "fnv1a64:e272464eb26f742b",
-      "jsonHash": "fnv1a64:17ec0ae9d3a112d6"
+      "textHash": "fnv1a64:419b22b6c702c57e",
+      "jsonHash": "fnv1a64:21da5d2733fdc42c"
     },
     {
       "language": "japanese",
       "chapter": 3,
-      "sourceHash": "fnv1a64:1a25d37b069264b0",
+      "sourceHash": "fnv1a64:7832024c6b7ac24d",
       "lessonIds": [
         "JA-W03-a",
         "JA-W03-ri",
@@ -59,17 +54,83 @@
         "JA-W03-to",
         "JA-W03-u",
         "JA-W03-arigatou-read",
-        "JA-W03-sa",
-        "JA-W03-ma",
-        "JA-W03-su",
-        "JA-C03-practice"
+        "JA-C01-arigatou"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "japanese/narration/ch03.txt",
       "json": "japanese/narration/ch03.json",
-      "textHash": "fnv1a64:cfe27fe655c7819d",
-      "jsonHash": "fnv1a64:a37a70fe9ab1f01d"
+      "textHash": "fnv1a64:0a64d358416e6526",
+      "jsonHash": "fnv1a64:e8dcc423abb08498"
+    },
+    {
+      "language": "japanese",
+      "chapter": 4,
+      "sourceHash": "fnv1a64:600d2c132460deff",
+      "lessonIds": [
+        "JA-W03-sa",
+        "JA-W03-ma",
+        "JA-W03-su",
+        "JA-C01-gozaimasu",
+        "JA-C03-practice"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "japanese/narration/ch04.txt",
+      "json": "japanese/narration/ch04.json",
+      "textHash": "fnv1a64:2ea24f5b24b362ef",
+      "jsonHash": "fnv1a64:eb9d4dec825afd24"
+    },
+    {
+      "language": "japanese",
+      "chapter": 5,
+      "sourceHash": "fnv1a64:0e00d97dd15baa40",
+      "lessonIds": [
+        "JA-W05-nichi-kanji",
+        "JA-W05-hon-kanji",
+        "JA-W05-gen-component",
+        "JA-W05-five-component",
+        "JA-W05-mouth-component",
+        "JA-W05-go-kanji",
+        "JA-C01-nihongo"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "japanese/narration/ch05.txt",
+      "json": "japanese/narration/ch05.json",
+      "textHash": "fnv1a64:7a1c67660ee7b849",
+      "jsonHash": "fnv1a64:ccecbd4aab2688d9"
+    },
+    {
+      "language": "japanese",
+      "chapter": 6,
+      "sourceHash": "fnv1a64:3c3914237ff34f56",
+      "lessonIds": [
+        "JA-W06-ko-katakana",
+        "JA-W06-long-mark",
+        "JA-W06-hi-katakana",
+        "JA-C01-koohii"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "japanese/narration/ch06.txt",
+      "json": "japanese/narration/ch06.json",
+      "textHash": "fnv1a64:209fe8f245728883",
+      "jsonHash": "fnv1a64:2190ee436a8e68c3"
+    },
+    {
+      "language": "japanese",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:0ab64e4757ca41cb",
+      "lessonIds": [
+        "JA-C01-practice"
+      ],
+      "voiceLessons": 1,
+      "drivablePrefix": 1,
+      "text": "japanese/narration/ch07.txt",
+      "json": "japanese/narration/ch07.json",
+      "textHash": "fnv1a64:1fea9cd630477599",
+      "jsonHash": "fnv1a64:7baffa779244b379"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
@@ -1,69 +1,34 @@
 {
   "language": "japanese",
-  "lessonCount": 29,
-  "atomMeasurableLessons": 29,
+  "lessonCount": 38,
+  "atomMeasurableLessons": 38,
   "atomMeasurementBlindLessons": 0,
   "durationViolations": 0,
   "atomLessonSpikes": 0,
-  "atomChapterSpikes": 1,
-  "glyphLessonSpikes": 4,
-  "scriptSystemSpikes": 5,
-  "scriptClosureViolations": 8,
-  "neverTaughtGlyphs": 21,
+  "atomChapterSpikes": 0,
+  "glyphLessonSpikes": 0,
+  "scriptSystemSpikes": 0,
+  "scriptClosureViolations": 0,
+  "neverTaughtGlyphs": 0,
   "orderDefects": 0,
   "lessonsWithoutSequence": 0,
   "unknownPrerequisites": 0,
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 0,
-  "atomsTaught": 39,
-  "atomsNeverRevisited": 8,
-  "reinforcementWindowMisses": 54,
+  "atomsTaught": 48,
+  "atomsNeverRevisited": 1,
+  "reinforcementWindowMisses": 0,
   "reinforcementMissesByWindow": {
-    "R1": 12,
-    "R2": 24,
-    "R3": 18,
+    "R1": 0,
+    "R2": 0,
+    "R3": 0,
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 28,
+  "writingPracticeLessons": 37,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
-  "findings": [
-    {
-      "language": "japanese",
-      "kind": "script-closure",
-      "count": 21,
-      "unit": "glyph(s)",
-      "detail": "teach every load-bearing glyph before asking the learner to decode it"
-    },
-    {
-      "language": "japanese",
-      "kind": "atom-step",
-      "count": 1,
-      "unit": "lesson/chapter spike(s)",
-      "detail": "split knowledge-atom spikes into smaller prerequisite-safe steps"
-    },
-    {
-      "language": "japanese",
-      "kind": "glyph-step",
-      "count": 9,
-      "unit": "lesson/system spike(s)",
-      "detail": "split new glyphs and writing systems across gentler steps"
-    },
-    {
-      "language": "japanese",
-      "kind": "reinforcement",
-      "count": 54,
-      "unit": "missed window(s)",
-      "detail": "add retrieval at the expanding R1-R4 intervals"
-    }
-  ],
-  "next": {
-    "language": "japanese",
-    "kind": "script-closure",
-    "count": 21,
-    "unit": "glyph(s)",
-    "detail": "teach every load-bearing glyph before asking the learner to decode it"
-  }
+  "findings": [],
+  "next": null
 }

--- a/code/learning/human-languages/core/lesson-modality/japanese.json
+++ b/code/learning/human-languages/core/lesson-modality/japanese.json
@@ -7,31 +7,31 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:fb35a9ffdc62b30e",
+  "sourceHash": "fnv1a64:a9f7c93c977af41a",
   "summary": {
-    "totalLessons": 29,
+    "totalLessons": 38,
     "voice": 1,
     "sight": 8,
-    "pen": 20,
+    "pen": 29,
     "drivableLessons": 1,
     "drivablePercent": 3,
     "trackCount": 1,
-    "chapterCount": 3,
-    "drivablePrefixTotal": 0,
-    "fullyDrivableChapters": 0,
-    "unstartableChapters": 3,
+    "chapterCount": 7,
+    "drivablePrefixTotal": 1,
+    "fullyDrivableChapters": 1,
+    "unstartableChapters": 6,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
   "tracks": [
     {
       "language": "japanese",
-      "lessonCount": 29,
+      "lessonCount": 38,
       "voice": 1,
       "sight": 8,
-      "pen": 20,
+      "pen": 29,
       "drivablePercent": 3,
-      "drivablePrefixTotal": 0,
+      "drivablePrefixTotal": 1,
       "modalities": [
         "voice",
         "sight",
@@ -40,25 +40,10 @@
       "chapters": [
         {
           "chapter": 1,
-          "lessonCount": 8,
-          "voice": 1,
-          "sight": 7,
-          "pen": 0,
-          "modalities": [
-            "voice",
-            "sight"
-          ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "JA-C01-hai",
-          "drivable": false,
-          "drivableLessonIds": []
-        },
-        {
-          "chapter": 2,
-          "lessonCount": 10,
+          "lessonCount": 6,
           "voice": 0,
-          "sight": 0,
-          "pen": 10,
+          "sight": 2,
+          "pen": 4,
           "modalities": [
             "sight",
             "pen"
@@ -69,11 +54,26 @@
           "drivableLessonIds": []
         },
         {
-          "chapter": 3,
-          "lessonCount": 11,
+          "chapter": 2,
+          "lessonCount": 7,
           "voice": 0,
           "sight": 1,
-          "pen": 10,
+          "pen": 6,
+          "modalities": [
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "JA-W01-ko",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 3,
+          "lessonCount": 8,
+          "voice": 0,
+          "sight": 1,
+          "pen": 7,
           "modalities": [
             "sight",
             "pen"
@@ -82,97 +82,169 @@
           "firstNonVoiceLesson": "JA-W03-a",
           "drivable": false,
           "drivableLessonIds": []
+        },
+        {
+          "chapter": 4,
+          "lessonCount": 5,
+          "voice": 0,
+          "sight": 2,
+          "pen": 3,
+          "modalities": [
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "JA-W03-sa",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 5,
+          "lessonCount": 7,
+          "voice": 0,
+          "sight": 1,
+          "pen": 6,
+          "modalities": [
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "JA-W05-nichi-kanji",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 6,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 1,
+          "pen": 3,
+          "modalities": [
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "JA-W06-ko-katakana",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 7,
+          "lessonCount": 1,
+          "voice": 1,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "JA-C01-practice"
+          ]
         }
       ]
     }
   ],
   "lessons": [
     {
-      "id": "JA-C01-hai",
+      "id": "JA-W01-i",
       "language": "japanese",
       "chapter": 1,
       "sequence": 10,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
+        "writing-type",
         "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:9e35a70226961635",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a7e27e6bcc99c599",
       "detachableSegments": [
-        "Script — two signs, two beats"
-      ]
+        "Script — the shape"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-C01-iie",
+      "id": "JA-W01-ha",
       "language": "japanese",
       "chapter": 1,
       "sequence": 20,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type",
+        "script-block",
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:48f5d1d0cb381ae2",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:92334fa860a65c08",
       "detachableSegments": [
-        "Script — one new sign, three beats"
-      ]
+        "Script — the shape"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-C01-konnichiwa",
+      "id": "JA-W01-hai-read",
       "language": "japanese",
       "chapter": 1,
       "sequence": 30,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
-        "script-block"
+        "writing-type",
+        "script-block",
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "sight-cue"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:a5f03af3d9b83495",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:d8ad87d72773e6a9",
       "detachableSegments": [
-        "Script — four new signs, and one you know"
-      ]
+        "Script — no new sign at all"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-C01-nihongo",
+      "id": "JA-W01-e",
       "language": "japanese",
       "chapter": 1,
       "sequence": 40,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
+        "writing-type",
         "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:30364ffdc03370b8",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:dcd8c95cde4d1310",
       "detachableSegments": [
-        "Script — kanji, and the readings problem"
-      ]
+        "Script — the shape"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-C01-koohii",
+      "id": "JA-C01-hai",
       "language": "japanese",
       "chapter": 1,
       "sequence": 50,
@@ -187,13 +259,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9d562bfdb6016d62",
+      "sourceHash": "fnv1a64:02e5572b856c1fa3",
       "detachableSegments": [
-        "Script — katakana, the borrowed-word script"
+        "Script — two signs, two beats"
       ]
     },
     {
-      "id": "JA-C01-arigatou",
+      "id": "JA-C01-iie",
       "language": "japanese",
       "chapter": 1,
       "sequence": 60,
@@ -208,52 +280,59 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1ff00726c195b8ce",
+      "sourceHash": "fnv1a64:be3de3c917443851",
       "detachableSegments": [
-        "Script — five signs and two small strokes"
+        "Script — one new sign, three beats"
       ]
     },
     {
-      "id": "JA-C01-gozaimasu",
+      "id": "JA-W01-ko",
       "language": "japanese",
-      "chapter": 1,
+      "chapter": 2,
       "sequence": 70,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
+        "writing-type",
         "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:a6d37ece38604436",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:b3833ba98c8971d6",
       "detachableSegments": [
-        "Script — five more signs, two of them dakuten"
-      ]
+        "Script — the shape"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-C01-practice",
+      "id": "JA-W01-n",
       "language": "japanese",
-      "chapter": 1,
+      "chapter": 2,
       "sequence": 80,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:fd0c2e1120a75440"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:88cd192cbab594e7",
+      "detachableSegments": [
+        "Script — the shape, and the exception"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "JA-W01-i",
+      "id": "JA-W01-ni",
       "language": "japanese",
       "chapter": 2,
       "sequence": 90,
@@ -269,14 +348,14 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:536c9f5fc624cc79",
+      "sourceHash": "fnv1a64:f9dc84723290cf6f",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-ha",
+      "id": "JA-W01-chi",
       "language": "japanese",
       "chapter": 2,
       "sequence": 100,
@@ -285,22 +364,21 @@
       "drivable": false,
       "reasons": [
         "writing-type",
-        "script-block",
-        "sight-cue"
+        "script-block"
       ],
       "coreModality": "pen",
       "coreReasons": [
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:319589a1fed4234f",
+      "sourceHash": "fnv1a64:34105778555f9a1c",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-hai-read",
+      "id": "JA-W01-wa",
       "language": "japanese",
       "chapter": 2,
       "sequence": 110,
@@ -309,23 +387,21 @@
       "drivable": false,
       "reasons": [
         "writing-type",
-        "script-block",
-        "sight-cue"
+        "script-block"
       ],
       "coreModality": "pen",
       "coreReasons": [
-        "writing-type",
-        "sight-cue"
+        "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:66f8ba352205ee5c",
+      "sourceHash": "fnv1a64:804f900a0f4a5619",
       "detachableSegments": [
-        "Script — no new sign at all"
+        "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-e",
+      "id": "JA-W01-konnichiwa-read",
       "language": "japanese",
       "chapter": 2,
       "sequence": 120,
@@ -341,39 +417,37 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:3794174c4b117901",
+      "sourceHash": "fnv1a64:1ec9c3e62e816050",
       "detachableSegments": [
-        "Script — the shape"
+        "Script — the assembly"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-ko",
+      "id": "JA-C01-konnichiwa",
       "language": "japanese",
       "chapter": 2,
       "sequence": 130,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type",
         "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:149060678bc7599f",
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e055b19edfbe2dd0",
       "detachableSegments": [
-        "Script — the shape"
-      ],
-      "delivery": "script"
+        "Script — five familiar signs"
+      ]
     },
     {
-      "id": "JA-W01-n",
+      "id": "JA-W03-a",
       "language": "japanese",
-      "chapter": 2,
+      "chapter": 3,
       "sequence": 140,
       "modality": "pen",
       "derived": "pen",
@@ -387,16 +461,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:f5495df027a5bdc1",
+      "sourceHash": "fnv1a64:8215b0106d85d878",
       "detachableSegments": [
-        "Script — the shape, and the exception"
+        "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-ni",
+      "id": "JA-W03-ri",
       "language": "japanese",
-      "chapter": 2,
+      "chapter": 3,
       "sequence": 150,
       "modality": "pen",
       "derived": "pen",
@@ -410,16 +484,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:07a76c17b5fc2d4d",
+      "sourceHash": "fnv1a64:aaa2265c474bc377",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-chi",
+      "id": "JA-W03-ka",
       "language": "japanese",
-      "chapter": 2,
+      "chapter": 3,
       "sequence": 160,
       "modality": "pen",
       "derived": "pen",
@@ -433,16 +507,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:35697da6506e00f6",
+      "sourceHash": "fnv1a64:dd39d35f40faff27",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-wa",
+      "id": "JA-W03-dakuten",
       "language": "japanese",
-      "chapter": 2,
+      "chapter": 3,
       "sequence": 170,
       "modality": "pen",
       "derived": "pen",
@@ -456,16 +530,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:20c37ccc88f42958",
+      "sourceHash": "fnv1a64:fca3eb6654e313a2",
       "detachableSegments": [
-        "Script — the shape"
+        "Script — the mark"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W01-konnichiwa-read",
+      "id": "JA-W03-to",
       "language": "japanese",
-      "chapter": 2,
+      "chapter": 3,
       "sequence": 180,
       "modality": "pen",
       "derived": "pen",
@@ -479,14 +553,14 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:a793162b6bbde88b",
+      "sourceHash": "fnv1a64:c92d1840828e1feb",
       "detachableSegments": [
-        "Script — the assembly"
+        "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-a",
+      "id": "JA-W03-u",
       "language": "japanese",
       "chapter": 3,
       "sequence": 190,
@@ -502,14 +576,14 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:9fb48f537aa8a915",
+      "sourceHash": "fnv1a64:95b897c6b964299f",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-ri",
+      "id": "JA-W03-arigatou-read",
       "language": "japanese",
       "chapter": 3,
       "sequence": 200,
@@ -525,39 +599,37 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:5caa787ea1875f95",
+      "sourceHash": "fnv1a64:a4649118286c6353",
       "detachableSegments": [
-        "Script — the shape"
+        "Script — the assembly"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-ka",
+      "id": "JA-C01-arigatou",
       "language": "japanese",
       "chapter": 3,
       "sequence": 210,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type",
         "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:6f3edd66798c67f7",
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d8f0b0bb450a2f2b",
       "detachableSegments": [
-        "Script — the shape"
-      ],
-      "delivery": "script"
+        "Script — five signs and two small strokes"
+      ]
     },
     {
-      "id": "JA-W03-dakuten",
+      "id": "JA-W03-sa",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 4,
       "sequence": 220,
       "modality": "pen",
       "derived": "pen",
@@ -571,16 +643,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:d9f194e131fd2166",
+      "sourceHash": "fnv1a64:264f3f50b7fc0641",
       "detachableSegments": [
-        "Script — the mark"
+        "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-to",
+      "id": "JA-W03-ma",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 4,
       "sequence": 230,
       "modality": "pen",
       "derived": "pen",
@@ -594,16 +666,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:38088b8286fa102a",
+      "sourceHash": "fnv1a64:de01d0ac381949a8",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-u",
+      "id": "JA-W03-su",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 4,
       "sequence": 240,
       "modality": "pen",
       "derived": "pen",
@@ -617,62 +689,58 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:eb053cfd07df4fd1",
+      "sourceHash": "fnv1a64:384ca3ef601b4442",
       "detachableSegments": [
         "Script — the shape"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-arigatou-read",
+      "id": "JA-C01-gozaimasu",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 4,
       "sequence": 250,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type",
         "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:605a237f83ea2d81",
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7efc64215810c473",
       "detachableSegments": [
-        "Script — the assembly"
-      ],
-      "delivery": "script"
+        "Script — five more signs, two of them dakuten"
+      ]
     },
     {
-      "id": "JA-W03-sa",
+      "id": "JA-C03-practice",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 4,
       "sequence": 260,
-      "modality": "pen",
-      "derived": "pen",
+      "modality": "sight",
+      "derived": "sight",
       "drivable": false,
       "reasons": [
-        "writing-type",
         "script-block"
       ],
-      "coreModality": "pen",
+      "coreModality": "voice",
       "coreReasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:f00367d39fd8befa",
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a9923606008ef393",
       "detachableSegments": [
-        "Script — the shape"
-      ],
-      "delivery": "script"
+        "Script — the second half"
+      ]
     },
     {
-      "id": "JA-W03-ma",
+      "id": "JA-W05-nichi-kanji",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 5,
       "sequence": 270,
       "modality": "pen",
       "derived": "pen",
@@ -686,16 +754,16 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:ea2d765801bc327c",
+      "sourceHash": "fnv1a64:bc9bcf20c5b9db2d",
       "detachableSegments": [
-        "Script — the shape"
+        "Script — build the sun"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-W03-su",
+      "id": "JA-W05-hon-kanji",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 5,
       "sequence": 280,
       "modality": "pen",
       "derived": "pen",
@@ -709,17 +777,109 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:0610ff38f0840af8",
+      "sourceHash": "fnv1a64:f410753d9ac7e65a",
       "detachableSegments": [
-        "Script — the shape"
+        "Script — five strokes"
       ],
       "delivery": "script"
     },
     {
-      "id": "JA-C03-practice",
+      "id": "JA-W05-gen-component",
       "language": "japanese",
-      "chapter": 3,
+      "chapter": 5,
       "sequence": 290,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4566d09ba88a8331",
+      "detachableSegments": [
+        "Script — one component, not a whole word yet"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W05-five-component",
+      "language": "japanese",
+      "chapter": 5,
+      "sequence": 300,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4106b4605705810f",
+      "detachableSegments": [
+        "Script — the top-right piece"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W05-mouth-component",
+      "language": "japanese",
+      "chapter": 5,
+      "sequence": 310,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:41e23e2b05cdd380",
+      "detachableSegments": [
+        "Script — the lower-right piece"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W05-go-kanji",
+      "language": "japanese",
+      "chapter": 5,
+      "sequence": 320,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a182967052442c0a",
+      "detachableSegments": [
+        "Script — three known blocks become one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-C01-nihongo",
+      "language": "japanese",
+      "chapter": 5,
+      "sequence": 330,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -731,10 +891,118 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:dcf1861ce20f29aa",
+      "sourceHash": "fnv1a64:89902cbc7dd1c0ae",
       "detachableSegments": [
-        "Script — the second half"
+        "Script — kanji, and the readings problem"
       ]
+    },
+    {
+      "id": "JA-W06-ko-katakana",
+      "language": "japanese",
+      "chapter": 6,
+      "sequence": 340,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0837ed70d3aa6bef",
+      "detachableSegments": [
+        "Script — two angular strokes"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W06-long-mark",
+      "language": "japanese",
+      "chapter": 6,
+      "sequence": 350,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:aedcf8d8d8a26aee",
+      "detachableSegments": [
+        "Script — length lives on the page"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W06-hi-katakana",
+      "language": "japanese",
+      "chapter": 6,
+      "sequence": 360,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:73a7c60d0b4e494b",
+      "detachableSegments": [
+        "Script — the last new shape"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-C01-koohii",
+      "language": "japanese",
+      "chapter": 6,
+      "sequence": 370,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5fb6b46583ca9190",
+      "detachableSegments": [
+        "Script — katakana, the borrowed-word script"
+      ]
+    },
+    {
+      "id": "JA-C01-practice",
+      "language": "japanese",
+      "chapter": 7,
+      "sequence": 380,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0e4c71783a8a05b5"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/japanese/CHANGELOG.md
+++ b/code/learning/human-languages/japanese/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Japanese curriculum track are recorded here.
 
 ## [Unreleased]
 
+### Changed — script closure before decoding (#12471)
+
+- Reordered the 29 existing lessons so every hiragana writing step precedes the
+  word that asks the learner to decode it; the old content-first order is gone.
+- Split the starter into seven small chapters, keeping hiragana, kanji, and
+  katakana arrivals separate and moving the four-skill doorway exchange to the
+  end of the runway.
+- Added nine <=5-minute writing lessons: `日`, `本`, three components and the
+  assembled `語`, followed by `コ`, the long-vowel mark `ー`, and `ヒ`.
+- Rewrote advanced etymology and keigo examples in romanization so fifteen rare
+  or unrelated signs no longer become accidental pre-A1 decoding tests.
+- Replaced the stale eight-session map with the complete 38-session authored
+  order and its machine-checked review rule.
+
 ### Added — cumulative pre-A1 writing evidence (#12365)
 
 - Turned four already gentle Chapter 2 lessons into an explicit cumulative

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -19,7 +19,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- eight short lessons in one cumulative chapter.\par}
+  {\large Starter edition --- thirty-eight short lessons in seven cumulative chapters.\par}
   \vspace{2cm}
   {\normalsize
     Copyright \copyright\ Adhithya Rajasekaran. Licensed under
@@ -37,17 +37,15 @@ only the writing that expression needs, explains where the word came from, and
 ends with a short retrieval prompt. There is no kana chart to memorise first.
 
 Japanese uses three writing systems at the same time, and an ordinary sentence
-contains all three. \emph{Hiragana} carries the grammar, \emph{kanji} carry the
-content words, and \emph{katakana} marks words borrowed from outside. This
-edition therefore opens all three in its first chapter rather than finishing one
-before starting the next, because no real sentence waits for you to.
+can contain all three. \emph{Hiragana} carries much of the grammar, \emph{kanji}
+carry many content words, and \emph{katakana} commonly marks words borrowed from
+outside. This edition introduces them in that order. Every load-bearing sign gets
+its own short lesson before a word asks you to decode it.
 
-Two habits are worth forming immediately. First, count beats. Every written kana
-is one beat of equal length, and length changes meaning: \ja{いえ} is a house,
-\ja{いいえ} is ``no''. Second, expect a kanji to have several readings. The
-character \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or
-\emph{ka} depending on the word it stands in, so this book always teaches the
-reading a word uses rather than pretending a character has one sound.
+Two habits are worth forming immediately. First, count beats: every kana carries
+one mora, and vowel length matters. Second, expect a kanji to have several
+readings. This book therefore teaches one sign, one relevant reading, and one
+useful word at a time rather than pretending a character has one fixed sound.
 
 Romanization stands beside the Japanese here and will fade in later editions.
 Where a lesson is teaching beat count it also spells a word out beat by beat,
@@ -69,6 +67,10 @@ are used. Nothing else is.
 \input{chapters/ch01-three-scripts}
 \input{chapters/ch02-hiragana-eight}
 \input{chapters/ch03-thanks}
+\input{chapters/ch04-polite-thanks}
+\input{chapters/ch05-nihongo-kanji}
+\input{chapters/ch06-koohii-katakana}
+\input{chapters/ch07-doorway-exchange}
 
 \backmatter
 
@@ -80,9 +82,9 @@ are used. Nothing else is.
 \addcontentsline{toc}{chapter}{Sources for this starter edition}
 
 Word histories follow Wiktionary's Japanese entries for
-\href{https://en.wiktionary.org/wiki/\%E3\%81\%AF\%E3\%81\%84}{\ja{はい}},
-\href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%AF}{\ja{今日は}},
-\href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{\ja{有難う}},
+\href{https://en.wiktionary.org/wiki/\%E3\%81\%AF\%E3\%81\%84}{hai},
+\href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%AF}{konnichiwa},
+\href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{arigatou},
 and
 \href{https://en.wiktionary.org/wiki/\%E3\%82\%B3\%E3\%83\%BC\%E3\%83\%92\%E3\%83\%BC}{\ja{コーヒー}}.
 The companion Markdown lessons carry the per-lesson citations and are the

--- a/code/learning/human-languages/japanese/book/chapter-modalities.tex
+++ b/code/learning/human-languages/japanese/book/chapter-modalities.tex
@@ -30,21 +30,49 @@
 
 \expandafter\def\csname hlchaptermodality1\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (7)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 8 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (2) \quad \hlpensign{}~\textbf{pen} (4)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 6 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality2\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlpensign{}~\textbf{pen} (10)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 10 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (6)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 7 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality3\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (10)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} none of the 11 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (7)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 8 lessons.%
+    \par}\medskip
+}
+
+\expandafter\def\csname hlchaptermodality4\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (2) \quad \hlpensign{}~\textbf{pen} (3)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 5 lessons.%
+    \par}\medskip
+}
+
+\expandafter\def\csname hlchaptermodality5\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (6)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 7 lessons.%
+    \par}\medskip
+}
+
+\expandafter\def\csname hlchaptermodality6\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (3)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} none of the 4 lessons.%
+    \par}\medskip
+}
+
+\expandafter\def\csname hlchaptermodality7\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} all 1 lesson.%
     \par}\medskip
 }

--- a/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 29
+% canonical-activities: 38
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -11,112 +11,82 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-C01-hai-beats}{\textbf{1.1}} \emph{\ja{はい} — yes, in two equal beats}\par
+\hypertarget{review-JA-W01-i-strokes}{\textbf{1.1}} \emph{\ja{い} — two strokes, one beat}\par
+\small How many strokes does the hiragana sign for 'i' have?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W01-ha-strokes}{\textbf{1.2}} \emph{\ja{は} — three strokes}\par
+\small How many strokes does the hiragana sign read 'ha' have?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W01-hai-read-beats}{\textbf{1.3}} \emph{Two signs, side by side — and a word appears}\par
+\small How many beats does the written sequence \ja{はい} take?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W01-e-beats}{\textbf{1.4}} \emph{\ja{え} — two strokes, and a second word for free}\par
+\small Write the final sign in i-i-e, then count the three visible beats.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-hai-beats}{\textbf{1.5}} \emph{\ja{はい} — yes, in two equal beats}\par
 \small Write the Japanese word for 'yes' in hiragana.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-C01-iie-length}{\textbf{1.2}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
+\hypertarget{review-JA-C01-iie-length}{\textbf{1.6}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
 \small How many beats (morae) does \ja{いいえ} hold?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-konnichiwa-particle}{\textbf{1.3}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
-\small The greeting ends in the sign \ja{は}. How is it pronounced there?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-nihongo-readings}{\textbf{1.4}} \emph{\ja{日本語} — three characters, and no single sound each}\par
-\small How is the character \ja{日} read inside \ja{日本語}?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-koohii-bar}{\textbf{1.5}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
-\small What does the bar \ja{ー} do in \ja{コーヒー}?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-arigatou-dakuten}{\textbf{1.6}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
-\small Which hiragana sign becomes \ja{が} when the dakuten is added?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-gozaimasu-level}{\textbf{1.7}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
-\small You are thanking a shop assistant you have never met. Which form do you use?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-C01-practice-final-line}{\textbf{1.8}} \emph{Practice — one daytime exchange, three scripts}\par
-\small Someone has just thanked you politely. Give the modest one-word reply this chapter taught.
 \end{minipage}\par\medskip
 
 \section*{Chapter 2}
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-i-strokes}{\textbf{2.1}} \emph{\ja{い} — two strokes, one beat}\par
-\small How many strokes does the hiragana sign for 'i' have?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-W01-ha-strokes}{\textbf{2.2}} \emph{\ja{は} — three strokes}\par
-\small How many strokes does the hiragana sign read 'ha' have?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-W01-hai-read-beats}{\textbf{2.3}} \emph{Two signs, side by side — and a word appears}\par
-\small How many beats (morae) does the written word for 'yes' take?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-W01-e-beats}{\textbf{2.4}} \emph{\ja{え} — two strokes, and a second word for free}\par
-\small How many beats (morae) does the written word for 'no' take?
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hypertarget{review-JA-W01-ko-strokes}{\textbf{2.5}} \emph{\ja{こ} — two strokes, and the greeting begins}\par
+\hypertarget{review-JA-W01-ko-strokes}{\textbf{2.1}} \emph{\ja{こ} — two strokes, and the greeting begins}\par
 \small How many strokes does the hiragana sign read 'ko' have?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-n-vowel}{\textbf{2.6}} \emph{\ja{ん} — one stroke, one beat, no vowel}\par
+\hypertarget{review-JA-W01-n-vowel}{\textbf{2.2}} \emph{\ja{ん} — one stroke, one beat, no vowel}\par
 \small Which vowel does this sign carry?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-ni-shared}{\textbf{2.7}} \emph{\ja{に} — three strokes, and a shape you half know}\par
+\hypertarget{review-JA-W01-ni-shared}{\textbf{2.3}} \emph{\ja{に} — three strokes, and a shape you half know}\par
 \small Two signs so far share a similar left-hand vertical. Does that shared shape tell you anything about their sound or meaning?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-chi-beats}{\textbf{2.8}} \emph{\ja{ち} — two strokes, four roman letters, one beat}\par
+\hypertarget{review-JA-W01-chi-beats}{\textbf{2.4}} \emph{\ja{ち} — two strokes, four roman letters, one beat}\par
 \small This sign is romanised with four letters. How many beats does it take?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-wa-particle}{\textbf{2.9}} \emph{\ja{わ} — the sign for \emph{wa}, and the trap beside it}\par
+\hypertarget{review-JA-W01-wa-particle}{\textbf{2.5}} \emph{\ja{わ} — the sign for \emph{wa}, and the trap beside it}\par
 \small The daytime greeting ends in a sound like 'wa'. Is it written with the sign for wa, or the sign for ha?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W01-konnichiwa-read-beats}{\textbf{2.10}} \emph{Five signs in a row — and the greeting is readable}\par
+\hypertarget{review-JA-W01-konnichiwa-read-beats}{\textbf{2.6}} \emph{Five signs in a row — and the greeting is readable}\par
 \small How many beats (morae) does the written daytime greeting take?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-konnichiwa-particle}{\textbf{2.7}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
+\small The greeting ends in the sign \ja{は}. How is it pronounced there?
 \end{minipage}\par\medskip
 
 \section*{Chapter 3}
@@ -165,26 +135,118 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W03-sa-za}{\textbf{3.8}} \emph{\ja{さ} — two strokes, and the ticks work here too}\par
+\hypertarget{review-JA-C01-arigatou-dakuten}{\textbf{3.8}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
+\small Which hiragana sign becomes \ja{が} when the dakuten is added?
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W03-sa-za}{\textbf{4.1}} \emph{\ja{さ} — two strokes, and the ticks work here too}\par
 \small What does the sign read 'sa' become when the dakuten is added?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W03-ma-strokes}{\textbf{3.9}} \emph{\ja{ま} — three strokes, and a loop you have drawn before}\par
+\hypertarget{review-JA-W03-ma-strokes}{\textbf{4.2}} \emph{\ja{ま} — three strokes, and a loop you have drawn before}\par
 \small How many strokes does the hiragana sign read 'ma' have?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-W03-su-devoice}{\textbf{3.10}} \emph{\ja{す} — two strokes, and a vowel you barely hear}\par
+\hypertarget{review-JA-W03-su-devoice}{\textbf{4.3}} \emph{\ja{す} — two strokes, and a vowel you barely hear}\par
 \small At the end of gozaimasu, what happens to the final u?
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hypertarget{review-JA-C03-practice-ticks}{\textbf{3.11}} \emph{Practice — the whole thank-you, off the page}\par
+\hypertarget{review-JA-C01-gozaimasu-level}{\textbf{4.4}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
+\small You are thanking a shop assistant you have never met. Which form do you use?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C03-practice-ticks}{\textbf{4.5}} \emph{Practice — the whole thank-you, off the page}\par
 \small In \ja{ありがとうございます}, how many signs are an earlier sign plus the dakuten?
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-nichi-kanji-four-strokes}{\textbf{5.1}} \emph{\ja{日} — one sun, four strokes}\par
+\small Write the four-stroke kanji read nichi in the word for Japanese.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-hon-kanji-root-mark}{\textbf{5.2}} \emph{\ja{本} — a tree with its root marked}\par
+\small Write the kanji read hon. Which stroke marks the root?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-gen-component-speech-side}{\textbf{5.3}} \emph{\ja{言} — build the speech side first}\par
+\small Write the component that will sit on the left of the kanji for language.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-five-component-four-strokes}{\textbf{5.4}} \emph{\ja{五} — four strokes for the sound side}\par
+\small Write the four-stroke component that cues go in the kanji for language.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-mouth-component-close-box}{\textbf{5.5}} \emph{\ja{口} — close a box in three strokes}\par
+\small Write the three-stroke mouth component that sits under \ja{五}.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W05-go-kanji-three-blocks}{\textbf{5.6}} \emph{\ja{語} — assemble; do not memorise fourteen loose strokes}\par
+\small Build the kanji read go, language, from the three blocks you know.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-nihongo-readings}{\textbf{5.7}} \emph{\ja{日本語} — three characters, and no single sound each}\par
+\small How is the character \ja{日} read inside \ja{日本語}?
+\end{minipage}\par\medskip
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W06-ko-katakana-ko}{\textbf{6.1}} \emph{\ja{コ} — same sound, a new script}\par
+\small Write ko in katakana, the script used for the borrowed word coffee.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W06-long-mark-beat}{\textbf{6.2}} \emph{\ja{ー} — one line, one extra beat}\par
+\small Add the katakana long-vowel mark to \ja{コ} so it reads kō.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W06-hi-katakana-two-strokes}{\textbf{6.3}} \emph{\ja{ヒ} — two strokes complete the inventory}\par
+\small Write hi in katakana, then place it after \ja{コー}.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-koohii-bar}{\textbf{6.4}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
+\small What does the bar \ja{ー} do in \ja{コーヒー}?
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-practice-four-skills}{\textbf{7.1}} \emph{Practice — one daytime exchange, three scripts}\par
+\small From sound alone, write nihongo in its three kanji. Then take B's part in the doorway exchange without notes.
 \end{minipage}\par\medskip
 
 \chapter*{Answer Key}
@@ -197,130 +259,95 @@ The first response is the canonical display answer. When a question accepts othe
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-C01-hai-beats}{\textbf{1.1}} \emph{\ja{はい} — yes, in two equal beats}\par
-\small \textbf{Answer:} \ja{はい}\par
-\footnotesize \textbf{Also accepted:} hai; ha-i
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-iie-length}{\textbf{1.2}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
-\small \textbf{Answer:} three\par
-\footnotesize \textbf{Also accepted:} 3; three beats; three morae
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-konnichiwa-particle}{\textbf{1.3}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
-\small \textbf{Answer:} wa\par
-\footnotesize \textbf{Also accepted:} as wa; \ja{わ}; the topic particle wa
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-nihongo-readings}{\textbf{1.4}} \emph{\ja{日本語} — three characters, and no single sound each}\par
-\small \textbf{Answer:} ni\par
-\footnotesize \textbf{Also accepted:} as ni; \ja{に}; read ni
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-koohii-bar}{\textbf{1.5}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
-\small \textbf{Answer:} it holds the vowel for one more beat\par
-\footnotesize \textbf{Also accepted:} lengthens the vowel; long vowel; it lengthens the previous vowel; adds a beat to the vowel
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-arigatou-dakuten}{\textbf{1.6}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
-\small \textbf{Answer:} \ja{か}\par
-\footnotesize \textbf{Also accepted:} ka; \ja{か} ka
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-gozaimasu-level}{\textbf{1.7}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
-\small \textbf{Answer:} \ja{ありがとうございます}\par
-\footnotesize \textbf{Also accepted:} arigato gozaimasu; arigatou gozaimasu; arigatō gozaimasu; the polite one
-\end{minipage}\par\medskip
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-C01-practice-final-line}{\textbf{1.8}} \emph{Practice — one daytime exchange, three scripts}\par
-\small \textbf{Answer:} \ja{いいえ}\par
-\footnotesize \textbf{Also accepted:} iie; no; not at all
-\end{minipage}\par\medskip
-
-\section*{Chapter 2}
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\hyperlink{review-JA-W01-i-strokes}{\textbf{2.1}} \emph{\ja{い} — two strokes, one beat}\par
+\hyperlink{review-JA-W01-i-strokes}{\textbf{1.1}} \emph{\ja{い} — two strokes, one beat}\par
 \small \textbf{Answer:} 2\par
 \footnotesize \textbf{Also accepted:} two; 2 strokes; two strokes
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-ha-strokes}{\textbf{2.2}} \emph{\ja{は} — three strokes}\par
+\hyperlink{review-JA-W01-ha-strokes}{\textbf{1.2}} \emph{\ja{は} — three strokes}\par
 \small \textbf{Answer:} 3\par
 \footnotesize \textbf{Also accepted:} three; 3 strokes; three strokes
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-hai-read-beats}{\textbf{2.3}} \emph{Two signs, side by side — and a word appears}\par
+\hyperlink{review-JA-W01-hai-read-beats}{\textbf{1.3}} \emph{Two signs, side by side — and a word appears}\par
 \small \textbf{Answer:} 2\par
 \footnotesize \textbf{Also accepted:} two; 2 beats; two beats
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-e-beats}{\textbf{2.4}} \emph{\ja{え} — two strokes, and a second word for free}\par
-\small \textbf{Answer:} 3\par
-\footnotesize \textbf{Also accepted:} three; 3 beats; three beats
+\hyperlink{review-JA-W01-e-beats}{\textbf{1.4}} \emph{\ja{え} — two strokes, and a second word for free}\par
+\small \textbf{Answer:} \ja{え}; 3\par
+\footnotesize \textbf{Also accepted:} \ja{え}; \ja{え}, three; e; 3
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-ko-strokes}{\textbf{2.5}} \emph{\ja{こ} — two strokes, and the greeting begins}\par
+\hyperlink{review-JA-C01-hai-beats}{\textbf{1.5}} \emph{\ja{はい} — yes, in two equal beats}\par
+\small \textbf{Answer:} \ja{はい}\par
+\footnotesize \textbf{Also accepted:} hai; ha-i
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-iie-length}{\textbf{1.6}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
+\small \textbf{Answer:} three\par
+\footnotesize \textbf{Also accepted:} 3; three beats; three morae
+\end{minipage}\par\medskip
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W01-ko-strokes}{\textbf{2.1}} \emph{\ja{こ} — two strokes, and the greeting begins}\par
 \small \textbf{Answer:} 2\par
 \footnotesize \textbf{Also accepted:} two; 2 strokes; two strokes
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-n-vowel}{\textbf{2.6}} \emph{\ja{ん} — one stroke, one beat, no vowel}\par
+\hyperlink{review-JA-W01-n-vowel}{\textbf{2.2}} \emph{\ja{ん} — one stroke, one beat, no vowel}\par
 \small \textbf{Answer:} none\par
 \footnotesize \textbf{Also accepted:} no vowel; not any; it has none; nothing
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-ni-shared}{\textbf{2.7}} \emph{\ja{に} — three strokes, and a shape you half know}\par
+\hyperlink{review-JA-W01-ni-shared}{\textbf{2.3}} \emph{\ja{に} — three strokes, and a shape you half know}\par
 \small \textbf{Answer:} no\par
 \footnotesize \textbf{Also accepted:} none; it does not; nothing; no it does not
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-chi-beats}{\textbf{2.8}} \emph{\ja{ち} — two strokes, four roman letters, one beat}\par
+\hyperlink{review-JA-W01-chi-beats}{\textbf{2.4}} \emph{\ja{ち} — two strokes, four roman letters, one beat}\par
 \small \textbf{Answer:} 1\par
 \footnotesize \textbf{Also accepted:} one; one beat; 1 beat
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-wa-particle}{\textbf{2.9}} \emph{\ja{わ} — the sign for \emph{wa}, and the trap beside it}\par
+\hyperlink{review-JA-W01-wa-particle}{\textbf{2.5}} \emph{\ja{わ} — the sign for \emph{wa}, and the trap beside it}\par
 \small \textbf{Answer:} ha\par
 \footnotesize \textbf{Also accepted:} the ha sign; sign for ha; ha sign
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W01-konnichiwa-read-beats}{\textbf{2.10}} \emph{Five signs in a row — and the greeting is readable}\par
+\hyperlink{review-JA-W01-konnichiwa-read-beats}{\textbf{2.6}} \emph{Five signs in a row — and the greeting is readable}\par
 \small \textbf{Answer:} 5\par
 \footnotesize \textbf{Also accepted:} five; 5 beats; five beats
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-konnichiwa-particle}{\textbf{2.7}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
+\small \textbf{Answer:} wa\par
+\footnotesize \textbf{Also accepted:} as wa; \ja{わ}; the topic particle wa
 \end{minipage}\par\medskip
 
 \section*{Chapter 3}
@@ -376,28 +403,134 @@ The first response is the canonical display answer. When a question accepts othe
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W03-sa-za}{\textbf{3.8}} \emph{\ja{さ} — two strokes, and the ticks work here too}\par
+\hyperlink{review-JA-C01-arigatou-dakuten}{\textbf{3.8}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
+\small \textbf{Answer:} \ja{か}\par
+\footnotesize \textbf{Also accepted:} ka; \ja{か} ka
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W03-sa-za}{\textbf{4.1}} \emph{\ja{さ} — two strokes, and the ticks work here too}\par
 \small \textbf{Answer:} za\par
 \footnotesize \textbf{Also accepted:} \ja{ざ}; it becomes za
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W03-ma-strokes}{\textbf{3.9}} \emph{\ja{ま} — three strokes, and a loop you have drawn before}\par
+\hyperlink{review-JA-W03-ma-strokes}{\textbf{4.2}} \emph{\ja{ま} — three strokes, and a loop you have drawn before}\par
 \small \textbf{Answer:} 3\par
 \footnotesize \textbf{Also accepted:} three; 3 strokes; three strokes
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-W03-su-devoice}{\textbf{3.10}} \emph{\ja{す} — two strokes, and a vowel you barely hear}\par
+\hyperlink{review-JA-W03-su-devoice}{\textbf{4.3}} \emph{\ja{す} — two strokes, and a vowel you barely hear}\par
 \small \textbf{Answer:} it is devoiced\par
 \footnotesize \textbf{Also accepted:} it goes quiet; devoiced; you barely hear it; the voice drops out; it is almost silent
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\hyperlink{review-JA-C03-practice-ticks}{\textbf{3.11}} \emph{Practice — the whole thank-you, off the page}\par
+\hyperlink{review-JA-C01-gozaimasu-level}{\textbf{4.4}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
+\small \textbf{Answer:} \ja{ありがとうございます}\par
+\footnotesize \textbf{Also accepted:} arigato gozaimasu; arigatou gozaimasu; arigatō gozaimasu; the polite one
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C03-practice-ticks}{\textbf{4.5}} \emph{Practice — the whole thank-you, off the page}\par
 \small \textbf{Answer:} 3\par
 \footnotesize \textbf{Also accepted:} three; 3 signs; three signs; ga za and go; \ja{が} \ja{ご} \ja{ざ}
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-nichi-kanji-four-strokes}{\textbf{5.1}} \emph{\ja{日} — one sun, four strokes}\par
+\small \textbf{Answer:} \ja{日}\par
+\footnotesize \textbf{Also accepted:} \ja{日} (nichi); nichi
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-hon-kanji-root-mark}{\textbf{5.2}} \emph{\ja{本} — a tree with its root marked}\par
+\small \textbf{Answer:} \ja{本} — the final short horizontal stroke\par
+\footnotesize \textbf{Also accepted:} \ja{本}; the last stroke; the short bottom line; final horizontal
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-gen-component-speech-side}{\textbf{5.3}} \emph{\ja{言} — build the speech side first}\par
+\small \textbf{Answer:} \ja{言}\par
+\footnotesize \textbf{Also accepted:} \ja{言} (speech); the speech component
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-five-component-four-strokes}{\textbf{5.4}} \emph{\ja{五} — four strokes for the sound side}\par
+\small \textbf{Answer:} \ja{五}\par
+\footnotesize \textbf{Also accepted:} \ja{五} (go); go; five
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-mouth-component-close-box}{\textbf{5.5}} \emph{\ja{口} — close a box in three strokes}\par
+\small \textbf{Answer:} \ja{口}\par
+\footnotesize \textbf{Also accepted:} \ja{口} (mouth); the mouth box
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W05-go-kanji-three-blocks}{\textbf{5.6}} \emph{\ja{語} — assemble; do not memorise fourteen loose strokes}\par
+\small \textbf{Answer:} \ja{語} = \ja{言} + \ja{五} + \ja{口}\par
+\footnotesize \textbf{Also accepted:} \ja{語}; \ja{言} + \ja{五} + \ja{口}; \ja{言五口}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-nihongo-readings}{\textbf{5.7}} \emph{\ja{日本語} — three characters, and no single sound each}\par
+\small \textbf{Answer:} ni\par
+\footnotesize \textbf{Also accepted:} as ni; \ja{に}; read ni
+\end{minipage}\par\medskip
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W06-ko-katakana-ko}{\textbf{6.1}} \emph{\ja{コ} — same sound, a new script}\par
+\small \textbf{Answer:} \ja{コ}\par
+\footnotesize \textbf{Also accepted:} \ja{コ} (ko); katakana \ja{コ}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W06-long-mark-beat}{\textbf{6.2}} \emph{\ja{ー} — one line, one extra beat}\par
+\small \textbf{Answer:} \ja{コー}\par
+\footnotesize \textbf{Also accepted:} \ja{コ} \ja{ー}; kō; ko-o
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W06-hi-katakana-two-strokes}{\textbf{6.3}} \emph{\ja{ヒ} — two strokes complete the inventory}\par
+\small \textbf{Answer:} \ja{コーヒ}\par
+\footnotesize \textbf{Also accepted:} \ja{ヒ}; \ja{コー} \ja{ヒ}; katakana hi
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-koohii-bar}{\textbf{6.4}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
+\small \textbf{Answer:} it holds the vowel for one more beat\par
+\footnotesize \textbf{Also accepted:} lengthens the vowel; long vowel; it lengthens the previous vowel; adds a beat to the vowel
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-practice-four-skills}{\textbf{7.1}} \emph{Practice — one daytime exchange, three scripts}\par
+\small \textbf{Answer:} \ja{日本語}; \ja{こんにちは。はい。いいえ。}\par
+\footnotesize \textbf{Also accepted:} \ja{日本語}
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/japanese/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-glossary.tex
@@ -11,14 +11,14 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \raggedright
 \textbf{\ja{ありがとう}}\enspace\emph{arigatō}\par
 \small thank you (plain)\par
-\footnotesize Introduced in Chapter 1.
+\footnotesize Introduced in Chapter 3.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{ありがとうございます}}\enspace\emph{arigatō gozaimasu}\par
 \small thank you (polite)\par
-\footnotesize Introduced in Chapter 1.
+\footnotesize Introduced in Chapter 4.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -39,19 +39,19 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 \raggedright
 \textbf{\ja{コーヒー}}\enspace\emph{kōhī}\par
 \small coffee\par
-\footnotesize Introduced in Chapter 1.
+\footnotesize Introduced in Chapter 6.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{こんにちは}}\enspace\emph{konnichiwa}\par
 \small hello (daytime greeting)\par
-\footnotesize Introduced in Chapter 1.
+\footnotesize Introduced in Chapter 2.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{日本語}}\enspace\emph{nihongo}\par
 \small the Japanese language\par
-\footnotesize Introduced in Chapter 1.
+\footnotesize Introduced in Chapter 5.
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/japanese/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 30
-% canonical-index-entries: 30
+% canonical-index-candidates: 43
+% canonical-index-entries: 43
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -8,26 +8,26 @@
 
 Look up an English meaning, a dedicated language topic, or a chapter topic. Each linked reference opens the chapter where the material is introduced; the focus labels name only explicitly typed lesson sections.
 
+\section*{A}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{A Daytime Greeting, One Sign at a Time}\par
+\footnotesize chapter topic; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
+\end{minipage}\par\smallskip
+
 \section*{C}
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{coffee}\enspace\emph{\ja{コーヒー}}\enspace(kōhī)\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
-\end{minipage}\par\smallskip
-
-\section*{E}
-
-\noindent\begin{minipage}[t]{\linewidth}
-\raggedright
-\textbf{Eight Signs, and Three Words You Can Read}\par
-\footnotesize chapter topic; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-koohii-katakana]{Chapter~6, p.~\pageref*{ch:ja-koohii-katakana}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\textbf{Eight Signs, One Mark, and the Longest Word You Know}\par
-\footnotesize chapter topic; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\textbf{Coffee in Katakana, Three Shapes}\par
+\footnotesize chapter topic; \hyperref[ch:ja-koohii-katakana]{Chapter~6, p.~\pageref*{ch:ja-koohii-katakana}}
 \end{minipage}\par\smallskip
 
 \section*{F}
@@ -35,7 +35,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{Five signs in a row — and the greeting is readable}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \section*{H}
@@ -43,15 +43,35 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{hello (daytime greeting)}\enspace\emph{\ja{こんにちは}}\enspace(konnichiwa)\par
-\footnotesize explicit focus: script, grammar, usage and culture; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, grammar, usage and culture; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \section*{N}
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{Nihongo, Built in Small Blocks}\par
+\footnotesize chapter topic; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{no; not at all}\enspace\emph{\ja{いいえ}}\enspace(iie)\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
+\end{minipage}\par\smallskip
+
+\section*{P}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Plain Thanks, One Sign at a Time}\par
+\footnotesize chapter topic; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Polite Thanks, Three More Signs}\par
+\footnotesize chapter topic; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
 \end{minipage}\par\smallskip
 
 \section*{T}
@@ -59,37 +79,43 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{thank you (plain)}\enspace\emph{\ja{ありがとう}}\enspace(arigatō)\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{thank you (polite)}\enspace\emph{\ja{ありがとうございます}}\enspace(arigatō gozaimasu)\par
-\footnotesize explicit focus: script, grammar; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, grammar; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{The Doorway Exchange}\par
+\footnotesize chapter topic; \hyperref[ch:ja-doorway-exchange]{Chapter~7, p.~\pageref*{ch:ja-doorway-exchange}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{the Japanese language}\enspace\emph{\ja{日本語}}\enspace(nihongo)\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
-\textbf{Three Writing Systems in One Doorway}\par
-\footnotesize chapter topic; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\textbf{Two Answers, Sign by Sign}\par
+\footnotesize chapter topic; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{Two signs, side by side — and a word appears}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{゛}— two ticks, and every sign you know doubles}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \section*{Y}
@@ -97,7 +123,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{yes}\enspace\emph{\ja{はい}}\enspace(hai)\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-three-scripts]{Chapter~1, p.~\pageref*{ch:ja-three-scripts}}
+\footnotesize explicit focus: script, etymology; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \section*{Other}
@@ -105,101 +131,155 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{あ} — three strokes, and the thank-you begins}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{ありがとう} — no new sign, and a whole word}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{い} — two strokes, one beat}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{う} — two strokes, and a vowel that stretches}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{え} — two strokes, and a second word for free}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{か} — three strokes, and a shape you will reuse}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{こ} — two strokes, and the greeting begins}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{さ} — two strokes, and the ticks work here too}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{す} — two strokes, and a vowel you barely hear}\par
-\footnotesize script and writing topic; explicit focus: script, usage and culture; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script, usage and culture; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{ち} — two strokes, four roman letters, one beat}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{と} — two strokes, and they never meet}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{に} — three strokes, and a shape you half know}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{は} — three strokes}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{ま} — three strokes, and a loop you have drawn before}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{り} — two strokes, and a tap rather than an r}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-thanks]{Chapter~3, p.~\pageref*{ch:ja-thanks}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-plain-thanks]{Chapter~3, p.~\pageref*{ch:ja-plain-thanks}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{わ} — the sign for \emph{wa}, and the trap beside it}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{\ja{ん} — one stroke, one beat, no vowel}\par
-\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-hiragana-eight]{Chapter~2, p.~\pageref*{ch:ja-hiragana-eight}}
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{コ} — same sound, a new script}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-koohii-katakana]{Chapter~6, p.~\pageref*{ch:ja-koohii-katakana}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{ヒ} — two strokes complete the inventory}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-koohii-katakana]{Chapter~6, p.~\pageref*{ch:ja-koohii-katakana}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{ー} — one line, one extra beat}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-koohii-katakana]{Chapter~6, p.~\pageref*{ch:ja-koohii-katakana}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{五} — four strokes for the sound side}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{口} — close a box in three strokes}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{日} — one sun, four strokes}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{本} — a tree with its root marked}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{言} — build the speech side first}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{語} — assemble; do not memorise fourteen loose strokes}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-nihongo-kanji]{Chapter~5, p.~\pageref*{ch:ja-nihongo-kanji}}
 \end{minipage}\par\smallskip

--- a/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
@@ -1,17 +1,183 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:76726ad2b2b0b3b1
-% canonical-lessons: JA-C01-hai, JA-C01-iie, JA-C01-konnichiwa, JA-C01-nihongo, JA-C01-koohii, JA-C01-arigatou, JA-C01-gozaimasu, JA-C01-practice
+% canonical-source-hash: fnv1a64:72fc5234b7dceb5b
+% canonical-lessons: JA-W01-i, JA-W01-ha, JA-W01-hai-read, JA-W01-e, JA-C01-hai, JA-C01-iie
 
-\chapter{Three Writing Systems in One Doorway}
-\label{ch:ja-three-scripts}
+\chapter{Two Answers, Sign by Sign}
+\label{ch:ja-two-answers}
 \hlchaptermodality{1}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can greet someone in the daytime, answer yes or no, and thank them politely, reading each word in the script Japanese actually uses for it.}
+\textbf{By the end of this chapter:} \emph{I can write the three hiragana signs in \ja{はい} and \ja{いいえ}, read both answers without romanization, and say each with even mora timing.}
 
-A six-line daytime doorway exchange that mixes hiragana and kanji and uses no untaught word.
+A yes-or-no choice using only three signs the learner has already traced, copied, recalled, and read.
 \end{chapteropening}
 
+\section[i]{\ja{い} — two strokes, one beat}
+
+\label{lesson:JA-W01-i}
+
+
+
+\begin{quote}
+You already know the rule that makes this writing system easy: \textbf{one sign, one beat.} Not one letter one sound, and not one sign one word — one sign, one \textbf{mora}, the even beat Japanese counts time in.
+
+What you have not had yet is a single sign taught on its own. Here is the first.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{い}
+\end{quote}
+
+Two strokes, both falling, the left one long and the right one short:
+
+1. the \textbf{left} stroke — start high, come down, and hook gently to the right at the bottom 2. the \textbf{right} stroke — a short downward tick, higher up and clear of the first
+
+It is read \textbf{i}, the vowel of English \emph{machine} — short, tight, never the \emph{eye} of English \emph{bite}.
+
+\textbf{Where the shape came from, and why it does not help you.} Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen \textbf{for their sound}, not their meaning, so unlike a Chinese component there is nothing inside \ja{い} to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} follow the visible \ja{い} once — long stroke first, then the short tick
+  \item \emph{Say it:} \textbf{i}, one clean beat
+\end{itemize}
+
+Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many beats does one hiragana sign take? (\textbf{One.})
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
+\end{tcolorbox}
+\section[ha]{\ja{は} — three strokes}
+
+\label{lesson:JA-W01-ha}
+
+
+
+\begin{quote}
+Write the two-stroke sign you met a moment ago. Long stroke, short tick.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{は}
+\end{quote}
+
+Three strokes. Look at it as a tall left post with a loop tied on its right.
+
+1. the \textbf{vertical}, down the left side, with the smallest flick left at the foot 2. a \textbf{short horizontal} crossing that vertical near the top, on its right 3. the \textbf{loop} — down from the right of that crossbar, round to the left, and back up to close
+
+Read \textbf{ha}, breathed rather than hard: the \emph{h} of English \emph{hat}, then the open \emph{a} of \emph{father}.
+
+\textbf{It has a second reading, and you have already used it.} Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it \emph{sounds} like.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Copy:} keep \ja{は} visible and write it once — vertical, crossbar, loop
+  \item \emph{Say it:} \textbf{ha}, one beat, breath not force
+\end{itemize}
+
+Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
+
+\subsection*{Your turn — review pulse}
+Say ? and tap its one mora before adding another sign.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which stroke of \ja{は} is written first? (The \textbf{vertical} on the left.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
+\end{tcolorbox}
+\section[hai]{Two signs, side by side — and a word appears}
+
+\label{lesson:JA-W01-hai-read}
+
+
+
+\begin{quote}
+Both signs are yours. Look at them for five seconds:
+
+\begin{quote}
+\ja{は}   \ja{い}
+\end{quote}
+
+Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
+\end{quote}
+
+\subsection*{Script — no new sign at all}
+Now write them touching:
+
+\begin{quote}
+\textbf{\ja{は}} + \textbf{\ja{い}} $\to$ \textbf{\ja{はい}}
+\end{quote}
+
+\textbf{ha} then \textbf{i}. Two beats, even, neither one stressed. You can now decode the sequence \emph{hai}. The word lesson after the next sign attaches its useful meaning.
+
+\textbf{Nothing new was introduced in this lesson.} No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are \textbf{reading} it — assembling it out of two pieces you can write from memory and sound out in order.
+
+That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ja{はい}} — sound each sign in turn, do not recall the word whole
+  \item \emph{Write it:} \ja{はい} — five strokes in total, three then two
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many new strokes did you have to learn in this lesson? (\textbf{None.})
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
+\end{tcolorbox}
+\section[e]{\ja{え} — two strokes, and a second word for free}
+
+\label{lesson:JA-W01-e}
+
+
+
+\begin{quote}
+Read the word for \emph{yes} off the page, sign by sign, out loud.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{え}
+\end{quote}
+
+Two strokes, and the second one does most of the work:
+
+1. a \textbf{short tick} at the top, on its own, clear of everything below 2. the \textbf{body} — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement
+
+Read \textbf{e}, the vowel of English \emph{bed} — short, and never the \emph{ay} of \emph{day}.
+
+\begin{grammarlens}[title={What you've built}]
+Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:
+
+\begin{quote}
+\textbf{\ja{い}} | \textbf{\ja{い}} | \textbf{\ja{え}}
+\end{quote}
+
+\textbf{i-i-e.} Three beats — and note that the first sign is written \textbf{twice}, because Japanese counts two full beats there. The next lesson attaches its meaning. For now, the whole task is decoding three known signs in order.
+\end{grammarlens}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item Cover the printed \textbf{\ja{え}}. Have a partner or recording say \textbf{e} once. If you are working alone, read the romanized cue \emph{e}, cover it, and continue.
+  \item \emph{Write from the heard or romanized cue:} \ja{え} — tick first, then the body in one movement
+  \item \emph{Read it:} \textbf{\ja{い} | \ja{い} | \ja{え}} — three beats, and do not shorten the doubled sign
+\end{itemize}
+
+Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Why is the first sign of that word written twice? (Because it is \textbf{two beats}, not one held longer.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
+\end{tcolorbox}
 \section[hai]{\ja{はい} — yes, in two equal beats}
 
 \label{lesson:JA-C01-hai}
@@ -32,7 +198,7 @@ Japanese runs left to right. \textbf{\ja{はい}} is written with two signs of \
 Five vowels, and they stay pure: \emph{a} as in father, \emph{i} as in machine, then \emph{u}, \emph{e}, \emph{o}. So \textbf{\ja{はい}} is \emph{ha-i}, two beats of the same length, and not the single gliding sound of English \textquotedblleft{}high.\textquotedblright{}
 
 \begin{cousinweb}
-\textbf{\ja{はい}} means \textbf{yes}, and also \textquotedblleft{}here you are,\textquotedblright{} \textquotedblleft{}I am listening,\textquotedblright{} and \textquotedblleft{}present.\textquotedblright{} Its origin is genuinely unsettled: some accounts tie it to \ja{拝} \emph{hai}, \textquotedblleft{}a bow\textquotedblright{}; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact.
+\textbf{\ja{はい}} means \textbf{yes}, and also \textquotedblleft{}here you are,\textquotedblright{} \textquotedblleft{}I am listening,\textquotedblright{} and \textquotedblleft{}present.\textquotedblright{} Its origin is genuinely unsettled: some accounts tie it to an older word \emph{hai}, \textquotedblleft{}a bow\textquotedblright{}; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact. The rare kanji sometimes used in that proposal can wait until a later reading chapter.
 
 Say plainly what is true here. Japanese shares no ancestor with English, so no cousin word is waiting in your vocabulary to hold \textbf{\ja{はい}} in place. What this track offers instead is the writing itself, built up one sign at a time, and — later — the real family Japanese does have, through the characters it borrowed.
 \end{cousinweb}
@@ -81,240 +247,11 @@ Beat count is not decoration. \textbf{\ja{いえ}} (two beats) means \textbf{hou
   \item \emph{Choose:} agree $\to$ \textbf{\ja{はい}}; decline $\to$ \textbf{\ja{いいえ}}
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Say ??, then write ? once from memory before learning the contrasting answer.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which single sign is new here? (\textbf{\ja{え}}.) What changes when the long \emph{i} is cut short? (The word becomes \textbf{\ja{いえ}}, house.)
 
 Source: \href{https://en.wiktionary.org/wiki/\%E3\%81\%84\%E3\%81\%84\%E3\%81\%88}{Wiktionary: \ja{いいえ}}.
-\end{tcolorbox}
-\section[konnichiwa]{\ja{こんにちは} — hello, and a sign that lies about its sound}
-
-\label{lesson:JA-C01-konnichiwa}
-
-
-
-\begin{quote}
-Retrieve \textbf{\ja{はい}} and the sign \textbf{\ja{は}}. You are about to meet \textbf{\ja{は}} again in the daytime greeting — where it is not pronounced \emph{ha}.
-\end{quote}
-
-\subsection*{Script — four new signs, and one you know}
-\begin{quote}
-\textbf{\ja{こんにちは}} — \textbf{\ja{こ}} \emph{ko} + \textbf{\ja{ん}} \emph{n} + \textbf{\ja{に}} \emph{ni} + \textbf{\ja{ち}} \emph{chi} + \textbf{\ja{は}}
-\end{quote}
-
-Four signs are new. \textbf{\ja{こ}} \emph{ko}, \textbf{\ja{に}} \emph{ni}, and \textbf{\ja{ち}} \emph{chi} behave like every hiragana so far: one sign, one consonant-plus-vowel beat.
-
-\textbf{\ja{ん}} is the exception worth naming. It is the one hiragana that is a bare consonant, and it still takes a full beat of its own. So \textbf{\ja{こんにちは}} is five signs and five beats: \emph{ko-n-ni-chi-wa}. Give \textbf{\ja{ん}} its own beat and the greeting sounds Japanese; swallow it and it does not.
-
-\begin{grammarlens}[title={Grammar Lens — the sign \ja{は}, read \emph{wa}}]
-The last sign is \textbf{\ja{は}}, which you learned as \emph{ha}. Here it is read \textbf{wa}.
-
-That is not an exception to memorize blindly. \textbf{\ja{は}} is Japanese's \textbf{topic particle} — the little word that marks what a sentence is about, roughly \textquotedblleft{}as for \_\_\_.\textquotedblright{} Japanese spelling was reformed in 1946 to follow pronunciation, but three grammatical particles were left at their older spellings because they are so frequent that respelling them would have rewritten every page in the country. \textbf{\ja{は}} is one of them. Rule to carry forward: \textbf{\ja{は}} is \emph{ha} inside a word, and \emph{wa} when it is doing the job of a particle.
-\end{grammarlens}
-
-\begin{culture}
-\textbf{\ja{こんにちは}} is the daytime greeting — roughly midday to dusk, not morning and not evening. It is a sentence that was abandoned halfway. In full it was \ja{今日}\ja{は}… \emph{konnichi wa…}, \textquotedblleft{}as for today …\textquotedblright{}, opening a longer enquiry after someone's health. The rest fell away and the topic marker stayed, which is why Japan's most common greeting ends on a grammatical particle instead of a word.
-
-Those two characters, \ja{今日} \emph{konnichi} \textquotedblleft{}this day,\textquotedblright{} belong to the third writing system, and the next lesson opens it.
-\end{culture}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Say it:} \textbf{\ja{こんにちは}} — \emph{ko-n-ni-chi-wa}, five beats{]} {[}REPEAT x2
-  \item \emph{Decide:} \textbf{\ja{は}} in \textbf{\ja{はい}} $\to$ \emph{ha}; \textbf{\ja{は}} ending the greeting $\to$ \emph{wa}
-  \item \emph{Greet:} someone at midday $\to$ \textbf{\ja{こんにちは}}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which sign takes a beat without a vowel? (\textbf{\ja{ん}}.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)
-
-Source: \href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%AF}{Wiktionary: \ja{こんにちは}}.
-\end{tcolorbox}
-\section[nihongo]{\ja{日本語} — three characters, and no single sound each}
-
-\label{lesson:JA-C01-nihongo}
-
-
-
-\begin{quote}
-Say \textbf{\ja{こんにちは}} (\emph{konnichiwa}). Its history hid two characters, \ja{今日}, that hiragana cannot show you. This lesson opens that second system by naming the language itself.
-\end{quote}
-
-\subsection*{Script — kanji, and the readings problem}
-\begin{quote}
-\textbf{\ja{日本語}} — \emph{ni} + \emph{hon} + \emph{go}
-\end{quote}
-
-These are \textbf{kanji}: characters borrowed from Chinese, each carrying a meaning rather than a sound. \ja{日} is sun or day. \ja{本} is origin or root. \ja{語} is language. So \ja{日本} is \textquotedblleft{}sun-origin\textquotedblright{} — the country the sun rises from — and \ja{日本語} is its language.
-
-Now the fact that makes kanji unlike any letter you have learned. A kanji does not have \emph{a} sound. \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or \emph{ka}, depending on the word it stands in — and in \ja{日本} it is shortened again, to \emph{ni}. There is no sensible way to teach \textquotedblleft{}the sound of \ja{日}.\textquotedblright{} What a lesson can teach is the \textbf{word}: you learn \ja{日本語} as \emph{nihongo}, and the reading of each character comes along with it.
-
-Two families of readings explain the spread. The \textbf{on} reading is Japan's version of the Chinese pronunciation, imported with the character. The \textbf{kun} reading is a native Japanese word written with a borrowed character that already meant the same thing. \ja{日本語} is on-readings throughout; \ja{今日} in the greeting is irregular even by those standards.
-
-\begin{cousinweb}
-Here the cousin web finally works — just not toward English. The on-readings \emph{nichi}, \emph{hon}, \emph{go} are borrowings of Middle Chinese, so \ja{日本語} has genuine relatives: Mandarin writes the same three characters and says \emph{Rìběnyǔ}; Korean borrowed the same compound as \emph{ilbon-eo}. Same characters, related imported sounds, one meaning, three languages.
-
-That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it.
-\end{cousinweb}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Say it:} \textbf{\ja{日本語}} — \emph{ni-ho-n-go}, four beats{]} {[}REPEAT x2
-  \item \emph{Name:} \ja{日} sun or day; \ja{本} origin; \ja{語} language
-  \item \emph{Connect:} Mandarin \emph{Rìběnyǔ}, Korean \emph{ilbon-eo}, same three characters
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What does \ja{日本} mean literally? (Sun-origin.) Does \ja{日} have one pronunciation? (No — the word it appears in chooses one.)
-
-Source: \href{https://en.wiktionary.org/wiki/\%E6\%97\%A5\%E6\%9C\%AC\%E8\%AA\%9E}{Wiktionary: \ja{日本語}}.
-\end{tcolorbox}
-\section[kōhī]{\ja{コーヒー} — the third system, and a word that really is a cousin}
-
-\label{lesson:JA-C01-koohii}
-
-
-
-\begin{quote}
-Recall how hiragana writes a long vowel: it writes the vowel twice, as in \textbf{\ja{いいえ}}. Katakana does it differently, and this word shows how.
-\end{quote}
-
-\subsection*{Script — katakana, the borrowed-word script}
-\begin{quote}
-\textbf{\ja{コーヒー}} — \textbf{\ja{コ}} \emph{ko} + \textbf{\ja{ー}} + \textbf{\ja{ヒ}} \emph{hi} + \textbf{\ja{ー}}
-\end{quote}
-
-This is \textbf{katakana}, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms.
-
-The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from \emph{fragments} of characters, shorthand that monks scribbled beside a text to remember how to read it. \textbf{\ja{こ}} and \textbf{\ja{コ}} even trace back to the same character, which is why they still look alike.
-
-\textbf{\ja{ー}} is the \emph{chōonpu}, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So \textbf{\ja{コーヒー}} is four beats: \emph{ko-o-hi-i}.
-
-\begin{cousinweb}
-\textbf{\ja{コーヒー}} is \textbf{coffee}, and it entered Japanese from Dutch \emph{koffie} through the Nagasaki trade. Dutch had it from Turkish \emph{kahve}, and Turkish from Arabic \emph{qahwa} — which is exactly where English \emph{coffee} comes from as well.
-
-So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads: \textbf{\ja{パン}} bread, from Portuguese \emph{pão}, and \textbf{\ja{アルバイト}} a part-time job, from German \emph{Arbeit}.
-\end{cousinweb}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Say it:} \textbf{\ja{コーヒー}} — \emph{ko-o-hi-i}, four beats{]} {[}REPEAT x2
-  \item \emph{Trace it:} Arabic \emph{qahwa} $\to$ Turkish \emph{kahve} $\to$ Dutch \emph{koffie} $\to$ \textbf{\ja{コーヒー}}
-  \item \emph{Decide:} a borrowed word is written in katakana, not hiragana
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which script signals a borrowed word? (Katakana.) How many beats does \textbf{\ja{コーヒー}} hold? (Four.)
-
-Source: \href{https://en.wiktionary.org/wiki/\%E3\%82\%B3\%E3\%83\%BC\%E3\%83\%92\%E3\%83\%BC}{Wiktionary: \ja{コーヒー}}.
-\end{tcolorbox}
-\section[arigatō]{\ja{ありがとう} — thanks, from “this hardly ever happens”}
-
-\label{lesson:JA-C01-arigatou}
-
-
-
-\begin{quote}
-Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds.
-\end{quote}
-
-\subsection*{Script — five signs and two small strokes}
-\begin{quote}
-\textbf{\ja{ありがとう}} — \textbf{\ja{あ}} \emph{a} + \textbf{\ja{り}} \emph{ri} + \textbf{\ja{が}} \emph{ga} + \textbf{\ja{と}} \emph{to} + \textbf{\ja{う}}
-\end{quote}
-
-\textbf{\ja{あ}} \emph{a}, \textbf{\ja{り}} \emph{ri}, \textbf{\ja{と}} \emph{to} and \textbf{\ja{う}} \emph{u} are ordinary hiragana. \textbf{\ja{が}} is the new idea: it is the sign \textbf{\ja{か}} \emph{ka} with two short strokes added at the top right. That mark is the \textbf{dakuten}, and it voices the consonant — the same two strokes turn \emph{ka} into \emph{ga}, \emph{sa} into \emph{za}, \emph{ta} into \emph{da}, \emph{ha} into \emph{ba}. One mark, learned once, doubles how much of the script you can read.
-
-The final \textbf{\ja{う}} does not sound like \emph{u} here. After \textbf{\ja{と}} it stretches the \emph{o}, so the word ends \emph{-tō} and holds five beats: \emph{a-ri-ga-to-o}. Hiragana lengthens a vowel by writing another vowel sign, where katakana used the bar \textbf{\ja{ー}}.
-
-\begin{cousinweb}
-Written in kanji, \textbf{\ja{ありがとう}} is \ja{有}\ja{り}\ja{難}\ja{う}: \ja{有}\ja{る} \emph{aru} \textquotedblleft{}to exist\textquotedblright{} plus \ja{難}\ja{し} \emph{katashi} \textquotedblleft{}difficult.\textquotedblright{} Its ancestor \ja{有}\ja{り}\ja{難}\ja{し} \emph{arigatashi} meant literally \textbf{\textquotedblleft{}hard to exist\textquotedblright{}} — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The \emph{k} of \emph{katashi} softened to \emph{g} inside the compound, which is the same voicing the dakuten writes.
-
-So the memory hook is inside the word, not inside English: saying \textbf{\ja{ありがとう}} is saying \emph{this was not a thing that had to happen}. No English cousin exists, and inventing one would be worse than admitting that.
-\end{cousinweb}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Say it:} \textbf{\ja{ありがとう}} — \emph{a-ri-ga-to-o}, five beats{]} {[}REPEAT x2
-  \item \emph{Build:} \textbf{\ja{か}} plus the dakuten $\to$ \textbf{\ja{が}}
-  \item \emph{Connect:} \ja{有}\ja{り}\ja{難}\ja{し} \textquotedblleft{}hard to exist\textquotedblright{} $\to$ rare $\to$ precious $\to$ thanks
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What did \ja{有}\ja{り}\ja{難}\ja{し} mean literally? (Hard to exist.) What does the last \textbf{\ja{う}} do? (It lengthens the \emph{o}.)
-
-Source: \href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{Wiktionary: \ja{ありがとう}}.
-\end{tcolorbox}
-\section[arigatō gozaimasu]{\ja{ありがとうございます} — politeness you cannot leave out}
-
-\label{lesson:JA-C01-gozaimasu}
-
-
-
-\begin{quote}
-Say \textbf{\ja{ありがとう}} once and rebuild \textbf{\ja{が}} from \textbf{\ja{か}}. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss.
-\end{quote}
-
-\subsection*{Script — five more signs, two of them dakuten}
-\begin{quote}
-\textbf{\ja{ございます}} — \textbf{\ja{ご}} \emph{go} + \textbf{\ja{ざ}} \emph{za} + \textbf{\ja{い}} \emph{i} + \textbf{\ja{ま}} \emph{ma} + \textbf{\ja{す}} \emph{su}
-\end{quote}
-
-Two of the five are dakuten forms you can already build: \textbf{\ja{ご}} is \textbf{\ja{こ}} with the two strokes, and \textbf{\ja{ざ}} is \textbf{\ja{さ}} \emph{sa} with them. \textbf{\ja{い}} you have read since \textbf{\ja{はい}}. Only \textbf{\ja{ま}} \emph{ma} and \textbf{\ja{す}} \emph{su} are genuinely new.
-
-The whole phrase is ten beats — \emph{a-ri-ga-to-o go-za-i-ma-su} — and the final \textbf{\ja{す}} is normally said with the \emph{u} barely voiced, close to a plain \emph{s}.
-
-\begin{grammarlens}[title={Grammar Lens — politeness is grammar here, not word choice}]
-\textbf{\ja{ございます}} is a verb. It is the polite form of \ja{ある} \emph{aru}, \textquotedblleft{}to be\textquotedblright{} — the same verb that sits inside \textbf{\ja{ありがとう}}. The route runs \ja{ある} $\to$ \ja{ござる} $\to$ \textbf{\ja{ございます}}, where the ending \textbf{-\ja{ます}} is the general politeness marker Japanese attaches to verbs.
-
-That is the difference this chapter has to name. In many languages politeness is a choice between two words for \textquotedblleft{}you.\textquotedblright{} Japanese instead marks it on the \textbf{predicate}, and every sentence has one, so every sentence is marked. There is no neutral setting: \textbf{\ja{ありがとう}} to a friend and \textbf{\ja{ありがとうございます}} to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately.
-
-At the far end of the system, the verb itself is replaced. \ja{言}\ja{う} \emph{iu} \textquotedblleft{}to say\textquotedblright{} becomes \ja{おっしゃる} when the speaker is honouring someone else and \ja{申}\ja{す} when humbling themselves. Same act, three verbs, chosen by who is doing what to whom. That is \textbf{keigo}, and this lesson is only its front door.
-\end{grammarlens}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Say it:} \textbf{\ja{ありがとうございます}} — ten beats, final \emph{su} light{]} {[}REPEAT x2
-  \item \emph{Choose:} a close friend $\to$ \textbf{\ja{ありがとう}}; a shop assistant $\to$ \textbf{\ja{ありがとうございます}}
-  \item \emph{Build:} \textbf{\ja{こ}} $\to$ \textbf{\ja{ご}}, \textbf{\ja{さ}} $\to$ \textbf{\ja{ざ}}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which verb hides inside \textbf{\ja{ございます}}? (\ja{ある}, \textquotedblleft{}to be.\textquotedblright{}) Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)
-
-Source: \href{https://en.wiktionary.org/wiki/\%E3\%81\%94\%E3\%81\%96\%E3\%81\%84\%E3\%81\%BE\%E3\%81\%99}{Wiktionary: \ja{ございます}}.
-\end{tcolorbox}
-\section[Practice]{Practice — one daytime exchange, three scripts}
-
-\label{lesson:JA-C01-practice}
-
-
-
-\begin{quote}
-Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here.
-\end{quote}
-
-\subsection*{The exchange — every line already learned}
-\begin{quote}
-A: \textbf{\ja{こんにちは。}} — \emph{Konnichiwa.} B: \textbf{\ja{こんにちは。}} — \emph{Konnichiwa.} A: \textbf{\ja{日本語}}? — \emph{Nihongo?} B: \textbf{\ja{はい。}} — \emph{Hai.} A: \textbf{\ja{ありがとうございます。}} — \emph{Arigatō gozaimasu.} B: \textbf{\ja{いいえ。}} — \emph{Iie.}
-\end{quote}
-
-Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so \textbf{\ja{日本語}} with the voice lifted is a complete and natural way to ask \textquotedblleft{}Japanese, then?\textquotedblright{} — and \textbf{\ja{はい}} answers it. B's closing \textbf{\ja{いいえ}} is the modest \textquotedblleft{}not at all\textquotedblright{} that waves thanks away.
-
-A single ordinary Japanese sentence mixes the systems: hiragana carries the grammar, kanji carries the content words, katakana carries the borrowings. That is why this chapter opened all three instead of finishing one.
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Run through:} both voices once with the Japanese, once with romanization only
-  \item \emph{Decide:} which line would change if B were a close friend{]} {[}PAUSE 3s
-  \item \emph{Swap:} take B's part while the other lines are read to you
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter.
 \end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch02-hiragana-eight.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch02-hiragana-eight.tex
@@ -1,182 +1,17 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:958b71163f0094dc
-% canonical-lessons: JA-W01-i, JA-W01-ha, JA-W01-hai-read, JA-W01-e, JA-W01-ko, JA-W01-n, JA-W01-ni, JA-W01-chi, JA-W01-wa, JA-W01-konnichiwa-read
+% canonical-source-hash: fnv1a64:3ea6a6cad1cc95e9
+% canonical-lessons: JA-W01-ko, JA-W01-n, JA-W01-ni, JA-W01-chi, JA-W01-wa, JA-W01-konnichiwa-read, JA-C01-konnichiwa
 
-\chapter{Eight Signs, and Three Words You Can Read}
-\label{ch:ja-hiragana-eight}
+\chapter{A Daytime Greeting, One Sign at a Time}
+\label{ch:ja-daytime-greeting}
 \hlchaptermodality{2}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can write eight hiragana signs from memory and read the daytime greeting and both yes-or-no answers by sounding out their signs in order, including the sign that is pronounced wa because it is a topic marker.}
+\textbf{By the end of this chapter:} \emph{I can write the five distinct signs in \ja{こんにちは}, read them in order, and remember why final \ja{は} is pronounced wa.}
 
-The daytime greeting assembled from five signs the reader can each write from memory, introducing nothing new — including the one read wa because it is a topic marker rather than the sign for that sound.
+A one-line daytime greeting whose five signs were each taught before the learner reads it.
 \end{chapteropening}
 
-\section[i]{\ja{い} — two strokes, one beat}
-
-\label{lesson:JA-W01-i}
-
-
-
-\begin{quote}
-You already know the rule that makes this writing system easy: \textbf{one sign, one beat.} Not one letter one sound, and not one sign one word — one sign, one \textbf{mora}, the even beat Japanese counts time in.
-
-What you have not had yet is a single sign taught on its own. Here is the first.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{い}
-\end{quote}
-
-Two strokes, both falling, the left one long and the right one short:
-
-1. the \textbf{left} stroke — start high, come down, and hook gently to the right at the bottom 2. the \textbf{right} stroke — a short downward tick, higher up and clear of the first
-
-It is read \textbf{i}, the vowel of English \emph{machine} — short, tight, never the \emph{eye} of English \emph{bite}.
-
-\textbf{Where the shape came from, and why it does not help you.} Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen \textbf{for their sound}, not their meaning, so unlike a Chinese component there is nothing inside \ja{い} to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind.
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Trace it:} follow the visible \ja{い} once — long stroke first, then the short tick
-  \item \emph{Say it:} \textbf{i}, one clean beat
-\end{itemize}
-
-Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-How many beats does one hiragana sign take? (\textbf{One.})
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
-\end{tcolorbox}
-\section[ha]{\ja{は} — three strokes}
-
-\label{lesson:JA-W01-ha}
-
-
-
-\begin{quote}
-Write the two-stroke sign you met a moment ago. Long stroke, short tick.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{は}
-\end{quote}
-
-Three strokes. Look at it as a tall left post with a loop tied on its right.
-
-1. the \textbf{vertical}, down the left side, with the smallest flick left at the foot 2. a \textbf{short horizontal} crossing that vertical near the top, on its right 3. the \textbf{loop} — down from the right of that crossbar, round to the left, and back up to close
-
-Read \textbf{ha}, breathed rather than hard: the \emph{h} of English \emph{hat}, then the open \emph{a} of \emph{father}.
-
-\textbf{It has a second reading, and you have already used it.} Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it \emph{sounds} like.
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Copy:} keep \ja{は} visible and write it once — vertical, crossbar, loop
-  \item \emph{Say it:} \textbf{ha}, one beat, breath not force
-\end{itemize}
-
-Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which stroke of \ja{は} is written first? (The \textbf{vertical} on the left.)
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
-\end{tcolorbox}
-\section[hai]{Two signs, side by side — and a word appears}
-
-\label{lesson:JA-W01-hai-read}
-
-
-
-\begin{quote}
-Both signs are yours. Look at them for five seconds:
-
-\begin{quote}
-\ja{は}   \ja{い}
-\end{quote}
-
-Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
-\end{quote}
-
-\subsection*{Script — no new sign at all}
-Now write them touching:
-
-\begin{quote}
-\textbf{\ja{は}} + \textbf{\ja{い}} $\to$ \textbf{\ja{はい}}
-\end{quote}
-
-\textbf{ha} then \textbf{i}. Two beats, even, neither one stressed. That is the word for \textbf{yes}, and it is the one you have been saying since your first minute in this language.
-
-\textbf{Nothing new was introduced in this lesson.} No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are \textbf{reading} it — assembling it out of two pieces you can write from memory and sound out in order.
-
-That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row.
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Read it:} \textbf{\ja{はい}} — sound each sign in turn, do not recall the word whole
-  \item \emph{Write it:} \ja{はい} — five strokes in total, three then two
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-How many new strokes did you have to learn in this lesson? (\textbf{None.})
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
-\end{tcolorbox}
-\section[e]{\ja{え} — two strokes, and a second word for free}
-
-\label{lesson:JA-W01-e}
-
-
-
-\begin{quote}
-Read the word for \emph{yes} off the page, sign by sign, out loud.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{え}
-\end{quote}
-
-Two strokes, and the second one does most of the work:
-
-1. a \textbf{short tick} at the top, on its own, clear of everything below 2. the \textbf{body} — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement
-
-Read \textbf{e}, the vowel of English \emph{bed} — short, and never the \emph{ay} of \emph{day}.
-
-\begin{grammarlens}[title={What you've built}]
-Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:
-
-\begin{quote}
-\textbf{\ja{い}} + \textbf{\ja{い}} + \textbf{\ja{え}} $\to$ \textbf{\ja{いいえ}}
-\end{quote}
-
-\textbf{i-i-e.} Three beats — and note that the first sign is written \textbf{twice}, because Japanese counts two full beats there. That is the word for \textbf{no}.
-
-You have now read both answers to a yes-or-no question, from the signs up. Neither of them was memorised as a picture.
-\end{grammarlens}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item Cover the printed \textbf{\ja{え}}. Have a partner or recording say \textbf{e} once. If you are working alone, read the romanized cue \emph{e}, cover it, and continue.
-  \item \emph{Write from the heard or romanized cue:} \ja{え} — tick first, then the body in one movement
-  \item \emph{Read it:} \ja{いいえ} — three beats, and do not shorten the doubled sign
-\end{itemize}
-
-Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Why is the first sign of that word written twice? (Because it is \textbf{two beats}, not one held longer.)
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}; stroke order per \emph{Hitsujun Shido no Tebiki} (Japanese Ministry of Education, 1958).
-\end{tcolorbox}
 \section[ko]{\ja{こ} — two strokes, and the greeting begins}
 
 \label{lesson:JA-W01-ko}
@@ -206,6 +41,9 @@ Nothing joins them. The gap between the two strokes is part of the shape — clo
   \item \emph{Write it:} \ja{こ} — upper stroke, then the longer lower one, and leave the gap
   \item \emph{Say it:} \textbf{ko}, one beat
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Say ??? and tap all three morae before writing the new sign.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which of the two strokes is longer? (The \textbf{lower} one.)
@@ -239,6 +77,9 @@ That is why Japanese counts morae rather than syllables, and it is the clearest 
   \item \emph{Write it:} \ja{ん} — one continuous stroke, no lifts
   \item \emph{Say it:} hold it for a full beat, as long as any other sign takes
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Cover the model and write ?? from its two known signs.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 If this sign has no vowel, how long is it held? (\textbf{A full beat} — the same as every other sign.)
@@ -274,6 +115,9 @@ Read \textbf{ni}: the \emph{n} of \emph{knee}, then the tight \emph{i} you learn
   \item \emph{Write it:} \ja{に} — vertical, short bar, long bar
   \item \emph{Notice:} write it beside \ja{は} and compare only the left post
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Before the new sign, write ? once and then ? once from memory.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which stroke of this sign comes first? (The \textbf{vertical}.)
@@ -363,6 +207,9 @@ Getting this backwards is the single most common beginner spelling error in Japa
   \item \emph{Decide:} hearing \emph{wa} at the end of the daytime greeting, which sign do you write?
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Say ??? again, keeping the two opening morae distinct.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which of the two is a fact about \textbf{grammar} rather than about sound? (The one where \ja{は} is read \emph{wa}.)
 
@@ -391,10 +238,10 @@ Add the fifth — the one that is read \emph{wa} because it is a topic marker �
 
 \textbf{ko-n-ni-chi-wa.} Five signs, \textbf{five beats}, all even. Say it against a steady tap and you will hear that the second beat, the one with no vowel, takes exactly as long as the four around it.
 
-\textbf{Nothing new was introduced in this lesson.} You have not learned a stroke, a sound or a word here. You have read a word you already knew how to say — from five pieces you can each write from memory, in order, including the one that sounds like something other than its name.
+No new stroke appears here. You have decoded five pieces you can each write from memory, in order, including the one that sounds like something other than its name. The next lesson attaches the daytime-greeting meaning to the line.
 
 \begin{grammarlens}[title={What you've built}]
-Eight signs, taught one at a time, and with them you can now read three whole words off the page: the greeting, and both answers to a yes-or-no question.
+Eight signs, taught one at a time, and with them you can now decode three whole sequences off the page. Two already carry useful answers; the five-sign sequence gets its daytime-greeting job in the next lesson.
 
 Hiragana has forty-six basic signs. You hold \textbf{eight}. The rest arrive the same way, one per lesson, and the words they unlock arrive free — because a word in this script is never more than the signs you already own, in a row.
 \end{grammarlens}
@@ -406,8 +253,56 @@ Hiragana has forty-six basic signs. You hold \textbf{eight}. The rest arrive the
   \item \emph{Write it:} the greeting, then say it once at speaking pace
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Write ? once, then set it beside ? and name which one closes the greeting.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 How many of the greeting's five signs were new in this lesson? (\textbf{None.})
 
 Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
+\end{tcolorbox}
+\section[konnichiwa]{\ja{こんにちは} — hello, and a sign that lies about its sound}
+
+\label{lesson:JA-C01-konnichiwa}
+
+
+
+\begin{quote}
+Retrieve \textbf{\ja{はい}} and the sign \textbf{\ja{は}}. You are about to meet \textbf{\ja{は}} again in the daytime greeting — where it is not pronounced \emph{ha}.
+\end{quote}
+
+\subsection*{Script — five familiar signs}
+\begin{quote}
+\textbf{\ja{こんにちは}} — \textbf{\ja{こ}} \emph{ko} + \textbf{\ja{ん}} \emph{n} + \textbf{\ja{に}} \emph{ni} + \textbf{\ja{ち}} \emph{chi} + \textbf{\ja{は}}
+\end{quote}
+
+You have written every sign separately. \textbf{\ja{こ}}, \textbf{\ja{に}}, and \textbf{\ja{ち}} each carry a consonant and vowel. \textbf{\ja{ん}} is the exception: a bare consonant with a full beat of its own. Read five signs in five beats: \emph{ko-n-ni-chi-wa}. Do not swallow \textbf{\ja{ん}}.
+
+\begin{grammarlens}[title={Grammar Lens — the sign \ja{は}, read \emph{wa}}]
+The last sign is \textbf{\ja{は}}, which you learned as \emph{ha}. Here it is read \textbf{wa}.
+
+Here \textbf{\ja{は}} is the \textbf{topic particle}, roughly \textquotedblleft{}as for \_\_\_.\textquotedblright{} It keeps an older spelling. Carry one small rule forward: read \textbf{\ja{は}} as \emph{ha} inside a word and as \emph{wa} when it is the particle.
+\end{grammarlens}
+
+\begin{culture}
+\textbf{\ja{こんにちは}} is the daytime greeting. It began as an unfinished sentence: \emph{konnichi wa…}, \textquotedblleft{}as for today …\textquotedblright{} The rest fell away and the topic marker stayed.
+
+The older phrase is often written with two kanji for \textquotedblleft{}this day.\textquotedblright{} You do not need to decode those yet. This chapter keeps the whole greeting in the hiragana signs you have already learned.
+\end{culture}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textbf{\ja{こんにちは}} — \emph{ko-n-ni-chi-wa}, five beats{]} {[}REPEAT x2
+  \item \emph{Decide:} \textbf{\ja{は}} in \textbf{\ja{はい}} $\to$ \emph{ha}; \textbf{\ja{は}} ending the greeting $\to$ \emph{wa}
+  \item \emph{Greet:} someone at midday $\to$ \textbf{\ja{こんにちは}}
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? from memory and give it one full mora.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which sign takes a beat without a vowel? (\textbf{\ja{ん}}.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)
+
+Source: \href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%AF}{Wiktionary: \ja{こんにちは}}.
 \end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch03-thanks.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch03-thanks.tex
@@ -1,15 +1,15 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3ff7e4c4a4bc5425
-% canonical-lessons: JA-W03-a, JA-W03-ri, JA-W03-ka, JA-W03-dakuten, JA-W03-to, JA-W03-u, JA-W03-arigatou-read, JA-W03-sa, JA-W03-ma, JA-W03-su, JA-C03-practice
+% canonical-source-hash: fnv1a64:263995256f27b91e
+% canonical-lessons: JA-W03-a, JA-W03-ri, JA-W03-ka, JA-W03-dakuten, JA-W03-to, JA-W03-u, JA-W03-arigatou-read, JA-C01-arigatou
 
-\chapter{Eight Signs, One Mark, and the Longest Word You Know}
-\label{ch:ja-thanks}
+\chapter{Plain Thanks, One Sign at a Time}
+\label{ch:ja-plain-thanks}
 \hlchaptermodality{3}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can write eight more hiragana from memory, add the dakuten to voice a sign I already know, and read \ja{ありがとうございます} off the page without the romanization.}
+\textbf{By the end of this chapter:} \emph{I can write and read \ja{ありがとう}, build \ja{が} with the dakuten, and say the five morae without swallowing the long final vowel.}
 
-The ten signs of the polite thank-you named one by one, three of them earlier signs wearing two ticks, and a short exchange in which every character on the page is one the reader can write.
+A plain thank-you read only after every distinct hiragana sign and the dakuten have their own small step.
 \end{chapteropening}
 
 \section[a]{\ja{あ} — three strokes, and the thank-you begins}
@@ -21,7 +21,7 @@ The ten signs of the polite thank-you named one by one, three of them earlier si
 \begin{quote}
 Write \ja{こんにちは} from memory. Five signs, all yours.
 
-You have been saying \textbf{\ja{ありがとう}} since Chapter 1 and reading it from the romanization. This chapter hands you the signs, one at a time, until the word is yours on the page as well as in the mouth.
+This chapter builds the five-sign plain thank-you from the page up. Its meaning arrives only after every sign is yours, so this first lesson asks for one shape: \textbf{\ja{あ}}.
 \end{quote}
 
 \subsection*{Script — the shape}
@@ -43,6 +43,9 @@ Read \textbf{a}: the \emph{a} of English \emph{father}, kept short. One beat.
   \item \emph{Write it:} \ja{あ} — horizontal, vertical, then the loop in one movement
   \item \emph{Say it:} \textbf{a}, one beat, short
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Give the daytime greeting, then write ? from memory.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Is the loop drawn as a separate circle, or in one movement? (\textbf{One movement}, crossing what you have already written.)
@@ -82,6 +85,9 @@ If you say an English \emph{r} here you will be understood and you will sound fo
   \item \emph{Say it:} \textbf{a}, then \textbf{ri} — the first two signs of the word
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Write ? from memory before tracing ?.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which of \ja{り}'s two strokes falls further? (The \textbf{right} one, by about double.)
 
@@ -116,6 +122,9 @@ Remember this shape more carefully than the others. \textbf{You are about to get
   \item \emph{Write it:} \ja{か} — hooked stroke, vertical, then the dot at the right
   \item \emph{Say it:} \textbf{ka}, one beat
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ?, then write the different sign that closes ????? and explain its particle reading.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which stroke is written last? (The \textbf{dot}, at the upper right.)
@@ -169,6 +178,9 @@ You have now met four signs that take it -- \ja{は}, \ja{こ}, \ja{ち} and \ja
   \item \emph{Say it:} \textbf{ka / ga}, then \textbf{ko / go} — the same mouth, voice off and on
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Write ????? from its five signs before adding any voice marks.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Does \ja{が} need a new shape learned? (\textbf{No} — it is \ja{か} plus two ticks.)
 
@@ -204,6 +216,9 @@ Read \textbf{to}: a clean \emph{t}, then the \emph{o} of \emph{more}, shortened.
   \item \emph{Say it:} \textbf{a, ri, ga, to} — four beats, and the word is nearly yours
 \end{itemize}
 
+\subsection*{Your turn — review pulse}
+Say the daytime greeting once without looking.
+
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which stroke is longer? (The \textbf{second}, the sweep.)
 
@@ -233,7 +248,7 @@ Read \textbf{u}: close to the \emph{oo} of \emph{food} but shorter, and with the
 \begin{grammarlens}[title={What you've built — and what this sign does after \ja{と}}]
 Something happens when \ja{う} follows \ja{と}, and it is the reason the written word and the spoken word look like they disagree.
 
-Written out, \ja{ありがとう} ends \textbf{\ja{と} + \ja{う}} — \emph{to} then \emph{u}, which reads as five beats. But nobody says \emph{a-ri-ga-to-u}. What you hear is a long \textbf{o}:
+The five-sign sequence you are building ends \textbf{\ja{と} + \ja{う}} — \emph{to} then \emph{u}, which reads as five beats. But the final two signs are heard as a long \textbf{o}:
 
 \begin{quote}
 written: a-ri-ga-to-u
@@ -247,7 +262,7 @@ spoken: a-ri-ga-\textbf{too}
 
 \textbf{\ja{う} after an o-sound does not add a syllable. It holds the one before it for a second beat.} The beat is still there — Japanese counts it, and dropping it makes the word sound clipped and wrong — but it is the same vowel continuing, not a new one.
 
-You met this once already without being told: the katakana word \ja{コーヒー} uses a long bar for the same job. Hiragana uses \ja{う}.
+Katakana will later receive a separate one-stroke length mark for the same job. Here the only written cue is the \textbf{\ja{う}} you have just learned.
 \end{grammarlens}
 
 \subsection*{Your turn}
@@ -309,211 +324,44 @@ How many signs did you have to learn for this word? (\textbf{Five} — but one o
 
 Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
 \end{tcolorbox}
-\section[sa]{\ja{さ} — two strokes, and the ticks work here too}
+\section[arigatō]{\ja{ありがとう} — thanks, from “this hardly ever happens”}
 
-\label{lesson:JA-W03-sa}
+\label{lesson:JA-C01-arigatou}
 
 
-
-\begin{quote}
-Write \ja{ありがとう}. All five signs, no help.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{さ}
-\end{quote}
-
-Three strokes:
-
-1. a short \textbf{horizontal}, near the top 2. a \textbf{short curving stroke} below it, falling down and left 3. a \textbf{separate small curve} at the foot, opening left — \textbf{not joined} to the stroke above it
-
-Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the \ja{さ} you see on a screen looks like two strokes. By hand it is three, and the break is real. The same split makes \ja{き} four strokes by hand and three in print.
-
-Read \textbf{sa}: a clean \emph{s}, then the short \emph{a}. One beat.
-
-And now the bargain again — \ja{さ} takes the dakuten:
 
 \begin{quote}
-\ja{さ} \emph{sa} $\to$ \textbf{\ja{ざ}} \emph{za}
+Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds.
 \end{quote}
 
-Same mouth, voice switched on, two ticks at the upper right. That is the third sign you have got for free, and it is the second sign of \ja{ございます}.
+\subsection*{Script — five signs and two small strokes}
+\begin{quote}
+\textbf{\ja{ありがとう}} — \textbf{\ja{あ}} \emph{a} + \textbf{\ja{り}} \emph{ri} + \textbf{\ja{が}} \emph{ga} + \textbf{\ja{と}} \emph{to} + \textbf{\ja{う}}
+\end{quote}
+
+\textbf{\ja{あ}} \emph{a}, \textbf{\ja{り}} \emph{ri}, \textbf{\ja{と}} \emph{to} and \textbf{\ja{う}} \emph{u} are ordinary hiragana. \textbf{\ja{が}} is the new idea: it is the sign \textbf{\ja{か}} \emph{ka} with two short strokes added at the top right. That mark is the \textbf{dakuten}, and it voices the consonant — the same two strokes turn \emph{ka} into \emph{ga}, \emph{sa} into \emph{za}, \emph{ta} into \emph{da}, \emph{ha} into \emph{ba}. One mark, learned once, doubles how much of the script you can read.
+
+The final \textbf{\ja{う}} does not sound like \emph{u} here. After \textbf{\ja{と}} it stretches the \emph{o}, so the word ends \emph{-tō} and holds five beats: \emph{a-ri-ga-to-o}. Hiragana lengthens a vowel here by writing another vowel sign. Katakana will get its own tiny length lesson later.
+
+\begin{cousinweb}
+The older form combines \emph{aru}, \textquotedblleft{}to exist,\textquotedblright{} with \emph{katashi}, \textquotedblleft{}difficult.\textquotedblright{} \emph{Arigatashi} therefore meant literally \textbf{\textquotedblleft{}hard to exist\textquotedblright{}} — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The \emph{k} of \emph{katashi} softened to \emph{g} inside the compound, which is the same voicing the dakuten writes. Its historical kanji spelling can wait until those signs receive their own lessons.
+
+So the memory hook is inside the word, not inside English: saying \textbf{\ja{ありがとう}} is saying \emph{this was not a thing that had to happen}. No English cousin exists, and inventing one would be worse than admitting that.
+\end{cousinweb}
 
 \subsection*{Your turn}
 \begin{itemize}
 \raggedright
-  \item \emph{Write it:} \ja{さ} — horizontal, the short curve, then the detached foot curve
-  \item \emph{Write it:} \ja{ざ} — the same, with two ticks
-  \item \emph{Say it:} \textbf{sa / za}
+  \item \emph{Say it:} \textbf{\ja{ありがとう}} — \emph{a-ri-ga-to-o}, five beats{]} {[}REPEAT x2
+  \item \emph{Build:} \textbf{\ja{か}} plus the dakuten $\to$ \textbf{\ja{が}}
+  \item \emph{Connect:} \emph{arigatashi} \textquotedblleft{}hard to exist\textquotedblright{} $\to$ rare $\to$ precious $\to$ thanks
 \end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? once from memory, then add the two dakuten strokes.
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-How many signs have the two ticks given you so far? (\textbf{Three} — \ja{が}, \ja{ご} and \ja{ざ}.)
+What did \emph{arigatashi} mean literally? (Hard to exist.) What does the last \textbf{\ja{う}} do? (It lengthens the \emph{o}.)
 
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
-\end{tcolorbox}
-\section[ma]{\ja{ま} — three strokes, and a loop you have drawn before}
-
-\label{lesson:JA-W03-ma}
-
-
-
-\begin{quote}
-Write \ja{さ}, then \ja{ざ}.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{ま}
-\end{quote}
-
-Three strokes, and the order is top-down as always:
-
-1. an \textbf{upper horizontal}, short 2. a \textbf{lower horizontal}, a little wider, below and parallel to it 3. a \textbf{looping vertical} that crosses both, falls, and curls left at the bottom
-
-The third stroke is the same movement you learned on \ja{あ} — down through what you have written, then a small loop at the foot. If \ja{あ}'s loop is comfortable, this one is already yours.
-
-Read \textbf{ma}: as in English \emph{mother}, shortened. One beat.
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \ja{ま} — two horizontals, then the looping vertical through them
-  \item \emph{Say it:} \textbf{ma}, one beat
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which earlier sign uses the same looping last stroke? (\textbf{\ja{あ}}.)
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
-\end{tcolorbox}
-\section[su]{\ja{す} — two strokes, and a vowel you barely hear}
-
-\label{lesson:JA-W03-su}
-
-
-
-\begin{quote}
-Write \ja{ま}. Two horizontals, then the loop.
-\end{quote}
-
-\subsection*{Script — the shape}
-\begin{quote}
-\ja{す}
-\end{quote}
-
-Two strokes:
-
-1. a short \textbf{horizontal}, near the top 2. a \textbf{vertical} crossing it, falling, and finishing in a loop that closes back on itself before tailing away
-
-The loop in \ja{す} is tighter than \ja{ま}'s — it comes back and crosses its own line.
-
-Read \textbf{su}: an \emph{s}, then the \emph{u} you met in \ja{う}.
-
-\begin{culture}
-At the end of a word, and especially in \textbf{\ja{ございます}}, that final \emph{u} is usually \textbf{devoiced} — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to \emph{-mass} than \emph{-masu}.
-
-This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear \emph{u} there is one of the most recognisable marks of a learner reading off a page.
-
-The sign is still written. The beat is still counted. Only the voice drops out.
-\end{culture}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Write it:} \ja{す} — horizontal, then the vertical with its closing loop
-  \item \emph{Say it:} \textbf{su}, then the same with the voice off — a whispered ending
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Is the beat dropped along with the voice? (\textbf{No} — the beat is still counted.)
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
-\end{tcolorbox}
-\section[Practice]{Practice — the whole thank-you, off the page}
-
-\label{lesson:JA-C03-practice}
-
-
-
-\begin{quote}
-Write \ja{ありがとう}. Five signs, no help.
-\end{quote}
-
-\subsection*{Script — the second half}
-\begin{quote}
-\ja{ございます}
-\end{quote}
-
-Five more signs, and \textbf{again nothing here is new}:
-
-\begin{itemize}
-\raggedright
-  \item \textbf{\ja{ご}} — \ja{こ} from Chapter 2, with the dakuten
-  \item \textbf{\ja{ざ}} — \ja{さ} from this chapter, with the dakuten
-  \item \textbf{\ja{い}} — from Chapter 2
-  \item \textbf{\ja{ま}} — from this chapter
-  \item \textbf{\ja{す}} — from this chapter, its \emph{u} devoiced
-\end{itemize}
-
-Two of the five are signs you already had, wearing two ticks.
-
-\begin{culture}
-\textbf{\ja{ありがとう}} on its own is warm and ordinary — friends, family, a shopkeeper you know. \textbf{\ja{ありがとうございます}} is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you.
-
-The difference is not strength. Adding \ja{ございます} does not mean you are \emph{more} grateful; it means you are being \textbf{more formal about it}. Getting that wrong in either direction is the commonest register mistake a beginner makes.
-
-If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing.
-\end{culture}
-
-\subsection*{The exchange}
-Two voices, and every sign on the page is one you can write:
-
-\begin{quote}
-\textbf{A:} \ja{こんにちは}
-\end{quote}
-
->
-
-\begin{quote}
-\textbf{B:} \ja{こんにちは}
-\end{quote}
-
->
-
-\begin{quote}
-\textbf{A:} \ja{ありがとうございます}
-\end{quote}
-
->
-
-\begin{quote}
-\textbf{B:} \ja{はい}
-\end{quote}
-
-\begin{grammarlens}[title={What you've built this chapter}]
-Eight new signs and one mark. The mark is the part worth remembering:
-
-\begin{itemize}
-\raggedright
-  \item \textbf{eight shapes} — \ja{あ} \ja{り} \ja{か} \ja{と} \ja{う} \ja{さ} \ja{ま} \ja{す}
-  \item \textbf{one mark} — \ja{゛}, which turned \ja{か} into \ja{が}, \ja{こ} into \ja{ご}, \ja{さ} into \ja{ざ}
-\end{itemize}
-
-Ten signs in \ja{ありがとうございます}, and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job \emph{smaller} the further you went into it, and it keeps doing that: every \emph{k}, \emph{s}, \emph{t} and \emph{h} sign you ever learn arrives with a voiced twin already attached.
-\end{grammarlens}
-
-\subsection*{Your turn}
-\begin{itemize}
-\raggedright
-  \item \emph{Read it:} \ja{ありがとうございます} — name each of the ten signs, then say it
-  \item \emph{Write it:} \ja{ございます} — five signs, two of them with ticks
-  \item \emph{Say it:} \textbf{arigatou gozaimasu} — and let the final u go quiet
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which form would you use with a stranger — the short one or the long one? (The \textbf{long} one; being slightly too polite costs nothing.)
-
-Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
+Source: \href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{Wiktionary: \ja{ありがとう}}.
 \end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch04-polite-thanks.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch04-polite-thanks.tex
@@ -1,0 +1,274 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:9265f112fa74be49
+% canonical-lessons: JA-W03-sa, JA-W03-ma, JA-W03-su, JA-C01-gozaimasu, JA-C03-practice
+
+\chapter{Polite Thanks, Three More Signs}
+\label{ch:ja-polite-thanks}
+\hlchaptermodality{4}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can add \ja{ございます} to a known thank-you, read every sign, and choose the polite form for someone outside my close circle.}
+
+A short casual-versus-polite choice with every sign taught and the register decision checked independently.
+\end{chapteropening}
+
+\section[sa]{\ja{さ} — two strokes, and the ticks work here too}
+
+\label{lesson:JA-W03-sa}
+
+
+
+\begin{quote}
+Write \ja{ありがとう}. All five signs, no help.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{さ}
+\end{quote}
+
+Three strokes:
+
+1. a short \textbf{horizontal}, near the top 2. a \textbf{short curving stroke} below it, falling down and left 3. a \textbf{separate small curve} at the foot, opening left — \textbf{not joined} to the stroke above it
+
+Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the \ja{さ} you see on a screen looks like two strokes. By hand it is three, and the break is real. Keep the handwritten gap even when a printed font closes it.
+
+Read \textbf{sa}: a clean \emph{s}, then the short \emph{a}. One beat.
+
+And now the bargain again — \ja{さ} takes the dakuten:
+
+\begin{quote}
+\ja{さ} \emph{sa} $\to$ \textbf{\ja{ざ}} \emph{za}
+\end{quote}
+
+Same mouth, voice switched on, two ticks at the upper right. That is the third voiced sign you have got for free. It will return in the polite ending ahead.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ja{さ} — horizontal, the short curve, then the detached foot curve
+  \item \emph{Write it:} \ja{ざ} — the same, with two ticks
+  \item \emph{Say it:} \textbf{sa / za}
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Say ?????, add the dakuten to ?, and recall how ?hard to exist? became thanks.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many signs have the two ticks given you so far? (\textbf{Three} — \ja{が}, \ja{ご} and \ja{ざ}.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
+\end{tcolorbox}
+\section[ma]{\ja{ま} — three strokes, and a loop you have drawn before}
+
+\label{lesson:JA-W03-ma}
+
+
+
+\begin{quote}
+Write \ja{さ}, then \ja{ざ}.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{ま}
+\end{quote}
+
+Three strokes, and the order is top-down as always:
+
+1. an \textbf{upper horizontal}, short 2. a \textbf{lower horizontal}, a little wider, below and parallel to it 3. a \textbf{looping vertical} that crosses both, falls, and curls left at the bottom
+
+The third stroke is the same movement you learned on \ja{あ} — down through what you have written, then a small loop at the foot. If \ja{あ}'s loop is comfortable, this one is already yours.
+
+Read \textbf{ma}: as in English \emph{mother}, shortened. One beat.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ja{ま} — two horizontals, then the looping vertical through them
+  \item \emph{Say it:} \textbf{ma}, one beat
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? from memory before tracing ?.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which earlier sign uses the same looping last stroke? (\textbf{\ja{あ}}.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
+\end{tcolorbox}
+\section[su]{\ja{す} — two strokes, and a vowel you barely hear}
+
+\label{lesson:JA-W03-su}
+
+
+
+\begin{quote}
+Write \ja{ま}. Two horizontals, then the loop.
+\end{quote}
+
+\subsection*{Script — the shape}
+\begin{quote}
+\ja{す}
+\end{quote}
+
+Two strokes:
+
+1. a short \textbf{horizontal}, near the top 2. a \textbf{vertical} crossing it, falling, and finishing in a loop that closes back on itself before tailing away
+
+The loop in \ja{す} is tighter than \ja{ま}'s — it comes back and crosses its own line.
+
+Read \textbf{su}: an \emph{s}, then the \emph{u} you met in \ja{う}.
+
+\begin{culture}
+At the end of a word, and especially in \textbf{\ja{ございます}}, that final \emph{u} is usually \textbf{devoiced} — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to \emph{-mass} than \emph{-masu}.
+
+This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear \emph{u} there is one of the most recognisable marks of a learner reading off a page.
+
+The sign is still written. The beat is still counted. Only the voice drops out.
+\end{culture}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ja{す} — horizontal, then the vertical with its closing loop
+  \item \emph{Say it:} \textbf{su}, then the same with the voice off — a whispered ending
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? from memory before tracing ?.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Is the beat dropped along with the voice? (\textbf{No} — the beat is still counted.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
+\end{tcolorbox}
+\section[arigatō gozaimasu]{\ja{ありがとうございます} — politeness you cannot leave out}
+
+\label{lesson:JA-C01-gozaimasu}
+
+
+
+\begin{quote}
+Say \textbf{\ja{ありがとう}} once and rebuild \textbf{\ja{が}} from \textbf{\ja{か}}. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss.
+\end{quote}
+
+\subsection*{Script — five more signs, two of them dakuten}
+\begin{quote}
+\textbf{\ja{ございます}} — \textbf{\ja{ご}} \emph{go} + \textbf{\ja{ざ}} \emph{za} + \textbf{\ja{い}} \emph{i} + \textbf{\ja{ま}} \emph{ma} + \textbf{\ja{す}} \emph{su}
+\end{quote}
+
+Two of the five are dakuten forms you can already build: \textbf{\ja{ご}} is \textbf{\ja{こ}} with the two strokes, and \textbf{\ja{ざ}} is \textbf{\ja{さ}} \emph{sa} with them. \textbf{\ja{い}} you have read since \textbf{\ja{はい}}. Only \textbf{\ja{ま}} \emph{ma} and \textbf{\ja{す}} \emph{su} are genuinely new.
+
+The whole phrase is ten beats — \emph{a-ri-ga-to-o go-za-i-ma-su} — and the final \textbf{\ja{す}} is normally said with the \emph{u} barely voiced, close to a plain \emph{s}.
+
+\begin{grammarlens}[title={Grammar Lens — politeness is grammar here, not word choice}]
+\textbf{\ja{ございます}} is a verb. It is the polite descendant of \emph{aru}, \textquotedblleft{}to be\textquotedblright{} — the same verb that sits inside \textbf{\ja{ありがとう}}. The historical route runs \emph{aru} to \emph{gozaru} to \textbf{\ja{ございます}}, where the ending \textbf{-\ja{ます}} is the general politeness marker Japanese attaches to verbs.
+
+That is the difference this chapter has to name. In many languages politeness is a choice between two words for \textquotedblleft{}you.\textquotedblright{} Japanese instead marks it on the \textbf{predicate}, and every sentence has one, so every sentence is marked. There is no neutral setting: \textbf{\ja{ありがとう}} to a friend and \textbf{\ja{ありがとうございます}} to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately.
+
+At the far end of the system, even the verb can be replaced: ordinary \emph{iu}, \textquotedblleft{}to say,\textquotedblright{} has the respectful form \emph{ossharu} and the humble form \emph{mōsu}. Same act, three verbs, chosen by who is doing what to whom. That is \textbf{keigo}, and this lesson is only its front door. Their spellings belong in later, separately taught script lessons.
+\end{grammarlens}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textbf{\ja{ありがとうございます}} — ten beats, final \emph{su} light{]} {[}REPEAT x2
+  \item \emph{Choose:} a close friend $\to$ \textbf{\ja{ありがとう}}; a shop assistant $\to$ \textbf{\ja{ありがとうございます}}
+  \item \emph{Build:} \textbf{\ja{こ}} $\to$ \textbf{\ja{ご}}, \textbf{\ja{さ}} $\to$ \textbf{\ja{ざ}}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which verb hides inside \textbf{\ja{ございます}}? (\emph{aru}, \textquotedblleft{}to be.\textquotedblright{}) Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)
+
+Source: \href{https://en.wiktionary.org/wiki/\%E3\%81\%94\%E3\%81\%96\%E3\%81\%84\%E3\%81\%BE\%E3\%81\%99}{Wiktionary: \ja{ございます}}.
+\end{tcolorbox}
+\section[Practice]{Practice — the whole thank-you, off the page}
+
+\label{lesson:JA-C03-practice}
+
+
+
+\begin{quote}
+Write \ja{ありがとう}. Five signs, no help.
+\end{quote}
+
+\subsection*{Script — the second half}
+\begin{quote}
+\ja{ございます}
+\end{quote}
+
+Five more signs, and \textbf{again nothing here is new}:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ja{ご}} — \ja{こ} from Chapter 2, with the dakuten
+  \item \textbf{\ja{ざ}} — \ja{さ} from this chapter, with the dakuten
+  \item \textbf{\ja{い}} — from Chapter 2
+  \item \textbf{\ja{ま}} — from this chapter
+  \item \textbf{\ja{す}} — from this chapter, its \emph{u} devoiced
+\end{itemize}
+
+Two of the five are signs you already had, wearing two ticks.
+
+\begin{culture}
+\textbf{\ja{ありがとう}} on its own is warm and ordinary — friends, family, a shopkeeper you know. \textbf{\ja{ありがとうございます}} is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you.
+
+The difference is not strength. Adding \ja{ございます} does not mean you are \emph{more} grateful; it means you are being \textbf{more formal about it}. Getting that wrong in either direction is the commonest register mistake a beginner makes.
+
+If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing.
+\end{culture}
+
+\subsection*{The exchange}
+Two voices, and every sign on the page is one you can write:
+
+\begin{quote}
+\textbf{A:} \ja{こんにちは}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{B:} \ja{こんにちは}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{A:} \ja{ありがとうございます}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{B:} \ja{はい}
+\end{quote}
+
+\begin{grammarlens}[title={What you've built this chapter}]
+Eight new signs and one mark. The mark is the part worth remembering:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{eight shapes} — \ja{あ} \ja{り} \ja{か} \ja{と} \ja{う} \ja{さ} \ja{ま} \ja{す}
+  \item \textbf{one mark} — \ja{゛}, which turned \ja{か} into \ja{が}, \ja{こ} into \ja{ご}, \ja{さ} into \ja{ざ}
+\end{itemize}
+
+Ten signs in \ja{ありがとうございます}, and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job \emph{smaller} the further you went into it, and it keeps doing that: every \emph{k}, \emph{s}, \emph{t} and \emph{h} sign you ever learn arrives with a voiced twin already attached.
+\end{grammarlens}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \ja{ありがとうございます} — name each of the ten signs, then say it
+  \item \emph{Write it:} \ja{ございます} — five signs, two of them with ticks
+  \item \emph{Say it:} \textbf{arigatou gozaimasu} — and let the final u go quiet
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Give plain thanks, then polite thanks. Name the dakuten and the ?hard to exist? memory hook.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which form would you use with a stranger — the short one or the long one? (The \textbf{long} one; being slightly too polite costs nothing.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}
+\end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch05-nihongo-kanji.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch05-nihongo-kanji.tex
@@ -1,0 +1,271 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2211c70d67acf7a1
+% canonical-lessons: JA-W05-nichi-kanji, JA-W05-hon-kanji, JA-W05-gen-component, JA-W05-five-component, JA-W05-mouth-component, JA-W05-go-kanji, JA-C01-nihongo
+
+\chapter{Nihongo, Built in Small Blocks}
+\label{ch:ja-nihongo-kanji}
+\hlchaptermodality{5}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can write \ja{日} and \ja{本}, assemble \ja{語} from three practised components, and read \ja{日本語} as nihongo.}
+
+Three kanji read as one known word after the simple signs and the complex sign's components were taught separately.
+\end{chapteropening}
+
+\section[nichi]{\ja{日} — one sun, four strokes}
+
+\label{lesson:JA-W05-nichi-kanji}
+
+
+
+\begin{quote}
+Say \emph{ni-chi}: two even beats. Today you attach those beats to one kanji, but you write only one new shape.
+\end{quote}
+
+\subsection*{Script — build the sun}
+\begin{quote}
+\ja{日}
+\end{quote}
+
+Write four strokes:
+
+1. the left side, down 2. the top and right side as one turning stroke 3. the short middle line, left to right 4. the bottom line, left to right
+
+The middle line touches both sides. Keep the shape taller than it is wide.
+
+Here it is read \emph{nichi}. It carries the broad idea \textbf{sun/day}. Kanji can have more than one reading; this lesson asks for only the reading in the word ahead.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{日} — side, corner, middle, bottom
+  \item \emph{Write it:} \ja{日} once from memory
+  \item \emph{Say it:} \textbf{nichi}, two beats
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Read ????? once and write its base sign ? without a model.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which line sits inside the box? (The \textbf{middle horizontal} line.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/065e5.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[hon]{\ja{本} — a tree with its root marked}
+
+\label{lesson:JA-W05-hon-kanji}
+
+
+
+\begin{quote}
+Write \ja{日} once. Read it \emph{nichi} here.
+\end{quote}
+
+\subsection*{Script — five strokes}
+\begin{quote}
+\ja{本}
+\end{quote}
+
+Write the large tree first, then mark its base:
+
+1. top horizontal 2. centre vertical, down through it 3. left-falling branch 4. right-falling branch 5. short horizontal across the lower stem
+
+That last stroke is the memory hook: it points to the \textbf{root}, so the sign came to mean \textbf{origin}. In the word ahead, read it \emph{hon}, one beat ending in \emph{n}.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{本} — cross, two branches, root mark
+  \item \emph{Write it:} \ja{本} once without looking
+  \item \emph{Say it:} \textbf{hon}, one beat
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? once from memory before beginning the new kanji.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which stroke comes last? (The short \textbf{root mark}.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/0672c.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[gen]{\ja{言} — build the speech side first}
+
+\label{lesson:JA-W05-gen-component}
+
+
+
+\begin{quote}
+Write \ja{本} and point to its short root mark. Now set it aside.
+\end{quote}
+
+\subsection*{Script — one component, not a whole word yet}
+\begin{quote}
+\ja{言}
+\end{quote}
+
+This is the \textbf{speech} component. Write it as a small top mark, three horizontal lines, then a three-stroke box. Keep the horizontals distinct and the box narrow.
+
+Do not memorise a vocabulary word for it today. Its job is visual: when it sits on the left, it signals that the larger kanji has something to do with words or speech. The next two tiny lessons build the right side.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{言} slowly, top to bottom
+  \item \emph{Cover and write:} \ja{言} once
+  \item \emph{Point to:} the small box at the bottom
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? once from memory before building the speech component.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Where will this component sit in the larger sign? (On the \textbf{left}.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/08a00.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[go]{\ja{五} — four strokes for the sound side}
+
+\label{lesson:JA-W05-five-component}
+
+
+
+\begin{quote}
+Trace \ja{言} once. Say “speech side.”
+\end{quote}
+
+\subsection*{Script — the top-right piece}
+\begin{quote}
+\ja{五}
+\end{quote}
+
+Write four strokes: top horizontal; a short vertical and turn; a second horizontal; then the long bottom horizontal. Keep the shape wider than tall.
+
+This sign means \textbf{five} on its own. Here, you only need its second job: it helps cue the sound \emph{go} inside the larger kanji that is coming.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{五} — top, turn, middle, bottom
+  \item \emph{Write it:} \ja{五} once from memory
+  \item \emph{Say it:} \textbf{go}, one beat
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which line is longest? (The \textbf{bottom} line.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/04e94.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[kuchi]{\ja{口} — close a box in three strokes}
+
+\label{lesson:JA-W05-mouth-component}
+
+
+
+\begin{quote}
+Write \ja{五} once. Leave a little space below it with your finger.
+\end{quote}
+
+\subsection*{Script — the lower-right piece}
+\begin{quote}
+\ja{口}
+\end{quote}
+
+Write three strokes:
+
+1. left side, down 2. top and right side as one turning stroke 3. bottom, left to right, closing the box
+
+It is the picture-sign for a \textbf{mouth}. In the larger kanji ahead, it sits under \ja{五}. Today the whole job is one small square.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{口} — side, corner, close
+  \item \emph{Write it:} \ja{口} once from memory
+  \item \emph{Stack:} point below \ja{五}, where \ja{口} will go
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Read ????? from memory before drawing the new box component.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which stroke closes the box? (The \textbf{bottom} stroke.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/053e3.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[go]{\ja{語} — assemble; do not memorise fourteen loose strokes}
+
+\label{lesson:JA-W05-go-kanji}
+
+
+
+\begin{quote}
+Point left and picture \ja{言}. Point upper-right and picture \ja{五}. Point lower-right and picture \ja{口}. Those are all the pieces.
+\end{quote}
+
+\subsection*{Script — three known blocks become one sign}
+\begin{quote}
+\ja{語}
+\end{quote}
+
+Build it in blocks:
+
+1. write \ja{言}, narrow, on the left 2. write \ja{五} in the upper-right 3. write \ja{口} directly under \ja{五}
+
+Read the whole sign \emph{go}, one beat. It means \textbf{language} here. There are fourteen strokes, but there are not fourteen new decisions: you already practised every block separately.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{語} by naming the blocks — speech, five, mouth
+  \item \emph{Cover and build:} \ja{言} + \ja{五} + \ja{口}
+  \item \emph{Read it:} \textbf{go} — language
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which component fills the left side? (\textbf{\ja{言}}, the speech component.)
+
+Source: \href{https://kanjivg.tagaini.net/kanjivg/kanji/08a9e.html}{KanjiVG stroke-order data}.
+\end{tcolorbox}
+\section[nihongo]{\ja{日本語} — three characters, and no single sound each}
+
+\label{lesson:JA-C01-nihongo}
+
+
+
+\begin{quote}
+Say \textbf{\ja{こんにちは}} (\emph{konnichiwa}). Now write \ja{日}, \ja{本}, and \ja{語} once each. This lesson joins those three already-practised kanji to name the language.
+\end{quote}
+
+\subsection*{Script — kanji, and the readings problem}
+\begin{quote}
+\textbf{\ja{日本語}} — \emph{ni} + \emph{hon} + \emph{go}
+\end{quote}
+
+These are \textbf{kanji}: characters borrowed from Chinese, each carrying a meaning rather than a sound. \ja{日} is sun or day. \ja{本} is origin or root. \ja{語} is language. So \ja{日本} is \textquotedblleft{}sun-origin\textquotedblright{} — the country the sun rises from — and \ja{日本語} is its language.
+
+Now the fact that makes kanji unlike any letter you have learned. A kanji does not have \emph{a} sound. \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or \emph{ka}, depending on the word it stands in — and in \ja{日本} it is shortened again, to \emph{ni}. There is no sensible way to teach \textquotedblleft{}the sound of \ja{日}.\textquotedblright{} What a lesson can teach is the \textbf{word}: you learn \ja{日本語} as \emph{nihongo}, and the reading of each character comes along with it.
+
+Two families of readings explain the spread. The \textbf{on} reading is Japan's version of the Chinese pronunciation, imported with the character. The \textbf{kun} reading is a native Japanese word written with a borrowed character that already meant the same thing. \ja{日本語} uses the imported reading family throughout. The older spelling behind the greeting is irregular even by those standards, so it remains postponed rather than becoming an unexplained decoding test.
+
+\begin{cousinweb}
+Here the cousin web finally works — just not toward English. The on-readings \emph{nichi}, \emph{hon}, \emph{go} are borrowings of Middle Chinese, so \ja{日本語} has genuine relatives: Mandarin writes the same three characters and says \emph{Rìběnyǔ}; Korean borrowed the same compound as \emph{ilbon-eo}. Same characters, related imported sounds, one meaning, three languages.
+
+That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it.
+\end{cousinweb}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textbf{\ja{日本語}} — \emph{ni-ho-n-go}, four beats{]} {[}REPEAT x2
+  \item \emph{Name:} \ja{日} sun or day; \ja{本} origin; \ja{語} language
+  \item \emph{Connect:} Mandarin \emph{Rìběnyǔ}, Korean \emph{ilbon-eo}, same three characters
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Build ? once from ?, ?, and ? before joining the full word.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \ja{日本} mean literally? (Sun-origin.) Does \ja{日} have one pronunciation? (No — the word it appears in chooses one.)
+
+Source: \href{https://en.wiktionary.org/wiki/\%E6\%97\%A5\%E6\%9C\%AC\%E8\%AA\%9E}{Wiktionary: \ja{日本語}}.
+\end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch06-koohii-katakana.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch06-koohii-katakana.tex
@@ -1,0 +1,165 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:7adbd5a272c5dded
+% canonical-lessons: JA-W06-ko-katakana, JA-W06-long-mark, JA-W06-hi-katakana, JA-C01-koohii
+
+\chapter{Coffee in Katakana, Three Shapes}
+\label{ch:ja-koohii-katakana}
+\hlchaptermodality{6}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can write \ja{コ}, \ja{ー}, and \ja{ヒ}, read \ja{コーヒー} as four morae, and explain that the long mark holds the preceding vowel.}
+
+A borrowed word made from only three distinct katakana shapes, each taught before the full word appears.
+\end{chapteropening}
+
+\section[ko]{\ja{コ} — same sound, a new script}
+
+\label{lesson:JA-W06-ko-katakana}
+
+
+
+\begin{quote}
+Read \ja{日本語} once. Now switch jobs: the next word came from abroad, so Japanese normally writes it in katakana.
+\end{quote}
+
+\subsection*{Script — two angular strokes}
+\begin{quote}
+\ja{コ}
+\end{quote}
+
+Write two strokes:
+
+1. top horizontal, then turn down at the right 2. bottom horizontal, left to right
+
+Read it \emph{ko}, the same mora as hiragana \ja{こ}. The sound is not new. Only the script is new: katakana is angular and commonly marks borrowed words.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{コ} — top-and-side, then bottom
+  \item \emph{Write it:} \ja{コ} once from memory
+  \item \emph{Contrast:} \ja{こ} is hiragana; \ja{コ} is katakana; both say \emph{ko}
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Trace ? once. Then recall why Japanese kanji readings connect to Chinese without giving each sign one fixed sound.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Does \ja{コ} introduce a new sound? (\textbf{No} — only a new written shape.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U30A0.pdf}{Unicode Katakana chart}.
+\end{tcolorbox}
+\section[chōonpu]{\ja{ー} — one line, one extra beat}
+
+\label{lesson:JA-W06-long-mark}
+
+
+
+\begin{quote}
+Write \ja{コ} and say \emph{ko}. Hold its vowel once: \emph{ko-o}.
+\end{quote}
+
+\subsection*{Script — length lives on the page}
+\begin{quote}
+\ja{コー}
+\end{quote}
+
+Write one horizontal stroke after the katakana sign. This mark is the \textbf{chōonpu}, the long-vowel mark. It does not have a sound by itself. It tells you to hold the vowel before it for one more mora.
+
+So \ja{コ} is \emph{ko}, while \ja{コー} is \emph{kō}: two beats, \emph{ko-o}. Keep the line centred and about as wide as the sign before it.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ja{コ}, then \ja{ー}
+  \item \emph{Tap:} \emph{ko} — one; hold \emph{o} — two
+  \item \emph{Read it:} \ja{コー} as \textbf{kō}, not \emph{ko}
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? once from memory, then return to the one-stroke length mark.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many extra beats does \ja{ー} add? (\textbf{One}.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U30A0.pdf}{Unicode Katakana chart}.
+\end{tcolorbox}
+\section[hi]{\ja{ヒ} — two strokes complete the inventory}
+
+\label{lesson:JA-W06-hi-katakana}
+
+
+
+\begin{quote}
+Write \ja{コー} and tap its two beats: \emph{ko-o}.
+\end{quote}
+
+\subsection*{Script — the last new shape}
+\begin{quote}
+\ja{ヒ}
+\end{quote}
+
+Write two strokes:
+
+1. a short stroke from right toward left 2. a longer vertical stroke that turns and sweeps right at the bottom
+
+Read it \emph{hi}, one mora. Japanese \emph{h} is light; keep the vowel clean, like the \emph{ee} in \emph{machine} but short.
+
+Now every distinct sign in the word ahead is known: \ja{コ}, \ja{ー}, and \ja{ヒ}.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \ja{ヒ} — short top, long bent body
+  \item \emph{Write it:} \ja{ヒ} once from memory
+  \item \emph{Build:} \ja{コ} + \ja{ー} + \ja{ヒ} + \ja{ー}
+\end{itemize}
+
+\subsection*{Your turn — review pulse}
+Write ? once from memory before switching back to katakana.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which stroke bends to the right? (The \textbf{second}, longer stroke.)
+
+Source: \href{https://www.unicode.org/charts/PDF/U30A0.pdf}{Unicode Katakana chart}.
+\end{tcolorbox}
+\section[kōhī]{\ja{コーヒー} — the third system, and a word that really is a cousin}
+
+\label{lesson:JA-C01-koohii}
+
+
+
+\begin{quote}
+Recall how hiragana writes a long vowel: it writes the vowel twice, as in \textbf{\ja{いいえ}}. Katakana does it differently, and this word shows how.
+\end{quote}
+
+\subsection*{Script — katakana, the borrowed-word script}
+\begin{quote}
+\textbf{\ja{コーヒー}} — \textbf{\ja{コ}} \emph{ko} + \textbf{\ja{ー}} + \textbf{\ja{ヒ}} \emph{hi} + \textbf{\ja{ー}}
+\end{quote}
+
+This is \textbf{katakana}, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms.
+
+The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from \emph{fragments} of characters, shorthand that monks scribbled beside a text to remember how to read it. \textbf{\ja{こ}} and \textbf{\ja{コ}} even trace back to the same character, which is why they still look alike.
+
+\textbf{\ja{ー}} is the \emph{chōonpu}, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So \textbf{\ja{コーヒー}} is four beats: \emph{ko-o-hi-i}.
+
+\begin{cousinweb}
+\textbf{\ja{コーヒー}} is \textbf{coffee}, and it entered Japanese from Dutch \emph{koffie} through the Nagasaki trade. Dutch had it from Turkish \emph{kahve}, and Turkish from Arabic \emph{qahwa} — which is exactly where English \emph{coffee} comes from as well.
+
+So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads include \emph{pan}, \textquotedblleft{}bread,\textquotedblright{} from Portuguese \emph{pão}, and \emph{arubaito}, \textquotedblleft{}a part-time job,\textquotedblright{} from German \emph{Arbeit}. Their katakana signs can wait for their own one-sign lessons.
+\end{cousinweb}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} \textbf{\ja{コーヒー}} — \emph{ko-o-hi-i}, four beats{]} {[}REPEAT x2
+  \item \emph{Trace it:} Arabic \emph{qahwa} $\to$ Turkish \emph{kahve} $\to$ Dutch \emph{koffie} $\to$ \textbf{\ja{コーヒー}}
+  \item \emph{Decide:} a borrowed word is written in katakana, not hiragana
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which script signals a borrowed word? (Katakana.) How many beats does \textbf{\ja{コーヒー}} hold? (Four.)
+
+Source: \href{https://en.wiktionary.org/wiki/\%E3\%82\%B3\%E3\%83\%BC\%E3\%83\%92\%E3\%83\%BC}{Wiktionary: \ja{コーヒー}}.
+\end{tcolorbox}

--- a/code/learning/human-languages/japanese/book/chapters/ch07-doorway-exchange.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch07-doorway-exchange.tex
@@ -1,0 +1,44 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:c6bb3d2770dc4aaa
+% canonical-lessons: JA-C01-practice
+
+\chapter{The Doorway Exchange}
+\label{ch:ja-doorway-exchange}
+\hlchaptermodality{7}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can greet, name the language, answer yes or no, and thank someone politely while listening, speaking, reading, and writing independently.}
+
+A six-line doorway exchange using only words and signs already taught in the preceding six chapters.
+\end{chapteropening}
+
+\section[Practice]{Practice — one daytime exchange, three scripts}
+
+\label{lesson:JA-C01-practice}
+
+
+
+\begin{quote}
+Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here.
+\end{quote}
+
+\subsection*{The exchange — every line already learned}
+\begin{quote}
+A: \textbf{\ja{こんにちは。}} — \emph{Konnichiwa.} B: \textbf{\ja{こんにちは。}} — \emph{Konnichiwa.} A: \textbf{\ja{日本語}}? — \emph{Nihongo?} B: \textbf{\ja{はい。}} — \emph{Hai.} A: \textbf{\ja{ありがとうございます。}} — \emph{Arigatō gozaimasu.} B: \textbf{\ja{いいえ。}} — \emph{Iie.}
+\end{quote}
+
+Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so \textbf{\ja{日本語}} with the voice lifted is a complete and natural way to ask \textquotedblleft{}Japanese, then?\textquotedblright{} — and \textbf{\ja{はい}} answers it. B's closing \textbf{\ja{いいえ}} is the modest \textquotedblleft{}not at all\textquotedblright{} that waves thanks away.
+
+An ordinary Japanese page mixes systems: hiragana carries much of the grammar, kanji carries many content words, and katakana commonly carries borrowings. The six earlier chapters introduced those systems separately; this payoff is where they finally work together.
+
+\subsection*{Your turn}
+1. \textbf{Listen:} hear one line with no text and identify greeting, language, answer, or thanks. 2. \textbf{Speak:} take B's part while the other lines are read aloud. 3. \textbf{Read:} run both voices from Japanese only, with the romanization covered. 4. \textbf{Write:} hear \textbf{\ja{日本語}}, wait ten seconds, and write the three kanji with no visible model.
+
+Score the four actions separately. A fluent spoken line cannot cover a missing kanji in writing, and recognition cannot cover an unanswered spoken cue.
+
+\subsection*{Your turn — review pulse}
+From memory, write ??, ???, ?????, ?????, ???, and ????. Circle the dakuten and say why the borrowed word uses katakana.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter.
+\end{tcolorbox}

--- a/code/learning/human-languages/japanese/chapters.json
+++ b/code/learning/human-languages/japanese/chapters.json
@@ -4,80 +4,93 @@
   "chapters": [
     {
       "chapter": 1,
-      "title": "Three Writing Systems in One Doorway",
-      "label": "ch:ja-three-scripts",
-      "canDo": "I can greet someone in the daytime, answer yes or no, and thank them politely, reading each word in the script Japanese actually uses for it.",
-      "spineNodes": [
-        "SPINE-RESPOND-BASIC",
-        "SPINE-MEET-GREET",
-        "SPINE-COURTESY-THANK"
-      ],
+      "title": "Two Answers, Sign by Sign",
+      "label": "ch:ja-two-answers",
+      "canDo": "I can write the three hiragana signs in はい and いいえ, read both answers without romanization, and say each with even mora timing.",
+      "spineNodes": ["SPINE-RESPOND-BASIC"],
       "payoff": {
-        "lesson": "JA-C01-practice",
-        "kind": "dialogue",
-        "summary": "A six-line daytime doorway exchange that mixes hiragana and kanji and uses no untaught word.",
-        "assesses": [
-          "JA-LEX-KONNICHIWA",
-          "JA-LEX-NIHONGO",
-          "JA-LEX-HAI",
-          "JA-LEX-IIE",
-          "JA-LEX-ARIGATOU-GOZAIMASU",
-          "JA-REGISTER-TEINEIGO",
-          "JA-PARTICLE-WA-SPELLING",
-          "JA-SCRIPT-HIRAGANA-MORA",
-          "JA-SCRIPT-KANJI-READINGS",
-          "JA-DIALOGUE-DOORWAY"
-        ]
+        "lesson": "JA-C01-iie",
+        "kind": "reading",
+        "summary": "A yes-or-no choice using only three signs the learner has already traced, copied, recalled, and read.",
+        "assesses": ["JA-LEX-HAI", "JA-LEX-IIE", "JA-SCRIPT-I-01", "JA-SCRIPT-HA-01", "JA-SCRIPT-E-01"]
       }
     },
     {
       "chapter": 2,
-      "title": "Eight Signs, and Three Words You Can Read",
-      "label": "ch:ja-hiragana-eight",
-      "canDo": "I can write eight hiragana signs from memory and read the daytime greeting and both yes-or-no answers by sounding out their signs in order, including the sign that is pronounced wa because it is a topic marker.",
-      "spineNodes": [
-        "SPINE-RESPOND-BASIC",
-        "SPINE-MEET-GREET"
-      ],
+      "title": "A Daytime Greeting, One Sign at a Time",
+      "label": "ch:ja-daytime-greeting",
+      "canDo": "I can write the five distinct signs in こんにちは, read them in order, and remember why final は is pronounced wa.",
+      "spineNodes": ["SPINE-MEET-GREET"],
       "payoff": {
-        "lesson": "JA-W01-konnichiwa-read",
-        "kind": "reading",
-        "summary": "The daytime greeting assembled from five signs the reader can each write from memory, introducing nothing new — including the one read wa because it is a topic marker rather than the sign for that sound.",
-        "assesses": [
-          "JA-SCRIPT-KONNICHIWA-READ-01",
-          "JA-SCRIPT-KO-01",
-          "JA-SCRIPT-N-01",
-          "JA-SCRIPT-NI-01",
-          "JA-SCRIPT-CHI-01",
-          "JA-SCRIPT-HA-01"
-        ]
+        "lesson": "JA-C01-konnichiwa",
+        "kind": "dialogue",
+        "summary": "A one-line daytime greeting whose five signs were each taught before the learner reads it.",
+        "assesses": ["JA-LEX-KONNICHIWA", "JA-PARTICLE-WA-SPELLING", "JA-SCRIPT-KONNICHIWA-READ-01", "JA-SCRIPT-KO-01", "JA-SCRIPT-N-01", "JA-SCRIPT-NI-01", "JA-SCRIPT-CHI-01", "JA-SCRIPT-WA-01"]
       }
     },
     {
       "chapter": 3,
-      "title": "Eight Signs, One Mark, and the Longest Word You Know",
-      "label": "ch:ja-thanks",
-      "canDo": "I can write eight more hiragana from memory, add the dakuten to voice a sign I already know, and read ありがとうございます off the page without the romanization.",
-      "spineNodes": [
-        "SPINE-COURTESY-THANK"
-      ],
+      "title": "Plain Thanks, One Sign at a Time",
+      "label": "ch:ja-plain-thanks",
+      "canDo": "I can write and read ありがとう, build が with the dakuten, and say the five morae without swallowing the long final vowel.",
+      "spineNodes": ["SPINE-COURTESY-THANK"],
+      "payoff": {
+        "lesson": "JA-C01-arigatou",
+        "kind": "dialogue",
+        "summary": "A plain thank-you read only after every distinct hiragana sign and the dakuten have their own small step.",
+        "assesses": ["JA-LEX-ARIGATOU", "JA-SCRIPT-DAKUTEN", "JA-ETYMON-ARIGATASHI", "JA-SCRIPT-ARIGATOU-READ-01", "JA-SCRIPT-A-01", "JA-SCRIPT-RI-01", "JA-SCRIPT-KA-01", "JA-SCRIPT-DAKUTEN-01", "JA-SCRIPT-TO-01", "JA-SCRIPT-U-01"]
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Polite Thanks, Three More Signs",
+      "label": "ch:ja-polite-thanks",
+      "canDo": "I can add ございます to a known thank-you, read every sign, and choose the polite form for someone outside my close circle.",
+      "spineNodes": ["SPINE-COURTESY-THANK"],
       "payoff": {
         "lesson": "JA-C03-practice",
         "kind": "dialogue",
-        "summary": "The ten signs of the polite thank-you named one by one, three of them earlier signs wearing two ticks, and a short exchange in which every character on the page is one the reader can write.",
-        "assesses": [
-          "JA-SCRIPT-A-01",
-          "JA-SCRIPT-RI-01",
-          "JA-SCRIPT-KA-01",
-          "JA-SCRIPT-TO-01",
-          "JA-SCRIPT-U-01",
-          "JA-SCRIPT-SA-01",
-          "JA-SCRIPT-MA-01",
-          "JA-SCRIPT-SU-01",
-          "JA-SCRIPT-DAKUTEN-01",
-          "JA-SCRIPT-ARIGATOU-READ-01",
-          "JA-SCRIPT-GOZAIMASU-READ-01"
-        ]
+        "summary": "A short casual-versus-polite choice with every sign taught and the register decision checked independently.",
+        "assesses": ["JA-LEX-ARIGATOU-GOZAIMASU", "JA-REGISTER-TEINEIGO", "JA-SCRIPT-GOZAIMASU-READ-01"]
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "Nihongo, Built in Small Blocks",
+      "label": "ch:ja-nihongo-kanji",
+      "canDo": "I can write 日 and 本, assemble 語 from three practised components, and read 日本語 as nihongo.",
+      "spineNodes": ["SPINE-MEET-GREET"],
+      "payoff": {
+        "lesson": "JA-C01-nihongo",
+        "kind": "reading",
+        "summary": "Three kanji read as one known word after the simple signs and the complex sign's components were taught separately.",
+        "assesses": ["JA-LEX-NIHONGO", "JA-SCRIPT-KANJI-READINGS", "JA-SCRIPT-KANJI-NICHI-01", "JA-SCRIPT-KANJI-HON-01", "JA-SCRIPT-KANJI-GO-01"]
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Coffee in Katakana, Three Shapes",
+      "label": "ch:ja-koohii-katakana",
+      "canDo": "I can write コ, ー, and ヒ, read コーヒー as four morae, and explain that the long mark holds the preceding vowel.",
+      "spineNodes": ["SPINE-MEET-GREET"],
+      "payoff": {
+        "lesson": "JA-C01-koohii",
+        "kind": "reading",
+        "summary": "A borrowed word made from only three distinct katakana shapes, each taught before the full word appears.",
+        "assesses": ["JA-LEX-KOOHII", "JA-SCRIPT-KATAKANA-KO-01", "JA-SCRIPT-KATAKANA-LONG-MARK-01", "JA-SCRIPT-KATAKANA-HI-01", "JA-SCRIPT-CHOUON"]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "The Doorway Exchange",
+      "label": "ch:ja-doorway-exchange",
+      "canDo": "I can greet, name the language, answer yes or no, and thank someone politely while listening, speaking, reading, and writing independently.",
+      "spineNodes": ["SPINE-RESPOND-BASIC", "SPINE-MEET-GREET", "SPINE-COURTESY-THANK"],
+      "payoff": {
+        "lesson": "JA-C01-practice",
+        "kind": "dialogue",
+        "summary": "A six-line doorway exchange using only words and signs already taught in the preceding six chapters.",
+        "assesses": ["JA-LEX-KONNICHIWA", "JA-LEX-NIHONGO", "JA-LEX-HAI", "JA-LEX-IIE", "JA-LEX-ARIGATOU-GOZAIMASU", "JA-DIALOGUE-DOORWAY"]
       }
     }
   ]

--- a/code/learning/human-languages/japanese/curriculum.json
+++ b/code/learning/human-languages/japanese/curriculum.json
@@ -6,12 +6,12 @@
       "id": "JA-PATH-001",
       "spine_node": "SPINE-RESPOND-BASIC",
       "lessons": [
-        "JA-C01-hai",
-        "JA-C01-iie",
         "JA-W01-i",
         "JA-W01-ha",
         "JA-W01-hai-read",
-        "JA-W01-e"
+        "JA-W01-e",
+        "JA-C01-hai",
+        "JA-C01-iie"
       ],
       "before": [],
       "inline": [
@@ -25,21 +25,17 @@
       "id": "JA-PATH-002",
       "spine_node": "SPINE-MEET-GREET",
       "lessons": [
-        "JA-C01-konnichiwa",
-        "JA-C01-nihongo",
-        "JA-C01-koohii",
         "JA-W01-ko",
         "JA-W01-n",
         "JA-W01-ni",
         "JA-W01-chi",
         "JA-W01-wa",
-        "JA-W01-konnichiwa-read"
+        "JA-W01-konnichiwa-read",
+        "JA-C01-konnichiwa"
       ],
       "before": [],
       "inline": [
-        "JA-EXT-002-TOPIC-PARTICLE-SPELLING",
-        "JA-EXT-003-KANJI-READINGS",
-        "JA-EXT-004-KATAKANA-LOANWORDS"
+        "JA-EXT-002-TOPIC-PARTICLE-SPELLING"
       ],
       "after": [
         "JA-EXT-009-HIRAGANA-GREETING"
@@ -49,22 +45,6 @@
       "id": "JA-PATH-003",
       "spine_node": "SPINE-COURTESY-THANK",
       "lessons": [
-        "JA-C01-arigatou",
-        "JA-C01-gozaimasu",
-        "JA-C01-practice"
-      ],
-      "before": [],
-      "inline": [
-        "JA-EXT-005-DAKUTEN",
-        "JA-EXT-006-TEINEIGO-REGISTER",
-        "JA-EXT-007-MIXED-SCRIPT-CONSOLIDATION"
-      ],
-      "after": []
-    },
-    {
-      "id": "JA-PATH-004",
-      "spine_node": "SPINE-COURTESY-THANK",
-      "lessons": [
         "JA-W03-a",
         "JA-W03-ri",
         "JA-W03-ka",
@@ -72,16 +52,77 @@
         "JA-W03-to",
         "JA-W03-u",
         "JA-W03-arigatou-read",
+        "JA-C01-arigatou"
+      ],
+      "before": [],
+      "inline": [
+        "JA-EXT-005-DAKUTEN",
+        "JA-EXT-010-HIRAGANA-THANKS"
+      ],
+      "after": []
+    },
+    {
+      "id": "JA-PATH-004",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
         "JA-W03-sa",
         "JA-W03-ma",
         "JA-W03-su",
+        "JA-C01-gozaimasu",
         "JA-C03-practice"
       ],
       "before": [],
       "inline": [
-        "JA-EXT-010-HIRAGANA-THANKS",
+        "JA-EXT-006-TEINEIGO-REGISTER",
         "JA-EXT-011-DAKUTEN-WRITING",
         "JA-EXT-012-POLITE-THANKS-CONSOLIDATION"
+      ],
+      "after": []
+    },
+    {
+      "id": "JA-PATH-005",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "JA-W05-nichi-kanji",
+        "JA-W05-hon-kanji",
+        "JA-W05-gen-component",
+        "JA-W05-five-component",
+        "JA-W05-mouth-component",
+        "JA-W05-go-kanji",
+        "JA-C01-nihongo"
+      ],
+      "before": [],
+      "inline": [
+        "JA-EXT-013-NIHONGO-KANJI",
+        "JA-EXT-003-KANJI-READINGS"
+      ],
+      "after": []
+    },
+    {
+      "id": "JA-PATH-006",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "JA-W06-ko-katakana",
+        "JA-W06-long-mark",
+        "JA-W06-hi-katakana",
+        "JA-C01-koohii"
+      ],
+      "before": [],
+      "inline": [
+        "JA-EXT-014-KOOHII-KATAKANA",
+        "JA-EXT-004-KATAKANA-LOANWORDS"
+      ],
+      "after": []
+    },
+    {
+      "id": "JA-PATH-007",
+      "spine_node": "SPINE-COURTESY-THANK",
+      "lessons": [
+        "JA-C01-practice"
+      ],
+      "before": [],
+      "inline": [
+        "JA-EXT-007-MIXED-SCRIPT-CONSOLIDATION"
       ],
       "after": []
     }
@@ -89,7 +130,9 @@
   "spine": {
     "SPINE-MEET-GREET": {
       "segments": [
-        "JA-PATH-002"
+        "JA-PATH-002",
+        "JA-PATH-005",
+        "JA-PATH-006"
       ],
       "omits": [
         "GREETING-FORMAL",
@@ -101,7 +144,8 @@
     "SPINE-COURTESY-THANK": {
       "segments": [
         "JA-PATH-003",
-        "JA-PATH-004"
+        "JA-PATH-004",
+        "JA-PATH-007"
       ],
       "omits": [
         "COURTESY-THANKS-CASUAL",
@@ -483,7 +527,7 @@
       "category": "script",
       "canDo": "I can read a three-kanji word and explain that a kanji carries a set of readings the word selects from, not one fixed sound.",
       "prerequisites": [
-        "JA-EXT-002-TOPIC-PARTICLE-SPELLING"
+        "JA-EXT-013-NIHONGO-KANJI"
       ],
       "lessons": [
         "JA-C01-nihongo"
@@ -496,7 +540,7 @@
       "category": "script",
       "canDo": "I can read a katakana loanword with its long-vowel bar and recognise katakana as the script that marks a word as borrowed.",
       "prerequisites": [
-        "JA-EXT-003-KANJI-READINGS"
+        "JA-EXT-014-KOOHII-KATAKANA"
       ],
       "lessons": [
         "JA-C01-koohii"
@@ -509,7 +553,7 @@
       "category": "script",
       "canDo": "I can add the dakuten to a hiragana sign to voice it, and read the etymology of arigatou without treating history as a production burden.",
       "prerequisites": [
-        "JA-EXT-004-KATAKANA-LOANWORDS"
+        "JA-EXT-010-HIRAGANA-THANKS"
       ],
       "lessons": [
         "JA-C01-arigatou"
@@ -535,7 +579,8 @@
       "category": "consolidation",
       "canDo": "I can run a short daytime exchange that mixes hiragana and kanji in one conversation using only independently learned lines.",
       "prerequisites": [
-        "JA-EXT-006-TEINEIGO-REGISTER"
+        "JA-EXT-006-TEINEIGO-REGISTER",
+        "JA-EXT-004-KATAKANA-LOANWORDS"
       ],
       "lessons": [
         "JA-C01-practice"
@@ -621,6 +666,39 @@
         "JA-W03-ma",
         "JA-W03-su",
         "JA-C03-practice"
+      ]
+    },
+    {
+      "id": "JA-EXT-013-NIHONGO-KANJI",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can write 日 and 本, build 語 from three separately practised components, and join the three signs without treating fourteen strokes as one jump.",
+      "prerequisites": [
+        "JA-EXT-012-POLITE-THANKS-CONSOLIDATION"
+      ],
+      "lessons": [
+        "JA-W05-nichi-kanji",
+        "JA-W05-hon-kanji",
+        "JA-W05-gen-component",
+        "JA-W05-five-component",
+        "JA-W05-mouth-component",
+        "JA-W05-go-kanji"
+      ]
+    },
+    {
+      "id": "JA-EXT-014-KOOHII-KATAKANA",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can write the three distinct katakana shapes in コーヒー and use the long mark to hold the preceding vowel for one more mora.",
+      "prerequisites": [
+        "JA-EXT-003-KANJI-READINGS"
+      ],
+      "lessons": [
+        "JA-W06-ko-katakana",
+        "JA-W06-long-mark",
+        "JA-W06-hi-katakana"
       ]
     }
   ]

--- a/code/learning/human-languages/japanese/lessons/JA-C01-arigatou.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-arigatou.md
@@ -2,31 +2,31 @@
 schema_version: 2
 id: JA-C01-arigatou
 spine_node: SPINE-COURTESY-THANK
-sequence: 60
-chapter: 1
+sequence: 210
+chapter: 3
 type: word
 headword: ありがとう
 romanization: arigatō
 gloss: thank you (plain)
 concept_tag: COURTESY-THANKS
-prerequisites: [JA-C01-koohii]
+prerequisites: [JA-W03-arigatou-read]
 sounds: [mora, dakuten, long-o]
 roots: [arigatashi]
-etymology_hook: ありがとう ← 有り難う “hard to exist” → rare → precious → thank you.
+etymology_hook: Arigatashi meant “hard to exist” → rare → precious → thank you.
 duration:
   max_seconds: 220
 requires:
-  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-CHOUON]
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-MORA-LENGTH, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-ARIGATOU-READ-01]
 introduces:
   knowledge: [JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI]
 practises:
-  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI]
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI, JA-SCRIPT-ARIGATOU-READ-01, JA-SCRIPT-A-01, JA-SCRIPT-RI-01, JA-SCRIPT-KA-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-TO-01, JA-SCRIPT-U-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
 register: plain-casual
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-koohii]
+reviews_of: [JA-W03-arigatou-read, JA-C01-konnichiwa]
 ---
 
 # ありがとう — thanks, from “this hardly ever happens”
@@ -50,34 +50,40 @@ One mark, learned once, doubles how much of the script you can read.
 
 The final **う** does not sound like *u* here. After **と** it stretches the *o*,
 so the word ends *-tō* and holds five beats: *a-ri-ga-to-o*. Hiragana lengthens
-a vowel by writing another vowel sign, where katakana used the bar **ー**.
+a vowel here by writing another vowel sign. Katakana will get its own tiny
+length lesson later.
 
-## The word, taken apart — 有り難う
+## The word, taken apart — *arigatashi*
 <!-- hl-knowledge: introduces=[JA-ETYMON-ARIGATASHI, JA-LEX-ARIGATOU]; assesses=[] -->
 
-Written in kanji, **ありがとう** is 有り難う: 有る *aru* "to exist" plus 難し
-*katashi* "difficult." Its ancestor 有り難し *arigatashi* meant literally **"hard
-to exist"** — that is, rare. Rare became precious, precious became grateful, and
-by the Edo period the word had settled into plain thanks. The *k* of *katashi*
-softened to *g* inside the compound, which is the same voicing the dakuten
-writes.
+The older form combines *aru*, "to exist," with *katashi*, "difficult."
+*Arigatashi* therefore meant literally **"hard to exist"** — that is, rare. Rare
+became precious, precious became grateful, and by the Edo period the word had
+settled into plain thanks. The *k* of *katashi* softened to *g* inside the
+compound, which is the same voicing the dakuten writes. Its historical kanji
+spelling can wait until those signs receive their own lessons.
 
 So the memory hook is inside the word, not inside English: saying **ありがとう**
 is saying *this was not a thing that had to happen*. No English cousin exists,
 and inventing one would be worse than admitting that.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI, JA-SCRIPT-ARIGATOU-READ-01, JA-SCRIPT-A-01, JA-SCRIPT-RI-01, JA-SCRIPT-KA-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-TO-01, JA-SCRIPT-U-01] -->
 
 - [YOU SAY: **ありがとう** — *a-ri-ga-to-o*, five beats] [REPEAT x2]
 - [YOU BUILD: **か** plus the dakuten → **が**]
-- [YOU CONNECT: 有り難し "hard to exist" → rare → precious → thanks]
+- [YOU CONNECT: *arigatashi* "hard to exist" → rare → precious → thanks]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KA-01] -->
+
+[PAUSE 15s] Write ? once from memory, then add the two dakuten strokes.
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-ETYMON-ARIGATASHI, JA-SCRIPT-ARIGATOU-READ-01, JA-SCRIPT-A-01, JA-SCRIPT-RI-01, JA-SCRIPT-KA-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-TO-01, JA-SCRIPT-U-01] -->
 <!-- hl-activity: {"id":"JA-C01-arigatou-dakuten","kind":"text","assesses":["JA-SCRIPT-DAKUTEN"],"prompt":"Which hiragana sign becomes が when the dakuten is added?","answer":"か","accepted":["ka","か ka"],"feedback":{"correct":"Right: か plus the two strokes is が.","incorrect":"It is か — the dakuten voices ka into ga."},"response_seconds":8} -->
 
-What did 有り難し mean literally? (Hard to exist.) What does the last **う**
+What did *arigatashi* mean literally? (Hard to exist.) What does the last **う**
 do? (It lengthens the *o*.)
 
 Source: [Wiktionary: ありがとう](https://en.wiktionary.org/wiki/%E6%9C%89%E9%9B%A3%E3%81%86).

--- a/code/learning/human-languages/japanese/lessons/JA-C01-gozaimasu.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-gozaimasu.md
@@ -2,14 +2,14 @@
 schema_version: 2
 id: JA-C01-gozaimasu
 spine_node: SPINE-COURTESY-THANK
-sequence: 70
-chapter: 1
+sequence: 250
+chapter: 4
 type: word
 headword: ありがとうございます
 romanization: arigatō gozaimasu
 gloss: thank you (polite)
 concept_tag: JA-WORD-ARIGATOU-GOZAIMASU
-prerequisites: [JA-C01-arigatou]
+prerequisites: [JA-W03-su]
 sounds: [mora, dakuten, long-o]
 roots: [gozaru]
 etymology_hook: Politeness in Japanese is not a different word but a different verb ending — and sometimes a different verb.
@@ -52,10 +52,10 @@ The whole phrase is ten beats — *a-ri-ga-to-o go-za-i-ma-su* — and the final
 ## Grammar Lens — politeness is grammar here, not word choice
 <!-- hl-knowledge: introduces=[JA-REGISTER-TEINEIGO, JA-LEX-ARIGATOU-GOZAIMASU]; assesses=[] -->
 
-**ございます** is a verb. It is the polite form of ある *aru*, "to be" — the same
-verb that sits inside **ありがとう**. The route runs ある → ござる → **ございます**,
-where the ending **-ます** is the general politeness marker Japanese attaches to
-verbs.
+**ございます** is a verb. It is the polite descendant of *aru*, "to be" — the
+same verb that sits inside **ありがとう**. The historical route runs *aru* to
+*gozaru* to **ございます**, where the ending **-ます** is the general politeness
+marker Japanese attaches to verbs.
 
 That is the difference this chapter has to name. In many languages politeness is
 a choice between two words for "you." Japanese instead marks it on the
@@ -64,10 +64,11 @@ no neutral setting: **ありがとう** to a friend and **ありがとうござ�
 stranger are not two styles of the same form, they are two different grammatical
 levels, and choosing wrongly is heard immediately.
 
-At the far end of the system, the verb itself is replaced. 言う *iu* "to say"
-becomes おっしゃる when the speaker is honouring someone else and 申す when
-humbling themselves. Same act, three verbs, chosen by who is doing what to whom.
-That is **keigo**, and this lesson is only its front door.
+At the far end of the system, even the verb can be replaced: ordinary *iu*, "to
+say," has the respectful form *ossharu* and the humble form *mōsu*. Same act,
+three verbs, chosen by who is doing what to whom. That is **keigo**, and this
+lesson is only its front door. Their spellings belong in later, separately
+taught script lessons.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO] -->
@@ -80,7 +81,7 @@ That is **keigo**, and this lesson is only its front door.
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO, JA-LEX-ARIGATOU] -->
 <!-- hl-activity: {"id":"JA-C01-gozaimasu-level","kind":"text","assesses":["JA-REGISTER-TEINEIGO"],"prompt":"You are thanking a shop assistant you have never met. Which form do you use?","answer":"ありがとうございます","accepted":["arigato gozaimasu","arigatou gozaimasu","arigatō gozaimasu","the polite one"],"feedback":{"correct":"Right: the polite -masu form is the default with someone outside your circle.","incorrect":"Use ありがとうございます — the plain ありがとう is for people close to you."},"response_seconds":10} -->
 
-Which verb hides inside **ございます**? (ある, "to be.") Can a Japanese sentence
+Which verb hides inside **ございます**? (*aru*, "to be.") Can a Japanese sentence
 avoid marking politeness? (No — the predicate always carries a level.)
 
 Source: [Wiktionary: ございます](https://en.wiktionary.org/wiki/%E3%81%94%E3%81%96%E3%81%84%E3%81%BE%E3%81%99).

--- a/code/learning/human-languages/japanese/lessons/JA-C01-hai.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-hai.md
@@ -2,31 +2,31 @@
 schema_version: 2
 id: JA-C01-hai
 spine_node: SPINE-RESPOND-BASIC
-sequence: 10
+sequence: 50
 chapter: 1
 type: word
 headword: はい
 romanization: hai
 gloss: yes
 concept_tag: RESPONSE-YES
-prerequisites: []
+prerequisites: [JA-W01-e]
 sounds: [mora, pure-vowels]
 roots: []
 etymology_hook: Two hiragana signs, two equal beats — Japanese counts morae, not syllables.
 duration:
   max_seconds: 180
 requires:
-  knowledge: []
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-HAI-READ-01]
 introduces:
-  knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA]
+  knowledge: [JA-LEX-HAI]
 practises:
-  knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA]
+  knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-HAI-READ-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: []
+reviews_of: [JA-W01-ha, JA-W01-i, JA-W01-hai-read]
 ---
 
 # はい — yes, in two equal beats
@@ -38,7 +38,7 @@ reviews_of: []
 language, and with the first of its three writing systems.
 
 ## Script — two signs, two beats
-<!-- hl-knowledge: introduces=[JA-SCRIPT-HIRAGANA-MORA]; assesses=[] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-HAI-READ-01] -->
 
 > **はい** — **は** *ha* + **い** *i*
 
@@ -55,9 +55,10 @@ single gliding sound of English "high."
 <!-- hl-knowledge: introduces=[JA-LEX-HAI]; assesses=[] -->
 
 **はい** means **yes**, and also "here you are," "I am listening," and
-"present." Its origin is genuinely unsettled: some accounts tie it to 拝 *hai*,
-"a bow"; others treat it as an old interjection. Neither is proven, so hold it
-as an open question rather than a fact.
+"present." Its origin is genuinely unsettled: some accounts tie it to an older
+word *hai*, "a bow"; others treat it as an old interjection. Neither is proven,
+so hold it as an open question rather than a fact. The rare kanji sometimes used
+in that proposal can wait until a later reading chapter.
 
 Say plainly what is true here. Japanese shares no ancestor with English, so no
 cousin word is waiting in your vocabulary to hold **はい** in place. What this

--- a/code/learning/human-languages/japanese/lessons/JA-C01-iie.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-iie.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-C01-iie
 spine_node: SPINE-RESPOND-BASIC
-sequence: 20
+sequence: 60
 chapter: 1
 type: word
 headword: いいえ
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH]
 practises:
-  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH]
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH, JA-LEX-HAI, JA-SCRIPT-I-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-hai]
+reviews_of: [JA-W01-i, JA-W01-e, JA-C01-hai]
 ---
 
 # いいえ — no, and why the extra beat matters
@@ -65,6 +65,11 @@ daily speech, which is worth knowing before you meet it as an answer to
 - [YOU SAY: **いいえ** — *i-i-e*, three even beats] [REPEAT x2]
 - [YOU CONTRAST: **いえ** house, **いいえ** no]
 - [YOU CHOOSE: agree → **はい**; decline → **いいえ**]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-HAI, JA-SCRIPT-I-01] -->
+
+[PAUSE 15s] Say ??, then write ? once from memory before learning the contrasting answer.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH] -->

--- a/code/learning/human-languages/japanese/lessons/JA-C01-konnichiwa.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-konnichiwa.md
@@ -2,14 +2,14 @@
 schema_version: 2
 id: JA-C01-konnichiwa
 spine_node: SPINE-MEET-GREET
-sequence: 30
-chapter: 1
+sequence: 130
+chapter: 2
 type: word
 headword: こんにちは
 romanization: konnichiwa
 gloss: hello (daytime greeting)
 concept_tag: GREETING-HELLO
-prerequisites: [JA-C01-iie]
+prerequisites: [JA-W01-konnichiwa-read]
 sounds: [mora, moraic-n, particle-wa]
 roots: [konnichi]
 etymology_hook: こんにちは is an abandoned sentence — “as for today …” — which is why it ends in a particle.
@@ -18,15 +18,15 @@ duration:
 requires:
   knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA]
 introduces:
-  knowledge: [JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING]
+  knowledge: [JA-LEX-KONNICHIWA]
 practises:
-  knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA, JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING]
+  knowledge: [JA-LEX-HAI, JA-SCRIPT-HIRAGANA-MORA, JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-KO-01, JA-SCRIPT-N-01, JA-SCRIPT-NI-01, JA-SCRIPT-CHI-01, JA-SCRIPT-WA-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, interpersonal]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-hai]
+reviews_of: [JA-W01-konnichiwa-read, JA-C01-hai]
 ---
 
 # こんにちは — hello, and a sign that lies about its sound
@@ -37,53 +37,49 @@ reviews_of: [JA-C01-hai]
 [PAUSE 2s] Retrieve **はい** and the sign **は**. You are about to meet **は**
 again in the daytime greeting — where it is not pronounced *ha*.
 
-## Script — four new signs, and one you know
+## Script — five familiar signs
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HIRAGANA-MORA] -->
 
 > **こんにちは** — **こ** *ko* + **ん** *n* + **に** *ni* + **ち** *chi* + **は**
 
-Four signs are new. **こ** *ko*, **に** *ni*, and **ち** *chi* behave like every
-hiragana so far: one sign, one consonant-plus-vowel beat.
-
-**ん** is the exception worth naming. It is the one hiragana that is a bare
-consonant, and it still takes a full beat of its own. So **こんにちは** is five
-signs and five beats: *ko-n-ni-chi-wa*. Give **ん** its own beat and the greeting
-sounds Japanese; swallow it and it does not.
+You have written every sign separately. **こ**, **に**, and **ち** each carry a
+consonant and vowel. **ん** is the exception: a bare consonant with a full beat
+of its own. Read five signs in five beats: *ko-n-ni-chi-wa*. Do not swallow
+**ん**.
 
 ## Grammar Lens — the sign は, read *wa*
-<!-- hl-knowledge: introduces=[JA-PARTICLE-WA-SPELLING]; assesses=[] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-PARTICLE-WA-SPELLING] -->
 
 The last sign is **は**, which you learned as *ha*. Here it is read **wa**.
 
-That is not an exception to memorize blindly. **は** is Japanese's **topic
-particle** — the little word that marks what a sentence is about, roughly "as
-for ___." Japanese spelling was reformed in 1946 to follow pronunciation, but
-three grammatical particles were left at their older spellings because they are
-so frequent that respelling them would have rewritten every page in the country.
-**は** is one of them. Rule to carry forward: **は** is *ha* inside a word, and
-*wa* when it is doing the job of a particle.
+Here **は** is the **topic particle**, roughly "as for ___." It keeps an older
+spelling. Carry one small rule forward: read **は** as *ha* inside a word and as
+*wa* when it is the particle.
 
 ## Why it's said this way
 <!-- hl-knowledge: introduces=[JA-LEX-KONNICHIWA]; assesses=[] -->
 
-**こんにちは** is the daytime greeting — roughly midday to dusk, not morning and
-not evening. It is a sentence that was abandoned halfway. In full it was
-今日は… *konnichi wa…*, "as for today …", opening a longer enquiry after
-someone's health. The rest fell away and the topic marker stayed, which is why
-Japan's most common greeting ends on a grammatical particle instead of a word.
+**こんにちは** is the daytime greeting. It began as an unfinished sentence:
+*konnichi wa…*, "as for today …" The rest fell away and the topic marker stayed.
 
-Those two characters, 今日 *konnichi* "this day," belong to the third writing
-system, and the next lesson opens it.
+The older phrase is often written with two kanji for "this day." You do not need
+to decode those yet. This chapter keeps the whole greeting in the hiragana signs
+you have already learned.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-KO-01, JA-SCRIPT-N-01, JA-SCRIPT-NI-01, JA-SCRIPT-CHI-01, JA-SCRIPT-WA-01] -->
 
 - [YOU SAY: **こんにちは** — *ko-n-ni-chi-wa*, five beats] [REPEAT x2]
 - [YOU DECIDE: **は** in **はい** → *ha*; **は** ending the greeting → *wa*]
 - [YOU GREET: someone at midday → **こんにちは**]
 
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-N-01] -->
+
+[PAUSE 15s] Write ? from memory and give it one full mora.
+
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-KO-01, JA-SCRIPT-N-01, JA-SCRIPT-NI-01, JA-SCRIPT-CHI-01, JA-SCRIPT-WA-01] -->
 <!-- hl-activity: {"id":"JA-C01-konnichiwa-particle","kind":"text","assesses":["JA-PARTICLE-WA-SPELLING"],"prompt":"The greeting ends in the sign は. How is it pronounced there?","answer":"wa","accepted":["as wa","わ","the topic particle wa"],"feedback":{"correct":"Right: は is read wa when it works as the topic particle.","incorrect":"It is read wa — は is the topic particle here, not the sound ha."},"response_seconds":9} -->
 
 Which sign takes a beat without a vowel? (**ん**.) Why does the greeting end in

--- a/code/learning/human-languages/japanese/lessons/JA-C01-koohii.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-koohii.md
@@ -2,31 +2,31 @@
 schema_version: 2
 id: JA-C01-koohii
 spine_node: SPINE-MEET-GREET
-sequence: 50
-chapter: 1
+sequence: 370
+chapter: 6
 type: word
 headword: コーヒー
 romanization: kōhī
 gloss: coffee
 concept_tag: JA-WORD-KOOHII
-prerequisites: [JA-C01-nihongo]
+prerequisites: [JA-W06-hi-katakana]
 sounds: [mora, mora-length, chouon]
 roots: [dutch-koffie, arabic-qahwa]
 etymology_hook: コーヒー came from Dutch koffie, and Dutch got it from Arabic qahwa — the same source as English coffee.
 duration:
   max_seconds: 215
 requires:
-  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-MORA-LENGTH, JA-SCRIPT-KANJI-READINGS]
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-MORA-LENGTH, JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-KATAKANA-HI-01, JA-SCRIPT-CHOUON]
 introduces:
-  knowledge: [JA-LEX-KOOHII, JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-CHOUON]
+  knowledge: [JA-LEX-KOOHII, JA-SCRIPT-KATAKANA-LOANWORDS]
 practises:
-  knowledge: [JA-SCRIPT-MORA-LENGTH, JA-LEX-KOOHII, JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-CHOUON]
+  knowledge: [JA-SCRIPT-MORA-LENGTH, JA-LEX-KOOHII, JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-CHOUON, JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-KATAKANA-HI-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, mediation]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-iie]
+reviews_of: [JA-W06-ko-katakana, JA-W06-long-mark, JA-W06-hi-katakana, JA-C01-nihongo]
 ---
 
 # コーヒー — the third system, and a word that really is a cousin
@@ -38,7 +38,7 @@ reviews_of: [JA-C01-iie]
 as in **いいえ**. Katakana does it differently, and this word shows how.
 
 ## Script — katakana, the borrowed-word script
-<!-- hl-knowledge: introduces=[JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-CHOUON]; assesses=[] -->
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KATAKANA-LOANWORDS]; assesses=[JA-SCRIPT-CHOUON, JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-KATAKANA-HI-01] -->
 
 > **コーヒー** — **コ** *ko* + **ー** + **ヒ** *hi* + **ー**
 
@@ -67,8 +67,9 @@ the Nagasaki trade. Dutch had it from Turkish *kahve*, and Turkish from Arabic
 So this word genuinely is a cousin of one you already own. Notice what kind of
 cousin: not an inherited relative, but the same borrowed object arriving from
 the same Arabic source by two different roads. That is the honest shape of most
-Japanese–English overlap. Other passengers on those roads: **パン** bread, from
-Portuguese *pão*, and **アルバイト** a part-time job, from German *Arbeit*.
+Japanese–English overlap. Other passengers on those roads include *pan*,
+"bread," from Portuguese *pão*, and *arubaito*, "a part-time job," from German
+*Arbeit*. Their katakana signs can wait for their own one-sign lessons.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KOOHII, JA-SCRIPT-CHOUON, JA-SCRIPT-KATAKANA-LOANWORDS] -->

--- a/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
@@ -2,31 +2,31 @@
 schema_version: 2
 id: JA-C01-nihongo
 spine_node: SPINE-MEET-GREET
-sequence: 40
-chapter: 1
+sequence: 330
+chapter: 5
 type: word
 headword: 日本語
 romanization: nihongo
 gloss: the Japanese language
 concept_tag: JA-WORD-NIHONGO
-prerequisites: [JA-C01-konnichiwa]
+prerequisites: [JA-W05-go-kanji]
 sounds: [mora, moraic-n]
 roots: [middle-chinese-nyit, middle-chinese-pwonx, middle-chinese-ngjoX]
 etymology_hook: 日 is nichi, jitsu, hi, bi, or ka — a kanji carries a set of readings, and the word picks one.
 duration:
   max_seconds: 220
 requires:
-  knowledge: [JA-LEX-KONNICHIWA, JA-SCRIPT-HIRAGANA-MORA]
+  knowledge: [JA-LEX-KONNICHIWA, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KANJI-NICHI-01, JA-SCRIPT-KANJI-HON-01, JA-SCRIPT-KANJI-GO-01]
 introduces:
   knowledge: [JA-LEX-NIHONGO, JA-SCRIPT-KANJI-READINGS, JA-BRIDGE-SINO-JAPANESE]
 practises:
-  knowledge: [JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-SCRIPT-KANJI-READINGS, JA-BRIDGE-SINO-JAPANESE]
+  knowledge: [JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-SCRIPT-KANJI-READINGS, JA-BRIDGE-SINO-JAPANESE, JA-SCRIPT-KANJI-GO-01]
 skills: [listening, speaking, reading]
 modes: [interpretive, mediation]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-konnichiwa]
+reviews_of: [JA-W05-nichi-kanji, JA-W05-hon-kanji, JA-W05-go-kanji, JA-C01-konnichiwa]
 ---
 
 # 日本語 — three characters, and no single sound each
@@ -34,9 +34,8 @@ reviews_of: [JA-C01-konnichiwa]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA] -->
 
-[PAUSE 2s] Say **こんにちは** (*konnichiwa*). Its history hid two characters, 今日, that
-hiragana cannot show you. This lesson opens that second system by naming the
-language itself.
+[PAUSE 2s] Say **こんにちは** (*konnichiwa*). Now write 日, 本, and 語 once each.
+This lesson joins those three already-practised kanji to name the language.
 
 ## Script — kanji, and the readings problem
 <!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-READINGS]; assesses=[] -->
@@ -58,8 +57,9 @@ along with it.
 Two families of readings explain the spread. The **on** reading is Japan's
 version of the Chinese pronunciation, imported with the character. The **kun**
 reading is a native Japanese word written with a borrowed character that
-already meant the same thing. 日本語 is on-readings throughout; 今日 in the
-greeting is irregular even by those standards.
+already meant the same thing. 日本語 uses the imported reading family throughout.
+The older spelling behind the greeting is irregular even by those standards,
+so it remains postponed rather than becoming an unexplained decoding test.
 
 ## The word, taken apart — the real family
 <!-- hl-knowledge: introduces=[JA-LEX-NIHONGO, JA-BRIDGE-SINO-JAPANESE]; assesses=[] -->
@@ -79,6 +79,11 @@ that anchor a European language. English has no share in it.
 - [YOU SAY: **日本語** — *ni-ho-n-go*, four beats] [REPEAT x2]
 - [YOU NAME: 日 sun or day; 本 origin; 語 language]
 - [YOU CONNECT: Mandarin *Rìběnyǔ*, Korean *ilbon-eo*, same three characters]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-GO-01] -->
+
+[PAUSE 15s] Build ? once from ?, ?, and ? before joining the full word.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-NIHONGO, JA-SCRIPT-KANJI-READINGS] -->

--- a/code/learning/human-languages/japanese/lessons/JA-C01-practice.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-practice.md
@@ -2,14 +2,14 @@
 schema_version: 2
 id: JA-C01-practice
 spine_node: SPINE-COURTESY-THANK
-sequence: 80
-chapter: 1
+sequence: 380
+chapter: 7
 type: practice-mix
 headword: こんにちは … ありがとうございます
 romanization: konnichiwa … arigatō gozaimasu
 gloss: a short daytime doorway exchange, start to finish
 concept_tag: JA-C01-PRACTICE
-prerequisites: [JA-C01-gozaimasu]
+prerequisites: [JA-C01-koohii]
 sounds: [mora, particle-wa]
 roots: []
 etymology_hook: Six lines, three writing systems, and not one word that has not already been taught.
@@ -20,8 +20,8 @@ requires:
 introduces:
   knowledge: [JA-DIALOGUE-DOORWAY]
 practises:
-  knowledge: [JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-LEX-HAI, JA-LEX-IIE, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KANJI-READINGS, JA-DIALOGUE-DOORWAY]
-skills: [listening, speaking, reading]
+  knowledge: [JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-LEX-HAI, JA-LEX-IIE, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KANJI-READINGS, JA-SCRIPT-KANJI-NICHI-01, JA-SCRIPT-KANJI-HON-01, JA-SCRIPT-KANJI-GO-01, JA-DIALOGUE-DOORWAY, JA-SCRIPT-N-01, JA-SCRIPT-WA-01, JA-BRIDGE-SINO-JAPANESE, JA-SCRIPT-CHI-01, JA-SCRIPT-E-01, JA-SCRIPT-HAI-READ-01, JA-SCRIPT-KA-01, JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-NI-01, JA-SCRIPT-TO-01, JA-LEX-KOOHII, JA-SCRIPT-A-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-HA-01, JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-KO-01, JA-SCRIPT-RI-01]
+skills: [listening, speaking, reading, writing]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, fluency]
 register: teineigo-polite
@@ -53,20 +53,32 @@ with the voice lifted is a complete and natural way to ask "Japanese, then?" —
 and **はい** answers it.
 B's closing **いいえ** is the modest "not at all" that waves thanks away.
 
-A single ordinary Japanese sentence mixes the systems: hiragana carries the
-grammar, kanji carries the content words, katakana carries the borrowings. That
-is why this chapter opened all three instead of finishing one.
+An ordinary Japanese page mixes systems: hiragana carries much of the grammar,
+kanji carries many content words, and katakana commonly carries borrowings. The
+six earlier chapters introduced those systems separately; this payoff is where
+they finally work together.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-DIALOGUE-DOORWAY, JA-REGISTER-TEINEIGO] -->
 
-- [YOU RUN: both voices once with the Japanese, once with romanization only]
-- [YOU DECIDE: which line would change if B were a close friend] [PAUSE 3s]
-- [YOU SWAP: take B's part while the other lines are read to you]
+1. **Listen:** hear one line with no text and identify greeting, language,
+   answer, or thanks.
+2. **Speak:** take B's part while the other lines are read aloud.
+3. **Read:** run both voices from Japanese only, with the romanization covered.
+4. **Write:** hear **日本語**, wait ten seconds, and write the three kanji with no
+   visible model.
+
+Score the four actions separately. A fluent spoken line cannot cover a missing
+kanji in writing, and recognition cannot cover an unanswered spoken cue.
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-N-01, JA-SCRIPT-WA-01, JA-BRIDGE-SINO-JAPANESE, JA-SCRIPT-CHI-01, JA-SCRIPT-E-01, JA-SCRIPT-HAI-READ-01, JA-SCRIPT-KA-01, JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-NI-01, JA-SCRIPT-TO-01, JA-LEX-KOOHII, JA-SCRIPT-A-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-HA-01, JA-SCRIPT-KATAKANA-LOANWORDS, JA-SCRIPT-KO-01, JA-SCRIPT-RI-01] -->
+
+[PAUSE 15s] From memory, write ??, ???, ?????, ?????, ???, and ????. Circle the dakuten and say why the borrowed word uses katakana.
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-LEX-HAI, JA-LEX-IIE, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KANJI-READINGS, JA-DIALOGUE-DOORWAY] -->
-<!-- hl-activity: {"id":"JA-C01-practice-final-line","kind":"text","assesses":["JA-DIALOGUE-DOORWAY"],"prompt":"Someone has just thanked you politely. Give the modest one-word reply this chapter taught.","answer":"いいえ","accepted":["iie","no","not at all"],"feedback":{"correct":"Right: いいえ waves the thanks away.","incorrect":"Answer いいえ — here it means 'not at all', not a flat refusal."},"response_seconds":9} -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-LEX-NIHONGO, JA-LEX-HAI, JA-LEX-IIE, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KANJI-READINGS, JA-SCRIPT-KANJI-NICHI-01, JA-SCRIPT-KANJI-HON-01, JA-SCRIPT-KANJI-GO-01, JA-DIALOGUE-DOORWAY] -->
+<!-- hl-activity: {"id":"JA-C01-practice-four-skills","kind":"text","assesses":["JA-DIALOGUE-DOORWAY","JA-LEX-NIHONGO","JA-SCRIPT-KANJI-NICHI-01","JA-SCRIPT-KANJI-HON-01","JA-SCRIPT-KANJI-GO-01"],"prompt":"From sound alone, write nihongo in its three kanji. Then take B's part in the doorway exchange without notes.","answer":"日本語; こんにちは。はい。いいえ。","accepted":["日本語"],"feedback":{"correct":"The three kanji are complete; now answer the spoken cues without notes.","incorrect":"Repair one known block at a time: 日 | 本 | 語, then rerun B's short lines."},"response_seconds":30} -->
 
 Run the exchange once from memory. If a line stalls, return to that one lesson
 rather than rereading the chapter.

--- a/code/learning/human-languages/japanese/lessons/JA-C03-practice.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C03-practice.md
@@ -2,14 +2,14 @@
 schema_version: 2
 id: JA-C03-practice
 spine_node: SPINE-COURTESY-THANK
-sequence: 290
-chapter: 3
+sequence: 260
+chapter: 4
 type: practice-mix
 headword: ありがとうございます
 romanization: arigatou gozaimasu
 gloss: ten signs, every one of them yours — the polite thank-you read off the page
 concept_tag: JA-C03-PRACTICE
-prerequisites: [JA-W03-su]
+prerequisites: [JA-C01-gozaimasu]
 sounds: [mora]
 roots: []
 etymology_hook: The longest word in the book, and by the end of this chapter there is nothing in it you have not written yourself.
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-GOZAIMASU-READ-01]
 practises:
-  knowledge: [JA-SCRIPT-GOZAIMASU-READ-01, JA-SCRIPT-ARIGATOU-READ-01, JA-SCRIPT-SA-01, JA-SCRIPT-MA-01, JA-SCRIPT-SU-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-KO-01, JA-SCRIPT-I-01]
+  knowledge: [JA-SCRIPT-GOZAIMASU-READ-01, JA-SCRIPT-ARIGATOU-READ-01, JA-SCRIPT-SA-01, JA-SCRIPT-MA-01, JA-SCRIPT-SU-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-KO-01, JA-SCRIPT-I-01, JA-ETYMON-ARIGATASHI, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO]
 skills: [reading, speaking, writing]
 modes: [interpretive, interpersonal, presentational]
 strands: [meaning-input, meaning-output, fluency]
@@ -97,6 +97,11 @@ ever learn arrives with a voiced twin already attached.
 - [YOU READ: ありがとうございます — name each of the ten signs, then say it]
 - [YOU WRITE: ございます — five signs, two of them with ticks]
 - [YOU SAY: **arigatou gozaimasu** — and let the final u go quiet]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-ETYMON-ARIGATASHI, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN, JA-LEX-ARIGATOU-GOZAIMASU, JA-REGISTER-TEINEIGO] -->
+
+[PAUSE 15s] Give plain thanks, then polite thanks. Name the dakuten and the ?hard to exist? memory hook.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-GOZAIMASU-READ-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-chi.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-chi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W01-chi
 spine_node: SPINE-MEET-GREET
-sequence: 160
+sequence: 100
 delivery: script
 chapter: 2
 type: writing

--- a/code/learning/human-languages/japanese/lessons/JA-W01-e.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-e.md
@@ -2,9 +2,9 @@
 schema_version: 2
 id: JA-W01-e
 spine_node: SPINE-RESPOND-BASIC
-sequence: 120
+sequence: 40
 delivery: script
-chapter: 2
+chapter: 1
 type: writing
 headword: え
 romanization: e
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-E-01]
 practises:
-  knowledge: [JA-SCRIPT-E-01, JA-SCRIPT-I-01, JA-LEX-IIE, JA-SCRIPT-HAI-READ-01]
+  knowledge: [JA-SCRIPT-E-01, JA-SCRIPT-I-01, JA-SCRIPT-HAI-READ-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-i, JA-C01-iie]
+reviews_of: [JA-W01-i]
 ---
 
 # え — two strokes, and a second word for free
@@ -50,35 +50,33 @@ Two strokes, and the second one does most of the work:
 Read **e**, the vowel of English *bed* — short, and never the *ay* of *day*.
 
 ## What you've built
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-SCRIPT-I-01, JA-LEX-IIE] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-SCRIPT-I-01] -->
 
 Three signs are now yours, and they spell more than one word. Put two of them
 together with the one you just learned:
 
-> **い** + **い** + **え** → **いいえ**
+> **い** | **い** | **え**
 
 **i-i-e.** Three beats — and note that the first sign is written **twice**,
-because Japanese counts two full beats there. That is the word for **no**.
-
-You have now read both answers to a yes-or-no question, from the signs up. Neither
-of them was memorised as a picture.
+because Japanese counts two full beats there. The next lesson attaches its
+meaning. For now, the whole task is decoding three known signs in order.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-LEX-IIE] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-SCRIPT-I-01] -->
 <!-- hl-writing-stage: dictation-transcription -->
 
 - Cover the printed **え**. Have a partner or recording say **e** once. If you
   are working alone, read the romanized cue *e*, cover it, and continue.
 - [YOU WRITE FROM THE HEARD OR ROMANIZED CUE: え — tick first, then the body in
   one movement]
-- [YOU READ: いいえ — three beats, and do not shorten the doubled sign]
+- [YOU READ: **い | い | え** — three beats, and do not shorten the doubled sign]
 
 Uncover the model only after your one transcription attempt. Compare, repair
 one stroke if needed, and stop.
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-LEX-IIE] -->
-<!-- hl-activity: {"id":"JA-W01-e-beats","kind":"text","assesses":["JA-LEX-IIE"],"prompt":"How many beats (morae) does the written word for 'no' take?","answer":"3","accepted":["three","3 beats","three beats"],"feedback":{"correct":"Three — the first sign is written twice and gets two full beats.","incorrect":"Three: the doubled sign carries two beats, not one long one."},"response_seconds":10} -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-E-01, JA-SCRIPT-I-01] -->
+<!-- hl-activity: {"id":"JA-W01-e-beats","kind":"text","assesses":["JA-SCRIPT-E-01"],"prompt":"Write the final sign in i-i-e, then count the three visible beats.","answer":"え; 3","accepted":["え","え, three","e; 3"],"feedback":{"correct":"Right: え finishes the three-sign sequence.","incorrect":"Write え: top tick, then the longer body. The full sequence has three beats."},"response_seconds":10} -->
 
 Why is the first sign of that word written twice? (Because it is **two beats**,
 not one held longer.)

--- a/code/learning/human-languages/japanese/lessons/JA-W01-ha.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-ha.md
@@ -2,9 +2,9 @@
 schema_version: 2
 id: JA-W01-ha
 spine_node: SPINE-RESPOND-BASIC
-sequence: 100
+sequence: 20
 delivery: script
-chapter: 2
+chapter: 1
 type: writing
 headword: は
 romanization: ha
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-HA-01]
 practises:
-  knowledge: [JA-SCRIPT-HA-01, JA-SCRIPT-I-01]
+  knowledge: [JA-SCRIPT-HA-01, JA-SCRIPT-I-01, JA-SCRIPT-HIRAGANA-MORA]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -66,6 +66,11 @@ after you have met the sign it *sounds* like.
 
 Look back at the model between strokes if you need to. This is one guided copy,
 not a memory test.
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HIRAGANA-MORA] -->
+
+[PAUSE 15s] Say ? and tap its one mora before adding another sign.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HA-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-hai-read.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-hai-read.md
@@ -2,9 +2,9 @@
 schema_version: 2
 id: JA-W01-hai-read
 spine_node: SPINE-RESPOND-BASIC
-sequence: 110
+sequence: 30
 delivery: script
-chapter: 2
+chapter: 1
 type: writing
 headword: はい
 romanization: hai
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-HAI-READ-01]
 practises:
-  knowledge: [JA-SCRIPT-HAI-READ-01, JA-SCRIPT-HA-01, JA-SCRIPT-I-01, JA-LEX-HAI]
+  knowledge: [JA-SCRIPT-HAI-READ-01, JA-SCRIPT-HA-01, JA-SCRIPT-I-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-ha, JA-W01-i, JA-C01-hai]
+reviews_of: [JA-W01-ha, JA-W01-i]
 ---
 
 # Two signs, side by side — and a word appears
@@ -50,9 +50,8 @@ Now write them touching:
 
 > **は** + **い** → **はい**
 
-**ha** then **i**. Two beats, even, neither one stressed. That is the word for
-**yes**, and it is the one you have been saying since your first minute in this
-language.
+**ha** then **i**. Two beats, even, neither one stressed. You can now decode the
+sequence *hai*. The word lesson after the next sign attaches its useful meaning.
 
 **Nothing new was introduced in this lesson.** No stroke, no sound, no word. What
 changed is where the word now lives: you are no longer recalling a shape you were
@@ -63,14 +62,14 @@ That is the whole method for this writing system, and it does not get harder. It
 gets longer. A word of five signs is five signs you already own, in a row.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HAI-READ-01, JA-LEX-HAI] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HAI-READ-01] -->
 
 - [YOU READ: **はい** — sound each sign in turn, do not recall the word whole]
 - [YOU WRITE: はい — five strokes in total, three then two]
 
 ## Wrap-up Recall
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HAI-READ-01, JA-LEX-HAI] -->
-<!-- hl-activity: {"id":"JA-W01-hai-read-beats","kind":"text","assesses":["JA-SCRIPT-HAI-READ-01"],"prompt":"How many beats (morae) does the written word for 'yes' take?","answer":"2","accepted":["two","2 beats","two beats"],"feedback":{"correct":"Two — one per sign, evenly.","incorrect":"Two: one beat per hiragana sign."},"response_seconds":8} -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HAI-READ-01] -->
+<!-- hl-activity: {"id":"JA-W01-hai-read-beats","kind":"text","assesses":["JA-SCRIPT-HAI-READ-01"],"prompt":"How many beats does the written sequence はい take?","answer":"2","accepted":["two","2 beats","two beats"],"feedback":{"correct":"Two — one per sign, evenly.","incorrect":"Two: one beat per hiragana sign."},"response_seconds":8} -->
 
 How many new strokes did you have to learn in this lesson? (**None.**)
 

--- a/code/learning/human-languages/japanese/lessons/JA-W01-i.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-i.md
@@ -2,23 +2,23 @@
 schema_version: 2
 id: JA-W01-i
 spine_node: SPINE-RESPOND-BASIC
-sequence: 90
+sequence: 10
 delivery: script
-chapter: 2
+chapter: 1
 type: writing
 headword: い
 romanization: i
 gloss: the hiragana sign for the mora i — two strokes, and the first sign you can write
-prerequisites: [JA-C01-iie]
+prerequisites: []
 sounds: [pure-vowels, mora]
 roots: []
 etymology_hook: い is a worn-down cursive of a Chinese character borrowed for its SOUND alone; every hiragana sign has that history, and none of them kept the meaning.
 duration:
   max_seconds: 180
 requires:
-  knowledge: [JA-SCRIPT-HIRAGANA-MORA]
+  knowledge: []
 introduces:
-  knowledge: [JA-SCRIPT-I-01]
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-I-01]
 practises:
   knowledge: [JA-SCRIPT-I-01, JA-SCRIPT-HIRAGANA-MORA]
 skills: [reading, writing]
@@ -26,13 +26,13 @@ modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-C01-hai, JA-C01-iie]
+reviews_of: []
 ---
 
 # い — two strokes, one beat
 
 ## Warm-up
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HIRAGANA-MORA] -->
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You already know the rule that makes this writing system easy: **one
 sign, one beat.** Not one letter one sound, and not one sign one word — one sign,
@@ -41,7 +41,7 @@ one **mora**, the even beat Japanese counts time in.
 What you have not had yet is a single sign taught on its own. Here is the first.
 
 ## Script — the shape
-<!-- hl-knowledge: introduces=[JA-SCRIPT-I-01]; assesses=[] -->
+<!-- hl-knowledge: introduces=[JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-I-01]; assesses=[] -->
 
 > い
 

--- a/code/learning/human-languages/japanese/lessons/JA-W01-ko.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-ko.md
@@ -2,14 +2,14 @@
 schema_version: 2
 id: JA-W01-ko
 spine_node: SPINE-MEET-GREET
-sequence: 130
+sequence: 70
 delivery: script
 chapter: 2
 type: writing
 headword: こ
 romanization: ko
 gloss: the hiragana sign for the mora ko — two strokes, and the start of the greeting
-prerequisites: [JA-W01-e, JA-C01-konnichiwa]
+prerequisites: [JA-C01-iie]
 sounds: [mora]
 roots: []
 etymology_hook: こ opens the daytime greeting, and the four signs after it are the rest of this chapter.
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-KO-01]
 practises:
-  knowledge: [JA-SCRIPT-KO-01, JA-SCRIPT-E-01]
+  knowledge: [JA-SCRIPT-KO-01, JA-SCRIPT-E-01, JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-e, JA-C01-konnichiwa]
+reviews_of: [JA-W01-e, JA-C01-hai]
 ---
 
 # こ — two strokes, and the greeting begins
@@ -57,6 +57,11 @@ it and you have a different sign.
 
 - [YOU WRITE: こ — upper stroke, then the longer lower one, and leave the gap]
 - [YOU SAY: **ko**, one beat]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH] -->
+
+[PAUSE 15s] Say ??? and tap all three morae before writing the new sign.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KO-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-konnichiwa-read.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-konnichiwa-read.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W01-konnichiwa-read
 spine_node: SPINE-MEET-GREET
-sequence: 180
+sequence: 120
 delivery: script
 chapter: 2
 type: writing
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-KONNICHIWA-READ-01]
 practises:
-  knowledge: [JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-KO-01, JA-SCRIPT-N-01, JA-SCRIPT-NI-01, JA-SCRIPT-CHI-01, JA-SCRIPT-HA-01, JA-LEX-KONNICHIWA, JA-SCRIPT-HIRAGANA-MORA, JA-PARTICLE-WA-SPELLING]
+  knowledge: [JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-KO-01, JA-SCRIPT-N-01, JA-SCRIPT-NI-01, JA-SCRIPT-CHI-01, JA-SCRIPT-HA-01, JA-SCRIPT-HIRAGANA-MORA, JA-PARTICLE-WA-SPELLING, JA-SCRIPT-WA-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, meaning-output, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-wa, JA-W01-ko, JA-W01-n, JA-W01-ni, JA-W01-chi, JA-C01-konnichiwa]
+reviews_of: [JA-W01-wa, JA-W01-ko, JA-W01-n, JA-W01-ni, JA-W01-chi]
 ---
 
 # Five signs in a row — and the greeting is readable
@@ -51,26 +51,31 @@ greeting is on the page:
 tap and you will hear that the second beat, the one with no vowel, takes exactly
 as long as the four around it.
 
-**Nothing new was introduced in this lesson.** You have not learned a stroke, a
-sound or a word here. You have read a word you already knew how to say — from
-five pieces you can each write from memory, in order, including the one that
-sounds like something other than its name.
+No new stroke appears here. You have decoded five pieces you can each write from
+memory, in order, including the one that sounds like something other than its
+name. The next lesson attaches the daytime-greeting meaning to the line.
 
 ## What you've built
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01, JA-LEX-KONNICHIWA] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01] -->
 
-Eight signs, taught one at a time, and with them you can now read three whole
-words off the page: the greeting, and both answers to a yes-or-no question.
+Eight signs, taught one at a time, and with them you can now decode three whole
+sequences off the page. Two already carry useful answers; the five-sign sequence
+gets its daytime-greeting job in the next lesson.
 
 Hiragana has forty-six basic signs. You hold **eight**. The rest arrive the same
 way, one per lesson, and the words they unlock arrive free — because a word in
 this script is never more than the signs you already own, in a row.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01, JA-LEX-KONNICHIWA] -->
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01] -->
 
 - [YOU READ: **こんにちは** — sound each sign in turn; do not recall it whole]
 - [YOU WRITE: the greeting, then say it once at speaking pace]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-WA-01] -->
+
+[PAUSE 15s] Write ? once, then set it beside ? and name which one closes the greeting.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01, JA-SCRIPT-HIRAGANA-MORA] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-n.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-n.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W01-n
 spine_node: SPINE-MEET-GREET
-sequence: 140
+sequence: 80
 delivery: script
 chapter: 2
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-N-01]
 practises:
-  knowledge: [JA-SCRIPT-N-01, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KO-01]
+  knowledge: [JA-SCRIPT-N-01, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-KO-01, JA-SCRIPT-HAI-READ-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -60,6 +60,11 @@ is.
 
 - [YOU WRITE: ん — one continuous stroke, no lifts]
 - [YOU SAY: hold it for a full beat, as long as any other sign takes]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HAI-READ-01] -->
+
+[PAUSE 15s] Cover the model and write ?? from its two known signs.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-N-01, JA-SCRIPT-HIRAGANA-MORA] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-ni.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-ni.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W01-ni
 spine_node: SPINE-MEET-GREET
-sequence: 150
+sequence: 90
 delivery: script
 chapter: 2
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-NI-01]
 practises:
-  knowledge: [JA-SCRIPT-NI-01, JA-SCRIPT-HA-01]
+  knowledge: [JA-SCRIPT-NI-01, JA-SCRIPT-HA-01, JA-SCRIPT-N-01, JA-SCRIPT-E-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -62,6 +62,11 @@ into it is the mistake this book keeps warning you off.
 
 - [YOU WRITE: に — vertical, short bar, long bar]
 - [YOU NOTICE: write it beside は and compare only the left post]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-N-01, JA-SCRIPT-E-01] -->
+
+[PAUSE 15s] Before the new sign, write ? once and then ? once from memory.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-NI-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W01-wa.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W01-wa.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W01-wa
 spine_node: SPINE-MEET-GREET
-sequence: 170
+sequence: 110
 delivery: script
 chapter: 2
 type: writing
@@ -16,17 +16,17 @@ etymology_hook: わ is the sign for the sound wa; the greeting ends in a differe
 duration:
   max_seconds: 200
 requires:
-  knowledge: [JA-SCRIPT-CHI-01, JA-SCRIPT-HA-01, JA-PARTICLE-WA-SPELLING]
+  knowledge: [JA-SCRIPT-CHI-01, JA-SCRIPT-HA-01]
 introduces:
-  knowledge: [JA-SCRIPT-WA-01]
+  knowledge: [JA-SCRIPT-WA-01, JA-PARTICLE-WA-SPELLING]
 practises:
-  knowledge: [JA-SCRIPT-WA-01, JA-SCRIPT-HA-01, JA-PARTICLE-WA-SPELLING]
+  knowledge: [JA-SCRIPT-WA-01, JA-SCRIPT-HA-01, JA-PARTICLE-WA-SPELLING, JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-chi, JA-W01-ha, JA-C01-konnichiwa]
+reviews_of: [JA-W01-chi, JA-W01-ha]
 ---
 
 # わ — the sign for *wa*, and the trap beside it
@@ -50,7 +50,7 @@ Two strokes:
 Read **wa**: like English *wa* in *wander*, one beat.
 
 ## What you've built — and the trap
-<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-WA-01, JA-PARTICLE-WA-SPELLING] -->
+<!-- hl-knowledge: introduces=[JA-PARTICLE-WA-SPELLING]; assesses=[JA-SCRIPT-WA-01] -->
 
 Here is the thing this sign exists in this lesson to protect you from.
 
@@ -79,6 +79,11 @@ attached rather than be quietly assumed.
 - [YOU WRITE: わ, then は beside it — two signs, one shared sound, different jobs]
 - [YOU DECIDE: hearing *wa* at the end of the daytime greeting, which sign do you
   write?]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-IIE, JA-SCRIPT-MORA-LENGTH] -->
+
+[PAUSE 15s] Say ??? again, keeping the two opening morae distinct.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-WA-01, JA-PARTICLE-WA-SPELLING] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-a.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-a.md
@@ -2,17 +2,17 @@
 schema_version: 2
 id: JA-W03-a
 spine_node: SPINE-COURTESY-THANK
-sequence: 190
+sequence: 140
 delivery: script
 chapter: 3
 type: writing
 headword: あ
 romanization: a
 gloss: the hiragana sign for the mora a — three strokes, and the first sign of the thank-you
-prerequisites: [JA-W01-konnichiwa-read]
+prerequisites: [JA-C01-konnichiwa]
 sounds: [mora]
 roots: []
-etymology_hook: あ opens ありがとう, the longest word this book has given you and the one you cannot yet read.
+etymology_hook: あ opens the five-sign sequence that will become a plain thank-you.
 duration:
   max_seconds: 180
 requires:
@@ -20,13 +20,13 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-A-01]
 practises:
-  knowledge: [JA-SCRIPT-A-01, JA-SCRIPT-KONNICHIWA-READ-01]
+  knowledge: [JA-SCRIPT-A-01, JA-SCRIPT-KONNICHIWA-READ-01, JA-LEX-KONNICHIWA, JA-SCRIPT-NI-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W01-konnichiwa-read, JA-C01-arigatou]
+reviews_of: [JA-W01-konnichiwa-read, JA-C01-konnichiwa]
 ---
 
 # あ — three strokes, and the thank-you begins
@@ -36,9 +36,9 @@ reviews_of: [JA-W01-konnichiwa-read, JA-C01-arigatou]
 
 [PAUSE 2s] Write こんにちは from memory. Five signs, all yours.
 
-You have been saying **ありがとう** since Chapter 1 and reading it from the
-romanization. This chapter hands you the signs, one at a time, until the word is
-yours on the page as well as in the mouth.
+This chapter builds the five-sign plain thank-you from the page up. Its meaning
+arrives only after every sign is yours, so this first lesson asks for one shape:
+**あ**.
 
 ## Script — the shape
 <!-- hl-knowledge: introduces=[JA-SCRIPT-A-01]; assesses=[] -->
@@ -62,6 +62,11 @@ Read **a**: the *a* of English *father*, kept short. One beat.
 
 - [YOU WRITE: あ — horizontal, vertical, then the loop in one movement]
 - [YOU SAY: **a**, one beat, short]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-SCRIPT-NI-01] -->
+
+[PAUSE 15s] Give the daytime greeting, then write ? from memory.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-A-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-arigatou-read.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-arigatou-read.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-arigatou-read
 spine_node: SPINE-COURTESY-THANK
-sequence: 250
+sequence: 200
 delivery: script
 chapter: 3
 type: writing
@@ -26,7 +26,7 @@ modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
 register: neutral-across-levels
 variety: standard-japanese-tokyo
-reviews_of: [JA-W03-a, JA-W03-ri, JA-W03-ka, JA-W03-dakuten, JA-W03-to, JA-W03-u, JA-C01-arigatou]
+reviews_of: [JA-W03-a, JA-W03-ri, JA-W03-ka, JA-W03-dakuten, JA-W03-to, JA-W03-u]
 ---
 
 # ありがとう — no new sign, and a whole word

--- a/code/learning/human-languages/japanese/lessons/JA-W03-dakuten.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-dakuten.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-dakuten
 spine_node: SPINE-COURTESY-THANK
-sequence: 220
+sequence: 170
 delivery: script
 chapter: 3
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-DAKUTEN-01]
 practises:
-  knowledge: [JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-KA-01, JA-SCRIPT-KO-01]
+  knowledge: [JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-KA-01, JA-SCRIPT-KO-01, JA-SCRIPT-KONNICHIWA-READ-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -72,6 +72,11 @@ are in the word this chapter is building.
 - [YOU WRITE: か, then add the two ticks to make が. Say both.]
 - [YOU WRITE: こ, then ご]
 - [YOU SAY: **ka / ga**, then **ko / go** — the same mouth, voice off and on]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KONNICHIWA-READ-01] -->
+
+[PAUSE 15s] Write ????? from its five signs before adding any voice marks.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-DAKUTEN-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-ka.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-ka.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-ka
 spine_node: SPINE-COURTESY-THANK
-sequence: 210
+sequence: 160
 delivery: script
 chapter: 3
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-KA-01]
 practises:
-  knowledge: [JA-SCRIPT-KA-01, JA-SCRIPT-RI-01]
+  knowledge: [JA-SCRIPT-KA-01, JA-SCRIPT-RI-01, JA-SCRIPT-WA-01, JA-PARTICLE-WA-SPELLING]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -59,6 +59,11 @@ between them is two small marks rather than a new character to learn.
 
 - [YOU WRITE: か — hooked stroke, vertical, then the dot at the right]
 - [YOU SAY: **ka**, one beat]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-WA-01, JA-PARTICLE-WA-SPELLING] -->
+
+[PAUSE 15s] Write ?, then write the different sign that closes ????? and explain its particle reading.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KA-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-ma.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-ma.md
@@ -2,9 +2,9 @@
 schema_version: 2
 id: JA-W03-ma
 spine_node: SPINE-COURTESY-THANK
-sequence: 270
+sequence: 230
 delivery: script
-chapter: 3
+chapter: 4
 type: writing
 headword: ま
 romanization: ma
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-MA-01]
 practises:
-  knowledge: [JA-SCRIPT-MA-01, JA-SCRIPT-SA-01]
+  knowledge: [JA-SCRIPT-MA-01, JA-SCRIPT-SA-01, JA-SCRIPT-TO-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -58,6 +58,11 @@ Read **ma**: as in English *mother*, shortened. One beat.
 
 - [YOU WRITE: ま — two horizontals, then the looping vertical through them]
 - [YOU SAY: **ma**, one beat]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-TO-01] -->
+
+[PAUSE 15s] Write ? from memory before tracing ?.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-MA-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-ri.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-ri.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-ri
 spine_node: SPINE-COURTESY-THANK
-sequence: 200
+sequence: 150
 delivery: script
 chapter: 3
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-RI-01]
 practises:
-  knowledge: [JA-SCRIPT-RI-01, JA-SCRIPT-A-01]
+  knowledge: [JA-SCRIPT-RI-01, JA-SCRIPT-A-01, JA-SCRIPT-CHI-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -64,6 +64,11 @@ in a way that one minute of practice fixes.
 - [YOU WRITE: り — short left stroke, then the long right descender. Leave the gap.]
 - [YOU SAY: **ri** — one tap, not an English r]
 - [YOU SAY: **a**, then **ri** — the first two signs of the word]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-CHI-01] -->
+
+[PAUSE 15s] Write ? from memory before tracing ?.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-RI-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-sa.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-sa.md
@@ -2,17 +2,17 @@
 schema_version: 2
 id: JA-W03-sa
 spine_node: SPINE-COURTESY-THANK
-sequence: 260
+sequence: 220
 delivery: script
-chapter: 3
+chapter: 4
 type: writing
 headword: さ
 romanization: sa
 gloss: the hiragana sign for the mora sa — two strokes, and the base of za
-prerequisites: [JA-W03-arigatou-read]
+prerequisites: [JA-C01-arigatou]
 sounds: [mora]
 roots: []
-etymology_hook: さ takes the dakuten too, and ざ is the second sign of ございます.
+etymology_hook: さ takes the dakuten too, and ざ will return in the polite ending ahead.
 duration:
   max_seconds: 180
 requires:
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-SA-01]
 practises:
-  knowledge: [JA-SCRIPT-SA-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-ARIGATOU-READ-01]
+  knowledge: [JA-SCRIPT-SA-01, JA-SCRIPT-DAKUTEN-01, JA-SCRIPT-ARIGATOU-READ-01, JA-ETYMON-ARIGATASHI, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -50,8 +50,8 @@ Three strokes:
 
 Watch that gap. Most printed fonts join the second and third strokes into one
 continuous descender, so the さ you see on a screen looks like two strokes. By
-hand it is three, and the break is real. The same split makes き four strokes by
-hand and three in print.
+hand it is three, and the break is real. Keep the handwritten gap even when a
+printed font closes it.
 
 Read **sa**: a clean *s*, then the short *a*. One beat.
 
@@ -60,7 +60,7 @@ And now the bargain again — さ takes the dakuten:
 > さ *sa* → **ざ** *za*
 
 Same mouth, voice switched on, two ticks at the upper right. That is the third
-sign you have got for free, and it is the second sign of ございます.
+voiced sign you have got for free. It will return in the polite ending ahead.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-SA-01] -->
@@ -68,6 +68,11 @@ sign you have got for free, and it is the second sign of ございます.
 - [YOU WRITE: さ — horizontal, the short curve, then the detached foot curve]
 - [YOU WRITE: ざ — the same, with two ticks]
 - [YOU SAY: **sa / za**]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-ETYMON-ARIGATASHI, JA-LEX-ARIGATOU, JA-SCRIPT-DAKUTEN] -->
+
+[PAUSE 15s] Say ?????, add the dakuten to ?, and recall how ?hard to exist? became thanks.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-SA-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-su.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-su.md
@@ -2,9 +2,9 @@
 schema_version: 2
 id: JA-W03-su
 spine_node: SPINE-COURTESY-THANK
-sequence: 280
+sequence: 240
 delivery: script
-chapter: 3
+chapter: 4
 type: writing
 headword: す
 romanization: su
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-SU-01]
 practises:
-  knowledge: [JA-SCRIPT-SU-01, JA-SCRIPT-MA-01]
+  knowledge: [JA-SCRIPT-SU-01, JA-SCRIPT-MA-01, JA-SCRIPT-U-01]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -70,6 +70,11 @@ The sign is still written. The beat is still counted. Only the voice drops out.
 
 - [YOU WRITE: す — horizontal, then the vertical with its closing loop]
 - [YOU SAY: **su**, then the same with the voice off — a whispered ending]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-U-01] -->
+
+[PAUSE 15s] Write ? from memory before tracing ?.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-SU-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-to.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-to.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-to
 spine_node: SPINE-COURTESY-THANK
-sequence: 230
+sequence: 180
 delivery: script
 chapter: 3
 type: writing
@@ -20,7 +20,7 @@ requires:
 introduces:
   knowledge: [JA-SCRIPT-TO-01]
 practises:
-  knowledge: [JA-SCRIPT-TO-01, JA-SCRIPT-DAKUTEN-01]
+  knowledge: [JA-SCRIPT-TO-01, JA-SCRIPT-DAKUTEN-01, JA-LEX-KONNICHIWA]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, language-focus]
@@ -58,6 +58,11 @@ Read **to**: a clean *t*, then the *o* of *more*, shortened. One beat.
 
 - [YOU WRITE: と — the small tick, then the long sweep. Do not join them.]
 - [YOU SAY: **a, ri, ga, to** — four beats, and the word is nearly yours]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA] -->
+
+[PAUSE 15s] Say the daytime greeting once without looking.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-TO-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W03-u.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W03-u.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: JA-W03-u
 spine_node: SPINE-COURTESY-THANK
-sequence: 240
+sequence: 190
 delivery: script
 chapter: 3
 type: writing
@@ -56,8 +56,8 @@ rounded than an English speaker expects. Do not push them forward.
 Something happens when う follows と, and it is the reason the written word and
 the spoken word look like they disagree.
 
-Written out, ありがとう ends **と + う** — *to* then *u*, which reads as five
-beats. But nobody says *a-ri-ga-to-u*. What you hear is a long **o**:
+The five-sign sequence you are building ends **と + う** — *to* then *u*, which
+reads as five beats. But the final two signs are heard as a long **o**:
 
 > written: a-ri-ga-to-u
 >
@@ -68,8 +68,8 @@ second beat.** The beat is still there — Japanese counts it, and dropping it
 makes the word sound clipped and wrong — but it is the same vowel continuing,
 not a new one.
 
-You met this once already without being told: the katakana word コーヒー uses a
-long bar for the same job. Hiragana uses う.
+Katakana will later receive a separate one-stroke length mark for the same job.
+Here the only written cue is the **う** you have just learned.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-U-01] -->

--- a/code/learning/human-languages/japanese/lessons/JA-W05-five-component.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-five-component.md
@@ -1,0 +1,63 @@
+---
+schema_version: 2
+id: JA-W05-five-component
+spine_node: SPINE-MEET-GREET
+sequence: 300
+delivery: script
+chapter: 5
+type: writing
+headword: 五
+romanization: go
+gloss: the four-stroke top of the sound side in the kanji for language
+prerequisites: [JA-W05-gen-component]
+sounds: [mora]
+roots: []
+etymology_hook: The familiar number five supplies the go sound inside the kanji read go.
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [JA-SCRIPT-KANJI-SPEECH-COMPONENT-01]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-FIVE-COMPONENT-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-FIVE-COMPONENT-01, JA-SCRIPT-KANJI-SPEECH-COMPONENT-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W05-gen-component, JA-W05-nichi-kanji]
+---
+
+# 五 — four strokes for the sound side
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-SPEECH-COMPONENT-01] -->
+
+[PAUSE 2s] Trace 言 once. Say “speech side.”
+
+## Script — the top-right piece
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-FIVE-COMPONENT-01]; assesses=[] -->
+
+> 五
+
+Write four strokes: top horizontal; a short vertical and turn; a second
+horizontal; then the long bottom horizontal. Keep the shape wider than tall.
+
+This sign means **five** on its own. Here, you only need its second job: it helps
+cue the sound *go* inside the larger kanji that is coming.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-FIVE-COMPONENT-01] -->
+
+- [YOU TRACE: 五 — top, turn, middle, bottom]
+- [YOU WRITE: 五 once from memory]
+- [YOU SAY: **go**, one beat]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-FIVE-COMPONENT-01] -->
+<!-- hl-activity: {"id":"JA-W05-five-component-four-strokes","kind":"text","assesses":["JA-SCRIPT-KANJI-FIVE-COMPONENT-01"],"prompt":"Write the four-stroke component that cues go in the kanji for language.","answer":"五","accepted":["五 (go)","go","five"],"feedback":{"correct":"Right: 五 supplies the go sound clue.","incorrect":"Use 五: top, turn, middle, long bottom."},"response_seconds":15} -->
+
+Which line is longest? (The **bottom** line.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/04e94.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W05-gen-component.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-gen-component.md
@@ -1,0 +1,69 @@
+---
+schema_version: 2
+id: JA-W05-gen-component
+spine_node: SPINE-MEET-GREET
+sequence: 290
+delivery: script
+chapter: 5
+type: writing
+headword: 言
+romanization: gen
+gloss: the speech component at the left of the kanji for language
+prerequisites: [JA-W05-hon-kanji]
+sounds: [mora]
+roots: []
+etymology_hook: The speech sign becomes the left-hand clue inside the kanji for language.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [JA-SCRIPT-KANJI-HON-01]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-SPEECH-COMPONENT-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-SPEECH-COMPONENT-01, JA-SCRIPT-KANJI-HON-01, JA-SCRIPT-SU-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W05-hon-kanji]
+---
+
+# 言 — build the speech side first
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-HON-01] -->
+
+[PAUSE 2s] Write 本 and point to its short root mark. Now set it aside.
+
+## Script — one component, not a whole word yet
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-SPEECH-COMPONENT-01]; assesses=[] -->
+
+> 言
+
+This is the **speech** component. Write it as a small top mark, three horizontal
+lines, then a three-stroke box. Keep the horizontals distinct and the box narrow.
+
+Do not memorise a vocabulary word for it today. Its job is visual: when it sits
+on the left, it signals that the larger kanji has something to do with words or
+speech. The next two tiny lessons build the right side.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-SPEECH-COMPONENT-01] -->
+
+- [YOU TRACE: 言 slowly, top to bottom]
+- [YOU COVER AND WRITE: 言 once]
+- [YOU POINT: the small box at the bottom]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-SU-01] -->
+
+[PAUSE 15s] Write ? once from memory before building the speech component.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-SPEECH-COMPONENT-01] -->
+<!-- hl-activity: {"id":"JA-W05-gen-component-speech-side","kind":"text","assesses":["JA-SCRIPT-KANJI-SPEECH-COMPONENT-01"],"prompt":"Write the component that will sit on the left of the kanji for language.","answer":"言","accepted":["言 (speech)","the speech component"],"feedback":{"correct":"Right: 言 is the speech side.","incorrect":"Use 言: the stacked lines and small box."},"response_seconds":18} -->
+
+Where will this component sit in the larger sign? (On the **left**.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/08a00.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W05-go-kanji.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-go-kanji.md
@@ -1,0 +1,68 @@
+---
+schema_version: 2
+id: JA-W05-go-kanji
+spine_node: SPINE-MEET-GREET
+sequence: 320
+delivery: script
+chapter: 5
+type: writing
+headword: 語
+romanization: go
+gloss: the kanji for language — one known speech side plus one known sound side
+prerequisites: [JA-W05-mouth-component]
+sounds: [mora]
+roots: [middle-chinese-ngjoX]
+etymology_hook: Speech on the left plus a go-sound clue on the right makes the sign read go, language.
+duration:
+  max_seconds: 225
+requires:
+  knowledge: [JA-SCRIPT-KANJI-SPEECH-COMPONENT-01, JA-SCRIPT-KANJI-FIVE-COMPONENT-01, JA-SCRIPT-KANJI-MOUTH-COMPONENT-01]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-GO-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-GO-01, JA-SCRIPT-KANJI-SPEECH-COMPONENT-01, JA-SCRIPT-KANJI-FIVE-COMPONENT-01, JA-SCRIPT-KANJI-MOUTH-COMPONENT-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W05-gen-component, JA-W05-five-component, JA-W05-mouth-component, JA-W05-nichi-kanji]
+---
+
+# 語 — assemble; do not memorise fourteen loose strokes
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-SPEECH-COMPONENT-01, JA-SCRIPT-KANJI-FIVE-COMPONENT-01, JA-SCRIPT-KANJI-MOUTH-COMPONENT-01] -->
+
+[PAUSE 2s] Point left and picture 言. Point upper-right and picture 五. Point
+lower-right and picture 口. Those are all the pieces.
+
+## Script — three known blocks become one sign
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-GO-01]; assesses=[] -->
+
+> 語
+
+Build it in blocks:
+
+1. write 言, narrow, on the left
+2. write 五 in the upper-right
+3. write 口 directly under 五
+
+Read the whole sign *go*, one beat. It means **language** here. There are fourteen
+strokes, but there are not fourteen new decisions: you already practised every
+block separately.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-GO-01] -->
+
+- [YOU TRACE: 語 by naming the blocks — speech, five, mouth]
+- [YOU COVER AND BUILD: 言 + 五 + 口]
+- [YOU READ: **go** — language]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-GO-01] -->
+<!-- hl-activity: {"id":"JA-W05-go-kanji-three-blocks","kind":"text","assesses":["JA-SCRIPT-KANJI-GO-01"],"prompt":"Build the kanji read go, language, from the three blocks you know.","answer":"語 = 言 + 五 + 口","accepted":["語","言 + 五 + 口","言五口"],"feedback":{"correct":"Right: 語 is speech on the left, five over mouth on the right.","incorrect":"Build 語: 言 on the left; 五 above 口 on the right."},"response_seconds":20} -->
+
+Which component fills the left side? (**言**, the speech component.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/08a9e.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W05-hon-kanji.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-hon-kanji.md
@@ -1,0 +1,73 @@
+---
+schema_version: 2
+id: JA-W05-hon-kanji
+spine_node: SPINE-MEET-GREET
+sequence: 280
+delivery: script
+chapter: 5
+type: writing
+headword: 本
+romanization: hon
+gloss: the five-stroke kanji for origin — the second sign in Japanese
+prerequisites: [JA-W05-nichi-kanji]
+sounds: [mora, moraic-n]
+roots: [middle-chinese-pwonx]
+etymology_hook: A short mark at a tree's base turned tree into root, origin, and then book.
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [JA-SCRIPT-KANJI-NICHI-01]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-HON-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-HON-01, JA-SCRIPT-KANJI-NICHI-01, JA-SCRIPT-MA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W05-nichi-kanji]
+---
+
+# 本 — a tree with its root marked
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-NICHI-01] -->
+
+[PAUSE 2s] Write 日 once. Read it *nichi* here.
+
+## Script — five strokes
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-HON-01]; assesses=[] -->
+
+> 本
+
+Write the large tree first, then mark its base:
+
+1. top horizontal
+2. centre vertical, down through it
+3. left-falling branch
+4. right-falling branch
+5. short horizontal across the lower stem
+
+That last stroke is the memory hook: it points to the **root**, so the sign came
+to mean **origin**. In the word ahead, read it *hon*, one beat ending in *n*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-HON-01] -->
+
+- [YOU TRACE: 本 — cross, two branches, root mark]
+- [YOU WRITE: 本 once without looking]
+- [YOU SAY: **hon**, one beat]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-MA-01] -->
+
+[PAUSE 15s] Write ? once from memory before beginning the new kanji.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-HON-01] -->
+<!-- hl-activity: {"id":"JA-W05-hon-kanji-root-mark","kind":"text","assesses":["JA-SCRIPT-KANJI-HON-01"],"prompt":"Write the kanji read hon. Which stroke marks the root?","answer":"本 — the final short horizontal stroke","accepted":["本","the last stroke","the short bottom line","final horizontal"],"feedback":{"correct":"Right: 本, with the short final line marking the root.","incorrect":"Write 本; the fifth, short horizontal line marks the root."},"response_seconds":18} -->
+
+Which stroke comes last? (The short **root mark**.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/0672c.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W05-mouth-component.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-mouth-component.md
@@ -1,0 +1,71 @@
+---
+schema_version: 2
+id: JA-W05-mouth-component
+spine_node: SPINE-MEET-GREET
+sequence: 310
+delivery: script
+chapter: 5
+type: writing
+headword: 口
+romanization: kuchi
+gloss: the three-stroke box under the sound clue in the kanji for language
+prerequisites: [JA-W05-five-component]
+sounds: [mora]
+roots: []
+etymology_hook: A simple open mouth becomes the lower-right block of the language sign.
+duration:
+  max_seconds: 170
+requires:
+  knowledge: [JA-SCRIPT-KANJI-FIVE-COMPONENT-01]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-MOUTH-COMPONENT-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-MOUTH-COMPONENT-01, JA-SCRIPT-KANJI-FIVE-COMPONENT-01, JA-SCRIPT-GOZAIMASU-READ-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W05-five-component, JA-W05-hon-kanji]
+---
+
+# 口 — close a box in three strokes
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-FIVE-COMPONENT-01] -->
+
+[PAUSE 2s] Write 五 once. Leave a little space below it with your finger.
+
+## Script — the lower-right piece
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-MOUTH-COMPONENT-01]; assesses=[] -->
+
+> 口
+
+Write three strokes:
+
+1. left side, down
+2. top and right side as one turning stroke
+3. bottom, left to right, closing the box
+
+It is the picture-sign for a **mouth**. In the larger kanji ahead, it sits under
+五. Today the whole job is one small square.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-MOUTH-COMPONENT-01] -->
+
+- [YOU TRACE: 口 — side, corner, close]
+- [YOU WRITE: 口 once from memory]
+- [YOU STACK: point below 五, where 口 will go]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-GOZAIMASU-READ-01] -->
+
+[PAUSE 15s] Read ????? from memory before drawing the new box component.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-MOUTH-COMPONENT-01] -->
+<!-- hl-activity: {"id":"JA-W05-mouth-component-close-box","kind":"text","assesses":["JA-SCRIPT-KANJI-MOUTH-COMPONENT-01"],"prompt":"Write the three-stroke mouth component that sits under 五.","answer":"口","accepted":["口 (mouth)","the mouth box"],"feedback":{"correct":"Right: 口 closes with the bottom stroke.","incorrect":"Use 口: left side, top-and-right corner, bottom."},"response_seconds":12} -->
+
+Which stroke closes the box? (The **bottom** stroke.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/053e3.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W05-nichi-kanji.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W05-nichi-kanji.md
@@ -1,0 +1,75 @@
+---
+schema_version: 2
+id: JA-W05-nichi-kanji
+spine_node: SPINE-MEET-GREET
+sequence: 270
+delivery: script
+chapter: 5
+type: writing
+headword: 日
+romanization: nichi
+gloss: the four-stroke kanji for sun or day — the first sign in Japanese
+prerequisites: [JA-C03-practice]
+sounds: [mora]
+roots: [middle-chinese-nyit]
+etymology_hook: A picture of the sun became a four-stroke box with one line of light inside.
+duration:
+  max_seconds: 190
+requires:
+  knowledge: [JA-SCRIPT-HIRAGANA-MORA]
+introduces:
+  knowledge: [JA-SCRIPT-KANJI-NICHI-01]
+practises:
+  knowledge: [JA-SCRIPT-KANJI-NICHI-01, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-GOZAIMASU-READ-01, JA-SCRIPT-SA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-C03-practice]
+---
+
+# 日 — one sun, four strokes
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-HIRAGANA-MORA] -->
+
+[PAUSE 2s] Say *ni-chi*: two even beats. Today you attach those beats to one
+kanji, but you write only one new shape.
+
+## Script — build the sun
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KANJI-NICHI-01]; assesses=[] -->
+
+> 日
+
+Write four strokes:
+
+1. the left side, down
+2. the top and right side as one turning stroke
+3. the short middle line, left to right
+4. the bottom line, left to right
+
+The middle line touches both sides. Keep the shape taller than it is wide.
+
+Here it is read *nichi*. It carries the broad idea **sun/day**. Kanji can have
+more than one reading; this lesson asks for only the reading in the word ahead.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-NICHI-01] -->
+
+- [YOU TRACE: 日 — side, corner, middle, bottom]
+- [YOU WRITE: 日 once from memory]
+- [YOU SAY: **nichi**, two beats]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-GOZAIMASU-READ-01, JA-SCRIPT-SA-01] -->
+
+[PAUSE 15s] Read ????? once and write its base sign ? without a model.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-NICHI-01] -->
+<!-- hl-activity: {"id":"JA-W05-nichi-kanji-four-strokes","kind":"text","assesses":["JA-SCRIPT-KANJI-NICHI-01"],"prompt":"Write the four-stroke kanji read nichi in the word for Japanese.","answer":"日","accepted":["日 (nichi)","nichi"],"feedback":{"correct":"Right: 日, the sun/day sign.","incorrect":"Use 日: left side, top-and-right corner, middle, bottom."},"response_seconds":15} -->
+
+Which line sits inside the box? (The **middle horizontal** line.)
+
+Source: [KanjiVG stroke-order data](https://kanjivg.tagaini.net/kanjivg/kanji/065e5.html).

--- a/code/learning/human-languages/japanese/lessons/JA-W06-hi-katakana.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W06-hi-katakana.md
@@ -1,0 +1,72 @@
+---
+schema_version: 2
+id: JA-W06-hi-katakana
+spine_node: SPINE-MEET-GREET
+sequence: 360
+delivery: script
+chapter: 6
+type: writing
+headword: ヒ
+romanization: hi
+gloss: the two-stroke katakana sign for hi — the remaining sign in coffee
+prerequisites: [JA-W06-long-mark]
+sounds: [mora]
+roots: []
+etymology_hook: Two spare strokes finish the borrowed word: a short left stroke, then the longer bent body.
+duration:
+  max_seconds: 175
+requires:
+  knowledge: [JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01]
+introduces:
+  knowledge: [JA-SCRIPT-KATAKANA-HI-01]
+practises:
+  knowledge: [JA-SCRIPT-KATAKANA-HI-01, JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-KANJI-MOUTH-COMPONENT-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W06-long-mark, JA-W06-ko-katakana]
+---
+
+# ヒ — two strokes complete the inventory
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01] -->
+
+[PAUSE 2s] Write コー and tap its two beats: *ko-o*.
+
+## Script — the last new shape
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KATAKANA-HI-01]; assesses=[] -->
+
+> ヒ
+
+Write two strokes:
+
+1. a short stroke from right toward left
+2. a longer vertical stroke that turns and sweeps right at the bottom
+
+Read it *hi*, one mora. Japanese *h* is light; keep the vowel clean, like the
+*ee* in *machine* but short.
+
+Now every distinct sign in the word ahead is known: コ, ー, and ヒ.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-HI-01] -->
+
+- [YOU TRACE: ヒ — short top, long bent body]
+- [YOU WRITE: ヒ once from memory]
+- [YOU BUILD: コ + ー + ヒ + ー]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-MOUTH-COMPONENT-01] -->
+
+[PAUSE 15s] Write ? once from memory before switching back to katakana.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-HI-01] -->
+<!-- hl-activity: {"id":"JA-W06-hi-katakana-two-strokes","kind":"text","assesses":["JA-SCRIPT-KATAKANA-HI-01"],"prompt":"Write hi in katakana, then place it after コー.","answer":"コーヒ","accepted":["ヒ","コー ヒ","katakana hi"],"feedback":{"correct":"Right: ヒ is the final distinct sign in the four-mora word ahead.","incorrect":"Use ヒ: short top stroke, then the longer bent body."},"response_seconds":12} -->
+
+Which stroke bends to the right? (The **second**, longer stroke.)
+
+Source: [Unicode Katakana chart](https://www.unicode.org/charts/PDF/U30A0.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-W06-ko-katakana.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W06-ko-katakana.md
@@ -1,0 +1,71 @@
+---
+schema_version: 2
+id: JA-W06-ko-katakana
+spine_node: SPINE-MEET-GREET
+sequence: 340
+delivery: script
+chapter: 6
+type: writing
+headword: コ
+romanization: ko
+gloss: the two-stroke katakana sign for ko — the first sign in coffee
+prerequisites: [JA-C01-nihongo]
+sounds: [mora]
+roots: []
+etymology_hook: Katakana signs were clipped from larger characters; コ keeps only a spare, angular frame.
+duration:
+  max_seconds: 175
+requires:
+  knowledge: [JA-LEX-NIHONGO]
+introduces:
+  knowledge: [JA-SCRIPT-KATAKANA-KO-01]
+practises:
+  knowledge: [JA-SCRIPT-KATAKANA-KO-01, JA-LEX-NIHONGO, JA-BRIDGE-SINO-JAPANESE, JA-SCRIPT-KANJI-READINGS, JA-SCRIPT-KANJI-SPEECH-COMPONENT-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-C01-nihongo, JA-W05-hon-kanji]
+---
+
+# コ — same sound, a new script
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-NIHONGO] -->
+
+[PAUSE 2s] Read 日本語 once. Now switch jobs: the next word came from abroad,
+so Japanese normally writes it in katakana.
+
+## Script — two angular strokes
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KATAKANA-KO-01]; assesses=[] -->
+
+> コ
+
+Write two strokes:
+
+1. top horizontal, then turn down at the right
+2. bottom horizontal, left to right
+
+Read it *ko*, the same mora as hiragana こ. The sound is not new. Only the
+script is new: katakana is angular and commonly marks borrowed words.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-KO-01] -->
+
+- [YOU TRACE: コ — top-and-side, then bottom]
+- [YOU WRITE: コ once from memory]
+- [YOU CONTRAST: こ is hiragana; コ is katakana; both say *ko*]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-BRIDGE-SINO-JAPANESE, JA-SCRIPT-KANJI-READINGS, JA-SCRIPT-KANJI-SPEECH-COMPONENT-01] -->
+
+[PAUSE 15s] Trace ? once. Then recall why Japanese kanji readings connect to Chinese without giving each sign one fixed sound.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-KO-01] -->
+<!-- hl-activity: {"id":"JA-W06-ko-katakana-ko","kind":"text","assesses":["JA-SCRIPT-KATAKANA-KO-01"],"prompt":"Write ko in katakana, the script used for the borrowed word coffee.","answer":"コ","accepted":["コ (ko)","katakana コ"],"feedback":{"correct":"Right: コ is katakana ko.","incorrect":"Use コ: top-and-right corner, then the bottom line."},"response_seconds":12} -->
+
+Does コ introduce a new sound? (**No** — only a new written shape.)
+
+Source: [Unicode Katakana chart](https://www.unicode.org/charts/PDF/U30A0.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-W06-long-mark.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W06-long-mark.md
@@ -1,0 +1,69 @@
+---
+schema_version: 2
+id: JA-W06-long-mark
+spine_node: SPINE-MEET-GREET
+sequence: 350
+delivery: script
+chapter: 6
+type: writing
+headword: ー
+romanization: chōonpu
+gloss: the one-stroke katakana mark that holds the preceding vowel for another beat
+prerequisites: [JA-W06-ko-katakana]
+sounds: [mora, mora-length, chouon]
+roots: []
+etymology_hook: One horizontal line buys one more beat of the vowel before it.
+duration:
+  max_seconds: 165
+requires:
+  knowledge: [JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-MORA-LENGTH]
+introduces:
+  knowledge: [JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-CHOUON]
+practises:
+  knowledge: [JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-CHOUON, JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-MORA-LENGTH, JA-SCRIPT-KANJI-FIVE-COMPONENT-01]
+skills: [listening, reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-across-levels
+variety: standard-japanese-tokyo
+reviews_of: [JA-W06-ko-katakana, JA-C01-iie]
+---
+
+# ー — one line, one extra beat
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-KO-01, JA-SCRIPT-MORA-LENGTH] -->
+
+[PAUSE 2s] Write コ and say *ko*. Hold its vowel once: *ko-o*.
+
+## Script — length lives on the page
+<!-- hl-knowledge: introduces=[JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-CHOUON]; assesses=[] -->
+
+> コー
+
+Write one horizontal stroke after the katakana sign. This mark is the
+**chōonpu**, the long-vowel mark. It does not have a sound by itself. It tells
+you to hold the vowel before it for one more mora.
+
+So コ is *ko*, while コー is *kō*: two beats, *ko-o*. Keep the line centred and
+about as wide as the sign before it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-CHOUON] -->
+
+- [YOU WRITE: コ, then ー]
+- [YOU TAP: *ko* — one; hold *o* — two]
+- [YOU READ: コー as **kō**, not *ko*]
+
+## Guided Practice — review pulse
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KANJI-FIVE-COMPONENT-01] -->
+
+[PAUSE 15s] Write ? once from memory, then return to the one-stroke length mark.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-SCRIPT-CHOUON] -->
+<!-- hl-activity: {"id":"JA-W06-long-mark-beat","kind":"text","assesses":["JA-SCRIPT-KATAKANA-LONG-MARK-01","JA-SCRIPT-CHOUON"],"prompt":"Add the katakana long-vowel mark to コ so it reads kō.","answer":"コー","accepted":["コ ー","kō","ko-o"],"feedback":{"correct":"Right: コー holds o for a second beat.","incorrect":"Write one horizontal mark after コ: コー."},"response_seconds":10} -->
+
+How many extra beats does ー add? (**One**.)
+
+Source: [Unicode Katakana chart](https://www.unicode.org/charts/PDF/U30A0.pdf).

--- a/code/learning/human-languages/japanese/narration/ch01.json
+++ b/code/learning/human-languages/japanese/narration/ch01.json
@@ -2,13 +2,628 @@
   "version": 1,
   "language": "japanese",
   "chapter": 1,
-  "title": "Three Writing Systems in One Doorway",
+  "title": "Two Answers, Sign by Sign",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:9927b0eced7c6fcf",
+  "sourceHash": "fnv1a64:fe825b2ffb8c58cd",
   "lessons": [
     {
-      "id": "JA-C01-hai",
+      "id": "JA-W01-i",
       "sequence": 10,
+      "title": "い (i) — two strokes, one beat",
+      "headword": "い",
+      "romanization": "i",
+      "gloss": "the hiragana sign for the mora i — two strokes, and the first sign you can write",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a7e27e6bcc99c599",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You already know the rule that makes this writing system easy: one sign, one beat. Not one letter one sound, and not one sign one word — one sign, one mora, the even beat Japanese counts time in."
+            },
+            {
+              "kind": "speech",
+              "text": "What you have not had yet is a single sign taught on its own. Here is the first."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "い (i)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two strokes, both falling, the left one long and the right one short:"
+            },
+            {
+              "kind": "speech",
+              "text": "the left stroke — start high, come down, and hook gently to the right at the bottom."
+            },
+            {
+              "kind": "speech",
+              "text": "the right stroke — a short downward tick, higher up and clear of the first."
+            },
+            {
+              "kind": "speech",
+              "text": "It is read i, the vowel of English machine — short, tight, never the eye of English bite."
+            },
+            {
+              "kind": "speech",
+              "text": "Where the shape came from, and why it does not help you. Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen for their sound, not their meaning, so unlike a Chinese component there is nothing inside い to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "follow the visible い once — long stroke first, then the short tick",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: follow the visible い once — long stroke first, then the short tick]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "i, one clean beat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **i**, one clean beat]"
+            },
+            {
+              "kind": "speech",
+              "text": "Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "How many beats does one hiragana sign take? (One.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W01-i-strokes",
+              "prompt": "How many strokes does the hiragana sign for 'i' have?",
+              "assesses": [
+                "JA-SCRIPT-I-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "2",
+                "two",
+                "2 strokes",
+                "two strokes"
+              ],
+              "feedback": {
+                "correct": "Two — a long falling stroke, then a short tick.",
+                "incorrect": "Two: the long left stroke, then the short right one."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W01-ha",
+      "sequence": 20,
+      "title": "は (ha) — three strokes",
+      "headword": "は",
+      "romanization": "ha",
+      "gloss": "the hiragana sign for the mora ha — three strokes, and the second half of a word you already say",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:92334fa860a65c08",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write the two-stroke sign you met a moment ago. Long stroke, short tick."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "は (ha)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three strokes. Look at it as a tall left post with a loop tied on its right."
+            },
+            {
+              "kind": "speech",
+              "text": "the vertical, down the left side, with the smallest flick left at the foot."
+            },
+            {
+              "kind": "speech",
+              "text": "a short horizontal crossing that vertical near the top, on its right."
+            },
+            {
+              "kind": "speech",
+              "text": "the loop — down from the right of that crossbar, round to the left, and back up to close."
+            },
+            {
+              "kind": "speech",
+              "text": "Read ha, breathed rather than hard: the h of English hat, then the open a of father."
+            },
+            {
+              "kind": "speech",
+              "text": "It has a second reading, and you have already used it. Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it sounds like."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "COPY",
+              "instruction": "keep は (ha) visible and write it once — vertical, crossbar, loop",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU COPY: keep は visible and write it once — vertical, crossbar, loop]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ha, one beat, breath not force",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **ha**, one beat, breath not force]"
+            },
+            {
+              "kind": "speech",
+              "text": "Look back at the model between strokes if you need to. This is one guided copy, not a memory test."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say? and tap its one mora before adding another sign."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which stroke of は (ha) is written first? (The vertical on the left.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W01-ha-strokes",
+              "prompt": "How many strokes does the hiragana sign read 'ha' have?",
+              "assesses": [
+                "JA-SCRIPT-HA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "3",
+                "three",
+                "3 strokes",
+                "three strokes"
+              ],
+              "feedback": {
+                "correct": "Three — vertical, crossbar, loop.",
+                "incorrect": "Three: the left vertical, the short crossbar, then the loop."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W01-hai-read",
+      "sequence": 30,
+      "title": "Two signs, side by side — and a word appears",
+      "headword": "はい",
+      "romanization": "hai",
+      "gloss": "the first word you can read rather than recall — two signs, both already yours",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:d8ad87d72773e6a9",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — no new sign at all",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Both signs are yours. Look at them for five seconds:"
+            },
+            {
+              "kind": "speech",
+              "text": "は (ha) い (i)."
+            },
+            {
+              "kind": "speech",
+              "text": "Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — no new sign at all",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Now write them touching:"
+            },
+            {
+              "kind": "speech",
+              "text": "は + い becomes はい (hai)."
+            },
+            {
+              "kind": "speech",
+              "text": "ha then i. Two beats, even, neither one stressed. You can now decode the sequence hai. The word lesson after the next sign attaches its useful meaning."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing new was introduced in this lesson. No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are reading it — assembling it out of two pieces you can write from memory and sound out in order."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "はい (hai) — sound each sign in turn, do not recall the word whole",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **はい** — sound each sign in turn, do not recall the word whole]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "はい (hai) — five strokes in total, three then two",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: はい — five strokes in total, three then two]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "How many new strokes did you have to learn in this lesson? (None.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W01-hai-read-beats",
+              "prompt": "How many beats does the written sequence はい (hai) take?",
+              "assesses": [
+                "JA-SCRIPT-HAI-READ-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "2",
+                "two",
+                "2 beats",
+                "two beats"
+              ],
+              "feedback": {
+                "correct": "Two — one per sign, evenly.",
+                "incorrect": "Two: one beat per hiragana sign."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W01-e",
+      "sequence": 40,
+      "title": "え — two strokes, and a second word for free",
+      "headword": "え",
+      "romanization": "e",
+      "gloss": "the hiragana sign for the mora e — two strokes, and the one that finishes the word for no",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:dcd8c95cde4d1310",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read the word for yes off the page, sign by sign, out loud."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "え (e)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two strokes, and the second one does most of the work:"
+            },
+            {
+              "kind": "speech",
+              "text": "a short tick at the top, on its own, clear of everything below."
+            },
+            {
+              "kind": "speech",
+              "text": "the body — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement."
+            },
+            {
+              "kind": "speech",
+              "text": "Read e, the vowel of English bed — short, and never the ay of day."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "notice",
+          "title": "What you've built",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:"
+            },
+            {
+              "kind": "speech",
+              "text": "い (i) | い (i) | え (e)."
+            },
+            {
+              "kind": "speech",
+              "text": "i-i-e. Three beats — and note that the first sign is written twice, because Japanese counts two full beats there. The next lesson attaches its meaning. For now, the whole task is decoding three known signs in order."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue."
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE FROM THE HEARD OR ROMANIZED CUE",
+              "instruction": "え — tick first, then the body in one movement",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE FROM THE HEARD OR ROMANIZED CUE: え — tick first, then the body in one movement]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "い | い | え — three beats, and do not shorten the doubled sign",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **い | い | え** — three beats, and do not shorten the doubled sign]"
+            },
+            {
+              "kind": "speech",
+              "text": "Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Why is the first sign of that word written twice? (Because it is two beats, not one held longer.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W01-e-beats",
+              "prompt": "Write the final sign in i-i-e, then count the three visible beats.",
+              "assesses": [
+                "JA-SCRIPT-E-01"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "え; 3",
+                "え",
+                "え, three",
+                "e; 3"
+              ],
+              "feedback": {
+                "correct": "Right: え finishes the three-sign sequence.",
+                "incorrect": "Write え: top tick, then the longer body. The full sequence has three beats."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C01-hai",
+      "sequence": 50,
       "title": "はい (hai) — yes, in two equal beats",
       "headword": "はい",
       "romanization": "hai",
@@ -19,7 +634,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9e35a70226961635",
+      "sourceHash": "fnv1a64:02e5572b856c1fa3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -74,7 +689,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "はい means yes, and also \"here you are,\" \"I am listening,\" and \"present.\" Its origin is genuinely unsettled: some accounts tie it to 拝 hai, \"a bow\"; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact."
+              "text": "はい means yes, and also \"here you are,\" \"I am listening,\" and \"present.\" Its origin is genuinely unsettled: some accounts tie it to an older word hai, \"a bow\"; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact. The rare kanji sometimes used in that proposal can wait until a later reading chapter."
             },
             {
               "kind": "speech",
@@ -104,7 +719,7 @@
             {
               "kind": "prompt",
               "action": "READ",
-              "instruction": "は, then い, left to right",
+              "instruction": "は (ha), then い, left to right",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
@@ -159,7 +774,7 @@
     },
     {
       "id": "JA-C01-iie",
-      "sequence": 20,
+      "sequence": 60,
       "title": "いいえ (iie) — no, and why the extra beat matters",
       "headword": "いいえ",
       "romanization": "iie",
@@ -170,7 +785,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:48f5d1d0cb381ae2",
+      "sourceHash": "fnv1a64:be3de3c917443851",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -270,6 +885,23 @@
         },
         {
           "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say??, then write? once from memory before learning the contrasting answer."
+            }
+          ]
+        },
+        {
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -299,920 +931,6 @@
               "feedback": {
                 "correct": "Right: i-i-e, three morae. Two beats would be いえ, 'house'.",
                 "incorrect": "Three: い, い, え — one beat per sign."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-konnichiwa",
-      "sequence": 30,
-      "title": "こんにちは (konnichiwa) — hello, and a sign that lies about its sound",
-      "headword": "こんにちは",
-      "romanization": "konnichiwa",
-      "gloss": "hello (daytime greeting)",
-      "script": "japanese",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a5f03af3d9b83495",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — four new signs, and one you know"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — four new signs, and one you know until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Retrieve はい (hai) and the sign は. You are about to meet は again in the daytime greeting — where it is not pronounced ha."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — four new signs, and one you know",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "こんにちは (konnichiwa) — こ ko + ん n + に ni + ち chi + は."
-            },
-            {
-              "kind": "speech",
-              "text": "Four signs are new. こ ko, に ni, and ち chi behave like every hiragana so far: one sign, one consonant-plus-vowel beat."
-            },
-            {
-              "kind": "speech",
-              "text": "ん is the exception worth naming. It is the one hiragana that is a bare consonant, and it still takes a full beat of its own. So こんにちは (konnichiwa) is five signs and five beats: ko-n-ni-chi-wa. Give ん its own beat and the greeting sounds Japanese; swallow it and it does not."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens — the sign は, read wa",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The last sign is は, which you learned as ha. Here it is read wa."
-            },
-            {
-              "kind": "speech",
-              "text": "That is not an exception to memorize blindly. は is Japanese's topic particle — the little word that marks what a sentence is about, roughly \"as for ___.\" Japanese spelling was reformed in 1946 to follow pronunciation, but three grammatical particles were left at their older spellings because they are so frequent that respelling them would have rewritten every page in the country. は is one of them. Rule to carry forward: は is ha inside a word, and wa when it is doing the job of a particle."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "こんにちは (konnichiwa) is the daytime greeting — roughly midday to dusk, not morning and not evening. It is a sentence that was abandoned halfway. In full it was 今日は… konnichi wa…, \"as for today …\", opening a longer enquiry after someone's health. The rest fell away and the topic marker stayed, which is why Japan's most common greeting ends on a grammatical particle instead of a word."
-            },
-            {
-              "kind": "speech",
-              "text": "Those two characters, 今日 konnichi \"this day,\" belong to the third writing system, and the next lesson opens it."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "こんにちは (konnichiwa) — ko-n-ni-chi-wa, five beats",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **こんにちは** — *ko-n-ni-chi-wa*, five beats]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "prompt",
-              "action": "DECIDE",
-              "instruction": "は in はい (hai) becomes ha; は ending the greeting becomes wa",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU DECIDE: **は** in **はい** → *ha*; **は** ending the greeting → *wa*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "GREET",
-              "instruction": "someone at midday becomes こんにちは (konnichiwa)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU GREET: someone at midday → **こんにちは**]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Which sign takes a beat without a vowel? (ん.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Wiktionary: こんにちは (konnichiwa)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-konnichiwa-particle",
-              "prompt": "The greeting ends in the sign は. How is it pronounced there?",
-              "assesses": [
-                "JA-PARTICLE-WA-SPELLING"
-              ],
-              "responseSeconds": 9,
-              "acceptedResponses": [
-                "wa",
-                "as wa",
-                "わ",
-                "the topic particle wa"
-              ],
-              "feedback": {
-                "correct": "Right: は is read wa when it works as the topic particle.",
-                "incorrect": "It is read wa — は is the topic particle here, not the sound ha."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-nihongo",
-      "sequence": 40,
-      "title": "日本語 (nihongo) — three characters, and no single sound each",
-      "headword": "日本語",
-      "romanization": "nihongo",
-      "gloss": "the Japanese language",
-      "script": "japanese",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:30364ffdc03370b8",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — kanji, and the readings problem"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — kanji, and the readings problem until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say こんにちは (konnichiwa). Its history hid two characters, 今日, that hiragana cannot show you. This lesson opens that second system by naming the language itself."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — kanji, and the readings problem",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "日本語 (nihongo) — ni + hon + go."
-            },
-            {
-              "kind": "speech",
-              "text": "These are kanji: characters borrowed from Chinese, each carrying a meaning rather than a sound. 日 is sun or day. 本 is origin or root. 語 is language. So 日本 is \"sun-origin\" — the country the sun rises from — and 日本語 (nihongo) is its language."
-            },
-            {
-              "kind": "speech",
-              "text": "Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach \"the sound of 日.\" What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it."
-            },
-            {
-              "kind": "speech",
-              "text": "Two families of readings explain the spread. The on reading is Japan's version of the Chinese pronunciation, imported with the character. The kun reading is a native Japanese word written with a borrowed character that already meant the same thing. 日本語 (nihongo) is on-readings throughout; 今日 in the greeting is irregular even by those standards."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart — the real family",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Here the cousin web finally works — just not toward English. The on-readings nichi, hon, go are borrowings of Middle Chinese, so 日本語 (nihongo) has genuine relatives: Mandarin writes the same three characters and says Rìběnyǔ; Korean borrowed the same compound as ilbon-eo. Same characters, related imported sounds, one meaning, three languages."
-            },
-            {
-              "kind": "speech",
-              "text": "That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "日本語 (nihongo) — ni-ho-n-go, four beats",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **日本語** — *ni-ho-n-go*, four beats]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "prompt",
-              "action": "NAME",
-              "instruction": "日 sun or day; 本 origin; 語 language",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU NAME: 日 sun or day; 本 origin; 語 language]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONNECT",
-              "instruction": "Mandarin Rìběnyǔ, Korean ilbon-eo, same three characters",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONNECT: Mandarin *Rìběnyǔ*, Korean *ilbon-eo*, same three characters]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "What does 日本 mean literally? (Sun-origin.) Does 日 have one pronunciation? (No — the word it appears in chooses one.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Wiktionary: 日本語 (nihongo)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-nihongo-readings",
-              "prompt": "How is the character 日 read inside 日本語 (nihongo)?",
-              "assesses": [
-                "JA-SCRIPT-KANJI-READINGS"
-              ],
-              "responseSeconds": 10,
-              "acceptedResponses": [
-                "ni",
-                "as ni",
-                "に",
-                "read ni"
-              ],
-              "feedback": {
-                "correct": "Right: ni here — though the same character is nichi, jitsu, hi, bi, or ka elsewhere.",
-                "incorrect": "In 日本語 it is ni. The character has no single sound; the word decides."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-koohii",
-      "sequence": 50,
-      "title": "コーヒー (kōhī) — the third system, and a word that really is a cousin",
-      "headword": "コーヒー",
-      "romanization": "kōhī",
-      "gloss": "coffee",
-      "script": "japanese",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9d562bfdb6016d62",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — katakana, the borrowed-word script",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — katakana, the borrowed-word script and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Recall how hiragana writes a long vowel: it writes the vowel twice, as in いいえ (iie). Katakana does it differently, and this word shows how."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — katakana, the borrowed-word script",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "コーヒー (kōhī) — コ ko + ー + ヒ hi + ー."
-            },
-            {
-              "kind": "speech",
-              "text": "This is katakana, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms."
-            },
-            {
-              "kind": "speech",
-              "text": "The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from fragments of characters, shorthand that monks scribbled beside a text to remember how to read it. こ and コ even trace back to the same character, which is why they still look alike."
-            },
-            {
-              "kind": "speech",
-              "text": "ー is the chōonpu, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So コーヒー (kōhī) is four beats: ko-o-hi-i."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart — a shared borrowing",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "コーヒー (kōhī) is coffee, and it entered Japanese from Dutch koffie through the Nagasaki trade. Dutch had it from Turkish kahve, and Turkish from Arabic qahwa — which is exactly where English coffee comes from as well."
-            },
-            {
-              "kind": "speech",
-              "text": "So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads: パン bread, from Portuguese pão, and アルバイト a part-time job, from German Arbeit."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "コーヒー (kōhī) — ko-o-hi-i, four beats",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **コーヒー** — *ko-o-hi-i*, four beats]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "prompt",
-              "action": "TRACE",
-              "instruction": "Arabic qahwa becomes Turkish kahve becomes Dutch koffie becomes コーヒー (kōhī)",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU TRACE: Arabic *qahwa* → Turkish *kahve* → Dutch *koffie* → **コーヒー**]"
-            },
-            {
-              "kind": "prompt",
-              "action": "DECIDE",
-              "instruction": "a borrowed word is written in katakana, not hiragana",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU DECIDE: a borrowed word is written in katakana, not hiragana]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Which script signals a borrowed word? (Katakana.) How many beats does コーヒー (kōhī) hold? (Four.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Wiktionary: コーヒー (kōhī)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-koohii-bar",
-              "prompt": "What does the bar ー do in コーヒー (kōhī)?",
-              "assesses": [
-                "JA-SCRIPT-CHOUON"
-              ],
-              "responseSeconds": 10,
-              "acceptedResponses": [
-                "it holds the vowel for one more beat",
-                "lengthens the vowel",
-                "long vowel",
-                "it lengthens the previous vowel",
-                "adds a beat to the vowel"
-              ],
-              "feedback": {
-                "correct": "Right: the chōonpu adds one more beat of the same vowel.",
-                "incorrect": "It lengthens the vowel before it by one beat — ko-o-hi-i."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-arigatou",
-      "sequence": 60,
-      "title": "ありがとう (arigatō) — thanks, from “this hardly ever happens”",
-      "headword": "ありがとう",
-      "romanization": "arigatō",
-      "gloss": "thank you (plain)",
-      "script": "japanese",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:1ff00726c195b8ce",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — five signs and two small strokes"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five signs and two small strokes until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — five signs and two small strokes",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ありがとう (arigatō) — あ a + り ri + が ga + と to + う."
-            },
-            {
-              "kind": "speech",
-              "text": "あ a, り ri, と to and う u are ordinary hiragana. が is the new idea: it is the sign か ka with two short strokes added at the top right. That mark is the dakuten, and it voices the consonant — the same two strokes turn ka into ga, sa into za, ta into da, ha into ba. One mark, learned once, doubles how much of the script you can read."
-            },
-            {
-              "kind": "speech",
-              "text": "The final う does not sound like u here. After と it stretches the o, so the word ends -tō and holds five beats: a-ri-ga-to-o. Hiragana lengthens a vowel by writing another vowel sign, where katakana used the bar ー."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart — 有り難う",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Written in kanji, ありがとう (arigatō) is 有り難う: 有る aru \"to exist\" plus 難し katashi \"difficult.\" Its ancestor 有り難し arigatashi meant literally \"hard to exist\" — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The k of katashi softened to g inside the compound, which is the same voicing the dakuten writes."
-            },
-            {
-              "kind": "speech",
-              "text": "So the memory hook is inside the word, not inside English: saying ありがとう (arigatō) is saying this was not a thing that had to happen. No English cousin exists, and inventing one would be worse than admitting that."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ありがとう (arigatō) — a-ri-ga-to-o, five beats",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **ありがとう** — *a-ri-ga-to-o*, five beats]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "prompt",
-              "action": "BUILD",
-              "instruction": "か plus the dakuten becomes が",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU BUILD: **か** plus the dakuten → **が**]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONNECT",
-              "instruction": "有り難し \"hard to exist\" becomes rare becomes precious becomes thanks",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONNECT: 有り難し \"hard to exist\" → rare → precious → thanks]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "What did 有り難し mean literally? (Hard to exist.) What does the last う do? (It lengthens the o.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Wiktionary: ありがとう (arigatō)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-arigatou-dakuten",
-              "prompt": "Which hiragana sign becomes が when the dakuten is added?",
-              "assesses": [
-                "JA-SCRIPT-DAKUTEN"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "か",
-                "ka",
-                "か ka"
-              ],
-              "feedback": {
-                "correct": "Right: か plus the two strokes is が.",
-                "incorrect": "It is か — the dakuten voices ka into ga."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-gozaimasu",
-      "sequence": 70,
-      "title": "ありがとうございます (arigatō gozaimasu) — politeness you cannot leave out",
-      "headword": "ありがとうございます",
-      "romanization": "arigatō gozaimasu",
-      "gloss": "thank you (polite)",
-      "script": "japanese",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a6d37ece38604436",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — five more signs, two of them dakuten"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five more signs, two of them dakuten until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say ありがとう (arigatō) once and rebuild が from か. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — five more signs, two of them dakuten",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ございます — ご go + ざ za + い i + ま ma + す su."
-            },
-            {
-              "kind": "speech",
-              "text": "Two of the five are dakuten forms you can already build: ご is こ with the two strokes, and ざ is さ sa with them. い you have read since はい (hai). Only ま ma and す su are genuinely new."
-            },
-            {
-              "kind": "speech",
-              "text": "The whole phrase is ten beats — a-ri-ga-to-o go-za-i-ma-su — and the final す is normally said with the u barely voiced, close to a plain s."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens — politeness is grammar here, not word choice",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ございます is a verb. It is the polite form of ある aru, \"to be\" — the same verb that sits inside ありがとう (arigatō). The route runs ある becomes ござる becomes ございます, where the ending -ます is the general politeness marker Japanese attaches to verbs."
-            },
-            {
-              "kind": "speech",
-              "text": "That is the difference this chapter has to name. In many languages politeness is a choice between two words for \"you.\" Japanese instead marks it on the predicate, and every sentence has one, so every sentence is marked. There is no neutral setting: ありがとう to a friend and ありがとうございます (arigatō gozaimasu) to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately."
-            },
-            {
-              "kind": "speech",
-              "text": "At the far end of the system, the verb itself is replaced. 言う iu \"to say\" becomes おっしゃる when the speaker is honouring someone else and 申す when humbling themselves. Same act, three verbs, chosen by who is doing what to whom. That is keigo, and this lesson is only its front door."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ありがとうございます (arigatō gozaimasu) — ten beats, final su light",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **ありがとうございます** — ten beats, final *su* light]"
-            },
-            {
-              "kind": "repeat",
-              "times": 2,
-              "source": "[REPEAT x2]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CHOOSE",
-              "instruction": "a close friend becomes ありがとう; a shop assistant becomes ありがとうございます (arigatō gozaimasu)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CHOOSE: a close friend → **ありがとう**; a shop assistant → **ありがとうございます**]"
-            },
-            {
-              "kind": "prompt",
-              "action": "BUILD",
-              "instruction": "こ becomes ご, さ becomes ざ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU BUILD: **こ** → **ご**, **さ** → **ざ**]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Which verb hides inside ございます? (ある, \"to be.\") Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Wiktionary: ございます."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-gozaimasu-level",
-              "prompt": "You are thanking a shop assistant you have never met. Which form do you use?",
-              "assesses": [
-                "JA-REGISTER-TEINEIGO"
-              ],
-              "responseSeconds": 10,
-              "acceptedResponses": [
-                "ありがとうございます",
-                "arigato gozaimasu",
-                "arigatou gozaimasu",
-                "arigatō gozaimasu",
-                "the polite one"
-              ],
-              "feedback": {
-                "correct": "Right: the polite -masu form is the default with someone outside your circle.",
-                "incorrect": "Use ありがとうございます — the plain ありがとう is for people close to you."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C01-practice",
-      "sequence": 80,
-      "title": "Practice — one daytime exchange, three scripts",
-      "headword": "こんにちは … ありがとうございます",
-      "romanization": "konnichiwa … arigatō gozaimasu",
-      "gloss": "a short daytime doorway exchange, start to finish",
-      "script": "japanese",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:fd0c2e1120a75440",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "input",
-          "title": "The exchange — every line already learned",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "A: こんにちは (konnichiwa)。 — Konnichiwa. B: こんにちは (konnichiwa)。 — Konnichiwa. A: 日本語 (nihongo)? — Nihongo? B: はい (hai)。 — Hai. A: ありがとうございます (arigatō gozaimasu)。 — Arigatō gozaimasu. B: いいえ (iie)。 — Iie."
-            },
-            {
-              "kind": "speech",
-              "text": "Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so 日本語 (nihongo) with the voice lifted is a complete and natural way to ask \"Japanese, then?\" — and はい (hai) answers it. B's closing いいえ (iie) is the modest \"not at all\" that waves thanks away."
-            },
-            {
-              "kind": "speech",
-              "text": "A single ordinary Japanese sentence mixes the systems: hiragana carries the grammar, kanji carries the content words, katakana carries the borrowings. That is why this chapter opened all three instead of finishing one."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "RUN",
-              "instruction": "both voices once with the Japanese, once with romanization only",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU RUN: both voices once with the Japanese, once with romanization only]"
-            },
-            {
-              "kind": "prompt",
-              "action": "DECIDE",
-              "instruction": "which line would change if B were a close friend",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU DECIDE: which line would change if B were a close friend]"
-            },
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SWAP",
-              "instruction": "take B's part while the other lines are read to you",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SWAP: take B's part while the other lines are read to you]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-C01-practice-final-line",
-              "prompt": "Someone has just thanked you politely. Give the modest one-word reply this chapter taught.",
-              "assesses": [
-                "JA-DIALOGUE-DOORWAY"
-              ],
-              "responseSeconds": 9,
-              "acceptedResponses": [
-                "いいえ",
-                "iie",
-                "no",
-                "not at all"
-              ],
-              "feedback": {
-                "correct": "Right: いいえ waves the thanks away.",
-                "incorrect": "Answer いいえ — here it means 'not at all', not a flat refusal."
               }
             }
           ]

--- a/code/learning/human-languages/japanese/narration/ch01.txt
+++ b/code/learning/human-languages/japanese/narration/ch01.txt
@@ -1,8 +1,140 @@
-Japanese, chapter 1: Three Writing Systems in One Doorway.
-8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+Japanese, chapter 1: Two Answers, Sign by Sign.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 8.
+Lesson 1 of 6.
+い (i) — two strokes, one beat.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You already know the rule that makes this writing system easy: one sign, one beat. Not one letter one sound, and not one sign one word — one sign, one mora, the even beat Japanese counts time in.
+What you have not had yet is a single sign taught on its own. Here is the first.
+
+Script — the shape.
+い (i).
+Two strokes, both falling, the left one long and the right one short:
+the left stroke — start high, come down, and hook gently to the right at the bottom.
+the right stroke — a short downward tick, higher up and clear of the first.
+It is read i, the vowel of English machine — short, tight, never the eye of English bite.
+Where the shape came from, and why it does not help you. Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen for their sound, not their meaning, so unlike a Chinese component there is nothing inside い to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind.
+
+Guided Practice.
+[once you have stopped driving — trace: follow the visible い once — long stroke first, then the short tick]
+[your turn — say: i, one clean beat]
+[pause 8 seconds for the answer]
+Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
+
+Wrap-up Recall.
+How many beats does one hiragana sign take? (One.)
+Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
+[question — say your answer, then pause 8 seconds]
+How many strokes does the hiragana sign for 'i' have?
+
+
+Lesson 2 of 6.
+は (ha) — three strokes.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write the two-stroke sign you met a moment ago. Long stroke, short tick.
+
+Script — the shape.
+は (ha).
+Three strokes. Look at it as a tall left post with a loop tied on its right.
+the vertical, down the left side, with the smallest flick left at the foot.
+a short horizontal crossing that vertical near the top, on its right.
+the loop — down from the right of that crossbar, round to the left, and back up to close.
+Read ha, breathed rather than hard: the h of English hat, then the open a of father.
+It has a second reading, and you have already used it. Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it sounds like.
+
+Guided Practice.
+[your turn — copy: keep は (ha) visible and write it once — vertical, crossbar, loop]
+[pause 8 seconds for the answer]
+[your turn — say: ha, one beat, breath not force]
+[pause 8 seconds for the answer]
+Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say? and tap its one mora before adding another sign.
+
+Wrap-up Recall.
+Which stroke of は (ha) is written first? (The vertical on the left.)
+Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
+[question — say your answer, then pause 8 seconds]
+How many strokes does the hiragana sign read 'ha' have?
+
+
+Lesson 3 of 6.
+Two signs, side by side — and a word appears.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 3 seconds]
+Both signs are yours. Look at them for five seconds:
+は (ha) い (i).
+Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
+
+Script — no new sign at all.
+Now write them touching:
+は + い becomes はい (hai).
+ha then i. Two beats, even, neither one stressed. You can now decode the sequence hai. The word lesson after the next sign attaches its useful meaning.
+Nothing new was introduced in this lesson. No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are reading it — assembling it out of two pieces you can write from memory and sound out in order.
+That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row.
+
+Guided Practice.
+[your turn — read: はい (hai) — sound each sign in turn, do not recall the word whole]
+[pause 8 seconds for the answer]
+[once you have stopped driving — write: はい (hai) — five strokes in total, three then two]
+
+Wrap-up Recall.
+How many new strokes did you have to learn in this lesson? (None.)
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 8 seconds]
+How many beats does the written sequence はい (hai) take?
+
+
+Lesson 4 of 6.
+え — two strokes, and a second word for free.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Read the word for yes off the page, sign by sign, out loud.
+
+Script — the shape.
+え (e).
+Two strokes, and the second one does most of the work:
+a short tick at the top, on its own, clear of everything below.
+the body — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement.
+Read e, the vowel of English bed — short, and never the ay of day.
+
+What you've built.
+Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:
+い (i) | い (i) | え (e).
+i-i-e. Three beats — and note that the first sign is written twice, because Japanese counts two full beats there. The next lesson attaches its meaning. For now, the whole task is decoding three known signs in order.
+
+Guided Practice.
+Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue.
+[once you have stopped driving — write from the heard or romanized cue: え — tick first, then the body in one movement]
+[your turn — read: い | い | え — three beats, and do not shorten the doubled sign]
+[pause 8 seconds for the answer]
+Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
+
+Wrap-up Recall.
+Why is the first sign of that word written twice? (Because it is two beats, not one held longer.)
+Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
+[question — say your answer, then pause 10 seconds]
+Write the final sign in i-i-e, then count the three visible beats.
+
+
+Lesson 5 of 6.
 はい (hai) — yes, in two equal beats.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — two signs, two beats until you have stopped, and I will say so again when we reach it.
@@ -17,14 +149,14 @@ Japanese runs left to right. はい (hai) is written with two signs of hiragana,
 Five vowels, and they stay pure: a as in father, i as in machine, then u, e, o. So はい (hai) is ha-i, two beats of the same length, and not the single gliding sound of English "high."
 
 The word, taken apart — はい.
-はい means yes, and also "here you are," "I am listening," and "present." Its origin is genuinely unsettled: some accounts tie it to 拝 hai, "a bow"; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact.
+はい means yes, and also "here you are," "I am listening," and "present." Its origin is genuinely unsettled: some accounts tie it to an older word hai, "a bow"; others treat it as an old interjection. Neither is proven, so hold it as an open question rather than a fact. The rare kanji sometimes used in that proposal can wait until a later reading chapter.
 Say plainly what is true here. Japanese shares no ancestor with English, so no cousin word is waiting in your vocabulary to hold はい (hai) in place. What this track offers instead is the writing itself, built up one sign at a time, and — later — the real family Japanese does have, through the characters it borrowed.
 
 Guided Practice.
 [your turn — say: はい (hai) — ha-i, two even beats]
 [pause 8 seconds for the answer]
 [repeat that twice]
-[your turn — read: は, then い, left to right]
+[your turn — read: は (ha), then い, left to right]
 [pause 8 seconds for the answer]
 [your turn — answer: your name is called becomes はい (hai)]
 [pause 8 seconds for the answer]
@@ -36,7 +168,7 @@ Source: Wiktionary: はい (hai).
 Write the Japanese word for 'yes' in hiragana.
 
 
-Lesson 2 of 8.
+Lesson 6 of 6.
 いいえ (iie) — no, and why the extra beat matters.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one new sign, three beats until you have stopped, and I will say so again when we reach it.
@@ -62,211 +194,12 @@ Guided Practice.
 [your turn — choose: agree becomes はい (hai); decline becomes いいえ (iie)]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say??, then write? once from memory before learning the contrasting answer.
+
 Wrap-up Recall.
 Which single sign is new here? (え.) What changes when the long i is cut short? (The word becomes いえ, house.)
 Source: Wiktionary: いいえ (iie).
 [question — say your answer, then pause 8 seconds]
 How many beats (morae) does いいえ (iie) hold?
-
-
-Lesson 3 of 8.
-こんにちは (konnichiwa) — hello, and a sign that lies about its sound.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — four new signs, and one you know until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Retrieve はい (hai) and the sign は. You are about to meet は again in the daytime greeting — where it is not pronounced ha.
-
-Script — four new signs, and one you know.
-こんにちは (konnichiwa) — こ ko + ん n + に ni + ち chi + は.
-Four signs are new. こ ko, に ni, and ち chi behave like every hiragana so far: one sign, one consonant-plus-vowel beat.
-ん is the exception worth naming. It is the one hiragana that is a bare consonant, and it still takes a full beat of its own. So こんにちは (konnichiwa) is five signs and five beats: ko-n-ni-chi-wa. Give ん its own beat and the greeting sounds Japanese; swallow it and it does not.
-
-Grammar Lens — the sign は, read wa.
-The last sign is は, which you learned as ha. Here it is read wa.
-That is not an exception to memorize blindly. は is Japanese's topic particle — the little word that marks what a sentence is about, roughly "as for ___." Japanese spelling was reformed in 1946 to follow pronunciation, but three grammatical particles were left at their older spellings because they are so frequent that respelling them would have rewritten every page in the country. は is one of them. Rule to carry forward: は is ha inside a word, and wa when it is doing the job of a particle.
-
-Why it's said this way.
-こんにちは (konnichiwa) is the daytime greeting — roughly midday to dusk, not morning and not evening. It is a sentence that was abandoned halfway. In full it was 今日は… konnichi wa…, "as for today …", opening a longer enquiry after someone's health. The rest fell away and the topic marker stayed, which is why Japan's most common greeting ends on a grammatical particle instead of a word.
-Those two characters, 今日 konnichi "this day," belong to the third writing system, and the next lesson opens it.
-
-Guided Practice.
-[your turn — say: こんにちは (konnichiwa) — ko-n-ni-chi-wa, five beats]
-[pause 8 seconds for the answer]
-[repeat that twice]
-[your turn — decide: は in はい (hai) becomes ha; は ending the greeting becomes wa]
-[pause 8 seconds for the answer]
-[your turn — greet: someone at midday becomes こんにちは (konnichiwa)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Which sign takes a beat without a vowel? (ん.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)
-Source: Wiktionary: こんにちは (konnichiwa).
-[question — say your answer, then pause 9 seconds]
-The greeting ends in the sign は. How is it pronounced there?
-
-
-Lesson 4 of 8.
-日本語 (nihongo) — three characters, and no single sound each.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — kanji, and the readings problem until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Say こんにちは (konnichiwa). Its history hid two characters, 今日, that hiragana cannot show you. This lesson opens that second system by naming the language itself.
-
-Script — kanji, and the readings problem.
-日本語 (nihongo) — ni + hon + go.
-These are kanji: characters borrowed from Chinese, each carrying a meaning rather than a sound. 日 is sun or day. 本 is origin or root. 語 is language. So 日本 is "sun-origin" — the country the sun rises from — and 日本語 (nihongo) is its language.
-Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach "the sound of 日." What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it.
-Two families of readings explain the spread. The on reading is Japan's version of the Chinese pronunciation, imported with the character. The kun reading is a native Japanese word written with a borrowed character that already meant the same thing. 日本語 (nihongo) is on-readings throughout; 今日 in the greeting is irregular even by those standards.
-
-The word, taken apart — the real family.
-Here the cousin web finally works — just not toward English. The on-readings nichi, hon, go are borrowings of Middle Chinese, so 日本語 (nihongo) has genuine relatives: Mandarin writes the same three characters and says Rìběnyǔ; Korean borrowed the same compound as ilbon-eo. Same characters, related imported sounds, one meaning, three languages.
-That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it.
-
-Guided Practice.
-[your turn — say: 日本語 (nihongo) — ni-ho-n-go, four beats]
-[pause 8 seconds for the answer]
-[repeat that twice]
-[your turn — name: 日 sun or day; 本 origin; 語 language]
-[pause 8 seconds for the answer]
-[your turn — connect: Mandarin Rìběnyǔ, Korean ilbon-eo, same three characters]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-What does 日本 mean literally? (Sun-origin.) Does 日 have one pronunciation? (No — the word it appears in chooses one.)
-Source: Wiktionary: 日本語 (nihongo).
-[question — say your answer, then pause 10 seconds]
-How is the character 日 read inside 日本語 (nihongo)?
-
-
-Lesson 5 of 8.
-コーヒー (kōhī) — the third system, and a word that really is a cousin.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — katakana, the borrowed-word script and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Recall how hiragana writes a long vowel: it writes the vowel twice, as in いいえ (iie). Katakana does it differently, and this word shows how.
-
-Script — katakana, the borrowed-word script.
-コーヒー (kōhī) — コ ko + ー + ヒ hi + ー.
-This is katakana, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms.
-The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from fragments of characters, shorthand that monks scribbled beside a text to remember how to read it. こ and コ even trace back to the same character, which is why they still look alike.
-ー is the chōonpu, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So コーヒー (kōhī) is four beats: ko-o-hi-i.
-
-The word, taken apart — a shared borrowing.
-コーヒー (kōhī) is coffee, and it entered Japanese from Dutch koffie through the Nagasaki trade. Dutch had it from Turkish kahve, and Turkish from Arabic qahwa — which is exactly where English coffee comes from as well.
-So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads: パン bread, from Portuguese pão, and アルバイト a part-time job, from German Arbeit.
-
-Guided Practice.
-[your turn — say: コーヒー (kōhī) — ko-o-hi-i, four beats]
-[pause 8 seconds for the answer]
-[repeat that twice]
-[once you have stopped driving — trace: Arabic qahwa becomes Turkish kahve becomes Dutch koffie becomes コーヒー (kōhī)]
-[your turn — decide: a borrowed word is written in katakana, not hiragana]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Which script signals a borrowed word? (Katakana.) How many beats does コーヒー (kōhī) hold? (Four.)
-Source: Wiktionary: コーヒー (kōhī).
-[question — say your answer, then pause 10 seconds]
-What does the bar ー do in コーヒー (kōhī)?
-
-
-Lesson 6 of 8.
-ありがとう (arigatō) — thanks, from “this hardly ever happens”.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five signs and two small strokes until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds.
-
-Script — five signs and two small strokes.
-ありがとう (arigatō) — あ a + り ri + が ga + と to + う.
-あ a, り ri, と to and う u are ordinary hiragana. が is the new idea: it is the sign か ka with two short strokes added at the top right. That mark is the dakuten, and it voices the consonant — the same two strokes turn ka into ga, sa into za, ta into da, ha into ba. One mark, learned once, doubles how much of the script you can read.
-The final う does not sound like u here. After と it stretches the o, so the word ends -tō and holds five beats: a-ri-ga-to-o. Hiragana lengthens a vowel by writing another vowel sign, where katakana used the bar ー.
-
-The word, taken apart — 有り難う.
-Written in kanji, ありがとう (arigatō) is 有り難う: 有る aru "to exist" plus 難し katashi "difficult." Its ancestor 有り難し arigatashi meant literally "hard to exist" — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The k of katashi softened to g inside the compound, which is the same voicing the dakuten writes.
-So the memory hook is inside the word, not inside English: saying ありがとう (arigatō) is saying this was not a thing that had to happen. No English cousin exists, and inventing one would be worse than admitting that.
-
-Guided Practice.
-[your turn — say: ありがとう (arigatō) — a-ri-ga-to-o, five beats]
-[pause 8 seconds for the answer]
-[repeat that twice]
-[your turn — build: か plus the dakuten becomes が]
-[pause 8 seconds for the answer]
-[your turn — connect: 有り難し "hard to exist" becomes rare becomes precious becomes thanks]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-What did 有り難し mean literally? (Hard to exist.) What does the last う do? (It lengthens the o.)
-Source: Wiktionary: ありがとう (arigatō).
-[question — say your answer, then pause 8 seconds]
-Which hiragana sign becomes が when the dakuten is added?
-
-
-Lesson 7 of 8.
-ありがとうございます (arigatō gozaimasu) — politeness you cannot leave out.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five more signs, two of them dakuten until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Say ありがとう (arigatō) once and rebuild が from か. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss.
-
-Script — five more signs, two of them dakuten.
-ございます — ご go + ざ za + い i + ま ma + す su.
-Two of the five are dakuten forms you can already build: ご is こ with the two strokes, and ざ is さ sa with them. い you have read since はい (hai). Only ま ma and す su are genuinely new.
-The whole phrase is ten beats — a-ri-ga-to-o go-za-i-ma-su — and the final す is normally said with the u barely voiced, close to a plain s.
-
-Grammar Lens — politeness is grammar here, not word choice.
-ございます is a verb. It is the polite form of ある aru, "to be" — the same verb that sits inside ありがとう (arigatō). The route runs ある becomes ござる becomes ございます, where the ending -ます is the general politeness marker Japanese attaches to verbs.
-That is the difference this chapter has to name. In many languages politeness is a choice between two words for "you." Japanese instead marks it on the predicate, and every sentence has one, so every sentence is marked. There is no neutral setting: ありがとう to a friend and ありがとうございます (arigatō gozaimasu) to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately.
-At the far end of the system, the verb itself is replaced. 言う iu "to say" becomes おっしゃる when the speaker is honouring someone else and 申す when humbling themselves. Same act, three verbs, chosen by who is doing what to whom. That is keigo, and this lesson is only its front door.
-
-Guided Practice.
-[your turn — say: ありがとうございます (arigatō gozaimasu) — ten beats, final su light]
-[pause 8 seconds for the answer]
-[repeat that twice]
-[your turn — choose: a close friend becomes ありがとう; a shop assistant becomes ありがとうございます (arigatō gozaimasu)]
-[pause 8 seconds for the answer]
-[your turn — build: こ becomes ご, さ becomes ざ]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Which verb hides inside ございます? (ある, "to be.") Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)
-Source: Wiktionary: ございます.
-[question — say your answer, then pause 10 seconds]
-You are thanking a shop assistant you have never met. Which form do you use?
-
-
-Lesson 8 of 8.
-Practice — one daytime exchange, three scripts.
-
-Warm-up.
-[pause 2 seconds]
-Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here.
-
-The exchange — every line already learned.
-A: こんにちは (konnichiwa)。 — Konnichiwa. B: こんにちは (konnichiwa)。 — Konnichiwa. A: 日本語 (nihongo)? — Nihongo? B: はい (hai)。 — Hai. A: ありがとうございます (arigatō gozaimasu)。 — Arigatō gozaimasu. B: いいえ (iie)。 — Iie.
-Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so 日本語 (nihongo) with the voice lifted is a complete and natural way to ask "Japanese, then?" — and はい (hai) answers it. B's closing いいえ (iie) is the modest "not at all" that waves thanks away.
-A single ordinary Japanese sentence mixes the systems: hiragana carries the grammar, kanji carries the content words, katakana carries the borrowings. That is why this chapter opened all three instead of finishing one.
-
-Guided Practice.
-[your turn — run: both voices once with the Japanese, once with romanization only]
-[pause 8 seconds for the answer]
-[your turn — decide: which line would change if B were a close friend]
-[pause 8 seconds for the answer]
-[pause 3 seconds]
-[your turn — swap: take B's part while the other lines are read to you]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter.
-[question — say your answer, then pause 9 seconds]
-Someone has just thanked you politely. Give the modest one-word reply this chapter taught.

--- a/code/learning/human-languages/japanese/narration/ch02.json
+++ b/code/learning/human-languages/japanese/narration/ch02.json
@@ -2,615 +2,13 @@
   "version": 1,
   "language": "japanese",
   "chapter": 2,
-  "title": "Eight Signs, and Three Words You Can Read",
+  "title": "A Daytime Greeting, One Sign at a Time",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:44f1c780f26d205d",
+  "sourceHash": "fnv1a64:4738d9e25fd92f72",
   "lessons": [
     {
-      "id": "JA-W01-i",
-      "sequence": 90,
-      "title": "い (i) — two strokes, one beat",
-      "headword": "い",
-      "romanization": "i",
-      "gloss": "the hiragana sign for the mora i — two strokes, and the first sign you can write",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:536c9f5fc624cc79",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You already know the rule that makes this writing system easy: one sign, one beat. Not one letter one sound, and not one sign one word — one sign, one mora, the even beat Japanese counts time in."
-            },
-            {
-              "kind": "speech",
-              "text": "What you have not had yet is a single sign taught on its own. Here is the first."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "い (i)."
-            },
-            {
-              "kind": "speech",
-              "text": "Two strokes, both falling, the left one long and the right one short:"
-            },
-            {
-              "kind": "speech",
-              "text": "the left stroke — start high, come down, and hook gently to the right at the bottom."
-            },
-            {
-              "kind": "speech",
-              "text": "the right stroke — a short downward tick, higher up and clear of the first."
-            },
-            {
-              "kind": "speech",
-              "text": "It is read i, the vowel of English machine — short, tight, never the eye of English bite."
-            },
-            {
-              "kind": "speech",
-              "text": "Where the shape came from, and why it does not help you. Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen for their sound, not their meaning, so unlike a Chinese component there is nothing inside い to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "TRACE",
-              "instruction": "follow the visible い once — long stroke first, then the short tick",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU TRACE: follow the visible い once — long stroke first, then the short tick]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "i, one clean beat",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **i**, one clean beat]"
-            },
-            {
-              "kind": "speech",
-              "text": "Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "How many beats does one hiragana sign take? (One.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W01-i-strokes",
-              "prompt": "How many strokes does the hiragana sign for 'i' have?",
-              "assesses": [
-                "JA-SCRIPT-I-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "2",
-                "two",
-                "2 strokes",
-                "two strokes"
-              ],
-              "feedback": {
-                "correct": "Two — a long falling stroke, then a short tick.",
-                "incorrect": "Two: the long left stroke, then the short right one."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-W01-ha",
-      "sequence": 100,
-      "title": "は (ha) — three strokes",
-      "headword": "は",
-      "romanization": "ha",
-      "gloss": "the hiragana sign for the mora ha — three strokes, and the second half of a word you already say",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:319589a1fed4234f",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write the two-stroke sign you met a moment ago. Long stroke, short tick."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "は (ha)."
-            },
-            {
-              "kind": "speech",
-              "text": "Three strokes. Look at it as a tall left post with a loop tied on its right."
-            },
-            {
-              "kind": "speech",
-              "text": "the vertical, down the left side, with the smallest flick left at the foot."
-            },
-            {
-              "kind": "speech",
-              "text": "a short horizontal crossing that vertical near the top, on its right."
-            },
-            {
-              "kind": "speech",
-              "text": "the loop — down from the right of that crossbar, round to the left, and back up to close."
-            },
-            {
-              "kind": "speech",
-              "text": "Read ha, breathed rather than hard: the h of English hat, then the open a of father."
-            },
-            {
-              "kind": "speech",
-              "text": "It has a second reading, and you have already used it. Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it sounds like."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "COPY",
-              "instruction": "keep は (ha) visible and write it once — vertical, crossbar, loop",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU COPY: keep は visible and write it once — vertical, crossbar, loop]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ha, one beat, breath not force",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **ha**, one beat, breath not force]"
-            },
-            {
-              "kind": "speech",
-              "text": "Look back at the model between strokes if you need to. This is one guided copy, not a memory test."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Which stroke of は (ha) is written first? (The vertical on the left.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W01-ha-strokes",
-              "prompt": "How many strokes does the hiragana sign read 'ha' have?",
-              "assesses": [
-                "JA-SCRIPT-HA-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "3",
-                "three",
-                "3 strokes",
-                "three strokes"
-              ],
-              "feedback": {
-                "correct": "Three — vertical, crossbar, loop.",
-                "incorrect": "Three: the left vertical, the short crossbar, then the loop."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-W01-hai-read",
-      "sequence": 110,
-      "title": "Two signs, side by side — and a word appears",
-      "headword": "はい",
-      "romanization": "hai",
-      "gloss": "the first word you can read rather than recall — two signs, both already yours",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:66f8ba352205ee5c",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "Script — no new sign at all",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Both signs are yours. Look at them for five seconds:"
-            },
-            {
-              "kind": "speech",
-              "text": "は (ha) い (i)."
-            },
-            {
-              "kind": "speech",
-              "text": "Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — no new sign at all",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Now write them touching:"
-            },
-            {
-              "kind": "speech",
-              "text": "は + い becomes はい (hai)."
-            },
-            {
-              "kind": "speech",
-              "text": "ha then i. Two beats, even, neither one stressed. That is the word for yes, and it is the one you have been saying since your first minute in this language."
-            },
-            {
-              "kind": "speech",
-              "text": "Nothing new was introduced in this lesson. No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are reading it — assembling it out of two pieces you can write from memory and sound out in order."
-            },
-            {
-              "kind": "speech",
-              "text": "That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "はい (hai) — sound each sign in turn, do not recall the word whole",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: **はい** — sound each sign in turn, do not recall the word whole]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "はい (hai) — five strokes in total, three then two",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: はい — five strokes in total, three then two]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "How many new strokes did you have to learn in this lesson? (None.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W01-hai-read-beats",
-              "prompt": "How many beats (morae) does the written word for 'yes' take?",
-              "assesses": [
-                "JA-SCRIPT-HAI-READ-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "2",
-                "two",
-                "2 beats",
-                "two beats"
-              ],
-              "feedback": {
-                "correct": "Two — one per sign, evenly.",
-                "incorrect": "Two: one beat per hiragana sign."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-W01-e",
-      "sequence": 120,
-      "title": "え — two strokes, and a second word for free",
-      "headword": "え",
-      "romanization": "e",
-      "gloss": "the hiragana sign for the mora e — two strokes, and the one that finishes the word for no",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:3794174c4b117901",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read the word for yes off the page, sign by sign, out loud."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "え (e)."
-            },
-            {
-              "kind": "speech",
-              "text": "Two strokes, and the second one does most of the work:"
-            },
-            {
-              "kind": "speech",
-              "text": "a short tick at the top, on its own, clear of everything below."
-            },
-            {
-              "kind": "speech",
-              "text": "the body — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement."
-            },
-            {
-              "kind": "speech",
-              "text": "Read e, the vowel of English bed — short, and never the ay of day."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "notice",
-          "title": "What you've built",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:"
-            },
-            {
-              "kind": "speech",
-              "text": "い (i) + い (i) + え becomes いいえ."
-            },
-            {
-              "kind": "speech",
-              "text": "i-i-e. Three beats — and note that the first sign is written twice, because Japanese counts two full beats there. That is the word for no."
-            },
-            {
-              "kind": "speech",
-              "text": "You have now read both answers to a yes-or-no question, from the signs up. Neither of them was memorised as a picture."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue."
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE FROM THE HEARD OR ROMANIZED CUE",
-              "instruction": "え — tick first, then the body in one movement",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE FROM THE HEARD OR ROMANIZED CUE: え — tick first, then the body in one movement]"
-            },
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "いいえ — three beats, and do not shorten the doubled sign",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: いいえ — three beats, and do not shorten the doubled sign]"
-            },
-            {
-              "kind": "speech",
-              "text": "Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Why is the first sign of that word written twice? (Because it is two beats, not one held longer.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958)."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W01-e-beats",
-              "prompt": "How many beats (morae) does the written word for 'no' take?",
-              "assesses": [
-                "JA-LEX-IIE"
-              ],
-              "responseSeconds": 10,
-              "acceptedResponses": [
-                "3",
-                "three",
-                "3 beats",
-                "three beats"
-              ],
-              "feedback": {
-                "correct": "Three — the first sign is written twice and gets two full beats.",
-                "incorrect": "Three: the doubled sign carries two beats, not one long one."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "JA-W01-ko",
-      "sequence": 130,
+      "sequence": 70,
       "title": "こ (ko) — two strokes, and the greeting begins",
       "headword": "こ",
       "romanization": "ko",
@@ -622,7 +20,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:149060678bc7599f",
+      "sourceHash": "fnv1a64:b3833ba98c8971d6",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -711,6 +109,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say??? and tap all three morae before writing the new sign."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -748,7 +163,7 @@
     },
     {
       "id": "JA-W01-n",
-      "sequence": 140,
+      "sequence": 80,
       "title": "ん — one stroke, one beat, no vowel",
       "headword": "ん",
       "romanization": "n",
@@ -760,7 +175,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f5495df027a5bdc1",
+      "sourceHash": "fnv1a64:88cd192cbab594e7",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -841,6 +256,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Cover the model and write?? from its two known signs."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -879,7 +311,7 @@
     },
     {
       "id": "JA-W01-ni",
-      "sequence": 150,
+      "sequence": 90,
       "title": "に (ni) — three strokes, and a shape you half know",
       "headword": "に",
       "romanization": "ni",
@@ -891,7 +323,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:07a76c17b5fc2d4d",
+      "sourceHash": "fnv1a64:f9dc84723290cf6f",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -974,7 +406,7 @@
             {
               "kind": "prompt",
               "action": "NOTICE",
-              "instruction": "write it beside は (ha) and compare only the left post",
+              "instruction": "write it beside は and compare only the left post",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
@@ -984,6 +416,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Before the new sign, write? once and then? once from memory."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1022,7 +471,7 @@
     },
     {
       "id": "JA-W01-chi",
-      "sequence": 160,
+      "sequence": 100,
       "title": "ち (chi) — two strokes, four roman letters, one beat",
       "headword": "ち",
       "romanization": "chi",
@@ -1034,7 +483,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:35697da6506e00f6",
+      "sourceHash": "fnv1a64:34105778555f9a1c",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1164,7 +613,7 @@
     },
     {
       "id": "JA-W01-wa",
-      "sequence": 170,
+      "sequence": 110,
       "title": "わ — the sign for wa, and the trap beside it",
       "headword": "わ",
       "romanization": "wa",
@@ -1176,7 +625,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:20c37ccc88f42958",
+      "sourceHash": "fnv1a64:804f900a0f4a5619",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1296,6 +745,23 @@
         },
         {
           "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say??? again, keeping the two opening morae distinct."
+            }
+          ]
+        },
+        {
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1333,7 +799,7 @@
     },
     {
       "id": "JA-W01-konnichiwa-read",
-      "sequence": 180,
+      "sequence": 120,
       "title": "Five signs in a row — and the greeting is readable",
       "headword": "こんにちは",
       "romanization": "konnichiwa",
@@ -1345,7 +811,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a793162b6bbde88b",
+      "sourceHash": "fnv1a64:1ec9c3e62e816050",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1391,7 +857,7 @@
             },
             {
               "kind": "speech",
-              "text": "こ + ん + に + ち + は (ha) becomes こんにちは (konnichiwa)."
+              "text": "こ + ん + に + ち + は becomes こんにちは (konnichiwa)."
             },
             {
               "kind": "speech",
@@ -1399,7 +865,7 @@
             },
             {
               "kind": "speech",
-              "text": "Nothing new was introduced in this lesson. You have not learned a stroke, a sound or a word here. You have read a word you already knew how to say — from five pieces you can each write from memory, in order, including the one that sounds like something other than its name."
+              "text": "No new stroke appears here. You have decoded five pieces you can each write from memory, in order, including the one that sounds like something other than its name. The next lesson attaches the daytime-greeting meaning to the line."
             }
           ]
         },
@@ -1410,7 +876,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Eight signs, taught one at a time, and with them you can now read three whole words off the page: the greeting, and both answers to a yes-or-no question."
+              "text": "Eight signs, taught one at a time, and with them you can now decode three whole sequences off the page. Two already carry useful answers; the five-sign sequence gets its daytime-greeting job in the next lesson."
             },
             {
               "kind": "speech",
@@ -1445,6 +911,23 @@
         },
         {
           "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once, then set it beside? and name which one closes the greeting."
+            }
+          ]
+        },
+        {
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1474,6 +957,186 @@
               "feedback": {
                 "correct": "Five — one per sign, and the vowel-less one counts fully.",
                 "incorrect": "Five: one beat per sign, including the one with no vowel."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C01-konnichiwa",
+      "sequence": 130,
+      "title": "こんにちは (konnichiwa) — hello, and a sign that lies about its sound",
+      "headword": "こんにちは",
+      "romanization": "konnichiwa",
+      "gloss": "hello (daytime greeting)",
+      "script": "japanese",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e055b19edfbe2dd0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — five familiar signs"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five familiar signs until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Retrieve はい and the sign は. You are about to meet は again in the daytime greeting — where it is not pronounced ha."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — five familiar signs",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "こんにちは (konnichiwa) — こ ko + ん n + に ni + ち chi + は."
+            },
+            {
+              "kind": "speech",
+              "text": "You have written every sign separately. こ, に, and ち each carry a consonant and vowel. ん is the exception: a bare consonant with a full beat of its own. Read five signs in five beats: ko-n-ni-chi-wa. Do not swallow ん."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens — the sign は, read wa",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The last sign is は, which you learned as ha. Here it is read wa."
+            },
+            {
+              "kind": "speech",
+              "text": "Here は is the topic particle, roughly \"as for ___.\" It keeps an older spelling. Carry one small rule forward: read は as ha inside a word and as wa when it is the particle."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "こんにちは (konnichiwa) is the daytime greeting. It began as an unfinished sentence: konnichi wa…, \"as for today …\" The rest fell away and the topic marker stayed."
+            },
+            {
+              "kind": "speech",
+              "text": "The older phrase is often written with two kanji for \"this day.\" You do not need to decode those yet. This chapter keeps the whole greeting in the hiragana signs you have already learned."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "こんにちは (konnichiwa) — ko-n-ni-chi-wa, five beats",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **こんにちは** — *ko-n-ni-chi-wa*, five beats]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "prompt",
+              "action": "DECIDE",
+              "instruction": "は in はい becomes ha; は ending the greeting becomes wa",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU DECIDE: **は** in **はい** → *ha*; **は** ending the greeting → *wa*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "GREET",
+              "instruction": "someone at midday becomes こんにちは (konnichiwa)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU GREET: someone at midday → **こんにちは**]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? from memory and give it one full mora."
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which sign takes a beat without a vowel? (ん.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Wiktionary: こんにちは (konnichiwa)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C01-konnichiwa-particle",
+              "prompt": "The greeting ends in the sign は. How is it pronounced there?",
+              "assesses": [
+                "JA-PARTICLE-WA-SPELLING"
+              ],
+              "responseSeconds": 9,
+              "acceptedResponses": [
+                "wa",
+                "as wa",
+                "わ",
+                "the topic particle wa"
+              ],
+              "feedback": {
+                "correct": "Right: は is read wa when it works as the topic particle.",
+                "incorrect": "It is read wa — は is the topic particle here, not the sound ha."
               }
             }
           ]

--- a/code/learning/human-languages/japanese/narration/ch02.txt
+++ b/code/learning/human-languages/japanese/narration/ch02.txt
@@ -1,137 +1,8 @@
-Japanese, chapter 2: Eight Signs, and Three Words You Can Read.
-10 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+Japanese, chapter 2: A Daytime Greeting, One Sign at a Time.
+7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 10.
-い (i) — two strokes, one beat.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You already know the rule that makes this writing system easy: one sign, one beat. Not one letter one sound, and not one sign one word — one sign, one mora, the even beat Japanese counts time in.
-What you have not had yet is a single sign taught on its own. Here is the first.
-
-Script — the shape.
-い (i).
-Two strokes, both falling, the left one long and the right one short:
-the left stroke — start high, come down, and hook gently to the right at the bottom.
-the right stroke — a short downward tick, higher up and clear of the first.
-It is read i, the vowel of English machine — short, tight, never the eye of English bite.
-Where the shape came from, and why it does not help you. Every hiragana sign began as a Chinese character written fast and cursively until it wore smooth. But those characters were chosen for their sound, not their meaning, so unlike a Chinese component there is nothing inside い to decode. The shape is a signature you learn, not a structure you read. This book will tell you when a shape carries information and when it does not, and this is the second kind.
-
-Guided Practice.
-[once you have stopped driving — trace: follow the visible い once — long stroke first, then the short tick]
-[your turn — say: i, one clean beat]
-[pause 8 seconds for the answer]
-Keep the model visible and stop after one traced sign. Copying without the model comes later; today your hand is only learning the direction of two strokes.
-
-Wrap-up Recall.
-How many beats does one hiragana sign take? (One.)
-Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
-[question — say your answer, then pause 8 seconds]
-How many strokes does the hiragana sign for 'i' have?
-
-
-Lesson 2 of 10.
-は (ha) — three strokes.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — the shape until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Write the two-stroke sign you met a moment ago. Long stroke, short tick.
-
-Script — the shape.
-は (ha).
-Three strokes. Look at it as a tall left post with a loop tied on its right.
-the vertical, down the left side, with the smallest flick left at the foot.
-a short horizontal crossing that vertical near the top, on its right.
-the loop — down from the right of that crossbar, round to the left, and back up to close.
-Read ha, breathed rather than hard: the h of English hat, then the open a of father.
-It has a second reading, and you have already used it. Keep that in your pocket for now — this sign is doing two jobs in Japanese, and the second one is what makes the greeting look misspelled to a beginner. It gets its own lesson, after you have met the sign it sounds like.
-
-Guided Practice.
-[your turn — copy: keep は (ha) visible and write it once — vertical, crossbar, loop]
-[pause 8 seconds for the answer]
-[your turn — say: ha, one beat, breath not force]
-[pause 8 seconds for the answer]
-Look back at the model between strokes if you need to. This is one guided copy, not a memory test.
-
-Wrap-up Recall.
-Which stroke of は (ha) is written first? (The vertical on the left.)
-Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
-[question — say your answer, then pause 8 seconds]
-How many strokes does the hiragana sign read 'ha' have?
-
-
-Lesson 3 of 10.
-Two signs, side by side — and a word appears.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script — no new sign at all and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 3 seconds]
-Both signs are yours. Look at them for five seconds:
-は (ha) い (i).
-Cover the model. Write the two signs in that order and say each beat as you finish it. Uncover the model, compare once, and repair at most one stroke. This short look-hide-write-check cycle is the whole delayed-copy step.
-
-Script — no new sign at all.
-Now write them touching:
-は + い becomes はい (hai).
-ha then i. Two beats, even, neither one stressed. That is the word for yes, and it is the one you have been saying since your first minute in this language.
-Nothing new was introduced in this lesson. No stroke, no sound, no word. What changed is where the word now lives: you are no longer recalling a shape you were shown, you are reading it — assembling it out of two pieces you can write from memory and sound out in order.
-That is the whole method for this writing system, and it does not get harder. It gets longer. A word of five signs is five signs you already own, in a row.
-
-Guided Practice.
-[your turn — read: はい (hai) — sound each sign in turn, do not recall the word whole]
-[pause 8 seconds for the answer]
-[once you have stopped driving — write: はい (hai) — five strokes in total, three then two]
-
-Wrap-up Recall.
-How many new strokes did you have to learn in this lesson? (None.)
-Source: Unicode Hiragana chart.
-[question — say your answer, then pause 8 seconds]
-How many beats (morae) does the written word for 'yes' take?
-
-
-Lesson 4 of 10.
-え — two strokes, and a second word for free.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Read the word for yes off the page, sign by sign, out loud.
-
-Script — the shape.
-え (e).
-Two strokes, and the second one does most of the work:
-a short tick at the top, on its own, clear of everything below.
-the body — across to the right, back down and left in a flat zigzag, then out to the lower right in one continuous movement.
-Read e, the vowel of English bed — short, and never the ay of day.
-
-What you've built.
-Three signs are now yours, and they spell more than one word. Put two of them together with the one you just learned:
-い (i) + い (i) + え becomes いいえ.
-i-i-e. Three beats — and note that the first sign is written twice, because Japanese counts two full beats there. That is the word for no.
-You have now read both answers to a yes-or-no question, from the signs up. Neither of them was memorised as a picture.
-
-Guided Practice.
-Cover the printed え. Have a partner or recording say e once. If you are working alone, read the romanized cue e, cover it, and continue.
-[once you have stopped driving — write from the heard or romanized cue: え — tick first, then the body in one movement]
-[your turn — read: いいえ — three beats, and do not shorten the doubled sign]
-[pause 8 seconds for the answer]
-Uncover the model only after your one transcription attempt. Compare, repair one stroke if needed, and stop.
-
-Wrap-up Recall.
-Why is the first sign of that word written twice? (Because it is two beats, not one held longer.)
-Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
-[question — say your answer, then pause 10 seconds]
-How many beats (morae) does the written word for 'no' take?
-
-
-Lesson 5 of 10.
+Lesson 1 of 7.
 こ (ko) — two strokes, and the greeting begins.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -153,6 +24,10 @@ Guided Practice.
 [your turn — say: ko, one beat]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say??? and tap all three morae before writing the new sign.
+
 Wrap-up Recall.
 Which of the two strokes is longer? (The lower one.)
 Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
@@ -160,7 +35,7 @@ Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japan
 How many strokes does the hiragana sign read 'ko' have?
 
 
-Lesson 6 of 10.
+Lesson 2 of 7.
 ん — one stroke, one beat, no vowel.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape, and the exception and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -180,6 +55,10 @@ Guided Practice.
 [your turn — say: hold it for a full beat, as long as any other sign takes]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Cover the model and write?? from its two known signs.
+
 Wrap-up Recall.
 If this sign has no vowel, how long is it held? (A full beat — the same as every other sign.)
 Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
@@ -187,7 +66,7 @@ Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japan
 Which vowel does this sign carry?
 
 
-Lesson 7 of 10.
+Lesson 3 of 7.
 に (ni) — three strokes, and a shape you half know.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -207,8 +86,12 @@ This is the first time two signs share a visible part, and it is worth naming, b
 
 Guided Practice.
 [once you have stopped driving — write: に (ni) — vertical, short bar, long bar]
-[your turn — notice: write it beside は (ha) and compare only the left post]
+[your turn — notice: write it beside は and compare only the left post]
 [pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Before the new sign, write? once and then? once from memory.
 
 Wrap-up Recall.
 Which stroke of this sign comes first? (The vertical.)
@@ -217,7 +100,7 @@ Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japan
 Two signs so far share a similar left-hand vertical. Does that shared shape tell you anything about their sound or meaning?
 
 
-Lesson 8 of 10.
+Lesson 4 of 7.
 ち (chi) — two strokes, four roman letters, one beat.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -247,7 +130,7 @@ Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japan
 This sign is romanised with four letters. How many beats does it take?
 
 
-Lesson 9 of 10.
+Lesson 5 of 7.
 わ — the sign for wa, and the trap beside it.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -277,6 +160,10 @@ Guided Practice.
 [your turn — decide: hearing wa at the end of the daytime greeting, which sign do you write?]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say??? again, keeping the two opening morae distinct.
+
 Wrap-up Recall.
 Which of the two is a fact about grammar rather than about sound? (The one where は is read wa.)
 Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japanese Ministry of Education, 1958).
@@ -284,7 +171,7 @@ Source: Unicode Hiragana chart; stroke order per Hitsujun Shido no Tebiki (Japan
 The daytime greeting ends in a sound like 'wa'. Is it written with the sign for wa, or the sign for ha?
 
 
-Lesson 10 of 10.
+Lesson 6 of 7.
 Five signs in a row — and the greeting is readable.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -296,12 +183,12 @@ Four signs, one after another, from memory. Say each beat as you finish writing 
 
 Script — the assembly.
 Add the fifth — the one that is read wa because it is a topic marker — and the greeting is on the page:
-こ + ん + に + ち + は (ha) becomes こんにちは (konnichiwa).
+こ + ん + に + ち + は becomes こんにちは (konnichiwa).
 ko-n-ni-chi-wa. Five signs, five beats, all even. Say it against a steady tap and you will hear that the second beat, the one with no vowel, takes exactly as long as the four around it.
-Nothing new was introduced in this lesson. You have not learned a stroke, a sound or a word here. You have read a word you already knew how to say — from five pieces you can each write from memory, in order, including the one that sounds like something other than its name.
+No new stroke appears here. You have decoded five pieces you can each write from memory, in order, including the one that sounds like something other than its name. The next lesson attaches the daytime-greeting meaning to the line.
 
 What you've built.
-Eight signs, taught one at a time, and with them you can now read three whole words off the page: the greeting, and both answers to a yes-or-no question.
+Eight signs, taught one at a time, and with them you can now decode three whole sequences off the page. Two already carry useful answers; the five-sign sequence gets its daytime-greeting job in the next lesson.
 Hiragana has forty-six basic signs. You hold eight. The rest arrive the same way, one per lesson, and the words they unlock arrive free — because a word in this script is never more than the signs you already own, in a row.
 
 Guided Practice.
@@ -309,8 +196,53 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [once you have stopped driving — write: the greeting, then say it once at speaking pace]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once, then set it beside? and name which one closes the greeting.
+
 Wrap-up Recall.
 How many of the greeting's five signs were new in this lesson? (None.)
 Source: Unicode Hiragana chart.
 [question — say your answer, then pause 10 seconds]
 How many beats (morae) does the written daytime greeting take?
+
+
+Lesson 7 of 7.
+こんにちは (konnichiwa) — hello, and a sign that lies about its sound.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five familiar signs until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Retrieve はい and the sign は. You are about to meet は again in the daytime greeting — where it is not pronounced ha.
+
+Script — five familiar signs.
+こんにちは (konnichiwa) — こ ko + ん n + に ni + ち chi + は.
+You have written every sign separately. こ, に, and ち each carry a consonant and vowel. ん is the exception: a bare consonant with a full beat of its own. Read five signs in five beats: ko-n-ni-chi-wa. Do not swallow ん.
+
+Grammar Lens — the sign は, read wa.
+The last sign is は, which you learned as ha. Here it is read wa.
+Here は is the topic particle, roughly "as for ___." It keeps an older spelling. Carry one small rule forward: read は as ha inside a word and as wa when it is the particle.
+
+Why it's said this way.
+こんにちは (konnichiwa) is the daytime greeting. It began as an unfinished sentence: konnichi wa…, "as for today …" The rest fell away and the topic marker stayed.
+The older phrase is often written with two kanji for "this day." You do not need to decode those yet. This chapter keeps the whole greeting in the hiragana signs you have already learned.
+
+Guided Practice.
+[your turn — say: こんにちは (konnichiwa) — ko-n-ni-chi-wa, five beats]
+[pause 8 seconds for the answer]
+[repeat that twice]
+[your turn — decide: は in はい becomes ha; は ending the greeting becomes wa]
+[pause 8 seconds for the answer]
+[your turn — greet: someone at midday becomes こんにちは (konnichiwa)]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? from memory and give it one full mora.
+
+Wrap-up Recall.
+Which sign takes a beat without a vowel? (ん.) Why does the greeting end in a particle? (It is the opening of a sentence nobody finishes any more.)
+Source: Wiktionary: こんにちは (konnichiwa).
+[question — say your answer, then pause 9 seconds]
+The greeting ends in the sign は. How is it pronounced there?

--- a/code/learning/human-languages/japanese/narration/ch03.json
+++ b/code/learning/human-languages/japanese/narration/ch03.json
@@ -2,13 +2,13 @@
   "version": 1,
   "language": "japanese",
   "chapter": 3,
-  "title": "Eight Signs, One Mark, and the Longest Word You Know",
+  "title": "Plain Thanks, One Sign at a Time",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:1a25d37b069264b0",
+  "sourceHash": "fnv1a64:7832024c6b7ac24d",
   "lessons": [
     {
       "id": "JA-W03-a",
-      "sequence": 190,
+      "sequence": 140,
       "title": "あ — three strokes, and the thank-you begins",
       "headword": "あ",
       "romanization": "a",
@@ -20,7 +20,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9fb48f537aa8a915",
+      "sourceHash": "fnv1a64:8215b0106d85d878",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -51,7 +51,7 @@
             },
             {
               "kind": "speech",
-              "text": "You have been saying ありがとう (arigatou) since Chapter 1 and reading it from the romanization. This chapter hands you the signs, one at a time, until the word is yours on the page as well as in the mouth."
+              "text": "This chapter builds the five-sign plain thank-you from the page up. Its meaning arrives only after every sign is yours, so this first lesson asks for one shape: あ."
             }
           ]
         },
@@ -117,6 +117,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the daytime greeting, then write? from memory."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -154,7 +171,7 @@
     },
     {
       "id": "JA-W03-ri",
-      "sequence": 200,
+      "sequence": 150,
       "title": "り (ri) — two strokes, and a tap rather than an r",
       "headword": "り",
       "romanization": "ri",
@@ -166,7 +183,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5caa787ea1875f95",
+      "sourceHash": "fnv1a64:aaa2265c474bc377",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -268,6 +285,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? from memory before tracing?."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -306,7 +340,7 @@
     },
     {
       "id": "JA-W03-ka",
-      "sequence": 210,
+      "sequence": 160,
       "title": "か (ka) — three strokes, and a shape you will reuse",
       "headword": "か",
       "romanization": "ka",
@@ -318,7 +352,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6f3edd66798c67f7",
+      "sourceHash": "fnv1a64:dd39d35f40faff27",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -411,6 +445,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write?, then write the different sign that closes????? and explain its particle reading."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -448,7 +499,7 @@
     },
     {
       "id": "JA-W03-dakuten",
-      "sequence": 220,
+      "sequence": 170,
       "title": "゛ (dakuten)— two ticks, and every sign you know doubles",
       "headword": "゛",
       "romanization": "dakuten",
@@ -460,7 +511,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d9f194e131fd2166",
+      "sourceHash": "fnv1a64:fca3eb6654e313a2",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -570,6 +621,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write????? from its five signs before adding any voice marks."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -609,7 +677,7 @@
     },
     {
       "id": "JA-W03-to",
-      "sequence": 230,
+      "sequence": 180,
       "title": "と (to) — two strokes, and they never meet",
       "headword": "と",
       "romanization": "to",
@@ -621,7 +689,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:38088b8286fa102a",
+      "sourceHash": "fnv1a64:c92d1840828e1feb",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -710,6 +778,23 @@
         },
         {
           "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say the daytime greeting once without looking."
+            }
+          ]
+        },
+        {
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -748,7 +833,7 @@
     },
     {
       "id": "JA-W03-u",
-      "sequence": 240,
+      "sequence": 190,
       "title": "う (u) — two strokes, and a vowel that stretches",
       "headword": "う",
       "romanization": "u",
@@ -760,7 +845,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eb053cfd07df4fd1",
+      "sourceHash": "fnv1a64:95b897c6b964299f",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -829,7 +914,7 @@
             },
             {
               "kind": "speech",
-              "text": "Written out, ありがとう (arigatou) ends と + う — to then u, which reads as five beats. But nobody says a-ri-ga-to-u. What you hear is a long o:"
+              "text": "The five-sign sequence you are building ends と + う — to then u, which reads as five beats. But the final two signs are heard as a long o:"
             },
             {
               "kind": "speech",
@@ -841,7 +926,7 @@
             },
             {
               "kind": "speech",
-              "text": "You met this once already without being told: the katakana word コーヒー uses a long bar for the same job. Hiragana uses う."
+              "text": "Katakana will later receive a separate one-stroke length mark for the same job. Here the only written cue is the う you have just learned."
             }
           ]
         },
@@ -910,8 +995,8 @@
     },
     {
       "id": "JA-W03-arigatou-read",
-      "sequence": 250,
-      "title": "ありがとう (arigatou) — no new sign, and a whole word",
+      "sequence": 200,
+      "title": "ありがとう (arigatou) (arigatō) — no new sign, and a whole word",
       "headword": "ありがとう",
       "romanization": "arigatou",
       "gloss": "five signs, all of them now yours — the thank-you read rather than recalled",
@@ -922,7 +1007,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:605a237f83ea2d81",
+      "sourceHash": "fnv1a64:a4649118286c6353",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -964,7 +1049,7 @@
             },
             {
               "kind": "speech",
-              "text": "ありがとう (arigatou)."
+              "text": "ありがとう (arigatou) (arigatō)."
             },
             {
               "kind": "speech",
@@ -1012,7 +1097,7 @@
             {
               "kind": "prompt",
               "action": "READ",
-              "instruction": "ありがとう (arigatou) — name each sign before you say the word",
+              "instruction": "ありがとう (arigatou) (arigatō) — name each sign before you say the word",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
@@ -1021,7 +1106,7 @@
             {
               "kind": "prompt",
               "action": "WRITE",
-              "instruction": "ありがとう (arigatou) — all five, in order, without looking above",
+              "instruction": "ありがとう (arigatou) (arigatō) — all five, in order, without looking above",
               "spoken": false,
               "scored": false,
               "responseSeconds": 8,
@@ -1055,7 +1140,7 @@
               "kind": "activity",
               "scored": true,
               "id": "JA-W03-arigatou-read-ga",
-              "prompt": "Which sign in ありがとう (arigatou) is another sign plus the dakuten, and what is underneath it?",
+              "prompt": "Which sign in ありがとう (arigatou) (arigatō) is another sign plus the dakuten, and what is underneath it?",
               "assesses": [
                 "JA-SCRIPT-ARIGATOU-READ-01"
               ],
@@ -1078,492 +1163,28 @@
       ]
     },
     {
-      "id": "JA-W03-sa",
-      "sequence": 260,
-      "title": "さ (sa) — two strokes, and the ticks work here too",
-      "headword": "さ",
-      "romanization": "sa",
-      "gloss": "the hiragana sign for the mora sa — two strokes, and the base of za",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:f00367d39fd8befa",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write ありがとう (arigatou). All five signs, no help."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "さ (sa)."
-            },
-            {
-              "kind": "speech",
-              "text": "Three strokes:"
-            },
-            {
-              "kind": "speech",
-              "text": "a short horizontal, near the top."
-            },
-            {
-              "kind": "speech",
-              "text": "a short curving stroke below it, falling down and left."
-            },
-            {
-              "kind": "speech",
-              "text": "a separate small curve at the foot, opening left — not joined to the stroke above it."
-            },
-            {
-              "kind": "speech",
-              "text": "Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the さ you see on a screen looks like two strokes. By hand it is three, and the break is real. The same split makes き four strokes by hand and three in print."
-            },
-            {
-              "kind": "speech",
-              "text": "Read sa: a clean s, then the short a. One beat."
-            },
-            {
-              "kind": "speech",
-              "text": "And now the bargain again — さ (sa) takes the dakuten:"
-            },
-            {
-              "kind": "speech",
-              "text": "さ sa becomes ざ za."
-            },
-            {
-              "kind": "speech",
-              "text": "Same mouth, voice switched on, two ticks at the upper right. That is the third sign you have got for free, and it is the second sign of ございます."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "さ (sa) — horizontal, the short curve, then the detached foot curve",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: さ — horizontal, the short curve, then the detached foot curve]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ざ — the same, with two ticks",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ざ — the same, with two ticks]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "sa / za",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **sa / za**]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "How many signs have the two ticks given you so far? (Three — が, ご and ざ.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W03-sa-za",
-              "prompt": "What does the sign read 'sa' become when the dakuten is added?",
-              "assesses": [
-                "JA-SCRIPT-SA-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "za",
-                "ざ",
-                "it becomes za"
-              ],
-              "feedback": {
-                "correct": "ざ za — same shape, voice switched on.",
-                "incorrect": "It becomes ざ, read za."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-W03-ma",
-      "sequence": 270,
-      "title": "ま (ma) — three strokes, and a loop you have drawn before",
-      "headword": "ま",
-      "romanization": "ma",
-      "gloss": "the hiragana sign for the mora ma — three strokes, two of them horizontal",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:ea2d765801bc327c",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write さ (sa), then ざ."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ま (ma)."
-            },
-            {
-              "kind": "speech",
-              "text": "Three strokes, and the order is top-down as always:"
-            },
-            {
-              "kind": "speech",
-              "text": "an upper horizontal, short."
-            },
-            {
-              "kind": "speech",
-              "text": "a lower horizontal, a little wider, below and parallel to it."
-            },
-            {
-              "kind": "speech",
-              "text": "a looping vertical that crosses both, falls, and curls left at the bottom."
-            },
-            {
-              "kind": "speech",
-              "text": "The third stroke is the same movement you learned on あ — down through what you have written, then a small loop at the foot. If あ's loop is comfortable, this one is already yours."
-            },
-            {
-              "kind": "speech",
-              "text": "Read ma: as in English mother, shortened. One beat."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ま (ma) — two horizontals, then the looping vertical through them",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ま — two horizontals, then the looping vertical through them]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ma, one beat",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **ma**, one beat]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Which earlier sign uses the same looping last stroke? (あ.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W03-ma-strokes",
-              "prompt": "How many strokes does the hiragana sign read 'ma' have?",
-              "assesses": [
-                "JA-SCRIPT-MA-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "3",
-                "three",
-                "3 strokes",
-                "three strokes"
-              ],
-              "feedback": {
-                "correct": "Three — two horizontals and the looping vertical.",
-                "incorrect": "Three: two horizontal strokes, then the looping vertical."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-W03-su",
-      "sequence": 280,
-      "title": "す (su) — two strokes, and a vowel you barely hear",
-      "headword": "す",
-      "romanization": "su",
-      "gloss": "the hiragana sign for the mora su — two strokes, and a vowel that often goes quiet",
-      "script": "japanese",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:0610ff38f0840af8",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script — the shape",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write ま (ma). Two horizontals, then the loop."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script — the shape",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "す (su)."
-            },
-            {
-              "kind": "speech",
-              "text": "Two strokes:"
-            },
-            {
-              "kind": "speech",
-              "text": "a short horizontal, near the top."
-            },
-            {
-              "kind": "speech",
-              "text": "a vertical crossing it, falling, and finishing in a loop that closes back on itself before tailing away."
-            },
-            {
-              "kind": "speech",
-              "text": "The loop in す (su) is tighter than ま (ma)'s — it comes back and crosses its own line."
-            },
-            {
-              "kind": "speech",
-              "text": "Read su: an s, then the u you met in う."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way — the vowel that goes quiet",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "At the end of a word, and especially in ございます, that final u is usually devoiced — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to -mass than -masu."
-            },
-            {
-              "kind": "speech",
-              "text": "This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear u there is one of the most recognisable marks of a learner reading off a page."
-            },
-            {
-              "kind": "speech",
-              "text": "The sign is still written. The beat is still counted. Only the voice drops out."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "す (su) — horizontal, then the vertical with its closing loop",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: す — horizontal, then the vertical with its closing loop]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "su, then the same with the voice off — a whispered ending",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: **su**, then the same with the voice off — a whispered ending]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Is the beat dropped along with the voice? (No — the beat is still counted.)"
-            },
-            {
-              "kind": "speech",
-              "text": "Source: Unicode Hiragana chart."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "JA-W03-su-devoice",
-              "prompt": "At the end of gozaimasu, what happens to the final u?",
-              "assesses": [
-                "JA-SCRIPT-SU-01"
-              ],
-              "responseSeconds": 12,
-              "acceptedResponses": [
-                "it is devoiced",
-                "it goes quiet",
-                "devoiced",
-                "you barely hear it",
-                "the voice drops out",
-                "it is almost silent"
-              ],
-              "feedback": {
-                "correct": "Devoiced — the beat is counted, the voice is not.",
-                "incorrect": "It is DEVOICED: the beat stays, the vocal cords do not switch on."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "JA-C03-practice",
-      "sequence": 290,
-      "title": "Practice — the whole thank-you, off the page",
-      "headword": "ありがとうございます",
-      "romanization": "arigatou gozaimasu",
-      "gloss": "ten signs, every one of them yours — the polite thank-you read off the page",
+      "id": "JA-C01-arigatou",
+      "sequence": 210,
+      "title": "ありがとう (arigatou) (arigatō) — thanks, from “this hardly ever happens”",
+      "headword": "ありがとう",
+      "romanization": "arigatō",
+      "gloss": "thank you (plain)",
       "script": "japanese",
       "modality": "sight",
       "derivedModality": "sight",
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dcf1861ce20f29aa",
+      "sourceHash": "fnv1a64:d8f0b0bb450a2f2b",
       "notice": {
         "modality": "sight",
         "needs": [
           "your eyes, for letter shapes on the page"
         ],
         "waitUntilStopped": [
-          "Script — the second half",
-          "Guided Practice"
+          "Script — five signs and two small strokes"
         ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the second half and Guided Practice until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five signs and two small strokes until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -1579,173 +1200,130 @@
             },
             {
               "kind": "speech",
-              "text": "Write ありがとう (arigatou). Five signs, no help."
+              "text": "Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds."
             }
           ]
         },
         {
           "index": 1,
           "type": "script",
-          "title": "Script — the second half",
+          "title": "Script — five signs and two small strokes",
           "segments": [
             {
               "kind": "speech",
-              "text": "ございます."
+              "text": "ありがとう (arigatou) (arigatō) — あ a + り ri + が ga + と to + う."
             },
             {
               "kind": "speech",
-              "text": "Five more signs, and again nothing here is new:"
+              "text": "あ a, り ri, と to and う u are ordinary hiragana. が is the new idea: it is the sign か ka with two short strokes added at the top right. That mark is the dakuten, and it voices the consonant — the same two strokes turn ka into ga, sa into za, ta into da, ha into ba. One mark, learned once, doubles how much of the script you can read."
             },
             {
               "kind": "speech",
-              "text": "ご — こ from Chapter 2, with the dakuten."
-            },
-            {
-              "kind": "speech",
-              "text": "ざ — さ (sa) from this chapter, with the dakuten."
-            },
-            {
-              "kind": "speech",
-              "text": "い — from Chapter 2."
-            },
-            {
-              "kind": "speech",
-              "text": "ま (ma) — from this chapter."
-            },
-            {
-              "kind": "speech",
-              "text": "す (su) — from this chapter, its u devoiced."
-            },
-            {
-              "kind": "speech",
-              "text": "Two of the five are signs you already had, wearing two ticks."
+              "text": "The final う does not sound like u here. After と it stretches the o, so the word ends -tō and holds five beats: a-ri-ga-to-o. Hiragana lengthens a vowel here by writing another vowel sign. Katakana will get its own tiny length lesson later."
             }
           ]
         },
         {
           "index": 2,
-          "type": "culture-pragmatics",
-          "title": "Why it's said this way — what the long form is doing",
+          "type": "etymology",
+          "title": "The word, taken apart — arigatashi",
           "segments": [
             {
               "kind": "speech",
-              "text": "ありがとう on its own is warm and ordinary — friends, family, a shopkeeper you know. ありがとうございます (arigatou gozaimasu) is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you."
+              "text": "The older form combines aru, \"to exist,\" with katashi, \"difficult.\" Arigatashi therefore meant literally \"hard to exist\" — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The k of katashi softened to g inside the compound, which is the same voicing the dakuten writes. Its historical kanji spelling can wait until those signs receive their own lessons."
             },
             {
               "kind": "speech",
-              "text": "The difference is not strength. Adding ございます does not mean you are more grateful; it means you are being more formal about it. Getting that wrong in either direction is the commonest register mistake a beginner makes."
-            },
-            {
-              "kind": "speech",
-              "text": "If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing."
+              "text": "So the memory hook is inside the word, not inside English: saying ありがとう (arigatou) (arigatō) is saying this was not a thing that had to happen. No English cousin exists, and inventing one would be worse than admitting that."
             }
           ]
         },
         {
           "index": 3,
-          "type": "input",
-          "title": "The exchange",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Two voices, and every sign on the page is one you can write:"
-            },
-            {
-              "kind": "speech",
-              "text": "A: こんにちは B: こんにちは A: ありがとうございます (arigatou gozaimasu) B: はい."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "notice",
-          "title": "What you've built this chapter",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Eight new signs and one mark. The mark is the part worth remembering:"
-            },
-            {
-              "kind": "speech",
-              "text": "eight shapes — あ り (ri) か (ka) と (to) う さ (sa) ま (ma) す (su)."
-            },
-            {
-              "kind": "speech",
-              "text": "one mark — ゛ (dakuten), which turned か (ka) into が, こ into ご, さ (sa) into ざ."
-            },
-            {
-              "kind": "speech",
-              "text": "Ten signs in ありがとうございます (arigatou gozaimasu), and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job smaller the further you went into it, and it keeps doing that: every k, s, t and h sign you ever learn arrives with a voiced twin already attached."
-            }
-          ]
-        },
-        {
-          "index": 5,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
             {
               "kind": "prompt",
-              "action": "READ",
-              "instruction": "ありがとうございます (arigatou gozaimasu) — name each of the ten signs, then say it",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: ありがとうございます — name each of the ten signs, then say it]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ございます — five signs, two of them with ticks",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ございます — five signs, two of them with ticks]"
-            },
-            {
-              "kind": "prompt",
               "action": "SAY",
-              "instruction": "arigatou gozaimasu — and let the final u go quiet",
+              "instruction": "ありがとう (arigatou) (arigatō) — a-ri-ga-to-o, five beats",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: **arigatou gozaimasu** — and let the final u go quiet]"
+              "source": "[YOU SAY: **ありがとう** — *a-ri-ga-to-o*, five beats]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "prompt",
+              "action": "BUILD",
+              "instruction": "か (ka) plus the dakuten becomes が",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU BUILD: **か** plus the dakuten → **が**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONNECT",
+              "instruction": "arigatashi \"hard to exist\" becomes rare becomes precious becomes thanks",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONNECT: *arigatashi* \"hard to exist\" → rare → precious → thanks]"
             }
           ]
         },
         {
-          "index": 6,
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once from memory, then add the two dakuten strokes."
+            }
+          ]
+        },
+        {
+          "index": 5,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
             {
               "kind": "speech",
-              "text": "Which form would you use with a stranger — the short one or the long one? (The long one; being slightly too polite costs nothing.)"
+              "text": "What did arigatashi mean literally? (Hard to exist.) What does the last う (u) do? (It lengthens the o.)"
             },
             {
               "kind": "speech",
-              "text": "Source: Unicode Hiragana chart."
+              "text": "Source: Wiktionary: ありがとう (arigatou) (arigatō)."
             },
             {
               "kind": "activity",
               "scored": true,
-              "id": "JA-C03-practice-ticks",
-              "prompt": "In ありがとうございます (arigatou gozaimasu), how many signs are an earlier sign plus the dakuten?",
+              "id": "JA-C01-arigatou-dakuten",
+              "prompt": "Which hiragana sign becomes が when the dakuten is added?",
               "assesses": [
-                "JA-SCRIPT-GOZAIMASU-READ-01"
+                "JA-SCRIPT-DAKUTEN"
               ],
-              "responseSeconds": 12,
+              "responseSeconds": 8,
               "acceptedResponses": [
-                "3",
-                "three",
-                "3 signs",
-                "three signs",
-                "ga za and go",
-                "が ご ざ"
+                "か",
+                "ka",
+                "か ka"
               ],
               "feedback": {
-                "correct": "Three — が, ご and ざ, from か, こ and さ.",
-                "incorrect": "Three: が from か, ご from こ, and ざ from さ."
+                "correct": "Right: か plus the two strokes is が.",
+                "incorrect": "It is か — the dakuten voices ka into ga."
               }
             }
           ]

--- a/code/learning/human-languages/japanese/narration/ch03.txt
+++ b/code/learning/human-languages/japanese/narration/ch03.txt
@@ -1,8 +1,8 @@
-Japanese, chapter 3: Eight Signs, One Mark, and the Longest Word You Know.
-11 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+Japanese, chapter 3: Plain Thanks, One Sign at a Time.
+8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 11.
+Lesson 1 of 8.
 あ — three strokes, and the thank-you begins.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -10,7 +10,7 @@ Before we start: this one needs your hands, so it is not a driving lesson. You w
 Warm-up.
 [pause 2 seconds]
 Write こんにちは from memory. Five signs, all yours.
-You have been saying ありがとう (arigatou) since Chapter 1 and reading it from the romanization. This chapter hands you the signs, one at a time, until the word is yours on the page as well as in the mouth.
+This chapter builds the five-sign plain thank-you from the page up. Its meaning arrives only after every sign is yours, so this first lesson asks for one shape: あ.
 
 Script — the shape.
 あ (a).
@@ -26,6 +26,10 @@ Guided Practice.
 [your turn — say: a, one beat, short]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Give the daytime greeting, then write? from memory.
+
 Wrap-up Recall.
 Is the loop drawn as a separate circle, or in one movement? (One movement, crossing what you have already written.)
 Source: Unicode Hiragana chart.
@@ -33,7 +37,7 @@ Source: Unicode Hiragana chart.
 How many strokes does the hiragana sign read 'a' have?
 
 
-Lesson 2 of 11.
+Lesson 2 of 8.
 り (ri) — two strokes, and a tap rather than an r.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -58,6 +62,10 @@ Guided Practice.
 [your turn — say: a, then ri — the first two signs of the word]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? from memory before tracing?.
+
 Wrap-up Recall.
 Which of り's two strokes falls further? (The right one, by about double.)
 Source: Unicode Hiragana chart.
@@ -65,7 +73,7 @@ Source: Unicode Hiragana chart.
 Is the Japanese r in 'ri' closer to an English r or to a single tap of the tongue?
 
 
-Lesson 3 of 11.
+Lesson 3 of 8.
 か (ka) — three strokes, and a shape you will reuse.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -88,6 +96,10 @@ Guided Practice.
 [your turn — say: ka, one beat]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write?, then write the different sign that closes????? and explain its particle reading.
+
 Wrap-up Recall.
 Which stroke is written last? (The dot, at the upper right.)
 Source: Unicode Hiragana chart.
@@ -95,7 +107,7 @@ Source: Unicode Hiragana chart.
 How many strokes does the hiragana sign read 'ka' have?
 
 
-Lesson 4 of 11.
+Lesson 4 of 8.
 ゛ (dakuten)— two ticks, and every sign you know doubles.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the mark and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -121,6 +133,10 @@ Guided Practice.
 [your turn — say: ka / ga, then ko / go — the same mouth, voice off and on]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write????? from its five signs before adding any voice marks.
+
 Wrap-up Recall.
 Does が need a new shape learned? (No — it is か (ka) plus two ticks.)
 Source: Unicode Hiragana chart.
@@ -128,7 +144,7 @@ Source: Unicode Hiragana chart.
 What do the two small marks of the dakuten do to a hiragana sign?
 
 
-Lesson 5 of 11.
+Lesson 5 of 8.
 と (to) — two strokes, and they never meet.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -150,6 +166,10 @@ Guided Practice.
 [your turn — say: a, ri, ga, to — four beats, and the word is nearly yours]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say the daytime greeting once without looking.
+
 Wrap-up Recall.
 Which stroke is longer? (The second, the sweep.)
 Source: Unicode Hiragana chart.
@@ -157,7 +177,7 @@ Source: Unicode Hiragana chart.
 Do the two strokes of the sign read 'to' touch each other?
 
 
-Lesson 6 of 11.
+Lesson 6 of 8.
 う (u) — two strokes, and a vowel that stretches.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -175,10 +195,10 @@ Read u: close to the oo of food but shorter, and with the lips much less rounded
 
 What you've built — and what this sign does after と.
 Something happens when う (u) follows と (to), and it is the reason the written word and the spoken word look like they disagree.
-Written out, ありがとう (arigatou) ends と + う — to then u, which reads as five beats. But nobody says a-ri-ga-to-u. What you hear is a long o:
+The five-sign sequence you are building ends と + う — to then u, which reads as five beats. But the final two signs are heard as a long o:
 written: a-ri-ga-to-u spoken: a-ri-ga-too.
 う after an o-sound does not add a syllable. It holds the one before it for a second beat. The beat is still there — Japanese counts it, and dropping it makes the word sound clipped and wrong — but it is the same vowel continuing, not a new one.
-You met this once already without being told: the katakana word コーヒー uses a long bar for the same job. Hiragana uses う.
+Katakana will later receive a separate one-stroke length mark for the same job. Here the only written cue is the う you have just learned.
 
 Guided Practice.
 [once you have stopped driving — write: う — the tick, then the wide curve]
@@ -192,8 +212,8 @@ Source: Unicode Hiragana chart.
 When u follows an o-sound in hiragana, what does it do?
 
 
-Lesson 7 of 11.
-ありがとう (arigatou) — no new sign, and a whole word.
+Lesson 7 of 8.
+ありがとう (arigatou) (arigatō) — no new sign, and a whole word.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the assembly and Guided Practice until you have stopped, and I will say so again when we reach it.
 
@@ -203,7 +223,7 @@ Write あ, り and か (ka) in a row. Then add the two ticks to the last one.
 
 Script — the assembly.
 Here is the word you have been saying since Chapter 1:
-ありがとう (arigatou).
+ありがとう (arigatou) (arigatō).
 Nothing in it is new. Take it sign by sign:
 あ — a, the three-stroke sign with the loop.
 り — ri, short left, long right, tapped.
@@ -215,9 +235,9 @@ That is the whole point of the last five lessons. In Chapter 1 this word was a s
 Read it slowly, once per sign, then at speed: a-ri-ga-to-o.
 
 Guided Practice.
-[your turn — read: ありがとう (arigatou) — name each sign before you say the word]
+[your turn — read: ありがとう (arigatou) (arigatō) — name each sign before you say the word]
 [pause 8 seconds for the answer]
-[once you have stopped driving — write: ありがとう (arigatou) — all five, in order, without looking above]
+[once you have stopped driving — write: ありがとう (arigatou) (arigatō) — all five, in order, without looking above]
 [your turn — say: arigatou — five beats, the last two one long o]
 [pause 8 seconds for the answer]
 
@@ -225,150 +245,42 @@ Wrap-up Recall.
 How many signs did you have to learn for this word? (Five — but one of them was free, because が is か (ka) with two ticks.)
 Source: Unicode Hiragana chart.
 [question — say your answer, then pause 12 seconds]
-Which sign in ありがとう (arigatou) is another sign plus the dakuten, and what is underneath it?
+Which sign in ありがとう (arigatou) (arigatō) is another sign plus the dakuten, and what is underneath it?
 
 
-Lesson 8 of 11.
-さ (sa) — two strokes, and the ticks work here too.
+Lesson 8 of 8.
+ありがとう (arigatou) (arigatō) — thanks, from “this hardly ever happens”.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five signs and two small strokes until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
-Write ありがとう (arigatou). All five signs, no help.
+Back to hiragana. Five signs are coming, and one small mark that unlocks a whole second row of sounds.
 
-Script — the shape.
-さ (sa).
-Three strokes:
-a short horizontal, near the top.
-a short curving stroke below it, falling down and left.
-a separate small curve at the foot, opening left — not joined to the stroke above it.
-Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the さ you see on a screen looks like two strokes. By hand it is three, and the break is real. The same split makes き four strokes by hand and three in print.
-Read sa: a clean s, then the short a. One beat.
-And now the bargain again — さ (sa) takes the dakuten:
-さ sa becomes ざ za.
-Same mouth, voice switched on, two ticks at the upper right. That is the third sign you have got for free, and it is the second sign of ございます.
+Script — five signs and two small strokes.
+ありがとう (arigatou) (arigatō) — あ a + り ri + が ga + と to + う.
+あ a, り ri, と to and う u are ordinary hiragana. が is the new idea: it is the sign か ka with two short strokes added at the top right. That mark is the dakuten, and it voices the consonant — the same two strokes turn ka into ga, sa into za, ta into da, ha into ba. One mark, learned once, doubles how much of the script you can read.
+The final う does not sound like u here. After と it stretches the o, so the word ends -tō and holds five beats: a-ri-ga-to-o. Hiragana lengthens a vowel here by writing another vowel sign. Katakana will get its own tiny length lesson later.
+
+The word, taken apart — arigatashi.
+The older form combines aru, "to exist," with katashi, "difficult." Arigatashi therefore meant literally "hard to exist" — that is, rare. Rare became precious, precious became grateful, and by the Edo period the word had settled into plain thanks. The k of katashi softened to g inside the compound, which is the same voicing the dakuten writes. Its historical kanji spelling can wait until those signs receive their own lessons.
+So the memory hook is inside the word, not inside English: saying ありがとう (arigatou) (arigatō) is saying this was not a thing that had to happen. No English cousin exists, and inventing one would be worse than admitting that.
 
 Guided Practice.
-[once you have stopped driving — write: さ (sa) — horizontal, the short curve, then the detached foot curve]
-[once you have stopped driving — write: ざ — the same, with two ticks]
-[your turn — say: sa / za]
+[your turn — say: ありがとう (arigatou) (arigatō) — a-ri-ga-to-o, five beats]
+[pause 8 seconds for the answer]
+[repeat that twice]
+[your turn — build: か (ka) plus the dakuten becomes が]
+[pause 8 seconds for the answer]
+[your turn — connect: arigatashi "hard to exist" becomes rare becomes precious becomes thanks]
 [pause 8 seconds for the answer]
 
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once from memory, then add the two dakuten strokes.
+
 Wrap-up Recall.
-How many signs have the two ticks given you so far? (Three — が, ご and ざ.)
-Source: Unicode Hiragana chart.
+What did arigatashi mean literally? (Hard to exist.) What does the last う (u) do? (It lengthens the o.)
+Source: Wiktionary: ありがとう (arigatou) (arigatō).
 [question — say your answer, then pause 8 seconds]
-What does the sign read 'sa' become when the dakuten is added?
-
-
-Lesson 9 of 11.
-ま (ma) — three strokes, and a loop you have drawn before.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Write さ (sa), then ざ.
-
-Script — the shape.
-ま (ma).
-Three strokes, and the order is top-down as always:
-an upper horizontal, short.
-a lower horizontal, a little wider, below and parallel to it.
-a looping vertical that crosses both, falls, and curls left at the bottom.
-The third stroke is the same movement you learned on あ — down through what you have written, then a small loop at the foot. If あ's loop is comfortable, this one is already yours.
-Read ma: as in English mother, shortened. One beat.
-
-Guided Practice.
-[once you have stopped driving — write: ま (ma) — two horizontals, then the looping vertical through them]
-[your turn — say: ma, one beat]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Which earlier sign uses the same looping last stroke? (あ.)
-Source: Unicode Hiragana chart.
-[question — say your answer, then pause 8 seconds]
-How many strokes does the hiragana sign read 'ma' have?
-
-
-Lesson 10 of 11.
-す (su) — two strokes, and a vowel you barely hear.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Write ま (ma). Two horizontals, then the loop.
-
-Script — the shape.
-す (su).
-Two strokes:
-a short horizontal, near the top.
-a vertical crossing it, falling, and finishing in a loop that closes back on itself before tailing away.
-The loop in す (su) is tighter than ま (ma)'s — it comes back and crosses its own line.
-Read su: an s, then the u you met in う.
-
-Why it's said this way — the vowel that goes quiet.
-At the end of a word, and especially in ございます, that final u is usually devoiced — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to -mass than -masu.
-This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear u there is one of the most recognisable marks of a learner reading off a page.
-The sign is still written. The beat is still counted. Only the voice drops out.
-
-Guided Practice.
-[once you have stopped driving — write: す (su) — horizontal, then the vertical with its closing loop]
-[your turn — say: su, then the same with the voice off — a whispered ending]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Is the beat dropped along with the voice? (No — the beat is still counted.)
-Source: Unicode Hiragana chart.
-[question — say your answer, then pause 12 seconds]
-At the end of gozaimasu, what happens to the final u?
-
-
-Lesson 11 of 11.
-Practice — the whole thank-you, off the page.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the second half and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Write ありがとう (arigatou). Five signs, no help.
-
-Script — the second half.
-ございます.
-Five more signs, and again nothing here is new:
-ご — こ from Chapter 2, with the dakuten.
-ざ — さ (sa) from this chapter, with the dakuten.
-い — from Chapter 2.
-ま (ma) — from this chapter.
-す (su) — from this chapter, its u devoiced.
-Two of the five are signs you already had, wearing two ticks.
-
-Why it's said this way — what the long form is doing.
-ありがとう on its own is warm and ordinary — friends, family, a shopkeeper you know. ありがとうございます (arigatou gozaimasu) is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you.
-The difference is not strength. Adding ございます does not mean you are more grateful; it means you are being more formal about it. Getting that wrong in either direction is the commonest register mistake a beginner makes.
-If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing.
-
-The exchange.
-Two voices, and every sign on the page is one you can write:
-A: こんにちは B: こんにちは A: ありがとうございます (arigatou gozaimasu) B: はい.
-
-What you've built this chapter.
-Eight new signs and one mark. The mark is the part worth remembering:
-eight shapes — あ り (ri) か (ka) と (to) う さ (sa) ま (ma) す (su).
-one mark — ゛ (dakuten), which turned か (ka) into が, こ into ご, さ (sa) into ざ.
-Ten signs in ありがとうございます (arigatou gozaimasu), and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job smaller the further you went into it, and it keeps doing that: every k, s, t and h sign you ever learn arrives with a voiced twin already attached.
-
-Guided Practice.
-[your turn — read: ありがとうございます (arigatou gozaimasu) — name each of the ten signs, then say it]
-[pause 8 seconds for the answer]
-[once you have stopped driving — write: ございます — five signs, two of them with ticks]
-[your turn — say: arigatou gozaimasu — and let the final u go quiet]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-Which form would you use with a stranger — the short one or the long one? (The long one; being slightly too polite costs nothing.)
-Source: Unicode Hiragana chart.
-[question — say your answer, then pause 12 seconds]
-In ありがとうございます (arigatou gozaimasu), how many signs are an earlier sign plus the dakuten?
+Which hiragana sign becomes が when the dakuten is added?

--- a/code/learning/human-languages/japanese/narration/ch04.json
+++ b/code/learning/human-languages/japanese/narration/ch04.json
@@ -1,0 +1,911 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "chapter": 4,
+  "title": "Polite Thanks, Three More Signs",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:600d2c132460deff",
+  "lessons": [
+    {
+      "id": "JA-W03-sa",
+      "sequence": 220,
+      "title": "さ (sa) — two strokes, and the ticks work here too",
+      "headword": "さ",
+      "romanization": "sa",
+      "gloss": "the hiragana sign for the mora sa — two strokes, and the base of za",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:264f3f50b7fc0641",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write ありがとう. All five signs, no help."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "さ (sa)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "a short horizontal, near the top."
+            },
+            {
+              "kind": "speech",
+              "text": "a short curving stroke below it, falling down and left."
+            },
+            {
+              "kind": "speech",
+              "text": "a separate small curve at the foot, opening left — not joined to the stroke above it."
+            },
+            {
+              "kind": "speech",
+              "text": "Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the さ (sa) you see on a screen looks like two strokes. By hand it is three, and the break is real. Keep the handwritten gap even when a printed font closes it."
+            },
+            {
+              "kind": "speech",
+              "text": "Read sa: a clean s, then the short a. One beat."
+            },
+            {
+              "kind": "speech",
+              "text": "And now the bargain again — さ (sa) takes the dakuten:"
+            },
+            {
+              "kind": "speech",
+              "text": "さ sa becomes ざ za."
+            },
+            {
+              "kind": "speech",
+              "text": "Same mouth, voice switched on, two ticks at the upper right. That is the third voiced sign you have got for free. It will return in the polite ending ahead."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "さ (sa) — horizontal, the short curve, then the detached foot curve",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: さ — horizontal, the short curve, then the detached foot curve]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ざ — the same, with two ticks",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ざ — the same, with two ticks]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "sa / za",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **sa / za**]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say?????, add the dakuten to?, and recall how?hard to exist? became thanks."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "How many signs have the two ticks given you so far? (Three — が, ご and ざ.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W03-sa-za",
+              "prompt": "What does the sign read 'sa' become when the dakuten is added?",
+              "assesses": [
+                "JA-SCRIPT-SA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "za",
+                "ざ",
+                "it becomes za"
+              ],
+              "feedback": {
+                "correct": "ざ za — same shape, voice switched on.",
+                "incorrect": "It becomes ざ, read za."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W03-ma",
+      "sequence": 230,
+      "title": "ま (ma) — three strokes, and a loop you have drawn before",
+      "headword": "ま",
+      "romanization": "ma",
+      "gloss": "the hiragana sign for the mora ma — three strokes, two of them horizontal",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:de01d0ac381949a8",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write さ (sa), then ざ."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ま (ma)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three strokes, and the order is top-down as always:"
+            },
+            {
+              "kind": "speech",
+              "text": "an upper horizontal, short."
+            },
+            {
+              "kind": "speech",
+              "text": "a lower horizontal, a little wider, below and parallel to it."
+            },
+            {
+              "kind": "speech",
+              "text": "a looping vertical that crosses both, falls, and curls left at the bottom."
+            },
+            {
+              "kind": "speech",
+              "text": "The third stroke is the same movement you learned on あ — down through what you have written, then a small loop at the foot. If あ's loop is comfortable, this one is already yours."
+            },
+            {
+              "kind": "speech",
+              "text": "Read ma: as in English mother, shortened. One beat."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ま (ma) — two horizontals, then the looping vertical through them",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ま — two horizontals, then the looping vertical through them]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ma, one beat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **ma**, one beat]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? from memory before tracing?."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which earlier sign uses the same looping last stroke? (あ.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W03-ma-strokes",
+              "prompt": "How many strokes does the hiragana sign read 'ma' have?",
+              "assesses": [
+                "JA-SCRIPT-MA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "3",
+                "three",
+                "3 strokes",
+                "three strokes"
+              ],
+              "feedback": {
+                "correct": "Three — two horizontals and the looping vertical.",
+                "incorrect": "Three: two horizontal strokes, then the looping vertical."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W03-su",
+      "sequence": 240,
+      "title": "す (su) — two strokes, and a vowel you barely hear",
+      "headword": "す",
+      "romanization": "su",
+      "gloss": "the hiragana sign for the mora su — two strokes, and a vowel that often goes quiet",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:384ca3ef601b4442",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write ま (ma). Two horizontals, then the loop."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "す (su)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "a short horizontal, near the top."
+            },
+            {
+              "kind": "speech",
+              "text": "a vertical crossing it, falling, and finishing in a loop that closes back on itself before tailing away."
+            },
+            {
+              "kind": "speech",
+              "text": "The loop in す (su) is tighter than ま (ma)'s — it comes back and crosses its own line."
+            },
+            {
+              "kind": "speech",
+              "text": "Read su: an s, then the u you met in う."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way — the vowel that goes quiet",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "At the end of a word, and especially in ございます, that final u is usually devoiced — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to -mass than -masu."
+            },
+            {
+              "kind": "speech",
+              "text": "This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear u there is one of the most recognisable marks of a learner reading off a page."
+            },
+            {
+              "kind": "speech",
+              "text": "The sign is still written. The beat is still counted. Only the voice drops out."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "す (su) — horizontal, then the vertical with its closing loop",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: す — horizontal, then the vertical with its closing loop]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "su, then the same with the voice off — a whispered ending",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **su**, then the same with the voice off — a whispered ending]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? from memory before tracing?."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Is the beat dropped along with the voice? (No — the beat is still counted.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W03-su-devoice",
+              "prompt": "At the end of gozaimasu, what happens to the final u?",
+              "assesses": [
+                "JA-SCRIPT-SU-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "it is devoiced",
+                "it goes quiet",
+                "devoiced",
+                "you barely hear it",
+                "the voice drops out",
+                "it is almost silent"
+              ],
+              "feedback": {
+                "correct": "Devoiced — the beat is counted, the voice is not.",
+                "incorrect": "It is DEVOICED: the beat stays, the vocal cords do not switch on."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C01-gozaimasu",
+      "sequence": 250,
+      "title": "ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — politeness you cannot leave out",
+      "headword": "ありがとうございます",
+      "romanization": "arigatō gozaimasu",
+      "gloss": "thank you (polite)",
+      "script": "japanese",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7efc64215810c473",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — five more signs, two of them dakuten"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five more signs, two of them dakuten until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say ありがとう once and rebuild が from か. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — five more signs, two of them dakuten",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ございます — ご go + ざ za + い i + ま ma + す su."
+            },
+            {
+              "kind": "speech",
+              "text": "Two of the five are dakuten forms you can already build: ご is こ with the two strokes, and ざ is さ sa with them. い you have read since はい. Only ま ma and す su are genuinely new."
+            },
+            {
+              "kind": "speech",
+              "text": "The whole phrase is ten beats — a-ri-ga-to-o go-za-i-ma-su — and the final す is normally said with the u barely voiced, close to a plain s."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens — politeness is grammar here, not word choice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ございます is a verb. It is the polite descendant of aru, \"to be\" — the same verb that sits inside ありがとう. The historical route runs aru to gozaru to ございます, where the ending -ます is the general politeness marker Japanese attaches to verbs."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the difference this chapter has to name. In many languages politeness is a choice between two words for \"you.\" Japanese instead marks it on the predicate, and every sentence has one, so every sentence is marked. There is no neutral setting: ありがとう to a friend and ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately."
+            },
+            {
+              "kind": "speech",
+              "text": "At the far end of the system, even the verb can be replaced: ordinary iu, \"to say,\" has the respectful form ossharu and the humble form mōsu. Same act, three verbs, chosen by who is doing what to whom. That is keigo, and this lesson is only its front door. Their spellings belong in later, separately taught script lessons."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — ten beats, final su light",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **ありがとうございます** — ten beats, final *su* light]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CHOOSE",
+              "instruction": "a close friend becomes ありがとう; a shop assistant becomes ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CHOOSE: a close friend → **ありがとう**; a shop assistant → **ありがとうございます**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "BUILD",
+              "instruction": "こ becomes ご, さ (sa) becomes ざ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU BUILD: **こ** → **ご**, **さ** → **ざ**]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which verb hides inside ございます? (aru, \"to be.\") Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Wiktionary: ございます."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C01-gozaimasu-level",
+              "prompt": "You are thanking a shop assistant you have never met. Which form do you use?",
+              "assesses": [
+                "JA-REGISTER-TEINEIGO"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "ありがとうございます",
+                "arigato gozaimasu",
+                "arigatou gozaimasu",
+                "arigatō gozaimasu",
+                "the polite one"
+              ],
+              "feedback": {
+                "correct": "Right: the polite -masu form is the default with someone outside your circle.",
+                "incorrect": "Use ありがとうございます — the plain ありがとう is for people close to you."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C03-practice",
+      "sequence": 260,
+      "title": "Practice — the whole thank-you, off the page",
+      "headword": "ありがとうございます",
+      "romanization": "arigatou gozaimasu",
+      "gloss": "ten signs, every one of them yours — the polite thank-you read off the page",
+      "script": "japanese",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a9923606008ef393",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the second half",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the second half and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write ありがとう. Five signs, no help."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the second half",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ございます."
+            },
+            {
+              "kind": "speech",
+              "text": "Five more signs, and again nothing here is new:"
+            },
+            {
+              "kind": "speech",
+              "text": "ご — こ from Chapter 2, with the dakuten."
+            },
+            {
+              "kind": "speech",
+              "text": "ざ — さ (sa) from this chapter, with the dakuten."
+            },
+            {
+              "kind": "speech",
+              "text": "い — from Chapter 2."
+            },
+            {
+              "kind": "speech",
+              "text": "ま (ma) — from this chapter."
+            },
+            {
+              "kind": "speech",
+              "text": "す (su) — from this chapter, its u devoiced."
+            },
+            {
+              "kind": "speech",
+              "text": "Two of the five are signs you already had, wearing two ticks."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way — what the long form is doing",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ありがとう on its own is warm and ordinary — friends, family, a shopkeeper you know. ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you."
+            },
+            {
+              "kind": "speech",
+              "text": "The difference is not strength. Adding ございます does not mean you are more grateful; it means you are being more formal about it. Getting that wrong in either direction is the commonest register mistake a beginner makes."
+            },
+            {
+              "kind": "speech",
+              "text": "If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "input",
+          "title": "The exchange",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Two voices, and every sign on the page is one you can write:"
+            },
+            {
+              "kind": "speech",
+              "text": "A: こんにちは B: こんにちは A: ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) B: はい."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "notice",
+          "title": "What you've built this chapter",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Eight new signs and one mark. The mark is the part worth remembering:"
+            },
+            {
+              "kind": "speech",
+              "text": "eight shapes — あ り か と う さ (sa) ま (ma) す (su)."
+            },
+            {
+              "kind": "speech",
+              "text": "one mark — ゛, which turned か into が, こ into ご, さ (sa) into ざ."
+            },
+            {
+              "kind": "speech",
+              "text": "Ten signs in ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu), and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job smaller the further you went into it, and it keeps doing that: every k, s, t and h sign you ever learn arrives with a voiced twin already attached."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — name each of the ten signs, then say it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: ありがとうございます — name each of the ten signs, then say it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ございます — five signs, two of them with ticks",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ございます — five signs, two of them with ticks]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "arigatou gozaimasu — and let the final u go quiet",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **arigatou gozaimasu** — and let the final u go quiet]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give plain thanks, then polite thanks. Name the dakuten and the?hard to exist? memory hook."
+            }
+          ]
+        },
+        {
+          "index": 7,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which form would you use with a stranger — the short one or the long one? (The long one; being slightly too polite costs nothing.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C03-practice-ticks",
+              "prompt": "In ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu), how many signs are an earlier sign plus the dakuten?",
+              "assesses": [
+                "JA-SCRIPT-GOZAIMASU-READ-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "3",
+                "three",
+                "3 signs",
+                "three signs",
+                "ga za and go",
+                "が ご ざ"
+              ],
+              "feedback": {
+                "correct": "Three — が, ご and ざ, from か, こ and さ.",
+                "incorrect": "Three: が from か, ご from こ, and ざ from さ."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/japanese/narration/ch04.txt
+++ b/code/learning/human-languages/japanese/narration/ch04.txt
@@ -1,0 +1,199 @@
+Japanese, chapter 4: Polite Thanks, Three More Signs.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 5.
+さ (sa) — two strokes, and the ticks work here too.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write ありがとう. All five signs, no help.
+
+Script — the shape.
+さ (sa).
+Three strokes:
+a short horizontal, near the top.
+a short curving stroke below it, falling down and left.
+a separate small curve at the foot, opening left — not joined to the stroke above it.
+Watch that gap. Most printed fonts join the second and third strokes into one continuous descender, so the さ (sa) you see on a screen looks like two strokes. By hand it is three, and the break is real. Keep the handwritten gap even when a printed font closes it.
+Read sa: a clean s, then the short a. One beat.
+And now the bargain again — さ (sa) takes the dakuten:
+さ sa becomes ざ za.
+Same mouth, voice switched on, two ticks at the upper right. That is the third voiced sign you have got for free. It will return in the polite ending ahead.
+
+Guided Practice.
+[once you have stopped driving — write: さ (sa) — horizontal, the short curve, then the detached foot curve]
+[once you have stopped driving — write: ざ — the same, with two ticks]
+[your turn — say: sa / za]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Say?????, add the dakuten to?, and recall how?hard to exist? became thanks.
+
+Wrap-up Recall.
+How many signs have the two ticks given you so far? (Three — が, ご and ざ.)
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 8 seconds]
+What does the sign read 'sa' become when the dakuten is added?
+
+
+Lesson 2 of 5.
+ま (ma) — three strokes, and a loop you have drawn before.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write さ (sa), then ざ.
+
+Script — the shape.
+ま (ma).
+Three strokes, and the order is top-down as always:
+an upper horizontal, short.
+a lower horizontal, a little wider, below and parallel to it.
+a looping vertical that crosses both, falls, and curls left at the bottom.
+The third stroke is the same movement you learned on あ — down through what you have written, then a small loop at the foot. If あ's loop is comfortable, this one is already yours.
+Read ma: as in English mother, shortened. One beat.
+
+Guided Practice.
+[once you have stopped driving — write: ま (ma) — two horizontals, then the looping vertical through them]
+[your turn — say: ma, one beat]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? from memory before tracing?.
+
+Wrap-up Recall.
+Which earlier sign uses the same looping last stroke? (あ.)
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 8 seconds]
+How many strokes does the hiragana sign read 'ma' have?
+
+
+Lesson 3 of 5.
+す (su) — two strokes, and a vowel you barely hear.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write ま (ma). Two horizontals, then the loop.
+
+Script — the shape.
+す (su).
+Two strokes:
+a short horizontal, near the top.
+a vertical crossing it, falling, and finishing in a loop that closes back on itself before tailing away.
+The loop in す (su) is tighter than ま (ma)'s — it comes back and crosses its own line.
+Read su: an s, then the u you met in う.
+
+Why it's said this way — the vowel that goes quiet.
+At the end of a word, and especially in ございます, that final u is usually devoiced — the mouth makes the shape, the beat is counted, but the vocal cords never switch on. What a listener hears is closer to -mass than -masu.
+This is not sloppiness or fast speech. It is what standard Tokyo Japanese does, and saying a full clear u there is one of the most recognisable marks of a learner reading off a page.
+The sign is still written. The beat is still counted. Only the voice drops out.
+
+Guided Practice.
+[once you have stopped driving — write: す (su) — horizontal, then the vertical with its closing loop]
+[your turn — say: su, then the same with the voice off — a whispered ending]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? from memory before tracing?.
+
+Wrap-up Recall.
+Is the beat dropped along with the voice? (No — the beat is still counted.)
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 12 seconds]
+At the end of gozaimasu, what happens to the final u?
+
+
+Lesson 4 of 5.
+ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — politeness you cannot leave out.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — five more signs, two of them dakuten until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Say ありがとう once and rebuild が from か. This lesson adds the ending that makes it usable with a stranger, a shopkeeper, or a boss.
+
+Script — five more signs, two of them dakuten.
+ございます — ご go + ざ za + い i + ま ma + す su.
+Two of the five are dakuten forms you can already build: ご is こ with the two strokes, and ざ is さ sa with them. い you have read since はい. Only ま ma and す su are genuinely new.
+The whole phrase is ten beats — a-ri-ga-to-o go-za-i-ma-su — and the final す is normally said with the u barely voiced, close to a plain s.
+
+Grammar Lens — politeness is grammar here, not word choice.
+ございます is a verb. It is the polite descendant of aru, "to be" — the same verb that sits inside ありがとう. The historical route runs aru to gozaru to ございます, where the ending -ます is the general politeness marker Japanese attaches to verbs.
+That is the difference this chapter has to name. In many languages politeness is a choice between two words for "you." Japanese instead marks it on the predicate, and every sentence has one, so every sentence is marked. There is no neutral setting: ありがとう to a friend and ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) to a stranger are not two styles of the same form, they are two different grammatical levels, and choosing wrongly is heard immediately.
+At the far end of the system, even the verb can be replaced: ordinary iu, "to say," has the respectful form ossharu and the humble form mōsu. Same act, three verbs, chosen by who is doing what to whom. That is keigo, and this lesson is only its front door. Their spellings belong in later, separately taught script lessons.
+
+Guided Practice.
+[your turn — say: ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — ten beats, final su light]
+[pause 8 seconds for the answer]
+[repeat that twice]
+[your turn — choose: a close friend becomes ありがとう; a shop assistant becomes ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu)]
+[pause 8 seconds for the answer]
+[your turn — build: こ becomes ご, さ (sa) becomes ざ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Which verb hides inside ございます? (aru, "to be.") Can a Japanese sentence avoid marking politeness? (No — the predicate always carries a level.)
+Source: Wiktionary: ございます.
+[question — say your answer, then pause 10 seconds]
+You are thanking a shop assistant you have never met. Which form do you use?
+
+
+Lesson 5 of 5.
+Practice — the whole thank-you, off the page.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the second half and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write ありがとう. Five signs, no help.
+
+Script — the second half.
+ございます.
+Five more signs, and again nothing here is new:
+ご — こ from Chapter 2, with the dakuten.
+ざ — さ (sa) from this chapter, with the dakuten.
+い — from Chapter 2.
+ま (ma) — from this chapter.
+す (su) — from this chapter, its u devoiced.
+Two of the five are signs you already had, wearing two ticks.
+
+Why it's said this way — what the long form is doing.
+ありがとう on its own is warm and ordinary — friends, family, a shopkeeper you know. ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) is the same thanks in polite form, and it is what you want for a stranger, a colleague, anyone serving you.
+The difference is not strength. Adding ございます does not mean you are more grateful; it means you are being more formal about it. Getting that wrong in either direction is the commonest register mistake a beginner makes.
+If you are unsure which to use, use the long one. Being slightly too polite in Japanese costs you nothing.
+
+The exchange.
+Two voices, and every sign on the page is one you can write:
+A: こんにちは B: こんにちは A: ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) B: はい.
+
+What you've built this chapter.
+Eight new signs and one mark. The mark is the part worth remembering:
+eight shapes — あ り か と う さ (sa) ま (ma) す (su).
+one mark — ゛, which turned か into が, こ into ご, さ (sa) into ざ.
+Ten signs in ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu), and only eight of them cost you a shape. The dakuten is the first thing in this book that made the job smaller the further you went into it, and it keeps doing that: every k, s, t and h sign you ever learn arrives with a voiced twin already attached.
+
+Guided Practice.
+[your turn — read: ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu) — name each of the ten signs, then say it]
+[pause 8 seconds for the answer]
+[once you have stopped driving — write: ございます — five signs, two of them with ticks]
+[your turn — say: arigatou gozaimasu — and let the final u go quiet]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Give plain thanks, then polite thanks. Name the dakuten and the?hard to exist? memory hook.
+
+Wrap-up Recall.
+Which form would you use with a stranger — the short one or the long one? (The long one; being slightly too polite costs nothing.)
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 12 seconds]
+In ありがとうございます (arigatou gozaimasu) (arigatō gozaimasu), how many signs are an earlier sign plus the dakuten?

--- a/code/learning/human-languages/japanese/narration/ch05.json
+++ b/code/learning/human-languages/japanese/narration/ch05.json
@@ -1,0 +1,1124 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "chapter": 5,
+  "title": "Nihongo, Built in Small Blocks",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:0e00d97dd15baa40",
+  "lessons": [
+    {
+      "id": "JA-W05-nichi-kanji",
+      "sequence": 270,
+      "title": "日 (nichi) — one sun, four strokes",
+      "headword": "日",
+      "romanization": "nichi",
+      "gloss": "the four-stroke kanji for sun or day — the first sign in Japanese",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:bc9bcf20c5b9db2d",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — build the sun",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — build the sun and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say ni-chi: two even beats. Today you attach those beats to one kanji, but you write only one new shape."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — build the sun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "日 (nichi)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write four strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "the left side, down."
+            },
+            {
+              "kind": "speech",
+              "text": "the top and right side as one turning stroke."
+            },
+            {
+              "kind": "speech",
+              "text": "the short middle line, left to right."
+            },
+            {
+              "kind": "speech",
+              "text": "the bottom line, left to right."
+            },
+            {
+              "kind": "speech",
+              "text": "The middle line touches both sides. Keep the shape taller than it is wide."
+            },
+            {
+              "kind": "speech",
+              "text": "Here it is read nichi. It carries the broad idea sun/day. Kanji can have more than one reading; this lesson asks for only the reading in the word ahead."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "日 (nichi) — side, corner, middle, bottom",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 日 — side, corner, middle, bottom]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "日 (nichi) once from memory",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: 日 once from memory]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "nichi, two beats",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **nichi**, two beats]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read????? once and write its base sign? without a model."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which line sits inside the box? (The middle horizontal line.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-nichi-kanji-four-strokes",
+              "prompt": "Write the four-stroke kanji read nichi in the word for Japanese.",
+              "assesses": [
+                "JA-SCRIPT-KANJI-NICHI-01"
+              ],
+              "responseSeconds": 15,
+              "acceptedResponses": [
+                "日",
+                "日 (nichi)",
+                "nichi"
+              ],
+              "feedback": {
+                "correct": "Right: 日, the sun/day sign.",
+                "incorrect": "Use 日: left side, top-and-right corner, middle, bottom."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W05-hon-kanji",
+      "sequence": 280,
+      "title": "本 (hon) — a tree with its root marked",
+      "headword": "本",
+      "romanization": "hon",
+      "gloss": "the five-stroke kanji for origin — the second sign in Japanese",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f410753d9ac7e65a",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — five strokes",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — five strokes and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write 日 once. Read it nichi here."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — five strokes",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "本 (hon)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write the large tree first, then mark its base:"
+            },
+            {
+              "kind": "speech",
+              "text": "top horizontal."
+            },
+            {
+              "kind": "speech",
+              "text": "centre vertical, down through it."
+            },
+            {
+              "kind": "speech",
+              "text": "left-falling branch."
+            },
+            {
+              "kind": "speech",
+              "text": "right-falling branch."
+            },
+            {
+              "kind": "speech",
+              "text": "short horizontal across the lower stem."
+            },
+            {
+              "kind": "speech",
+              "text": "That last stroke is the memory hook: it points to the root, so the sign came to mean origin. In the word ahead, read it hon, one beat ending in n."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "本 (hon) — cross, two branches, root mark",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 本 — cross, two branches, root mark]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "本 (hon) once without looking",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: 本 once without looking]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "hon, one beat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **hon**, one beat]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once from memory before beginning the new kanji."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which stroke comes last? (The short root mark.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-hon-kanji-root-mark",
+              "prompt": "Write the kanji read hon. Which stroke marks the root?",
+              "assesses": [
+                "JA-SCRIPT-KANJI-HON-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "本 — the final short horizontal stroke",
+                "本",
+                "the last stroke",
+                "the short bottom line",
+                "final horizontal"
+              ],
+              "feedback": {
+                "correct": "Right: 本, with the short final line marking the root.",
+                "incorrect": "Write 本; the fifth, short horizontal line marks the root."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W05-gen-component",
+      "sequence": 290,
+      "title": "言 (gen) — build the speech side first",
+      "headword": "言",
+      "romanization": "gen",
+      "gloss": "the speech component at the left of the kanji for language",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4566d09ba88a8331",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one component, not a whole word yet",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — one component, not a whole word yet and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write 本 (hon) and point to its short root mark. Now set it aside."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one component, not a whole word yet",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "言 (gen)."
+            },
+            {
+              "kind": "speech",
+              "text": "This is the speech component. Write it as a small top mark, three horizontal lines, then a three-stroke box. Keep the horizontals distinct and the box narrow."
+            },
+            {
+              "kind": "speech",
+              "text": "Do not memorise a vocabulary word for it today. Its job is visual: when it sits on the left, it signals that the larger kanji has something to do with words or speech. The next two tiny lessons build the right side."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "言 (gen) slowly, top to bottom",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 言 slowly, top to bottom]"
+            },
+            {
+              "kind": "prompt",
+              "action": "COVER AND WRITE",
+              "instruction": "言 (gen) once",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU COVER AND WRITE: 言 once]"
+            },
+            {
+              "kind": "prompt",
+              "action": "POINT",
+              "instruction": "the small box at the bottom",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU POINT: the small box at the bottom]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once from memory before building the speech component."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Where will this component sit in the larger sign? (On the left.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-gen-component-speech-side",
+              "prompt": "Write the component that will sit on the left of the kanji for language.",
+              "assesses": [
+                "JA-SCRIPT-KANJI-SPEECH-COMPONENT-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "言",
+                "言 (speech)",
+                "the speech component"
+              ],
+              "feedback": {
+                "correct": "Right: 言 is the speech side.",
+                "incorrect": "Use 言: the stacked lines and small box."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W05-five-component",
+      "sequence": 300,
+      "title": "五 (go) — four strokes for the sound side",
+      "headword": "五",
+      "romanization": "go",
+      "gloss": "the four-stroke top of the sound side in the kanji for language",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4106b4605705810f",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the top-right piece",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the top-right piece and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Trace 言 (gen) once. Say “speech side.”"
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the top-right piece",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "五 (go)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write four strokes: top horizontal; a short vertical and turn; a second horizontal; then the long bottom horizontal. Keep the shape wider than tall."
+            },
+            {
+              "kind": "speech",
+              "text": "This sign means five on its own. Here, you only need its second job: it helps cue the sound go inside the larger kanji that is coming."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "五 (go) — top, turn, middle, bottom",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 五 — top, turn, middle, bottom]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "五 (go) once from memory",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: 五 once from memory]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "go, one beat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **go**, one beat]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which line is longest? (The bottom line.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-five-component-four-strokes",
+              "prompt": "Write the four-stroke component that cues go in the kanji for language.",
+              "assesses": [
+                "JA-SCRIPT-KANJI-FIVE-COMPONENT-01"
+              ],
+              "responseSeconds": 15,
+              "acceptedResponses": [
+                "五",
+                "五 (go)",
+                "go",
+                "five"
+              ],
+              "feedback": {
+                "correct": "Right: 五 supplies the go sound clue.",
+                "incorrect": "Use 五: top, turn, middle, long bottom."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W05-mouth-component",
+      "sequence": 310,
+      "title": "口 (kuchi) — close a box in three strokes",
+      "headword": "口",
+      "romanization": "kuchi",
+      "gloss": "the three-stroke box under the sound clue in the kanji for language",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:41e23e2b05cdd380",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the lower-right piece",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the lower-right piece and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write 五 (go) once. Leave a little space below it with your finger."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the lower-right piece",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "口 (kuchi)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write three strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "left side, down."
+            },
+            {
+              "kind": "speech",
+              "text": "top and right side as one turning stroke."
+            },
+            {
+              "kind": "speech",
+              "text": "bottom, left to right, closing the box."
+            },
+            {
+              "kind": "speech",
+              "text": "It is the picture-sign for a mouth. In the larger kanji ahead, it sits under 五 (go). Today the whole job is one small square."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "口 (kuchi) — side, corner, close",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 口 — side, corner, close]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "口 (kuchi) once from memory",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: 口 once from memory]"
+            },
+            {
+              "kind": "prompt",
+              "action": "STACK",
+              "instruction": "point below 五, where 口 (kuchi) will go",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU STACK: point below 五, where 口 will go]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read????? from memory before drawing the new box component."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which stroke closes the box? (The bottom stroke.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-mouth-component-close-box",
+              "prompt": "Write the three-stroke mouth component that sits under 五 (go).",
+              "assesses": [
+                "JA-SCRIPT-KANJI-MOUTH-COMPONENT-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "口",
+                "口 (mouth)",
+                "the mouth box"
+              ],
+              "feedback": {
+                "correct": "Right: 口 closes with the bottom stroke.",
+                "incorrect": "Use 口: left side, top-and-right corner, bottom."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W05-go-kanji",
+      "sequence": 320,
+      "title": "語 (go) — assemble; do not memorise fourteen loose strokes",
+      "headword": "語",
+      "romanization": "go",
+      "gloss": "the kanji for language — one known speech side plus one known sound side",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a182967052442c0a",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — three known blocks become one sign",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — three known blocks become one sign and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Point left and picture 言 (gen). Point upper-right and picture 五 (go). Point lower-right and picture 口 (kuchi). Those are all the pieces."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — three known blocks become one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "語 (go)."
+            },
+            {
+              "kind": "speech",
+              "text": "Build it in blocks:"
+            },
+            {
+              "kind": "speech",
+              "text": "write 言 (gen), narrow, on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "write 五 (go) in the upper-right."
+            },
+            {
+              "kind": "speech",
+              "text": "write 口 (kuchi) directly under 五 (go)."
+            },
+            {
+              "kind": "speech",
+              "text": "Read the whole sign go, one beat. It means language here. There are fourteen strokes, but there are not fourteen new decisions: you already practised every block separately."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "語 (go) by naming the blocks — speech, five, mouth",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: 語 by naming the blocks — speech, five, mouth]"
+            },
+            {
+              "kind": "prompt",
+              "action": "COVER AND BUILD",
+              "instruction": "言 (gen) + 五 (go) + 口 (kuchi)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU COVER AND BUILD: 言 + 五 + 口]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "go — language",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **go** — language]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which component fills the left side? (言 (gen), the speech component.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: KanjiVG stroke-order data."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W05-go-kanji-three-blocks",
+              "prompt": "Build the kanji read go, language, from the three blocks you know.",
+              "assesses": [
+                "JA-SCRIPT-KANJI-GO-01"
+              ],
+              "responseSeconds": 20,
+              "acceptedResponses": [
+                "語 = 言 + 五 + 口",
+                "語",
+                "言 + 五 + 口",
+                "言五口"
+              ],
+              "feedback": {
+                "correct": "Right: 語 is speech on the left, five over mouth on the right.",
+                "incorrect": "Build 語: 言 on the left; 五 above 口 on the right."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C01-nihongo",
+      "sequence": 330,
+      "title": "日本語 (nihongo) — three characters, and no single sound each",
+      "headword": "日本語",
+      "romanization": "nihongo",
+      "gloss": "the Japanese language",
+      "script": "japanese",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:89902cbc7dd1c0ae",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — kanji, and the readings problem"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — kanji, and the readings problem until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say こんにちは (konnichiwa). Now write 日, 本 (hon), and 語 (go) once each. This lesson joins those three already-practised kanji to name the language."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — kanji, and the readings problem",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "日本語 (nihongo) — ni + hon + go."
+            },
+            {
+              "kind": "speech",
+              "text": "These are kanji: characters borrowed from Chinese, each carrying a meaning rather than a sound. 日 (nichi) is sun or day. 本 is origin or root. 語 is language. So 日本 is \"sun-origin\" — the country the sun rises from — and 日本語 (nihongo) is its language."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach \"the sound of 日.\" What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it."
+            },
+            {
+              "kind": "speech",
+              "text": "Two families of readings explain the spread. The on reading is Japan's version of the Chinese pronunciation, imported with the character. The kun reading is a native Japanese word written with a borrowed character that already meant the same thing. 日本語 (nihongo) uses the imported reading family throughout. The older spelling behind the greeting is irregular even by those standards, so it remains postponed rather than becoming an unexplained decoding test."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart — the real family",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here the cousin web finally works — just not toward English. The on-readings nichi, hon, go are borrowings of Middle Chinese, so 日本語 (nihongo) has genuine relatives: Mandarin writes the same three characters and says Rìběnyǔ; Korean borrowed the same compound as ilbon-eo. Same characters, related imported sounds, one meaning, three languages."
+            },
+            {
+              "kind": "speech",
+              "text": "That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "日本語 (nihongo) — ni-ho-n-go, four beats",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **日本語** — *ni-ho-n-go*, four beats]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "prompt",
+              "action": "NAME",
+              "instruction": "日 (nichi) sun or day; 本 (hon) origin; 語 (go) language",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU NAME: 日 sun or day; 本 origin; 語 language]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONNECT",
+              "instruction": "Mandarin Rìběnyǔ, Korean ilbon-eo, same three characters",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONNECT: Mandarin *Rìběnyǔ*, Korean *ilbon-eo*, same three characters]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Build? once from?,?, and? before joining the full word."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "What does 日本 mean literally? (Sun-origin.) Does 日 (nichi) have one pronunciation? (No — the word it appears in chooses one.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Wiktionary: 日本語 (nihongo)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C01-nihongo-readings",
+              "prompt": "How is the character 日 (nichi) read inside 日本語 (nihongo)?",
+              "assesses": [
+                "JA-SCRIPT-KANJI-READINGS"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "ni",
+                "as ni",
+                "に",
+                "read ni"
+              ],
+              "feedback": {
+                "correct": "Right: ni here — though the same character is nichi, jitsu, hi, bi, or ka elsewhere.",
+                "incorrect": "In 日本語 it is ni. The character has no single sound; the word decides."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/japanese/narration/ch05.txt
+++ b/code/learning/human-languages/japanese/narration/ch05.txt
@@ -1,0 +1,236 @@
+Japanese, chapter 5: Nihongo, Built in Small Blocks.
+7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 7.
+日 (nichi) — one sun, four strokes.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — build the sun and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Say ni-chi: two even beats. Today you attach those beats to one kanji, but you write only one new shape.
+
+Script — build the sun.
+日 (nichi).
+Write four strokes:
+the left side, down.
+the top and right side as one turning stroke.
+the short middle line, left to right.
+the bottom line, left to right.
+The middle line touches both sides. Keep the shape taller than it is wide.
+Here it is read nichi. It carries the broad idea sun/day. Kanji can have more than one reading; this lesson asks for only the reading in the word ahead.
+
+Guided Practice.
+[once you have stopped driving — trace: 日 (nichi) — side, corner, middle, bottom]
+[once you have stopped driving — write: 日 (nichi) once from memory]
+[your turn — say: nichi, two beats]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Read????? once and write its base sign? without a model.
+
+Wrap-up Recall.
+Which line sits inside the box? (The middle horizontal line.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 15 seconds]
+Write the four-stroke kanji read nichi in the word for Japanese.
+
+
+Lesson 2 of 7.
+本 (hon) — a tree with its root marked.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — five strokes and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write 日 once. Read it nichi here.
+
+Script — five strokes.
+本 (hon).
+Write the large tree first, then mark its base:
+top horizontal.
+centre vertical, down through it.
+left-falling branch.
+right-falling branch.
+short horizontal across the lower stem.
+That last stroke is the memory hook: it points to the root, so the sign came to mean origin. In the word ahead, read it hon, one beat ending in n.
+
+Guided Practice.
+[once you have stopped driving — trace: 本 (hon) — cross, two branches, root mark]
+[once you have stopped driving — write: 本 (hon) once without looking]
+[your turn — say: hon, one beat]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once from memory before beginning the new kanji.
+
+Wrap-up Recall.
+Which stroke comes last? (The short root mark.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 18 seconds]
+Write the kanji read hon. Which stroke marks the root?
+
+
+Lesson 3 of 7.
+言 (gen) — build the speech side first.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — one component, not a whole word yet and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write 本 (hon) and point to its short root mark. Now set it aside.
+
+Script — one component, not a whole word yet.
+言 (gen).
+This is the speech component. Write it as a small top mark, three horizontal lines, then a three-stroke box. Keep the horizontals distinct and the box narrow.
+Do not memorise a vocabulary word for it today. Its job is visual: when it sits on the left, it signals that the larger kanji has something to do with words or speech. The next two tiny lessons build the right side.
+
+Guided Practice.
+[once you have stopped driving — trace: 言 (gen) slowly, top to bottom]
+[your turn — cover and write: 言 (gen) once]
+[pause 8 seconds for the answer]
+[once you have stopped driving — point: the small box at the bottom]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once from memory before building the speech component.
+
+Wrap-up Recall.
+Where will this component sit in the larger sign? (On the left.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 18 seconds]
+Write the component that will sit on the left of the kanji for language.
+
+
+Lesson 4 of 7.
+五 (go) — four strokes for the sound side.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the top-right piece and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Trace 言 (gen) once. Say “speech side.”
+
+Script — the top-right piece.
+五 (go).
+Write four strokes: top horizontal; a short vertical and turn; a second horizontal; then the long bottom horizontal. Keep the shape wider than tall.
+This sign means five on its own. Here, you only need its second job: it helps cue the sound go inside the larger kanji that is coming.
+
+Guided Practice.
+[once you have stopped driving — trace: 五 (go) — top, turn, middle, bottom]
+[once you have stopped driving — write: 五 (go) once from memory]
+[your turn — say: go, one beat]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Which line is longest? (The bottom line.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 15 seconds]
+Write the four-stroke component that cues go in the kanji for language.
+
+
+Lesson 5 of 7.
+口 (kuchi) — close a box in three strokes.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the lower-right piece and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write 五 (go) once. Leave a little space below it with your finger.
+
+Script — the lower-right piece.
+口 (kuchi).
+Write three strokes:
+left side, down.
+top and right side as one turning stroke.
+bottom, left to right, closing the box.
+It is the picture-sign for a mouth. In the larger kanji ahead, it sits under 五 (go). Today the whole job is one small square.
+
+Guided Practice.
+[once you have stopped driving — trace: 口 (kuchi) — side, corner, close]
+[once you have stopped driving — write: 口 (kuchi) once from memory]
+[your turn — stack: point below 五, where 口 (kuchi) will go]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Read????? from memory before drawing the new box component.
+
+Wrap-up Recall.
+Which stroke closes the box? (The bottom stroke.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 12 seconds]
+Write the three-stroke mouth component that sits under 五 (go).
+
+
+Lesson 6 of 7.
+語 (go) — assemble; do not memorise fourteen loose strokes.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — three known blocks become one sign and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Point left and picture 言 (gen). Point upper-right and picture 五 (go). Point lower-right and picture 口 (kuchi). Those are all the pieces.
+
+Script — three known blocks become one sign.
+語 (go).
+Build it in blocks:
+write 言 (gen), narrow, on the left.
+write 五 (go) in the upper-right.
+write 口 (kuchi) directly under 五 (go).
+Read the whole sign go, one beat. It means language here. There are fourteen strokes, but there are not fourteen new decisions: you already practised every block separately.
+
+Guided Practice.
+[once you have stopped driving — trace: 語 (go) by naming the blocks — speech, five, mouth]
+[your turn — cover and build: 言 (gen) + 五 (go) + 口 (kuchi)]
+[pause 8 seconds for the answer]
+[your turn — read: go — language]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Which component fills the left side? (言 (gen), the speech component.)
+Source: KanjiVG stroke-order data.
+[question — say your answer, then pause 20 seconds]
+Build the kanji read go, language, from the three blocks you know.
+
+
+Lesson 7 of 7.
+日本語 (nihongo) — three characters, and no single sound each.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — kanji, and the readings problem until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Say こんにちは (konnichiwa). Now write 日, 本 (hon), and 語 (go) once each. This lesson joins those three already-practised kanji to name the language.
+
+Script — kanji, and the readings problem.
+日本語 (nihongo) — ni + hon + go.
+These are kanji: characters borrowed from Chinese, each carrying a meaning rather than a sound. 日 (nichi) is sun or day. 本 is origin or root. 語 is language. So 日本 is "sun-origin" — the country the sun rises from — and 日本語 (nihongo) is its language.
+Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach "the sound of 日." What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it.
+Two families of readings explain the spread. The on reading is Japan's version of the Chinese pronunciation, imported with the character. The kun reading is a native Japanese word written with a borrowed character that already meant the same thing. 日本語 (nihongo) uses the imported reading family throughout. The older spelling behind the greeting is irregular even by those standards, so it remains postponed rather than becoming an unexplained decoding test.
+
+The word, taken apart — the real family.
+Here the cousin web finally works — just not toward English. The on-readings nichi, hon, go are borrowings of Middle Chinese, so 日本語 (nihongo) has genuine relatives: Mandarin writes the same three characters and says Rìběnyǔ; Korean borrowed the same compound as ilbon-eo. Same characters, related imported sounds, one meaning, three languages.
+That is a real, checkable connection, and it is the honest replacement for the Latin roots that anchor a European language. English has no share in it.
+
+Guided Practice.
+[your turn — say: 日本語 (nihongo) — ni-ho-n-go, four beats]
+[pause 8 seconds for the answer]
+[repeat that twice]
+[your turn — name: 日 (nichi) sun or day; 本 (hon) origin; 語 (go) language]
+[pause 8 seconds for the answer]
+[your turn — connect: Mandarin Rìběnyǔ, Korean ilbon-eo, same three characters]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Build? once from?,?, and? before joining the full word.
+
+Wrap-up Recall.
+What does 日本 mean literally? (Sun-origin.) Does 日 (nichi) have one pronunciation? (No — the word it appears in chooses one.)
+Source: Wiktionary: 日本語 (nihongo).
+[question — say your answer, then pause 10 seconds]
+How is the character 日 (nichi) read inside 日本語 (nihongo)?

--- a/code/learning/human-languages/japanese/narration/ch06.json
+++ b/code/learning/human-languages/japanese/narration/ch06.json
@@ -1,0 +1,645 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "chapter": 6,
+  "title": "Coffee in Katakana, Three Shapes",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:3c3914237ff34f56",
+  "lessons": [
+    {
+      "id": "JA-W06-ko-katakana",
+      "sequence": 340,
+      "title": "コ (ko) — same sound, a new script",
+      "headword": "コ",
+      "romanization": "ko",
+      "gloss": "the two-stroke katakana sign for ko — the first sign in coffee",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0837ed70d3aa6bef",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — two angular strokes",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — two angular strokes and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read 日本語 once. Now switch jobs: the next word came from abroad, so Japanese normally writes it in katakana."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — two angular strokes",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "コ (ko)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write two strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "top horizontal, then turn down at the right."
+            },
+            {
+              "kind": "speech",
+              "text": "bottom horizontal, left to right."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it ko, the same mora as hiragana こ. The sound is not new. Only the script is new: katakana is angular and commonly marks borrowed words."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "コ (ko) — top-and-side, then bottom",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: コ — top-and-side, then bottom]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "コ (ko) once from memory",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: コ once from memory]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "こ is hiragana; コ is katakana; both say ko",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: こ is hiragana; コ is katakana; both say *ko*]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Trace? once. Then recall why Japanese kanji readings connect to Chinese without giving each sign one fixed sound."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Does コ (ko) introduce a new sound? (No — only a new written shape.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Katakana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W06-ko-katakana-ko",
+              "prompt": "Write ko in katakana, the script used for the borrowed word coffee.",
+              "assesses": [
+                "JA-SCRIPT-KATAKANA-KO-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "コ",
+                "コ (ko)",
+                "katakana コ"
+              ],
+              "feedback": {
+                "correct": "Right: コ is katakana ko.",
+                "incorrect": "Use コ: top-and-right corner, then the bottom line."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W06-long-mark",
+      "sequence": 350,
+      "title": "ー (chōonpu) — one line, one extra beat",
+      "headword": "ー",
+      "romanization": "chōonpu",
+      "gloss": "the one-stroke katakana mark that holds the preceding vowel for another beat",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:aedcf8d8d8a26aee",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — length lives on the page",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — length lives on the page and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write コ and say ko. Hold its vowel once: ko-o."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — length lives on the page",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "コー."
+            },
+            {
+              "kind": "speech",
+              "text": "Write one horizontal stroke after the katakana sign. This mark is the chōonpu, the long-vowel mark. It does not have a sound by itself. It tells you to hold the vowel before it for one more mora."
+            },
+            {
+              "kind": "speech",
+              "text": "So コ is ko, while コー is kō: two beats, ko-o. Keep the line centred and about as wide as the sign before it."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "コ (ko), then ー (chōonpu)",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: コ, then ー]"
+            },
+            {
+              "kind": "prompt",
+              "action": "TAP",
+              "instruction": "ko — one; hold o — two",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TAP: *ko* — one; hold *o* — two]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "コー as kō, not ko",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: コー as **kō**, not *ko*]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once from memory, then return to the one-stroke length mark."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "How many extra beats does ー (chōonpu) add? (One.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Katakana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W06-long-mark-beat",
+              "prompt": "Add the katakana long-vowel mark to コ (ko) so it reads kō.",
+              "assesses": [
+                "JA-SCRIPT-KATAKANA-LONG-MARK-01",
+                "JA-SCRIPT-CHOUON"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "コー",
+                "コ ー",
+                "kō",
+                "ko-o"
+              ],
+              "feedback": {
+                "correct": "Right: コー holds o for a second beat.",
+                "incorrect": "Write one horizontal mark after コ: コー."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W06-hi-katakana",
+      "sequence": 360,
+      "title": "ヒ (hi) — two strokes complete the inventory",
+      "headword": "ヒ",
+      "romanization": "hi",
+      "gloss": "the two-stroke katakana sign for hi — the remaining sign in coffee",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:73a7c60d0b4e494b",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — the last new shape",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the last new shape and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write コー and tap its two beats: ko-o."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — the last new shape",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ヒ (hi)."
+            },
+            {
+              "kind": "speech",
+              "text": "Write two strokes:"
+            },
+            {
+              "kind": "speech",
+              "text": "a short stroke from right toward left."
+            },
+            {
+              "kind": "speech",
+              "text": "a longer vertical stroke that turns and sweeps right at the bottom."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it hi, one mora. Japanese h is light; keep the vowel clean, like the ee in machine but short."
+            },
+            {
+              "kind": "speech",
+              "text": "Now every distinct sign in the word ahead is known: コ (ko), ー (chōonpu), and ヒ (hi)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "ヒ (hi) — short top, long bent body",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: ヒ — short top, long bent body]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ヒ (hi) once from memory",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ヒ once from memory]"
+            },
+            {
+              "kind": "prompt",
+              "action": "BUILD",
+              "instruction": "コ (ko) + ー (chōonpu) + ヒ (hi) + ー (chōonpu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU BUILD: コ + ー + ヒ + ー]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write? once from memory before switching back to katakana."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which stroke bends to the right? (The second, longer stroke.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Katakana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W06-hi-katakana-two-strokes",
+              "prompt": "Write hi in katakana, then place it after コー.",
+              "assesses": [
+                "JA-SCRIPT-KATAKANA-HI-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "コーヒ",
+                "ヒ",
+                "コー ヒ",
+                "katakana hi"
+              ],
+              "feedback": {
+                "correct": "Right: ヒ is the final distinct sign in the four-mora word ahead.",
+                "incorrect": "Use ヒ: short top stroke, then the longer bent body."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C01-koohii",
+      "sequence": 370,
+      "title": "コーヒー (kōhī) — the third system, and a word that really is a cousin",
+      "headword": "コーヒー",
+      "romanization": "kōhī",
+      "gloss": "coffee",
+      "script": "japanese",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5fb6b46583ca9190",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — katakana, the borrowed-word script",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — katakana, the borrowed-word script and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Recall how hiragana writes a long vowel: it writes the vowel twice, as in いいえ. Katakana does it differently, and this word shows how."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — katakana, the borrowed-word script",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "コーヒー (kōhī) — コ ko + ー (chōonpu) + ヒ hi + ー (chōonpu)."
+            },
+            {
+              "kind": "speech",
+              "text": "This is katakana, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms."
+            },
+            {
+              "kind": "speech",
+              "text": "The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from fragments of characters, shorthand that monks scribbled beside a text to remember how to read it. こ and コ (ko) even trace back to the same character, which is why they still look alike."
+            },
+            {
+              "kind": "speech",
+              "text": "ー is the chōonpu, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So コーヒー (kōhī) is four beats: ko-o-hi-i."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart — a shared borrowing",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "コーヒー (kōhī) is coffee, and it entered Japanese from Dutch koffie through the Nagasaki trade. Dutch had it from Turkish kahve, and Turkish from Arabic qahwa — which is exactly where English coffee comes from as well."
+            },
+            {
+              "kind": "speech",
+              "text": "So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads include pan, \"bread,\" from Portuguese pão, and arubaito, \"a part-time job,\" from German Arbeit. Their katakana signs can wait for their own one-sign lessons."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "コーヒー (kōhī) — ko-o-hi-i, four beats",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: **コーヒー** — *ko-o-hi-i*, four beats]"
+            },
+            {
+              "kind": "repeat",
+              "times": 2,
+              "source": "[REPEAT x2]"
+            },
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "Arabic qahwa becomes Turkish kahve becomes Dutch koffie becomes コーヒー (kōhī)",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: Arabic *qahwa* → Turkish *kahve* → Dutch *koffie* → **コーヒー**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "DECIDE",
+              "instruction": "a borrowed word is written in katakana, not hiragana",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU DECIDE: a borrowed word is written in katakana, not hiragana]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Which script signals a borrowed word? (Katakana.) How many beats does コーヒー (kōhī) hold? (Four.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Wiktionary: コーヒー (kōhī)."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C01-koohii-bar",
+              "prompt": "What does the bar ー (chōonpu) do in コーヒー (kōhī)?",
+              "assesses": [
+                "JA-SCRIPT-CHOUON"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "it holds the vowel for one more beat",
+                "lengthens the vowel",
+                "long vowel",
+                "it lengthens the previous vowel",
+                "adds a beat to the vowel"
+              ],
+              "feedback": {
+                "correct": "Right: the chōonpu adds one more beat of the same vowel.",
+                "incorrect": "It lengthens the vowel before it by one beat — ko-o-hi-i."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/japanese/narration/ch06.txt
+++ b/code/learning/human-languages/japanese/narration/ch06.txt
@@ -1,0 +1,135 @@
+Japanese, chapter 6: Coffee in Katakana, Three Shapes.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+コ (ko) — same sound, a new script.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — two angular strokes and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Read 日本語 once. Now switch jobs: the next word came from abroad, so Japanese normally writes it in katakana.
+
+Script — two angular strokes.
+コ (ko).
+Write two strokes:
+top horizontal, then turn down at the right.
+bottom horizontal, left to right.
+Read it ko, the same mora as hiragana こ. The sound is not new. Only the script is new: katakana is angular and commonly marks borrowed words.
+
+Guided Practice.
+[once you have stopped driving — trace: コ (ko) — top-and-side, then bottom]
+[once you have stopped driving — write: コ (ko) once from memory]
+[your turn — contrast: こ is hiragana; コ is katakana; both say ko]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Trace? once. Then recall why Japanese kanji readings connect to Chinese without giving each sign one fixed sound.
+
+Wrap-up Recall.
+Does コ (ko) introduce a new sound? (No — only a new written shape.)
+Source: Unicode Katakana chart.
+[question — say your answer, then pause 12 seconds]
+Write ko in katakana, the script used for the borrowed word coffee.
+
+
+Lesson 2 of 4.
+ー (chōonpu) — one line, one extra beat.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — length lives on the page and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write コ and say ko. Hold its vowel once: ko-o.
+
+Script — length lives on the page.
+コー.
+Write one horizontal stroke after the katakana sign. This mark is the chōonpu, the long-vowel mark. It does not have a sound by itself. It tells you to hold the vowel before it for one more mora.
+So コ is ko, while コー is kō: two beats, ko-o. Keep the line centred and about as wide as the sign before it.
+
+Guided Practice.
+[once you have stopped driving — write: コ (ko), then ー (chōonpu)]
+[your turn — tap: ko — one; hold o — two]
+[pause 8 seconds for the answer]
+[your turn — read: コー as kō, not ko]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once from memory, then return to the one-stroke length mark.
+
+Wrap-up Recall.
+How many extra beats does ー (chōonpu) add? (One.)
+Source: Unicode Katakana chart.
+[question — say your answer, then pause 10 seconds]
+Add the katakana long-vowel mark to コ (ko) so it reads kō.
+
+
+Lesson 3 of 4.
+ヒ (hi) — two strokes complete the inventory.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — the last new shape and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Write コー and tap its two beats: ko-o.
+
+Script — the last new shape.
+ヒ (hi).
+Write two strokes:
+a short stroke from right toward left.
+a longer vertical stroke that turns and sweeps right at the bottom.
+Read it hi, one mora. Japanese h is light; keep the vowel clean, like the ee in machine but short.
+Now every distinct sign in the word ahead is known: コ (ko), ー (chōonpu), and ヒ (hi).
+
+Guided Practice.
+[once you have stopped driving — trace: ヒ (hi) — short top, long bent body]
+[once you have stopped driving — write: ヒ (hi) once from memory]
+[your turn — build: コ (ko) + ー (chōonpu) + ヒ (hi) + ー (chōonpu)]
+[pause 8 seconds for the answer]
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+Write? once from memory before switching back to katakana.
+
+Wrap-up Recall.
+Which stroke bends to the right? (The second, longer stroke.)
+Source: Unicode Katakana chart.
+[question — say your answer, then pause 12 seconds]
+Write hi in katakana, then place it after コー.
+
+
+Lesson 4 of 4.
+コーヒー (kōhī) — the third system, and a word that really is a cousin.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — katakana, the borrowed-word script and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Recall how hiragana writes a long vowel: it writes the vowel twice, as in いいえ. Katakana does it differently, and this word shows how.
+
+Script — katakana, the borrowed-word script.
+コーヒー (kōhī) — コ ko + ー (chōonpu) + ヒ hi + ー (chōonpu).
+This is katakana, the third system, and it is a full twin of hiragana: the same beats, the same five vowels, different shapes. Its job is different too. Katakana marks a word as coming from outside — borrowed vocabulary, foreign names, sound effects, scientific terms.
+The two scripts are siblings by origin as well as by sound. Hiragana came from whole Chinese characters written in flowing cursive; katakana came from fragments of characters, shorthand that monks scribbled beside a text to remember how to read it. こ and コ (ko) even trace back to the same character, which is why they still look alike.
+ー is the chōonpu, the long-vowel bar. It holds the previous vowel for one more beat, and it belongs to katakana almost exclusively. So コーヒー (kōhī) is four beats: ko-o-hi-i.
+
+The word, taken apart — a shared borrowing.
+コーヒー (kōhī) is coffee, and it entered Japanese from Dutch koffie through the Nagasaki trade. Dutch had it from Turkish kahve, and Turkish from Arabic qahwa — which is exactly where English coffee comes from as well.
+So this word genuinely is a cousin of one you already own. Notice what kind of cousin: not an inherited relative, but the same borrowed object arriving from the same Arabic source by two different roads. That is the honest shape of most Japanese–English overlap. Other passengers on those roads include pan, "bread," from Portuguese pão, and arubaito, "a part-time job," from German Arbeit. Their katakana signs can wait for their own one-sign lessons.
+
+Guided Practice.
+[your turn — say: コーヒー (kōhī) — ko-o-hi-i, four beats]
+[pause 8 seconds for the answer]
+[repeat that twice]
+[once you have stopped driving — trace: Arabic qahwa becomes Turkish kahve becomes Dutch koffie becomes コーヒー (kōhī)]
+[your turn — decide: a borrowed word is written in katakana, not hiragana]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Which script signals a borrowed word? (Katakana.) How many beats does コーヒー (kōhī) hold? (Four.)
+Source: Wiktionary: コーヒー (kōhī).
+[question — say your answer, then pause 10 seconds]
+What does the bar ー (chōonpu) do in コーヒー (kōhī)?

--- a/code/learning/human-languages/japanese/narration/ch07.json
+++ b/code/learning/human-languages/japanese/narration/ch07.json
@@ -1,0 +1,142 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "chapter": 7,
+  "title": "The Doorway Exchange",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:0ab64e4757ca41cb",
+  "lessons": [
+    {
+      "id": "JA-C01-practice",
+      "sequence": 380,
+      "title": "Practice — one daytime exchange, three scripts",
+      "headword": "こんにちは … ありがとうございます",
+      "romanization": "konnichiwa … arigatō gozaimasu",
+      "gloss": "a short daytime doorway exchange, start to finish",
+      "script": "japanese",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:0e4c71783a8a05b5",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "The exchange — every line already learned",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "A: こんにちは。 — Konnichiwa. B: こんにちは。 — Konnichiwa. A: 日本語? — Nihongo? B: はい。 — Hai. A: ありがとうございます。 — Arigatō gozaimasu. B: いいえ。 — Iie."
+            },
+            {
+              "kind": "speech",
+              "text": "Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so 日本語 with the voice lifted is a complete and natural way to ask \"Japanese, then?\" — and はい answers it. B's closing いいえ is the modest \"not at all\" that waves thanks away."
+            },
+            {
+              "kind": "speech",
+              "text": "An ordinary Japanese page mixes systems: hiragana carries much of the grammar, kanji carries many content words, and katakana commonly carries borrowings. The six earlier chapters introduced those systems separately; this payoff is where they finally work together."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Listen: hear one line with no text and identify greeting, language, answer, or thanks."
+            },
+            {
+              "kind": "speech",
+              "text": "Speak: take B's part while the other lines are read aloud."
+            },
+            {
+              "kind": "speech",
+              "text": "Read: run both voices from Japanese only, with the romanization covered."
+            },
+            {
+              "kind": "speech",
+              "text": "Write: hear 日本語, wait ten seconds, and write the three kanji with no visible model."
+            },
+            {
+              "kind": "speech",
+              "text": "Score the four actions separately. A fluent spoken line cannot cover a missing kanji in writing, and recognition cannot cover an unanswered spoken cue."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice — review pulse",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "From memory, write??,???,?????,?????,???, and????. Circle the dakuten and say why the borrowed word uses katakana."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C01-practice-four-skills",
+              "prompt": "From sound alone, write nihongo in its three kanji. Then take B's part in the doorway exchange without notes.",
+              "assesses": [
+                "JA-DIALOGUE-DOORWAY",
+                "JA-LEX-NIHONGO",
+                "JA-SCRIPT-KANJI-NICHI-01",
+                "JA-SCRIPT-KANJI-HON-01",
+                "JA-SCRIPT-KANJI-GO-01"
+              ],
+              "responseSeconds": 30,
+              "acceptedResponses": [
+                "日本語; こんにちは。はい。いいえ。",
+                "日本語"
+              ],
+              "feedback": {
+                "correct": "The three kanji are complete; now answer the spoken cues without notes.",
+                "incorrect": "Repair one known block at a time: 日 | 本 | 語, then rerun B's short lines."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/japanese/narration/ch07.txt
+++ b/code/learning/human-languages/japanese/narration/ch07.txt
@@ -1,0 +1,31 @@
+Japanese, chapter 7: The Doorway Exchange.
+1 lesson. All 1 can be done entirely by ear.
+
+
+Lesson 1 of 1.
+Practice — one daytime exchange, three scripts.
+
+Warm-up.
+[pause 2 seconds]
+Before reading on, retrieve three answers: the daytime greeting, the short yes, and the short no. Nothing new is added here.
+
+The exchange — every line already learned.
+A: こんにちは。 — Konnichiwa. B: こんにちは。 — Konnichiwa. A: 日本語? — Nihongo? B: はい。 — Hai. A: ありがとうございます。 — Arigatō gozaimasu. B: いいえ。 — Iie.
+Three lines of hiragana, one of kanji, and no word that has not been taught. Japanese lets a bare noun with a rising tone stand as a question, so 日本語 with the voice lifted is a complete and natural way to ask "Japanese, then?" — and はい answers it. B's closing いいえ is the modest "not at all" that waves thanks away.
+An ordinary Japanese page mixes systems: hiragana carries much of the grammar, kanji carries many content words, and katakana commonly carries borrowings. The six earlier chapters introduced those systems separately; this payoff is where they finally work together.
+
+Guided Practice.
+Listen: hear one line with no text and identify greeting, language, answer, or thanks.
+Speak: take B's part while the other lines are read aloud.
+Read: run both voices from Japanese only, with the romanization covered.
+Write: hear 日本語, wait ten seconds, and write the three kanji with no visible model.
+Score the four actions separately. A fluent spoken line cannot cover a missing kanji in writing, and recognition cannot cover an unanswered spoken cue.
+
+Guided Practice — review pulse.
+[pause 15 seconds]
+From memory, write??,???,?????,?????,???, and????. Circle the dakuten and say why the borrowed word uses katakana.
+
+Wrap-up Recall.
+Run the exchange once from memory. If a line stalls, return to that one lesson rather than rereading the chapter.
+[question — say your answer, then pause 30 seconds]
+From sound alone, write nihongo in its three kanji. Then take B's part in the doorway exchange without notes.

--- a/code/learning/human-languages/japanese/session-map.md
+++ b/code/learning/human-languages/japanese/session-map.md
@@ -1,72 +1,66 @@
-# Japanese Session Map — Authored Chapter 1
+# Japanese Session Map — Script Before Decoding
 
-This is the authoritative order for the eight authored Japanese lessons. Each
-lesson is an independent, prerequisite-safe step of three or four minutes. A
-study session may combine the new step with the reviews shown here, but it never
-fuses them into one indivisible lesson.
+This is the authoritative order for the starter course. Every new lesson is an
+independent step of at most 225 seconds. A learner may add due review prompts,
+but no session fuses two new signs into one indivisible lesson.
 
-Reviews use the session-count intervals in
-[`HL00`](../../../specs/HL00-human-language-curriculum-framework.md): a lesson
-introduced in session *N* returns at *N+1, N+3, N+7,* and *N+15*.
-
-## A note on the car
-
-Seven of these eight lessons are marked 👁 **sight**: they teach the shape of a
-sign, and no voice can read a shape aloud. Only the closing practice is 🚗
-**voice**. That is an honest measurement rather than a failure — a three-script
-language is genuinely less drivable than a Latin-script one — and it is recorded
-here so a commuting learner plans around it instead of discovering it at speed.
-Do the script lessons stopped; run the recall prompts and the practice exchange
-on the road.
+The governing rule is simple: a sign becomes load-bearing only after a script
+lesson has isolated its shape, sound or reading, and a small writing action. A
+historical spelling or advanced example that has not earned that preparation is
+given in romanization and postponed.
 
 ## New-lesson sessions
 
-| Session | New lesson | Reviews due | Cumulative practice |
-|---|---|---|---|
-| **S1** | [`JA-C01-hai`](./lessons/JA-C01-hai.md): **はい** *hai* | — | read two hiragana; answer yes |
-| **S2** | [`JA-C01-iie`](./lessons/JA-C01-iie.md): **いいえ** *iie* | *hai* *(N+1)* | choose yes or no; hold the long *i* |
-| **S3** | [`JA-C01-konnichiwa`](./lessons/JA-C01-konnichiwa.md): **こんにちは** | *iie* *(N+1)* | greet at midday; read は two ways |
-| **S4** | [`JA-C01-nihongo`](./lessons/JA-C01-nihongo.md): **日本語** *nihongo* | *hai* *(N+3)*; *konnichiwa* *(N+1)* | name the language; read three kanji |
-| **S5** | [`JA-C01-koohii`](./lessons/JA-C01-koohii.md): **コーヒー** *kōhī* | *iie* *(N+3)*; *nihongo* *(N+1)* | read katakana; trace the borrowing |
-| **S6** | [`JA-C01-arigatou`](./lessons/JA-C01-arigatou.md): **ありがとう** *arigatō* | *konnichiwa* *(N+3)*; *kōhī* *(N+1)* | thank plainly; build が from か |
-| **S7** | [`JA-C01-gozaimasu`](./lessons/JA-C01-gozaimasu.md): **ありがとうございます** | *hai* *(N+7)*; *nihongo* *(N+3)*; *arigatō* *(N+1)* | choose the polite level |
-| **S8** | [`JA-C01-practice`](./lessons/JA-C01-practice.md): the doorway exchange | *iie* *(N+7)*; *kōhī* *(N+3)*; *arigatō gozaimasu* *(N+1)* | run both voices using only learned lines |
+| Session | Chapter | New lesson | One small outcome |
+|---|---:|---|---|
+| **S1** | 1 | [`JA-W01-i`](./lessons/JA-W01-i.md) | trace and write **い** |
+| **S2** | 1 | [`JA-W01-ha`](./lessons/JA-W01-ha.md) | trace and write **は** |
+| **S3** | 1 | [`JA-W01-hai-read`](./lessons/JA-W01-hai-read.md) | join **は + い** |
+| **S4** | 1 | [`JA-W01-e`](./lessons/JA-W01-e.md) | trace and write **え** |
+| **S5** | 1 | [`JA-C01-hai`](./lessons/JA-C01-hai.md) | hear, say, read and write **はい** |
+| **S6** | 1 | [`JA-C01-iie`](./lessons/JA-C01-iie.md) | contrast **はい / いいえ** |
+| **S7** | 2 | [`JA-W01-ko`](./lessons/JA-W01-ko.md) | trace and write **こ** |
+| **S8** | 2 | [`JA-W01-n`](./lessons/JA-W01-n.md) | trace and write **ん** |
+| **S9** | 2 | [`JA-W01-ni`](./lessons/JA-W01-ni.md) | trace and write **に** |
+| **S10** | 2 | [`JA-W01-chi`](./lessons/JA-W01-chi.md) | trace and write **ち** |
+| **S11** | 2 | [`JA-W01-wa`](./lessons/JA-W01-wa.md) | trace and write **わ** |
+| **S12** | 2 | [`JA-W01-konnichiwa-read`](./lessons/JA-W01-konnichiwa-read.md) | assemble the greeting |
+| **S13** | 2 | [`JA-C01-konnichiwa`](./lessons/JA-C01-konnichiwa.md) | use the daytime greeting |
+| **S14** | 3 | [`JA-W03-a`](./lessons/JA-W03-a.md) | trace and write **あ** |
+| **S15** | 3 | [`JA-W03-ri`](./lessons/JA-W03-ri.md) | trace and write **り** |
+| **S16** | 3 | [`JA-W03-ka`](./lessons/JA-W03-ka.md) | trace and write **か** |
+| **S17** | 3 | [`JA-W03-dakuten`](./lessons/JA-W03-dakuten.md) | add the dakuten |
+| **S18** | 3 | [`JA-W03-to`](./lessons/JA-W03-to.md) | trace and write **と** |
+| **S19** | 3 | [`JA-W03-u`](./lessons/JA-W03-u.md) | trace and write **う** |
+| **S20** | 3 | [`JA-W03-arigatou-read`](./lessons/JA-W03-arigatou-read.md) | assemble **ありがとう** |
+| **S21** | 3 | [`JA-C01-arigatou`](./lessons/JA-C01-arigatou.md) | use plain thanks |
+| **S22** | 4 | [`JA-W03-sa`](./lessons/JA-W03-sa.md) | trace and write **さ / ざ** |
+| **S23** | 4 | [`JA-W03-ma`](./lessons/JA-W03-ma.md) | trace and write **ま** |
+| **S24** | 4 | [`JA-W03-su`](./lessons/JA-W03-su.md) | trace and write **す** |
+| **S25** | 4 | [`JA-C01-gozaimasu`](./lessons/JA-C01-gozaimasu.md) | choose polite thanks |
+| **S26** | 4 | [`JA-C03-practice`](./lessons/JA-C03-practice.md) | read the complete polite form |
+| **S27** | 5 | [`JA-W05-nichi-kanji`](./lessons/JA-W05-nichi-kanji.md) | write four-stroke **日** |
+| **S28** | 5 | [`JA-W05-hon-kanji`](./lessons/JA-W05-hon-kanji.md) | write five-stroke **本** |
+| **S29** | 5 | [`JA-W05-gen-component`](./lessons/JA-W05-gen-component.md) | practise speech component **言** |
+| **S30** | 5 | [`JA-W05-five-component`](./lessons/JA-W05-five-component.md) | practise sound clue **五** |
+| **S31** | 5 | [`JA-W05-mouth-component`](./lessons/JA-W05-mouth-component.md) | practise box component **口** |
+| **S32** | 5 | [`JA-W05-go-kanji`](./lessons/JA-W05-go-kanji.md) | assemble **語** from three blocks |
+| **S33** | 5 | [`JA-C01-nihongo`](./lessons/JA-C01-nihongo.md) | read and write **日本語** |
+| **S34** | 6 | [`JA-W06-ko-katakana`](./lessons/JA-W06-ko-katakana.md) | write katakana **コ** |
+| **S35** | 6 | [`JA-W06-long-mark`](./lessons/JA-W06-long-mark.md) | add one mora with **ー** |
+| **S36** | 6 | [`JA-W06-hi-katakana`](./lessons/JA-W06-hi-katakana.md) | write katakana **ヒ** |
+| **S37** | 6 | [`JA-C01-koohii`](./lessons/JA-C01-koohii.md) | read **コーヒー** as four morae |
+| **S38** | 7 | [`JA-C01-practice`](./lessons/JA-C01-practice.md) | run the complete doorway exchange |
 
-Each session adds at most three new knowledge atoms, and most add two. The
-chapter introduces eighteen in total; the closing exchange retrieves ten of them.
+## Review rule
 
-## Carry-forward review ledger
+The `reviews_of` field in each lesson is the machine-checked review queue. The
+fixed no-tracking fallback uses the session-count windows from
+[`HL00`](../../../specs/HL00-human-language-curriculum-framework.md): retrieve a
+new atom at N+1, N+3, N+7 and N+15 when the authored runway is long enough, then
+move it into the mixed pool. A missed item returns sooner; it never causes the
+new-sign lesson to grow beyond five minutes.
 
-Chapter 2 will supply the new lesson for these sessions. Until it exists, use the
-due item as a short retrieval session and fill the bonus queue only with material
-already learned.
-
-| Session | Fixed review due |
-|---|---|
-| **S9** | *konnichiwa* *(N+7)*; *arigatō* *(N+3)* |
-| **S10** | *nihongo* *(N+7)*; *arigatō gozaimasu* *(N+3)*; the exchange *(N+1)* |
-| **S11** | *kōhī* *(N+7)*; the exchange *(N+3)* |
-| **S12** | *arigatō* *(N+7)* |
-| **S13** | *arigatō gozaimasu* *(N+7)* |
-| **S15** | *the exchange* *(N+7)* |
-| **S16** | *hai* *(N+15)* |
-| **S17** | *iie* *(N+15)* |
-| **S18** | *konnichiwa* *(N+15)* |
-| **S19** | *nihongo* *(N+15)* |
-| **S20** | *kōhī* *(N+15)* |
-| **S21** | *arigatō* *(N+15)* |
-| **S22** | *arigatō gozaimasu* *(N+15)* |
-| **S23** | the exchange *(N+15)* |
-
-Sessions absent from the ledger have no fixed item due; use their bonus queue for
-cumulative retrieval.
-
-After a fourth successful resurfacing an item moves into the long-term mixed pool.
-A missed item returns sooner under adaptive review; this fixed ledger is the
-no-tracking fallback the book relies on.
-
-## Schedule check
-
-Every Chapter 1 lesson has all four fixed resurfacing sessions on or before S23.
-Chapter 2 can begin at S9 while this ledger continues in the review portion of
-each session.
+The six chapter payoffs at S6, S13, S21, S26, S33 and S37 are cumulative review
+points. S38 checks listening, speaking, reading and writing separately rather
+than letting recognition stand in for production.

--- a/code/learning/human-languages/progress/japanese.md
+++ b/code/learning/human-languages/progress/japanese.md
@@ -2,8 +2,8 @@
 
 - Track: [Japanese](../japanese/README.md)
 - Family / script: Japonic / Japanese
-- Canonical lessons: 29
-- Mapped lessons: 29
-- Book progress: 3 chapters; through Ch. 3; 3 generated
+- Canonical lessons: 38
+- Mapped lessons: 38
+- Book progress: 7 chapters; through Ch. 7; 7 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/gentle-ramp.test.ts
@@ -217,6 +217,6 @@ describe("the corpus-wide super-gentle ramp", () => {
     });
     expect(
       report.tracks.filter((track) => track.findings.length === 0).map((track) => track.language),
-    ).toEqual(["marwadi"]);
+    ).toEqual(["japanese", "marwadi"]);
   }, 30_000);
 });

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -300,18 +300,19 @@ describe("real curriculum", () => {
     expect(urduFarewell.frontmatter.headword).toBe("خدا حافظ");
   });
 
-  it("keeps the Japanese Chapter 1 mixed-script chain closed and under five minutes", () => {
-    // Japanese is the corpus's first track that needs more than one writing system
-    // at a time, so this asserts the property rather than only the counts: the same
-    // chapter must actually carry hiragana, katakana, and kanji headwords, and the
-    // closing exchange must still be reachable without an untaught atom.
+  it("keeps the Japanese script-before-decoding chain closed and under five minutes", () => {
+    // Japanese needs three writing systems, but putting all three in Chapter 1 made
+    // the learner decode before the sign lessons. Pin the repaired structure: seven
+    // small chapters, one objective activity per lesson, and a final mixed-script
+    // exchange only after the hiragana, kanji and katakana ramps.
     const report = buildCurriculumGapReport({ registry, lessons, books });
-    const chapter = lessons.filter(
-      (lesson) => lesson.language === "japanese" && lesson.realization.chapter === 1,
+    const japanese = lessons.filter((lesson) => lesson.language === "japanese");
+    expect(japanese).toHaveLength(38);
+    expect(new Set(japanese.map((lesson) => lesson.realization.chapter))).toEqual(
+      new Set([1, 2, 3, 4, 5, 6, 7]),
     );
-    expect(chapter).toHaveLength(8);
-    expect(chapter.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
-    expect(chapter.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);
+    expect(japanese.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
+    expect(japanese.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);
     expect(
       report.duration.violations.filter((lesson) => lesson.language === "japanese"),
     ).toEqual([]);
@@ -322,7 +323,7 @@ describe("real curriculum", () => {
     ).toEqual([]);
 
     const headwords = new Map(
-      chapter.map((lesson) => [lesson.realization.lessonId, lesson.realization.headword]),
+      japanese.map((lesson) => [lesson.realization.lessonId, lesson.realization.headword]),
     );
     expect(headwords.get("JA-C01-konnichiwa")).toBe("こんにちは"); // hiragana
     expect(headwords.get("JA-C01-nihongo")).toBe("日本語"); // kanji

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -337,12 +337,13 @@ describe("the script ramp against the real corpus", () => {
     expect(report.summary.lessonViolations).toBe(58); // Urdu shukriya split: -1 -- IMPROVEMENT, the new trace-only step introduces three shapes and the word lesson adds the remaining two before guided copying // Arabic harakat split: -1 -- IMPROVEMENT, the new four-minute middle step carries exactly sukūn, shadda, and fatḥatan, so no lesson introduces more than three of the marks // Urdu order recovery: +1, making UR-C01-shukriya's existing five-shape spike measurable instead of hiding it behind invalid alphabetical order; #12261 owns the real split // Arabic order recovery: +1, making AR-W06-harakat-and-hamza's existing four-mark spike measurable instead of hiding it behind invalid alphabetical order // Punjabi order recovery: -3 -- IMPROVEMENT, the authored order spreads first-seen Gurmukhi shapes more gently than filename order // HL-C259: -1 -- IMPROVEMENT, one fewer ramp violation once gujarati declares its atoms // HL-C134: the hand-written prose carried back into the lessons is now visible to this measurement — the words were always on the page, only the markdown had not seen them
 
     */
-    // All five are Japanese Chapter 1, which opens kanji beside hiragana in its very
-    // first lesson and adds katakana in its fifth.
+    // Japanese used to own all five violations: Chapter 1 opened kanji beside
+    // hiragana and then added katakana in its fifth lesson. The script-first rewrite
+    // now opens one system at a time, so no track crosses this ceiling.
     expect(report.summary.systemViolations).toBe(
       report.tracks.reduce((sum, track) => sum + track.systemViolations, 0),
     );
-    expect(new Set(report.systems.map((v) => v.language))).toEqual(new Set(["japanese"]));
+    expect(new Set(report.systems.map((v) => v.language))).toEqual(new Set());
 
     // The cousin layer's footprint. Not a violation — a reason to keep that layer
     // visually skippable, so a reader who knows no sister language can pass it by.


### PR DESCRIPTION
## Summary

- reorder the Japanese starter from content-before-script into 38 prerequisite-safe lessons across seven small chapters
- add nine isolated kanji/component/katakana writing lessons so every visible sign is taught before it becomes a decoding burden
- remove advanced incidental previews, add learner-visible spaced retrieval, and keep the final listening, speaking, reading, and writing checks independent
- regenerate the Japanese book, narration, modality, progress, answer-key, glossary, index, and gentle-ramp artifacts

## Measured outcome

- unexplained Japanese signs: 21 -> 0
- decode-before-teaching violations: 8 -> 0
- lessons opening multiple writing systems: Japanese 5 -> 0; corpus-wide 0
- Japanese forward references: 5 -> 0
- Japanese missed reinforcement windows: 58 -> 0
- Japanese gentle-ramp findings: all categories -> 0
- all 38 lessons remain below five minutes (maximum declared duration: 225 seconds)

Japanese now joins Marwadi as one of the two tracks currently carrying zero gentle-ramp findings. This is a pre-A1 foundation slice, not a claim that the track is complete through C2.

## Validation

- `npx vitest run --maxWorkers=1`: 93 files, 957 tests passed
- post-rebase focused suite: 5 files, 69 tests passed
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`
- `git diff --check`

Closes #12471