### PR TITLE
feat(human-languages): add Marwadi wellbeing exchange

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1714,6 +1714,18 @@
       "scriptSet": "marwadi-main"
     },
     {
+      "language": "marwadi",
+      "chapter": 7,
+      "output": "marwadi/book/chapters/ch07-wellbeing-question.tex",
+      "scriptSet": "marwadi-main"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 8,
+      "output": "marwadi/book/chapters/ch08-wellbeing-answer.tex",
+      "scriptSet": "marwadi-main"
+    },
+    {
       "language": "kannada",
       "chapter": 6,
       "output": "kannada/book/chapters/ch06-dative-case.tex",

--- a/code/learning/human-languages/core/generated-book-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-book-hashes/marwadi.json
@@ -89,6 +89,29 @@
         "MW-C05-practice"
       ],
       "tex": "marwadi/book/chapters/ch06-name-question.tex"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:3ad5f180edf12c4d",
+      "lessonIds": [
+        "MW-C06-hear-question",
+        "MW-C06-question"
+      ],
+      "tex": "marwadi/book/chapters/ch07-wellbeing-question.tex"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:eea0f7d4266d9e26",
+      "lessonIds": [
+        "MW-C06-hear-answer",
+        "MW-W06-uu-matra",
+        "MW-W06-ttha",
+        "MW-C06-answer",
+        "MW-C06-practice"
+      ],
+      "tex": "marwadi/book/chapters/ch08-wellbeing-answer.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
@@ -120,6 +120,39 @@
       "json": "marwadi/narration/ch06.json",
       "textHash": "fnv1a64:2b329b7f39bbf9bb",
       "jsonHash": "fnv1a64:7e496b4ebee71aaf"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 7,
+      "sourceHash": "fnv1a64:83bef818d89813aa",
+      "lessonIds": [
+        "MW-C06-hear-question",
+        "MW-C06-question"
+      ],
+      "voiceLessons": 1,
+      "drivablePrefix": 1,
+      "text": "marwadi/narration/ch07.txt",
+      "json": "marwadi/narration/ch07.json",
+      "textHash": "fnv1a64:a6b0626462b7a1a2",
+      "jsonHash": "fnv1a64:6dcb82878540b25a"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:662213f5ad3a5b77",
+      "lessonIds": [
+        "MW-C06-hear-answer",
+        "MW-W06-uu-matra",
+        "MW-W06-ttha",
+        "MW-C06-answer",
+        "MW-C06-practice"
+      ],
+      "voiceLessons": 2,
+      "drivablePrefix": 1,
+      "text": "marwadi/narration/ch08.txt",
+      "json": "marwadi/narration/ch08.json",
+      "textHash": "fnv1a64:fbe7aee098259530",
+      "jsonHash": "fnv1a64:51aebbc82dca9e75"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
@@ -1,7 +1,7 @@
 {
   "language": "marwadi",
-  "lessonCount": 40,
-  "atomMeasurableLessons": 40,
+  "lessonCount": 47,
+  "atomMeasurableLessons": 47,
   "atomMeasurementBlindLessons": 0,
   "durationViolations": 0,
   "atomLessonSpikes": 0,
@@ -16,8 +16,8 @@
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 0,
-  "atomsTaught": 47,
-  "atomsNeverRevisited": 2,
+  "atomsTaught": 60,
+  "atomsNeverRevisited": 1,
   "reinforcementWindowMisses": 0,
   "reinforcementMissesByWindow": {
     "R1": 0,
@@ -26,7 +26,7 @@
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 22,
+  "writingPracticeLessons": 26,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [],

--- a/code/learning/human-languages/core/lesson-modality/marwadi.json
+++ b/code/learning/human-languages/core/lesson-modality/marwadi.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:016f79a807123102",
+  "sourceHash": "fnv1a64:a6103c888d014026",
   "summary": {
-    "totalLessons": 40,
-    "voice": 18,
-    "sight": 0,
-    "pen": 22,
-    "drivableLessons": 18,
+    "totalLessons": 47,
+    "voice": 21,
+    "sight": 2,
+    "pen": 24,
+    "drivableLessons": 21,
     "drivablePercent": 45,
     "trackCount": 1,
-    "chapterCount": 6,
-    "drivablePrefixTotal": 3,
+    "chapterCount": 8,
+    "drivablePrefixTotal": 5,
     "fullyDrivableChapters": 0,
     "unstartableChapters": 3,
     "overriddenLessons": 0,
@@ -26,12 +26,12 @@
   "tracks": [
     {
       "language": "marwadi",
-      "lessonCount": 40,
-      "voice": 18,
-      "sight": 0,
-      "pen": 22,
+      "lessonCount": 47,
+      "voice": 21,
+      "sight": 2,
+      "pen": 24,
       "drivablePercent": 45,
-      "drivablePrefixTotal": 3,
+      "drivablePrefixTotal": 5,
       "modalities": [
         "voice",
         "sight",
@@ -138,6 +138,41 @@
           "drivable": false,
           "drivableLessonIds": [
             "MW-C05-hear-tharo"
+          ]
+        },
+        {
+          "chapter": 7,
+          "lessonCount": 2,
+          "voice": 1,
+          "sight": 1,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "MW-C06-question",
+          "drivable": false,
+          "drivableLessonIds": [
+            "MW-C06-hear-question"
+          ]
+        },
+        {
+          "chapter": 8,
+          "lessonCount": 5,
+          "voice": 2,
+          "sight": 1,
+          "pen": 2,
+          "modalities": [
+            "voice",
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "MW-W06-uu-matra",
+          "drivable": false,
+          "drivableLessonIds": [
+            "MW-C06-hear-answer"
           ]
         }
       ]
@@ -996,6 +1031,148 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:9c47f3942c50897f"
+    },
+    {
+      "id": "MW-C06-hear-question",
+      "language": "marwadi",
+      "chapter": 7,
+      "sequence": 410,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d7af2be142c8d046"
+    },
+    {
+      "id": "MW-C06-question",
+      "language": "marwadi",
+      "chapter": 7,
+      "sequence": 420,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bf295d3bc8fa0fd7",
+      "detachableSegments": [
+        "Script — three known groups"
+      ]
+    },
+    {
+      "id": "MW-C06-hear-answer",
+      "language": "marwadi",
+      "chapter": 8,
+      "sequence": 430,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a926370a2742eae6"
+    },
+    {
+      "id": "MW-W06-uu-matra",
+      "language": "marwadi",
+      "chapter": 8,
+      "sequence": 440,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:5f227ede862c08b7",
+      "detachableSegments": [
+        "Script — one vowel mark"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W06-ttha",
+      "language": "marwadi",
+      "chapter": 8,
+      "sequence": 450,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:10746a44f9d36211",
+      "detachableSegments": [
+        "Script — one consonant"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-C06-answer",
+      "language": "marwadi",
+      "chapter": 8,
+      "sequence": 460,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6df3a77f362e3fb2",
+      "detachableSegments": [
+        "Script — build three heard groups"
+      ]
+    },
+    {
+      "id": "MW-C06-practice",
+      "language": "marwadi",
+      "chapter": 8,
+      "sequence": 470,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:920fdc110ecb88f1"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/marwadi/CHANGELOG.md
+++ b/code/learning/human-languages/marwadi/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased — ask how someone is
+
+- Added a seven-session Chapter 7 for **आप कैसो हो? — हूं ठीक हूं.**, securing
+  both lines by ear before the complete exchange is assessed.
+- Reused every sign in the question and isolated the answer's only two new
+  signs, **ू** and **ठ**, in separate <=2.5-minute writing steps.
+- Realized `SPINE-CHECK-WELLBEING` with source-attested polite/formal language
+  and independently scored listening, speaking, reading, and writing.
+- Kept regional variation explicit and left good, so-so, and additional
+  wellbeing answers as measured follow-up debt.
+
 ## Unreleased — ask one name, give one name
 
 - Added an eighteen-session Chapters 5–6 runway for **थारो नाम कांई है?** and

--- a/code/learning/human-languages/marwadi/book/book.tex
+++ b/code/learning/human-languages/marwadi/book/book.tex
@@ -17,7 +17,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- twenty-two lessons, each no longer than five minutes.\par}
+  {\large Starter edition --- forty-seven lessons, each no longer than five minutes.\par}
   \vspace{2cm}
   {\normalsize Copyright \copyright\ Adhithya Rajasekaran. Licensed under
     \href{https://creativecommons.org/licenses/by-sa/4.0/}%
@@ -45,8 +45,10 @@ more signs before adding respectful affirmative \mw{हां सा}. Chapter 4
 teaches \emph{pāṇī}, ``water,'' by ear, then isolates each new sign before the
 learner reads and writes \mw{पाणी}. Chapter 5 builds the name answer
 \mw{म्हारो नाम राम है}; Chapter 6 adds the question
-\mw{थारो नाम कांई है?}. These are real pre-A1 steps, not a claim
-that the level is complete.
+\mw{थारो नाम कांई है?}. Chapter 7 asks \mw{आप कैसो हो?} entirely with known
+signs. Chapter 8 answers \mw{हूं ठीक हूं}, adding only two new signs after
+meaning and sound are secure.
+These are real pre-A1 steps, not a claim that the level is complete.
 
 \tableofcontents
 \mainmatter
@@ -57,6 +59,8 @@ that the level is complete.
 \input{chapters/ch04-paani}
 \input{chapters/ch05-name-answer}
 \input{chapters/ch06-name-question}
+\input{chapters/ch07-wellbeing-question}
+\input{chapters/ch08-wellbeing-answer}
 
 \backmatter
 \input{chapters/appendix-pronunciation}
@@ -79,6 +83,9 @@ comparative dictionary for its Indo-Aryan history.
 Chapters 5 and 6 use the Ek Bharat Shreshtha Bharat language report for the exact
 name-question and name-answer pair, cross-checked against SIL's dictionary and
 Rajasthan Sahitya Akademi prose for the component forms.
+Chapters 7 and 8 use Marwari Pathshala's explicitly polite/formal wellbeing
+question and its documented reply, with SIL's dictionary archive as the variety
+and orthography reference.
 
 \input{chapters/appendix-index}
 \end{document}

--- a/code/learning/human-languages/marwadi/book/chapter-modalities.tex
+++ b/code/learning/human-languages/marwadi/book/chapter-modalities.tex
@@ -69,3 +69,17 @@
     \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 8 lessons.%
     \par}\medskip
 }
+
+\expandafter\def\csname hlchaptermodality7\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} all 2 lessons.%
+    \par}\medskip
+}
+
+\expandafter\def\csname hlchaptermodality8\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlsightsign{}~\textbf{eyes} (1) \quad \hlpensign{}~\textbf{pen} (2)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 5 lessons.%
+    \par}\medskip
+}

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 40
+% canonical-activities: 47
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -257,6 +257,52 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 \raggedright
 \hypertarget{review-MW-C05-practice-name-exchange}{\textbf{6.8}} \emph{Practice — ask one name and give one name}\par
 \small From sound alone, write the Marwadi question What is your name?, then answer aloud with a chosen name.
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C06-hear-question-meaning}{\textbf{7.1}} \emph{Hear \emph{āp kaiso ho?} — ask about someone, politely}\par
+\small You hear āp kaiso ho? What is the speaker asking?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C06-question-write}{\textbf{7.2}} \emph{\mw{आप} \mw{कैसो} \mw{हो}? — the question your hand already knows}\par
+\small Write the polite question āp kaiso ho? from the sound groups.
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C06-hear-answer-meaning}{\textbf{8.1}} \emph{Hear \emph{hū̃ ṭhīk hū̃} — I am fine}\par
+\small You hear hū̃ ṭhīk hū̃. What does the speaker report?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W06-uu-matra-build}{\textbf{8.2}} \emph{\mw{ू} — hold the vowel below a known sign}\par
+\small Which vowel sign turns \mw{ह} into \mw{हू}?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W06-ttha-read}{\textbf{8.3}} \emph{\mw{ठ} — curl back, then release breath}\par
+\small Read the new curled-back, breathed sign \mw{ठ}.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C06-answer-write}{\textbf{8.4}} \emph{\mw{हूं} \mw{ठीक} \mw{हूं}. — two new signs complete the answer}\par
+\small From the sound hū̃ ṭhīk hū̃, write I am fine.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C06-practice-wellbeing}{\textbf{8.5}} \emph{Practice — ask how someone is and answer}\par
+\small From sound alone, write I am fine, then ask the polite wellbeing question aloud.
 \end{minipage}\par\medskip
 
 \chapter*{Answer Key}
@@ -550,4 +596,57 @@ The first response is the canonical display answer. When a question accepts othe
 \hyperlink{review-MW-C05-practice-name-exchange}{\textbf{6.8}} \emph{Practice — ask one name and give one name}\par
 \small \textbf{Answer:} \mw{थारो} \mw{नाम} \mw{कांई} \mw{है}? — \mw{म्हारो} \mw{नाम} {[}name{]} \mw{है।}\par
 \footnotesize \textbf{Also accepted:} \mw{थारो} \mw{नाम} \mw{कांई} \mw{है}; thāro nām kāĩ hai
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C06-hear-question-meaning}{\textbf{7.1}} \emph{Hear \emph{āp kaiso ho?} — ask about someone, politely}\par
+\small \textbf{Answer:} How are you?\par
+\footnotesize \textbf{Also accepted:} how the other person is; about their wellbeing
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C06-question-write}{\textbf{7.2}} \emph{\mw{आप} \mw{कैसो} \mw{हो}? — the question your hand already knows}\par
+\small \textbf{Answer:} \mw{आप} \mw{कैसो} \mw{हो}?\par
+\footnotesize \textbf{Also accepted:} \mw{आप} \mw{कैसो} \mw{हो}
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C06-hear-answer-meaning}{\textbf{8.1}} \emph{Hear \emph{hū̃ ṭhīk hū̃} — I am fine}\par
+\small \textbf{Answer:} I am fine.\par
+\footnotesize \textbf{Also accepted:} I am well; I'm fine; I'm well
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W06-uu-matra-build}{\textbf{8.2}} \emph{\mw{ू} — hold the vowel below a known sign}\par
+\small \textbf{Answer:} \mw{ू}\par
+\footnotesize \textbf{Also accepted:} long u matra; long ū sign
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W06-ttha-read}{\textbf{8.3}} \emph{\mw{ठ} — curl back, then release breath}\par
+\small \textbf{Answer:} ṭha\par
+\footnotesize \textbf{Also accepted:} ttha; \mw{ठ}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C06-answer-write}{\textbf{8.4}} \emph{\mw{हूं} \mw{ठीक} \mw{हूं}. — two new signs complete the answer}\par
+\small \textbf{Answer:} \mw{हूं} \mw{ठीक} \mw{हूं}.\par
+\footnotesize \textbf{Also accepted:} \mw{हूं} \mw{ठीक} \mw{हूं}; \mw{हूं} \mw{ठीक} \mw{हूं।}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C06-practice-wellbeing}{\textbf{8.5}} \emph{Practice — ask how someone is and answer}\par
+\small \textbf{Answer:} \mw{हूं} \mw{ठीक} \mw{हूं}. — \mw{आप} \mw{कैसो} \mw{हो}?\par
+\footnotesize \textbf{Also accepted:} \mw{हूं} \mw{ठीक} \mw{हूं}; \mw{हूं} \mw{ठीक} \mw{हूं।}
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-glossary.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
-% canonical-entries: 9
+% canonical-entries: 11
 
 \chapter*{Glossary}
 \addcontentsline{toc}{chapter}{Glossary}
@@ -16,9 +16,23 @@ This glossary collects every word and phrase taught in the book. Pronunciation a
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\mw{आप} \mw{कैसो} \mw{हो}?}\enspace\emph{āp kaiso ho?}\par
+\small how are you? (polite/formal)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\mw{हां} \mw{सा}}\enspace\emph{hā(n) sā}\par
 \small yes, respectfully\par
 \footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{हूं} \mw{ठीक} \mw{हूं}.}\enspace\emph{hū̃ ṭhīk hū̃.}\par
+\small I am fine.\par
+\footnotesize Introduced in Chapter 8.
 \end{minipage}\par\medskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 33
-% canonical-index-entries: 33
+% canonical-index-candidates: 39
+% canonical-index-entries: 39
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -42,6 +42,34 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{Haan Sa: A Respectful Yes, Sign by Sign}\par
 \footnotesize chapter topic; \hyperref[ch:mw-haan-saa]{Chapter~3, p.~\pageref*{ch:mw-haan-saa}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ू} — hold the vowel below a known sign}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-wellbeing-answer]{Chapter~8, p.~\pageref*{ch:mw-wellbeing-answer}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{how are you? (polite/formal)}\enspace\emph{\mw{आप} \mw{कैसो} \mw{हो}?}\enspace(āp kaiso ho?)\par
+\footnotesize explicit focus: script; \hyperref[ch:mw-wellbeing-question]{Chapter~7, p.~\pageref*{ch:mw-wellbeing-question}}
+\end{minipage}\par\smallskip
+
+\section*{I}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{I am fine.}\enspace\emph{\mw{हूं} \mw{ठीक} \mw{हूं}.}\enspace(hū̃ ṭhīk hū̃.)\par
+\footnotesize explicit focus: script; \hyperref[ch:mw-wellbeing-answer]{Chapter~8, p.~\pageref*{ch:mw-wellbeing-answer}}
+\end{minipage}\par\smallskip
+
+\section*{K}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Kaiso Ho: Ask How Someone Is}\par
+\footnotesize chapter topic; \hyperref[ch:mw-wellbeing-question]{Chapter~7, p.~\pageref*{ch:mw-wellbeing-question}}
 \end{minipage}\par\smallskip
 
 \section*{M}
@@ -124,6 +152,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{Thik Hoon: Answer in Two New Signs}\par
+\footnotesize chapter topic; \hyperref[ch:mw-wellbeing-answer]{Chapter~8, p.~\pageref*{ch:mw-wellbeing-answer}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\mw{ै} — turn \emph{ha} into \emph{hai}}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-name-answer]{Chapter~5, p.~\pageref*{ch:mw-name-answer}}
 \end{minipage}\par\smallskip
@@ -174,6 +208,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\mw{क} — the first sign in \emph{kāĩ}}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-name-question]{Chapter~6, p.~\pageref*{ch:mw-name-question}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ठ} — curl back, then release breath}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-wellbeing-answer]{Chapter~8, p.~\pageref*{ch:mw-wellbeing-answer}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/marwadi/book/chapters/ch07-wellbeing-question.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/ch07-wellbeing-question.tex
@@ -1,0 +1,64 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3ad5f180edf12c4d
+% canonical-lessons: MW-C06-hear-question, MW-C06-question
+
+\chapter{Kaiso Ho: Ask How Someone Is}
+\label{ch:mw-wellbeing-question}
+\hlchaptermodality{7}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can recognise, say, read, and write the polite wellbeing question \mw{आप} \mw{कैसो} \mw{हो}?.}
+
+A source-attested formal wellbeing question heard first and then written entirely with signs from earlier chapters.
+\end{chapteropening}
+
+\section[āp kaiso ho?]{Hear \emph{āp kaiso ho?} — ask about someone, politely}
+
+\label{lesson:MW-C06-hear-question}
+
+
+
+\begin{quote}
+Write \textbf{\mw{पाणी}}, ask the name question once, and answer it once. Recall that \emph{kāĩ} asks \textbf{what}, then put the page out of sight. The next question has a different social job.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\emph{āp kaiso ho?} — \textbf{How are you?}, polite/formal
+\end{quote}
+
+Hear three groups: \emph{āp | kai-so | ho?} The first addresses the other person respectfully; \emph{kaiso} asks how; rising \emph{ho?} keeps the line a question. Listen twice, then say the three groups once. Do not spell them yet.
+
+\subsection*{Your turn}
+Choose the right situation: asking a respected person how they are, or asking their name. Say \emph{āp kaiso ho?} only for the first situation.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the three sound groups once, then stop.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}
+\section[āp kaiso ho?]{\mw{आप} \mw{कैसो} \mw{हो}? — the question your hand already knows}
+
+\label{lesson:MW-C06-question}
+
+
+
+\begin{quote}
+Write \textbf{\mw{पाणी}} from memory, then write \textbf{\mw{क}}. Hear \emph{āp kaiso ho?}, give its meaning, and say the three groups back.
+\end{quote}
+
+\subsection*{Script — three known groups}
+\begin{quote}
+\textbf{\mw{आप} | \mw{कैसो} | \mw{हो}?}
+\end{quote}
+
+No new sign appears. Read slowly: \textbf{\mw{आ} + \mw{प}}, then \textbf{\mw{क} + \mw{ै} + \mw{स} + \mw{ो}}, then \textbf{\mw{ह} + \mw{ो}}. The question mark preserves the rising social cue you heard first.
+
+\subsection*{Your turn}
+Read the line once. Cover it for ten seconds, then write the three groups. Open the model and repair only the group that changed.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read what you wrote once. Stop before learning the answer.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}

--- a/code/learning/human-languages/marwadi/book/chapters/ch08-wellbeing-answer.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/ch08-wellbeing-answer.tex
@@ -1,0 +1,147 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:eea0f7d4266d9e26
+% canonical-lessons: MW-C06-hear-answer, MW-W06-uu-matra, MW-W06-ttha, MW-C06-answer, MW-C06-practice
+
+\chapter{Thik Hoon: Answer in Two New Signs}
+\label{ch:mw-wellbeing-answer}
+\hlchaptermodality{8}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can answer \mw{हूं} \mw{ठीक} \mw{हूं}, then complete a polite wellbeing exchange in separately scored listening, speaking, reading, and writing tasks.}
+
+A source-attested wellbeing answer whose only new written shapes are isolated before the complete four-skill exchange.
+\end{chapteropening}
+
+\section[hū̃ ṭhīk hū̃]{Hear \emph{hū̃ ṭhīk hū̃} — I am fine}
+
+\label{lesson:MW-C06-hear-answer}
+
+
+
+\begin{quote}
+Write independent \textbf{\mw{ई}}, say that \emph{mhāro} means \textbf{my}, then ask \emph{āp kaiso ho?} once from memory. Keep the page closed.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\emph{hū̃ ṭhīk hū̃} — \textbf{I am fine}
+\end{quote}
+
+Hear three groups: \emph{hū̃ | ṭhīk | hū̃}. The first and last groups match. Hold the \emph{ū} and let the ending nasal colour it; do not add a separate final syllable. The middle begins with a curled-back, breathed \emph{ṭh}. Say the line once. Its two unfamiliar written shapes come later.
+
+\subsection*{Your turn}
+Hear the question, then answer \emph{hū̃ ṭhīk hū̃}. Switch roles once. Keep this an ear-and-voice exercise.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the answer once without looking at any spelling.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}
+\section[ū]{\mw{ू} — hold the vowel below a known sign}
+
+\label{lesson:MW-W06-uu-matra}
+
+
+
+\begin{quote}
+Write \textbf{\mw{कांई}}, then write \textbf{\mw{म्हारो}} and point to the virāma. Say \emph{hū̃ ṭhīk hū̃}, then write known \textbf{\mw{ह}} once.
+\end{quote}
+
+\subsection*{Script — one vowel mark}
+\begin{quote}
+\textbf{\mw{ू}}
+\end{quote}
+
+This is the dependent long-\emph{ū} sign. It hangs below and to the right of a consonant. Add it to known \textbf{\mw{ह}}: \textbf{\mw{ह} + \mw{ू} = \mw{हू}}. Hold the vowel for one beat longer than a short \emph{u}.
+
+\subsection*{Your turn}
+Keep \textbf{\mw{ू}} visible. Finger-trace the mark once, copy it once, then add it to \textbf{\mw{ह}} twice. Say \emph{hū} after the hand stops.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Cover the model and write \textbf{\mw{हू}} once.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[ṭha]{\mw{ठ} — curl back, then release breath}
+
+\label{lesson:MW-W06-ttha}
+
+
+
+\begin{quote}
+Write \textbf{\mw{रो}} and point to \textbf{\mw{ो}}. Write \textbf{\mw{हू}}, then say the middle sound group \emph{ṭhīk} without spelling it.
+\end{quote}
+
+\subsection*{Script — one consonant}
+\begin{quote}
+\textbf{\mw{ठ}}
+\end{quote}
+
+Read \textbf{\mw{ठ}} as \emph{ṭha}. Curl the tongue tip back, release it, and let a small breath follow. Keep it distinct from dental \textbf{\mw{थ}}, which your hand already knows.
+
+\subsection*{Your turn}
+Keep \textbf{\mw{ठ}} visible. Finger-trace once, copy once, then alternate \textbf{\mw{ठ} | \mw{थ}} while saying \emph{ṭha | tha}.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Cover the model and write \textbf{\mw{ठ}} once.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[hū̃ ṭhīk hū̃.]{\mw{हूं} \mw{ठीक} \mw{हूं}. — two new signs complete the answer}
+
+\label{lesson:MW-C06-answer}
+
+
+
+\begin{quote}
+Write \textbf{\mw{म्हारो}} from memory. Say \emph{hū̃ ṭhīk hū̃}, write \textbf{\mw{ू}}, and write \textbf{\mw{ठ}}.
+\end{quote}
+
+\subsection*{Script — build three heard groups}
+\begin{quote}
+\textbf{\mw{हूं} | \mw{ठीक} | \mw{हूं}.}
+\end{quote}
+
+Build \textbf{\mw{हूं}} as \textbf{\mw{ह} + \mw{ू} + \mw{ं}}. Build \textbf{\mw{ठीक}} as \textbf{\mw{ठ} + \mw{ी} + \mw{क}}. Every sign except the two from the last lessons was already secure. The repeated first and last group make the line easier to hold in memory.
+
+\subsection*{Your turn}
+1. Read \textbf{\mw{हूं} | \mw{ठीक} | \mw{हूं}} once. 2. Cover it for ten seconds. 3. Write all three groups, then say the answer.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read the answer once from your own handwriting.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}
+\section[Practice]{Practice — ask how someone is and answer}
+
+\label{lesson:MW-C06-practice}
+
+
+
+\begin{quote}
+Ask and answer one name. Then change the topic: ask how the other person is.
+\end{quote}
+
+\subsection*{The exchange}
+\begin{quote}
+\textbf{\mw{आप} \mw{कैसो} \mw{हो}?}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\mw{हूं} \mw{ठीक} \mw{हूं}.}
+\end{quote}
+
+The first line is polite/formal. The reply reports being fine. Other regions and relationships may choose another pronoun or question form; this chapter assesses the source-attested pair it has taught.
+
+\subsection*{Your turn}
+1. \textbf{Listen:} hear one line and identify question or answer. 2. \textbf{Speak:} hear the question and answer without notes. 3. \textbf{Read:} match the printed question to its answer. 4. \textbf{Write:} hear the answer, wait ten seconds, and write it with no model.
+
+Score all four separately. A correct reading does not replace missing writing; a correct written line does not replace the spoken reply.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Stop after one accurate exchange. Speed can wait.
+
+Sources: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2} and \href{https://nepal.sil.org/resources/archives/63768}{SIL International, \emph{Marwari–English Dictionary} archive}.
+\end{tcolorbox}

--- a/code/learning/human-languages/marwadi/chapters.json
+++ b/code/learning/human-languages/marwadi/chapters.json
@@ -131,6 +131,47 @@
           "MW-DIALOGUE-NAME-EXCHANGE-01"
         ]
       }
+    },
+    {
+      "chapter": 7,
+      "title": "Kaiso Ho: Ask How Someone Is",
+      "label": "ch:mw-wellbeing-question",
+      "canDo": "I can recognise, say, read, and write the polite wellbeing question आप कैसो हो?.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "MW-C06-question",
+        "kind": "question",
+        "summary": "A source-attested formal wellbeing question heard first and then written entirely with signs from earlier chapters.",
+        "assesses": [
+          "MW-LEX-AAP-01",
+          "MW-LEX-KAISO-01",
+          "MW-QUESTION-WELLBEING-HEARD-01",
+          "MW-SCRIPT-WELLBEING-QUESTION-01"
+        ]
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Thik Hoon: Answer in Two New Signs",
+      "label": "ch:mw-wellbeing-answer",
+      "canDo": "I can answer हूं ठीक हूं, then complete a polite wellbeing exchange in separately scored listening, speaking, reading, and writing tasks.",
+      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "payoff": {
+        "lesson": "MW-C06-practice",
+        "kind": "dialogue",
+        "summary": "A source-attested wellbeing answer whose only new written shapes are isolated before the complete four-skill exchange.",
+        "assesses": [
+          "MW-LEX-HOON-01",
+          "MW-LEX-THIK-01",
+          "MW-ANSWER-WELLBEING-HEARD-01",
+          "MW-SCRIPT-UU-MATRA-01",
+          "MW-SCRIPT-TTHA-01",
+          "MW-SCRIPT-HOON-01",
+          "MW-SCRIPT-THIK-01",
+          "MW-ANSWER-WELLBEING-01",
+          "MW-DIALOGUE-WELLBEING-01"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/curriculum.json
+++ b/code/learning/human-languages/marwadi/curriculum.json
@@ -41,6 +41,14 @@
       "before": [],
       "inline": ["MW-EXT-009-HEAR-MHARO", "MW-EXT-010-WRITE-MHARO", "MW-EXT-011-NAME-ANSWER", "MW-EXT-012-HEAR-THARO", "MW-EXT-013-WRITE-NAME-QUESTION", "MW-EXT-014-EXCHANGE-NAMES"],
       "after": []
+    },
+    {
+      "id": "MW-PATH-006",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": ["MW-C06-hear-question", "MW-C06-question", "MW-C06-hear-answer", "MW-W06-uu-matra", "MW-W06-ttha", "MW-C06-answer", "MW-C06-practice"],
+      "before": [],
+      "inline": ["MW-EXT-015-HEAR-WELLBEING-QUESTION", "MW-EXT-016-WRITE-WELLBEING-QUESTION", "MW-EXT-017-BUILD-WELLBEING-ANSWER", "MW-EXT-018-WELLBEING-EXCHANGE"],
+      "after": []
     }
   ],
   "spine": {
@@ -48,7 +56,7 @@
     "SPINE-COURTESY-THANK": { "segments": ["MW-PATH-002"], "omits": ["COURTESY-THANKS-CASUAL", "COURTESY-YOUREWELCOME"], "relocates": {} },
     "SPINE-RESPOND-BASIC": { "segments": ["MW-PATH-003"], "omits": ["RESPONSE-NO", "RESPONSE-YESNO", "RESPONSE-OKAY"], "relocates": {} },
     "SPINE-EXCHANGE-NAMES": { "segments": ["MW-PATH-005"], "omits": ["PRONOUN-I", "PRONOUN-ME", "PRONOUN-YOU", "WORD-IS", "INTRO-WHATS-YOUR-NAME", "INTRO-NICE-TO-MEET-YOU"], "relocates": {} },
-    "SPINE-CHECK-WELLBEING": { "segments": [], "omits": ["QUESTION-HOW", "STATE-HOW-ARE-YOU", "WORD-GOOD", "WORD-WELL", "WORD-SOSO"], "relocates": {} },
+    "SPINE-CHECK-WELLBEING": { "segments": ["MW-PATH-006"], "omits": ["QUESTION-HOW", "WORD-GOOD", "WORD-SOSO"], "relocates": {} },
     "SPINE-POLITE-REQUEST-REPAIR": { "segments": ["MW-PATH-004"], "omits": ["COURTESY-PLEASE", "COURTESY-SORRY"], "relocates": {} },
     "SPINE-TAKE-LEAVE": { "segments": [], "omits": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"], "relocates": {} },
     "SPINE-TIME-OF-DAY": { "segments": [], "omits": ["TIME-DAY", "TIME-MORNING", "TIME-AFTERNOON", "TIME-EVENING", "TIME-NIGHT", "GREETING-DAY", "GREETING-MORNING", "GREETING-AFTERNOON", "GREETING-EVENING"], "relocates": {} },
@@ -204,6 +212,42 @@
       "canDo": "I can ask what another person's name is and answer with a chosen name in listening, speaking, reading, and independent writing tasks.",
       "prerequisites": ["MW-EXT-013-WRITE-NAME-QUESTION"],
       "lessons": ["MW-C05-practice"]
+    },
+    {
+      "id": "MW-EXT-015-HEAR-WELLBEING-QUESTION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "vocabulary",
+      "canDo": "I can recognise āp kaiso ho? by ear as a polite question about wellbeing and say its three sound groups.",
+      "prerequisites": ["MW-EXT-014-EXCHANGE-NAMES"],
+      "lessons": ["MW-C06-hear-question"]
+    },
+    {
+      "id": "MW-EXT-016-WRITE-WELLBEING-QUESTION",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can read and write आप कैसो हो? by reusing only signs taught in earlier chapters.",
+      "prerequisites": ["MW-EXT-015-HEAR-WELLBEING-QUESTION"],
+      "lessons": ["MW-C06-question"]
+    },
+    {
+      "id": "MW-EXT-017-BUILD-WELLBEING-ANSWER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can hear hū̃ ṭhīk hū̃, isolate ू and ठ, and write हूं ठीक हूं after a short delay.",
+      "prerequisites": ["MW-EXT-016-WRITE-WELLBEING-QUESTION"],
+      "lessons": ["MW-C06-hear-answer", "MW-W06-uu-matra", "MW-W06-ttha", "MW-C06-answer"]
+    },
+    {
+      "id": "MW-EXT-018-WELLBEING-EXCHANGE",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can ask how a person is and answer that I am fine in independently scored listening, speaking, reading, and writing tasks.",
+      "prerequisites": ["MW-EXT-017-BUILD-WELLBEING-ANSWER"],
+      "lessons": ["MW-C06-practice"]
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/lessons/MW-C06-answer.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C06-answer.md
@@ -1,0 +1,63 @@
+---
+schema_version: 2
+id: MW-C06-answer
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 460
+chapter: 8
+type: phrase
+headword: हूं ठीक हूं.
+romanization: hū̃ ṭhīk hū̃.
+gloss: I am fine.
+concept_tag: WORD-WELL
+prerequisites: [MW-W06-ttha]
+sounds: [long-uu, nasal-vowel, retroflex-tth, long-ii]
+roots: []
+etymology_hook: The sound-first answer now needs only two newly isolated signs.
+duration:
+  max_seconds: 190
+requires:
+  knowledge: [MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01]
+introduces:
+  knowledge: [MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01]
+practises:
+  knowledge: [MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-MHARO-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C06-hear-question, MW-C06-hear-answer, MW-W06-uu-matra, MW-W06-ttha]
+---
+
+# हूं ठीक हूं. — two new signs complete the answer
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-MHARO-01] -->
+
+[PAUSE 15s] Write **म्हारो** from memory. Say *hū̃ ṭhīk hū̃*, write **ू**, and
+write **ठ**.
+
+## Script — build three heard groups
+<!-- hl-knowledge: introduces=[MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01]; assesses=[MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01] -->
+
+> **हूं | ठीक | हूं.**
+
+Build **हूं** as **ह + ू + ं**. Build **ठीक** as **ठ + ी + क**. Every sign except
+the two from the last lessons was already secure. The repeated first and last
+group make the line easier to hold in memory.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01, MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01] -->
+<!-- hl-writing-stage: delayed-copy -->
+
+1. Read **हूं | ठीक | हूं** once.
+2. Cover it for ten seconds.
+3. Write all three groups, then say the answer.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01] -->
+<!-- hl-activity: {"id":"MW-C06-answer-write","kind":"text","assesses":["MW-SCRIPT-HOON-01","MW-SCRIPT-THIK-01","MW-ANSWER-WELLBEING-01"],"prompt":"From the sound hū̃ ṭhīk hū̃, write I am fine.","answer":"हूं ठीक हूं.","accepted":["हूं ठीक हूं","हूं ठीक हूं।"],"feedback":{"correct":"The repeated हूं holds the answer together.","incorrect":"Rebuild three groups: हूं | ठीक | हूं."},"response_seconds":20} -->
+
+Read the answer once from your own handwriting.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-C06-hear-answer.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C06-hear-answer.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-C06-hear-answer
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 430
+chapter: 8
+type: listening-speaking
+headword: "hū̃ ṭhīk hū̃"
+romanization: hū̃ ṭhīk hū̃
+gloss: I am fine
+concept_tag: WORD-WELL
+prerequisites: [MW-C06-question]
+sounds: [long-uu, nasal-vowel, retroflex-tth, long-ii]
+roots: []
+etymology_hook: Secure the answer by ear before two unfamiliar written shapes appear.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-SCRIPT-WELLBEING-QUESTION-01]
+introduces:
+  knowledge: [MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01]
+practises:
+  knowledge: [MW-SCRIPT-WELLBEING-QUESTION-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-II-INDEPENDENT-01, MW-LEX-MHARO-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01]
+skills: [listening, speaking]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C06-question, MW-C06-hear-question]
+---
+
+# Hear *hū̃ ṭhīk hū̃* — I am fine
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-WELLBEING-QUESTION-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-II-INDEPENDENT-01, MW-LEX-MHARO-01] -->
+
+[PAUSE 12s] Write independent **ई**, say that *mhāro* means **my**, then ask
+*āp kaiso ho?* once from memory. Keep the page closed.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01]; assesses=[] -->
+
+> *hū̃ ṭhīk hū̃* — **I am fine**
+
+Hear three groups: *hū̃ | ṭhīk | hū̃*. The first and last groups match. Hold the
+*ū* and let the ending nasal colour it; do not add a separate final syllable.
+The middle begins with a curled-back, breathed *ṭh*. Say the line once. Its two
+unfamiliar written shapes come later.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01] -->
+
+Hear the question, then answer *hū̃ ṭhīk hū̃*. Switch roles once. Keep this an
+ear-and-voice exercise.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01] -->
+<!-- hl-activity: {"id":"MW-C06-hear-answer-meaning","kind":"text","assesses":["MW-ANSWER-WELLBEING-HEARD-01"],"prompt":"You hear hū̃ ṭhīk hū̃. What does the speaker report?","answer":"I am fine.","accepted":["I am well","I'm fine","I'm well"],"feedback":{"correct":"Right: the speaker says they are fine.","incorrect":"The answer means I am fine."},"response_seconds":8} -->
+
+Say the answer once without looking at any spelling.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-C06-hear-question.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C06-hear-question.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-C06-hear-question
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 410
+chapter: 7
+type: listening-speaking
+headword: "āp kaiso ho?"
+romanization: āp kaiso ho?
+gloss: how are you? (polite/formal)
+concept_tag: QUESTION-HOW
+prerequisites: [MW-C05-practice]
+sounds: [long-aa, open-ai, long-o]
+roots: []
+etymology_hook: Learn the social job first; the complete spelling uses only signs your hand already knows.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-DIALOGUE-NAME-EXCHANGE-01]
+introduces:
+  knowledge: [MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01]
+practises:
+  knowledge: [MW-QUESTION-NAME-01, MW-DIALOGUE-NAME-EXCHANGE-01, MW-SCRIPT-PAANI-01, MW-LEX-KAIN-01, MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01]
+skills: [listening, speaking]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output]
+register: polite-formal
+variety: central-marwari-devanagari
+reviews_of: [MW-C05-practice]
+---
+
+# Hear *āp kaiso ho?* — ask about someone, politely
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-QUESTION-NAME-01, MW-DIALOGUE-NAME-EXCHANGE-01, MW-SCRIPT-PAANI-01, MW-LEX-KAIN-01] -->
+
+[PAUSE 12s] Write **पाणी**, ask the name question once, and answer it once.
+Recall that *kāĩ* asks **what**, then put the page out of sight. The next
+question has a different social job.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01]; assesses=[] -->
+
+> *āp kaiso ho?* — **How are you?**, polite/formal
+
+Hear three groups: *āp | kai-so | ho?* The first addresses the other person
+respectfully; *kaiso* asks how; rising *ho?* keeps the line a question. Listen
+twice, then say the three groups once. Do not spell them yet.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01] -->
+
+Choose the right situation: asking a respected person how they are, or asking
+their name. Say *āp kaiso ho?* only for the first situation.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01] -->
+<!-- hl-activity: {"id":"MW-C06-hear-question-meaning","kind":"text","assesses":["MW-QUESTION-WELLBEING-HEARD-01"],"prompt":"You hear āp kaiso ho? What is the speaker asking?","answer":"How are you?","accepted":["how the other person is","about their wellbeing"],"feedback":{"correct":"Right: it is a polite wellbeing question.","incorrect":"This question asks how the other person is."},"response_seconds":8} -->
+
+Say the three sound groups once, then stop.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-C06-practice.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C06-practice.md
@@ -1,0 +1,69 @@
+---
+schema_version: 2
+id: MW-C06-practice
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 470
+chapter: 8
+type: practice-mix
+headword: आप कैसो हो? — हूं ठीक हूं.
+romanization: āp kaiso ho? — hū̃ ṭhīk hū̃.
+gloss: How are you? I am fine.
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [MW-C06-answer]
+sounds: [long-aa, open-ai, long-o, long-uu, nasal-vowel, retroflex-tth, long-ii]
+roots: []
+etymology_hook: A complete social exchange joins two short lines already secured by ear and hand.
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-WELLBEING-QUESTION-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01]
+introduces:
+  knowledge: [MW-DIALOGUE-WELLBEING-01]
+practises:
+  knowledge: [MW-QUESTION-NAME-01, MW-DIALOGUE-NAME-EXCHANGE-01, MW-LEX-NAAM-01, MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-WELLBEING-QUESTION-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01, MW-DIALOGUE-WELLBEING-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: polite-formal
+variety: central-marwari-devanagari
+reviews_of: [MW-C05-practice, MW-C06-hear-question, MW-C06-question, MW-C06-hear-answer, MW-C06-answer]
+---
+
+# Practice — ask how someone is and answer
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-QUESTION-NAME-01, MW-DIALOGUE-NAME-EXCHANGE-01, MW-LEX-NAAM-01] -->
+
+[PAUSE 15s] Ask and answer one name. Then change the topic: ask how the other
+person is.
+
+## The exchange
+<!-- hl-knowledge: introduces=[MW-DIALOGUE-WELLBEING-01]; assesses=[MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-WELLBEING-QUESTION-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01] -->
+
+> **आप कैसो हो?**
+>
+> **हूं ठीक हूं.**
+
+The first line is polite/formal. The reply reports being fine. Other regions
+and relationships may choose another pronoun or question form; this chapter
+assesses the source-attested pair it has taught.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-WELLBEING-QUESTION-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01, MW-DIALOGUE-WELLBEING-01] -->
+
+1. **Listen:** hear one line and identify question or answer.
+2. **Speak:** hear the question and answer without notes.
+3. **Read:** match the printed question to its answer.
+4. **Write:** hear the answer, wait ten seconds, and write it with no model.
+
+Score all four separately. A correct reading does not replace missing writing;
+a correct written line does not replace the spoken reply.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-WELLBEING-QUESTION-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-ANSWER-WELLBEING-01, MW-DIALOGUE-WELLBEING-01] -->
+<!-- hl-writing-stage: dictation-transcription -->
+<!-- hl-activity: {"id":"MW-C06-practice-wellbeing","kind":"text","assesses":["MW-SCRIPT-WELLBEING-QUESTION-01","MW-SCRIPT-HOON-01","MW-SCRIPT-THIK-01","MW-ANSWER-WELLBEING-01","MW-DIALOGUE-WELLBEING-01"],"prompt":"From sound alone, write I am fine, then ask the polite wellbeing question aloud.","answer":"हूं ठीक हूं. — आप कैसो हो?","accepted":["हूं ठीक हूं","हूं ठीक हूं।"],"feedback":{"correct":"Writing and speech complete the two roles.","incorrect":"Repair the written answer as हूं | ठीक | हूं, then ask आप कैसो हो? aloud."},"response_seconds":30} -->
+
+Stop after one accurate exchange. Speed can wait.
+
+Sources: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english) and [SIL International, *Marwari–English Dictionary* archive](https://nepal.sil.org/resources/archives/63768).

--- a/code/learning/human-languages/marwadi/lessons/MW-C06-question.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C06-question.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-C06-question
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 420
+chapter: 7
+type: phrase
+headword: आप कैसो हो?
+romanization: āp kaiso ho?
+gloss: how are you? (polite/formal)
+concept_tag: STATE-HOW-ARE-YOU
+prerequisites: [MW-C06-hear-question]
+sounds: [long-aa, open-ai, long-o]
+roots: []
+etymology_hook: The ear already owns the line; writing simply reuses known signs in three groups.
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01]
+introduces:
+  knowledge: [MW-SCRIPT-WELLBEING-QUESTION-01]
+practises:
+  knowledge: [MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-WELLBEING-QUESTION-01, MW-SCRIPT-THARO-01, MW-SCRIPT-KAIN-01, MW-SCRIPT-KA-01, MW-PERFORMANCE-PAANI-FOUR-SKILL-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: polite-formal
+variety: central-marwari-devanagari
+reviews_of: [MW-C06-hear-question, MW-C05-tharo, MW-C05-kain]
+---
+
+# आप कैसो हो? — the question your hand already knows
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-AAP-01, MW-LEX-KAISO-01, MW-QUESTION-WELLBEING-HEARD-01, MW-SCRIPT-KA-01, MW-PERFORMANCE-PAANI-FOUR-SKILL-01] -->
+
+[PAUSE 12s] Write **पाणी** from memory, then write **क**. Hear *āp kaiso ho?*,
+give its meaning, and say the three groups back.
+
+## Script — three known groups
+<!-- hl-knowledge: introduces=[MW-SCRIPT-WELLBEING-QUESTION-01]; assesses=[MW-SCRIPT-THARO-01, MW-SCRIPT-KAIN-01] -->
+
+> **आप | कैसो | हो?**
+
+No new sign appears. Read slowly: **आ + प**, then **क + ै + स + ो**, then
+**ह + ो**. The question mark preserves the rising social cue you heard first.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-WELLBEING-QUESTION-01] -->
+<!-- hl-writing-stage: delayed-copy -->
+
+Read the line once. Cover it for ten seconds, then write the three groups. Open
+the model and repair only the group that changed.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-WELLBEING-QUESTION-01, MW-QUESTION-WELLBEING-HEARD-01] -->
+<!-- hl-activity: {"id":"MW-C06-question-write","kind":"text","assesses":["MW-SCRIPT-WELLBEING-QUESTION-01"],"prompt":"Write the polite question āp kaiso ho? from the sound groups.","answer":"आप कैसो हो?","accepted":["आप कैसो हो"],"feedback":{"correct":"The three known groups make the complete question.","incorrect":"Rebuild one group at a time: आप | कैसो | हो?"},"response_seconds":18} -->
+
+Read what you wrote once. Stop before learning the answer.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-W06-ttha.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W06-ttha.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-W06-ttha
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 450
+delivery: script
+chapter: 8
+type: writing
+headword: ठ
+romanization: ṭha
+gloss: the aspirated retroflex consonant ttha
+prerequisites: [MW-W06-uu-matra]
+sounds: [retroflex-tth]
+roots: []
+etymology_hook: The tongue curls back and releases a small breath; one sign carries that whole onset.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-LEX-THIK-01, MW-SCRIPT-UU-MATRA-01]
+introduces:
+  knowledge: [MW-SCRIPT-TTHA-01]
+practises:
+  knowledge: [MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-O-MATRA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-W06-uu-matra, MW-C06-hear-answer]
+---
+
+# ठ — curl back, then release breath
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-O-MATRA-01] -->
+
+[PAUSE 12s] Write **रो** and point to **ो**. Write **हू**, then say the middle
+sound group *ṭhīk* without spelling it.
+
+## Script — one consonant
+<!-- hl-knowledge: introduces=[MW-SCRIPT-TTHA-01]; assesses=[] -->
+
+> **ठ**
+
+Read **ठ** as *ṭha*. Curl the tongue tip back, release it, and let a small breath
+follow. Keep it distinct from dental **थ**, which your hand already knows.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-TTHA-01] -->
+<!-- hl-writing-stage: observe-trace -->
+
+Keep **ठ** visible. Finger-trace once, copy once, then alternate **ठ | थ** while
+saying *ṭha | tha*.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-TTHA-01, MW-SCRIPT-UU-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W06-ttha-read","kind":"text","assesses":["MW-SCRIPT-TTHA-01"],"prompt":"Read the new curled-back, breathed sign ठ.","answer":"ṭha","accepted":["ttha","ठ"],"feedback":{"correct":"Right: ठ is retroflex ṭha.","incorrect":"Curl the tongue back and release breath: ṭha."},"response_seconds":8} -->
+
+Cover the model and write **ठ** once.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/lessons/MW-W06-uu-matra.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W06-uu-matra.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-W06-uu-matra
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 440
+delivery: script
+chapter: 8
+type: writing
+headword: ू
+romanization: ū
+gloss: the dependent long-u vowel sign
+prerequisites: [MW-C06-hear-answer]
+sounds: [long-uu]
+roots: []
+etymology_hook: One small mark changes a known consonant from ha to hū.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-HA-01]
+introduces:
+  knowledge: [MW-SCRIPT-UU-MATRA-01]
+practises:
+  knowledge: [MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-HA-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-KAIN-01, MW-SCRIPT-VIRAMA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C06-hear-answer, MW-W03-ha]
+---
+
+# ू — hold the vowel below a known sign
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-HOON-01, MW-LEX-THIK-01, MW-ANSWER-WELLBEING-HEARD-01, MW-SCRIPT-HA-01, MW-SCRIPT-KAIN-01, MW-SCRIPT-VIRAMA-01] -->
+
+[PAUSE 15s] Write **कांई**, then write **म्हारो** and point to the virāma. Say
+*hū̃ ṭhīk hū̃*, then write known **ह** once.
+
+## Script — one vowel mark
+<!-- hl-knowledge: introduces=[MW-SCRIPT-UU-MATRA-01]; assesses=[MW-SCRIPT-HA-01] -->
+
+> **ू**
+
+This is the dependent long-*ū* sign. It hangs below and to the right of a
+consonant. Add it to known **ह**: **ह + ू = हू**. Hold the vowel for one beat
+longer than a short *u*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-UU-MATRA-01] -->
+<!-- hl-writing-stage: observe-trace -->
+
+Keep **ू** visible. Finger-trace the mark once, copy it once, then add it to
+**ह** twice. Say *hū* after the hand stops.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-UU-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W06-uu-matra-build","kind":"text","assesses":["MW-SCRIPT-UU-MATRA-01"],"prompt":"Which vowel sign turns ह into हू?","answer":"ू","accepted":["long u matra","long ū sign"],"feedback":{"correct":"Right: ू hangs below to make हू.","incorrect":"Use the dependent long-ū sign: ू."},"response_seconds":8} -->
+
+Cover the model and write **हू** once.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/narration/ch07.json
+++ b/code/learning/human-languages/marwadi/narration/ch07.json
@@ -1,0 +1,209 @@
+{
+  "version": 1,
+  "language": "marwadi",
+  "chapter": 7,
+  "title": "Kaiso Ho: Ask How Someone Is",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:83bef818d89813aa",
+  "lessons": [
+    {
+      "id": "MW-C06-hear-question",
+      "sequence": 410,
+      "title": "Hear āp kaiso ho? — ask about someone, politely",
+      "headword": "āp kaiso ho?",
+      "romanization": "āp kaiso ho?",
+      "gloss": "how are you? (polite/formal)",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d7af2be142c8d046",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write पाणी, ask the name question once, and answer it once. Recall that kāĩ asks what, then put the page out of sight. The next question has a different social job."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "āp kaiso ho? — How are you?, polite/formal."
+            },
+            {
+              "kind": "speech",
+              "text": "Hear three groups: āp | kai-so | ho? The first addresses the other person respectfully; kaiso asks how; rising ho? keeps the line a question. Listen twice, then say the three groups once. Do not spell them yet."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Choose the right situation: asking a respected person how they are, or asking their name. Say āp kaiso ho? only for the first situation."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say the three sound groups once, then stop."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C06-hear-question-meaning",
+              "prompt": "You hear āp kaiso ho? What is the speaker asking?",
+              "assesses": [
+                "MW-QUESTION-WELLBEING-HEARD-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "how are you?",
+                "how the other person is",
+                "about their wellbeing"
+              ],
+              "feedback": {
+                "correct": "Right: it is a polite wellbeing question.",
+                "incorrect": "This question asks how the other person is."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C06-question",
+      "sequence": 420,
+      "title": "आप कैसो हो? (āp kaiso ho?) — the question your hand already knows",
+      "headword": "आप कैसो हो?",
+      "romanization": "āp kaiso ho?",
+      "gloss": "how are you? (polite/formal)",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:bf295d3bc8fa0fd7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — three known groups"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — three known groups until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write पाणी from memory, then write क. Hear āp kaiso ho?, give its meaning, and say the three groups back."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — three known groups",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आप | कैसो | हो?"
+            },
+            {
+              "kind": "speech",
+              "text": "No new sign appears. Read slowly: आ + प, then क + ै + स + ो, then ह + ो. The question mark preserves the rising social cue you heard first."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read the line once. Cover it for ten seconds, then write the three groups. Open the model and repair only the group that changed."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read what you wrote once. Stop before learning the answer."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C06-question-write",
+              "prompt": "Write the polite question āp kaiso ho? from the sound groups.",
+              "assesses": [
+                "MW-SCRIPT-WELLBEING-QUESTION-01"
+              ],
+              "responseSeconds": 18,
+              "acceptedResponses": [
+                "आप कैसो हो?",
+                "आप कैसो हो"
+              ],
+              "feedback": {
+                "correct": "The three known groups make the complete question.",
+                "incorrect": "Rebuild one group at a time: आप | कैसो | हो?"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/marwadi/narration/ch07.txt
+++ b/code/learning/human-languages/marwadi/narration/ch07.txt
@@ -1,0 +1,46 @@
+Marwadi (Marwari), chapter 7: Kaiso Ho: Ask How Someone Is.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 2.
+Hear āp kaiso ho? — ask about someone, politely.
+
+Warm-up.
+[pause 12 seconds]
+Write पाणी, ask the name question once, and answer it once. Recall that kāĩ asks what, then put the page out of sight. The next question has a different social job.
+
+You'll want to know.
+āp kaiso ho? — How are you?, polite/formal.
+Hear three groups: āp | kai-so | ho? The first addresses the other person respectfully; kaiso asks how; rising ho? keeps the line a question. Listen twice, then say the three groups once. Do not spell them yet.
+
+Guided Practice.
+Choose the right situation: asking a respected person how they are, or asking their name. Say āp kaiso ho? only for the first situation.
+
+Wrap-up Recall.
+Say the three sound groups once, then stop.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 8 seconds]
+You hear āp kaiso ho? What is the speaker asking?
+
+
+Lesson 2 of 2.
+आप कैसो हो? (āp kaiso ho?) — the question your hand already knows.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — three known groups until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Write पाणी from memory, then write क. Hear āp kaiso ho?, give its meaning, and say the three groups back.
+
+Script — three known groups.
+आप | कैसो | हो?
+No new sign appears. Read slowly: आ + प, then क + ै + स + ो, then ह + ो. The question mark preserves the rising social cue you heard first.
+
+Guided Practice.
+Read the line once. Cover it for ten seconds, then write the three groups. Open the model and repair only the group that changed.
+
+Wrap-up Recall.
+Read what you wrote once. Stop before learning the answer.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 18 seconds]
+Write the polite question āp kaiso ho? from the sound groups.

--- a/code/learning/human-languages/marwadi/narration/ch08.json
+++ b/code/learning/human-languages/marwadi/narration/ch08.json
@@ -1,0 +1,548 @@
+{
+  "version": 1,
+  "language": "marwadi",
+  "chapter": 8,
+  "title": "Thik Hoon: Answer in Two New Signs",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:662213f5ad3a5b77",
+  "lessons": [
+    {
+      "id": "MW-C06-hear-answer",
+      "sequence": 430,
+      "title": "Hear hū̃ ṭhīk hū̃ — I am fine",
+      "headword": "hū̃ ṭhīk hū̃",
+      "romanization": "hū̃ ṭhīk hū̃",
+      "gloss": "I am fine",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a926370a2742eae6",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write independent ई, say that mhāro means my, then ask āp kaiso ho? once from memory. Keep the page closed."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "hū̃ ṭhīk hū̃ — I am fine."
+            },
+            {
+              "kind": "speech",
+              "text": "Hear three groups: hū̃ | ṭhīk | hū̃. The first and last groups match. Hold the ū and let the ending nasal colour it; do not add a separate final syllable. The middle begins with a curled-back, breathed ṭh. Say the line once. Its two unfamiliar written shapes come later."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hear the question, then answer hū̃ ṭhīk hū̃. Switch roles once. Keep this an ear-and-voice exercise."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say the answer once without looking at any spelling."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C06-hear-answer-meaning",
+              "prompt": "You hear hū̃ ṭhīk hū̃. What does the speaker report?",
+              "assesses": [
+                "MW-ANSWER-WELLBEING-HEARD-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "i am fine.",
+                "i am well",
+                "i'm fine",
+                "i'm well"
+              ],
+              "feedback": {
+                "correct": "Right: the speaker says they are fine.",
+                "incorrect": "The answer means I am fine."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W06-uu-matra",
+      "sequence": 440,
+      "title": "ू (ū) — hold the vowel below a known sign",
+      "headword": "ू",
+      "romanization": "ū",
+      "gloss": "the dependent long-u vowel sign",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5f227ede862c08b7",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one vowel mark"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write कांई, then write म्हारो and point to the virāma. Say hū̃ ṭhīk hū̃, then write known ह once."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one vowel mark",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ू (ū)."
+            },
+            {
+              "kind": "speech",
+              "text": "This is the dependent long-ū sign. It hangs below and to the right of a consonant. Add it to known ह: ह + ू = हू. Hold the vowel for one beat longer than a short u."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Keep ू visible. Finger-trace the mark once, copy it once, then add it to ह twice. Say hū after the hand stops."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the model and write हू once."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W06-uu-matra-build",
+              "prompt": "Which vowel sign turns ह into हू?",
+              "assesses": [
+                "MW-SCRIPT-UU-MATRA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "ू",
+                "long u matra",
+                "long ū sign"
+              ],
+              "feedback": {
+                "correct": "Right: ू hangs below to make हू.",
+                "incorrect": "Use the dependent long-ū sign: ू."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W06-ttha",
+      "sequence": 450,
+      "title": "ठ (ṭha) — curl back, then release breath",
+      "headword": "ठ",
+      "romanization": "ṭha",
+      "gloss": "the aspirated retroflex consonant ttha",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:10746a44f9d36211",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one consonant"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one consonant until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write रो and point to ो. Write हू, then say the middle sound group ṭhīk without spelling it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one consonant",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ठ (ṭha)."
+            },
+            {
+              "kind": "speech",
+              "text": "Read ठ as ṭha. Curl the tongue tip back, release it, and let a small breath follow. Keep it distinct from dental थ, which your hand already knows."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Keep ठ visible. Finger-trace once, copy once, then alternate ठ | थ while saying ṭha | tha."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the model and write ठ (ṭha) once."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W06-ttha-read",
+              "prompt": "Read the new curled-back, breathed sign ठ (ṭha).",
+              "assesses": [
+                "MW-SCRIPT-TTHA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "ṭha",
+                "ttha",
+                "ठ"
+              ],
+              "feedback": {
+                "correct": "Right: ठ is retroflex ṭha.",
+                "incorrect": "Curl the tongue back and release breath: ṭha."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C06-answer",
+      "sequence": 460,
+      "title": "हूं ठीक हूं. (hū̃ ṭhīk hū̃.) — two new signs complete the answer",
+      "headword": "हूं ठीक हूं.",
+      "romanization": "hū̃ ṭhīk hū̃.",
+      "gloss": "I am fine.",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:6df3a77f362e3fb2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — build three heard groups"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — build three heard groups until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write म्हारो from memory. Say hū̃ ṭhīk hū̃, write ू, and write ठ (ṭha)."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — build three heard groups",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "हूं | ठीक | हूं."
+            },
+            {
+              "kind": "speech",
+              "text": "Build हूं as ह + ू (ū) + ं. Build ठीक as ठ (ṭha) + ी + क. Every sign except the two from the last lessons was already secure. The repeated first and last group make the line easier to hold in memory."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read हूं | ठीक | हूं once."
+            },
+            {
+              "kind": "speech",
+              "text": "Cover it for ten seconds."
+            },
+            {
+              "kind": "speech",
+              "text": "Write all three groups, then say the answer."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read the answer once from your own handwriting."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C06-answer-write",
+              "prompt": "From the sound hū̃ ṭhīk hū̃, write I am fine.",
+              "assesses": [
+                "MW-SCRIPT-HOON-01",
+                "MW-SCRIPT-THIK-01",
+                "MW-ANSWER-WELLBEING-01"
+              ],
+              "responseSeconds": 20,
+              "acceptedResponses": [
+                "हूं ठीक हूं.",
+                "हूं ठीक हूं",
+                "हूं ठीक हूं।"
+              ],
+              "feedback": {
+                "correct": "The repeated हूं holds the answer together.",
+                "incorrect": "Rebuild three groups: हूं | ठीक | हूं."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C06-practice",
+      "sequence": 470,
+      "title": "Practice — ask how someone is and answer",
+      "headword": "आप कैसो हो? — हूं ठीक हूं.",
+      "romanization": "āp kaiso ho? — hū̃ ṭhīk hū̃.",
+      "gloss": "How are you? I am fine.",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:920fdc110ecb88f1",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask and answer one name. Then change the topic: ask how the other person is."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "The exchange",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आप कैसो हो? हूं ठीक हूं. (hū̃ ṭhīk hū̃.)"
+            },
+            {
+              "kind": "speech",
+              "text": "The first line is polite/formal. The reply reports being fine. Other regions and relationships may choose another pronoun or question form; this chapter assesses the source-attested pair it has taught."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Listen: hear one line and identify question or answer."
+            },
+            {
+              "kind": "speech",
+              "text": "Speak: hear the question and answer without notes."
+            },
+            {
+              "kind": "speech",
+              "text": "Read: match the printed question to its answer."
+            },
+            {
+              "kind": "speech",
+              "text": "Write: hear the answer, wait ten seconds, and write it with no model."
+            },
+            {
+              "kind": "speech",
+              "text": "Score all four separately. A correct reading does not replace missing writing; a correct written line does not replace the spoken reply."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Stop after one accurate exchange. Speed can wait."
+            },
+            {
+              "kind": "speech",
+              "text": "Sources: Marwari Pathshala, Lesson 2 and SIL International, Marwari–English Dictionary archive."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C06-practice-wellbeing",
+              "prompt": "From sound alone, write I am fine, then ask the polite wellbeing question aloud.",
+              "assesses": [
+                "MW-SCRIPT-WELLBEING-QUESTION-01",
+                "MW-SCRIPT-HOON-01",
+                "MW-SCRIPT-THIK-01",
+                "MW-ANSWER-WELLBEING-01",
+                "MW-DIALOGUE-WELLBEING-01"
+              ],
+              "responseSeconds": 30,
+              "acceptedResponses": [
+                "हूं ठीक हूं. — आप कैसो हो?",
+                "हूं ठीक हूं",
+                "हूं ठीक हूं।"
+              ],
+              "feedback": {
+                "correct": "Writing and speech complete the two roles.",
+                "incorrect": "Repair the written answer as हूं | ठीक | हूं, then ask आप कैसो हो? aloud."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/marwadi/narration/ch08.txt
+++ b/code/learning/human-languages/marwadi/narration/ch08.txt
@@ -1,0 +1,119 @@
+Marwadi (Marwari), chapter 8: Thik Hoon: Answer in Two New Signs.
+5 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 5.
+Hear hū̃ ṭhīk hū̃ — I am fine.
+
+Warm-up.
+[pause 12 seconds]
+Write independent ई, say that mhāro means my, then ask āp kaiso ho? once from memory. Keep the page closed.
+
+You'll want to know.
+hū̃ ṭhīk hū̃ — I am fine.
+Hear three groups: hū̃ | ṭhīk | hū̃. The first and last groups match. Hold the ū and let the ending nasal colour it; do not add a separate final syllable. The middle begins with a curled-back, breathed ṭh. Say the line once. Its two unfamiliar written shapes come later.
+
+Guided Practice.
+Hear the question, then answer hū̃ ṭhīk hū̃. Switch roles once. Keep this an ear-and-voice exercise.
+
+Wrap-up Recall.
+Say the answer once without looking at any spelling.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 8 seconds]
+You hear hū̃ ṭhīk hū̃. What does the speaker report?
+
+
+Lesson 2 of 5.
+ू (ū) — hold the vowel below a known sign.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 15 seconds]
+Write कांई, then write म्हारो and point to the virāma. Say hū̃ ṭhīk hū̃, then write known ह once.
+
+Script — one vowel mark.
+ू (ū).
+This is the dependent long-ū sign. It hangs below and to the right of a consonant. Add it to known ह: ह + ू = हू. Hold the vowel for one beat longer than a short u.
+
+Guided Practice.
+Keep ू visible. Finger-trace the mark once, copy it once, then add it to ह twice. Say hū after the hand stops.
+
+Wrap-up Recall.
+Cover the model and write हू once.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 8 seconds]
+Which vowel sign turns ह into हू?
+
+
+Lesson 3 of 5.
+ठ (ṭha) — curl back, then release breath.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one consonant until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Write रो and point to ो. Write हू, then say the middle sound group ṭhīk without spelling it.
+
+Script — one consonant.
+ठ (ṭha).
+Read ठ as ṭha. Curl the tongue tip back, release it, and let a small breath follow. Keep it distinct from dental थ, which your hand already knows.
+
+Guided Practice.
+Keep ठ visible. Finger-trace once, copy once, then alternate ठ | थ while saying ṭha | tha.
+
+Wrap-up Recall.
+Cover the model and write ठ (ṭha) once.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 8 seconds]
+Read the new curled-back, breathed sign ठ (ṭha).
+
+
+Lesson 4 of 5.
+हूं ठीक हूं. (hū̃ ṭhīk hū̃.) — two new signs complete the answer.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — build three heard groups until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 15 seconds]
+Write म्हारो from memory. Say hū̃ ṭhīk hū̃, write ू, and write ठ (ṭha).
+
+Script — build three heard groups.
+हूं | ठीक | हूं.
+Build हूं as ह + ू (ū) + ं. Build ठीक as ठ (ṭha) + ी + क. Every sign except the two from the last lessons was already secure. The repeated first and last group make the line easier to hold in memory.
+
+Guided Practice.
+Read हूं | ठीक | हूं once.
+Cover it for ten seconds.
+Write all three groups, then say the answer.
+
+Wrap-up Recall.
+Read the answer once from your own handwriting.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 20 seconds]
+From the sound hū̃ ṭhīk hū̃, write I am fine.
+
+
+Lesson 5 of 5.
+Practice — ask how someone is and answer.
+
+Warm-up.
+[pause 15 seconds]
+Ask and answer one name. Then change the topic: ask how the other person is.
+
+The exchange.
+आप कैसो हो? हूं ठीक हूं. (hū̃ ṭhīk hū̃.)
+The first line is polite/formal. The reply reports being fine. Other regions and relationships may choose another pronoun or question form; this chapter assesses the source-attested pair it has taught.
+
+Guided Practice.
+Listen: hear one line and identify question or answer.
+Speak: hear the question and answer without notes.
+Read: match the printed question to its answer.
+Write: hear the answer, wait ten seconds, and write it with no model.
+Score all four separately. A correct reading does not replace missing writing; a correct written line does not replace the spoken reply.
+
+Wrap-up Recall.
+Stop after one accurate exchange. Speed can wait.
+Sources: Marwari Pathshala, Lesson 2 and SIL International, Marwari–English Dictionary archive.
+[question — say your answer, then pause 30 seconds]
+From sound alone, write I am fine, then ask the polite wellbeing question aloud.

--- a/code/learning/human-languages/marwadi/session-map.md
+++ b/code/learning/human-languages/marwadi/session-map.md
@@ -46,6 +46,13 @@ memory demand at a time.
 | S38 | `MW-W05-ii-independent`: **ई** | distinguish independent **ई** from attached **ी** | guided copy of one vowel sign |
 | S39 | `MW-C05-kain`: **कांई** | assemble only known signs and give the meaning | delayed copy of one word |
 | S40 | `MW-C05-practice` | ask and answer one name in four separate skills | question dictation plus spoken answer |
+| S41 | `MW-C06-hear-question` | identify *āp kaiso ho?* as a polite wellbeing question | none; sound and meaning only |
+| S42 | `MW-C06-question` | read **आप कैसो हो?** from known signs | delayed copy of the question |
+| S43 | `MW-C06-hear-answer` | identify *hū̃ ṭhīk hū̃* as I am fine | none; sound and meaning only |
+| S44 | `MW-W06-uu-matra` | add **ू** to known **ह** | observe, trace, copy one vowel mark |
+| S45 | `MW-W06-ttha` | distinguish retroflex **ठ** from dental **थ** | observe, trace, copy one consonant |
+| S46 | `MW-C06-answer` | assemble **हूं | ठीक | हूं** | delayed copy of the answer |
+| S47 | `MW-C06-practice` | ask and answer about wellbeing in four separate skills | answer dictation plus spoken question |
 
 Reviews use expanding spacing: repeat S7 the next day, after three days, after
 one week, and after two weeks. A failed written recall sends the learner back to

--- a/code/learning/human-languages/progress/marwadi.md
+++ b/code/learning/human-languages/progress/marwadi.md
@@ -2,8 +2,8 @@
 
 - Track: [Marwadi (Marwari)](../marwadi/README.md)
 - Family / script: Indo-Aryan / Devanagari
-- Canonical lessons: 40
-- Mapped lessons: 40
-- Book progress: 6 chapters; through Ch. 6; 6 generated
+- Canonical lessons: 47
+- Mapped lessons: 47
+- Book progress: 8 chapters; through Ch. 8; 8 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
@@ -45,13 +45,18 @@ it("pins Marwadi's complete pre-A1 writing ramp", () => {
     "guided-copy",
     "delayed-copy",
     "dictation-transcription",
+    "delayed-copy",
+    "observe-trace",
+    "observe-trace",
+    "delayed-copy",
+    "dictation-transcription",
   ]);
 });
 
 it("pins Marwadi-owned chapters and objective activities", () => {
   const lessons = loadTrackLessons("marwadi");
   expect(new Set(lessons.map((lesson) => Number(lesson.frontmatter.chapter)))).toEqual(
-    new Set([1, 2, 3, 4, 5, 6]),
+    new Set([1, 2, 3, 4, 5, 6, 7, 8]),
   );
   expect(
     lessons
@@ -80,6 +85,11 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-C05-naam-delayed",
     "MW-C05-practice-name-exchange",
     "MW-C05-tharo-contrast",
+    "MW-C06-answer-write",
+    "MW-C06-hear-answer-meaning",
+    "MW-C06-hear-question-meaning",
+    "MW-C06-practice-wellbeing",
+    "MW-C06-question-write",
     "MW-W01-aa-matra-change",
     "MW-W01-ra-read",
     "MW-W01-raam-build",
@@ -99,5 +109,7 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-W05-o-matra-read",
     "MW-W05-tha-read",
     "MW-W05-virama-function",
+    "MW-W06-ttha-read",
+    "MW-W06-uu-matra-build",
   ]);
 });


### PR DESCRIPTION
## Summary
- add seven <=5-minute Marwadi sessions across two deliberately small chapters for the respectful wellbeing exchange
- teach the sound and meaning of `आप कैसो हो?` and `हूं ठीक हूं.` before asking learners to decode and write them
- introduce only two new Devanagari signs (`ू`, `ठ`), then close listening, speaking, reading, and writing in separately scored practice
- close all 11 newly measurable review windows and realize the wellbeing function in the shared pre-A1 spine
- regenerate the standalone book, narration, modality, progress, and gentle-ramp artifacts

## Gentle-ramp evidence
- 47 total Marwadi sessions
- 0 lessons over five minutes
- 0 atom-load or chapter-load spikes
- 0 unexplained script signs or decode violations
- 0 forward references
- 0 reinforcement-window misses
- 0 chapter-payoff findings
- 0 Marwadi gentle-ramp findings overall

## Sources
- [Marwari Pathshala lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english) for the polite/formal question and answer pair
- [SIL Marwari-English Dictionary](https://nepal.sil.org/resources/archives/63768) for Devanagari/Latin orthographic context

## Validation
- `npx vitest run --maxWorkers=1` — 93 files, 957 tests passed before rebase
- post-rebase focused suite — 5 files, 49 tests passed
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`

Closes #12473