### PR TITLE
feat(human-languages): add Japanese farewell ramp

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1678,6 +1678,12 @@
       "scriptSet": "japanese-main"
     },
     {
+      "language": "japanese",
+      "chapter": 8,
+      "output": "japanese/book/chapters/ch08-sayounara.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
       "language": "marwadi",
       "chapter": 1,
       "output": "marwadi/book/chapters/ch01-ram-ram-sa.tex",

--- a/code/learning/human-languages/core/generated-book-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-book-hashes/japanese.json
@@ -95,6 +95,20 @@
         "JA-C01-practice"
       ],
       "tex": "japanese/book/chapters/ch07-doorway-exchange.tex"
+    },
+    {
+      "language": "japanese",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:d64e918691ac117b",
+      "lessonIds": [
+        "JA-C08-hear-sayounara",
+        "JA-W08-yo",
+        "JA-W08-na",
+        "JA-W08-ra",
+        "JA-W08-sayounara-read",
+        "JA-C08-sayounara"
+      ],
+      "tex": "japanese/book/chapters/ch08-sayounara.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-narration-hashes/japanese.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/japanese.json
@@ -131,6 +131,25 @@
       "json": "japanese/narration/ch07.json",
       "textHash": "fnv1a64:1fea9cd630477599",
       "jsonHash": "fnv1a64:7baffa779244b379"
+    },
+    {
+      "language": "japanese",
+      "chapter": 8,
+      "sourceHash": "fnv1a64:bd93a1ad38841025",
+      "lessonIds": [
+        "JA-C08-hear-sayounara",
+        "JA-W08-yo",
+        "JA-W08-na",
+        "JA-W08-ra",
+        "JA-W08-sayounara-read",
+        "JA-C08-sayounara"
+      ],
+      "voiceLessons": 2,
+      "drivablePrefix": 1,
+      "text": "japanese/narration/ch08.txt",
+      "json": "japanese/narration/ch08.json",
+      "textHash": "fnv1a64:c65e512a5bb52fa1",
+      "jsonHash": "fnv1a64:77e64533b06e8b59"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/japanese.json
@@ -1,7 +1,7 @@
 {
   "language": "japanese",
-  "lessonCount": 38,
-  "atomMeasurableLessons": 38,
+  "lessonCount": 44,
+  "atomMeasurableLessons": 44,
   "atomMeasurementBlindLessons": 0,
   "durationViolations": 0,
   "atomLessonSpikes": 0,
@@ -16,7 +16,7 @@
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 0,
-  "atomsTaught": 48,
+  "atomsTaught": 55,
   "atomsNeverRevisited": 1,
   "reinforcementWindowMisses": 0,
   "reinforcementMissesByWindow": {
@@ -26,7 +26,7 @@
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 37,
+  "writingPracticeLessons": 41,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [],

--- a/code/learning/human-languages/core/lesson-modality/japanese.json
+++ b/code/learning/human-languages/core/lesson-modality/japanese.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:a9f7c93c977af41a",
+  "sourceHash": "fnv1a64:7f721a42e52fae8a",
   "summary": {
-    "totalLessons": 38,
-    "voice": 1,
+    "totalLessons": 44,
+    "voice": 3,
     "sight": 8,
-    "pen": 29,
-    "drivableLessons": 1,
-    "drivablePercent": 3,
+    "pen": 33,
+    "drivableLessons": 3,
+    "drivablePercent": 7,
     "trackCount": 1,
-    "chapterCount": 7,
-    "drivablePrefixTotal": 1,
+    "chapterCount": 8,
+    "drivablePrefixTotal": 2,
     "fullyDrivableChapters": 1,
     "unstartableChapters": 6,
     "overriddenLessons": 0,
@@ -26,12 +26,12 @@
   "tracks": [
     {
       "language": "japanese",
-      "lessonCount": 38,
-      "voice": 1,
+      "lessonCount": 44,
+      "voice": 3,
       "sight": 8,
-      "pen": 29,
-      "drivablePercent": 3,
-      "drivablePrefixTotal": 1,
+      "pen": 33,
+      "drivablePercent": 7,
+      "drivablePrefixTotal": 2,
       "modalities": [
         "voice",
         "sight",
@@ -142,6 +142,24 @@
           "drivable": true,
           "drivableLessonIds": [
             "JA-C01-practice"
+          ]
+        },
+        {
+          "chapter": 8,
+          "lessonCount": 6,
+          "voice": 2,
+          "sight": 0,
+          "pen": 4,
+          "modalities": [
+            "voice",
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "JA-W08-yo",
+          "drivable": false,
+          "drivableLessonIds": [
+            "JA-C08-hear-sayounara"
           ]
         }
       ]
@@ -1003,6 +1021,136 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:0e4c71783a8a05b5"
+    },
+    {
+      "id": "JA-C08-hear-sayounara",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 390,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fe8f2516981477bf"
+    },
+    {
+      "id": "JA-W08-yo",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 400,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7adf3796c5f5cfbd",
+      "detachableSegments": [
+        "Script — one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W08-na",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 410,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:f8702b9da343b4be",
+      "detachableSegments": [
+        "Script — one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W08-ra",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 420,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:d24535b05993d433",
+      "detachableSegments": [
+        "Script — one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-W08-sayounara-read",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 430,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4fa49efb9d3a15fc",
+      "detachableSegments": [
+        "Script — join five known signs"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "JA-C08-sayounara",
+      "language": "japanese",
+      "chapter": 8,
+      "sequence": 440,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c45ebbecebac9936"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/japanese/CHANGELOG.md
+++ b/code/learning/human-languages/japanese/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Japanese curriculum track are recorded here.
 
 ## [Unreleased]
 
+### Added — one sound-first farewell (#12475)
+
+- Added six <=5-minute sessions for **さようなら**: sound and social job first,
+  then only the three new signs **よ**, **な**, and **ら**, a sign-by-sign
+  assembly, and a four-skill payoff.
+- Reused known **さ** and **う** instead of reteaching them, while preserving a
+  trace-copy-recall writing ramp for the genuinely new shapes.
+- Realized the shared `FAREWELL` function without pretending this one expression
+  covers every relationship or departure context.
+- Grounded the A1 headword and contextual warning in Japan Foundation Marugoto
+  and Irodori materials.
+
 ### Changed — script closure before decoding (#12471)
 
 - Reordered the 29 existing lessons so every hiragana writing step precedes the

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -19,7 +19,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- thirty-eight short lessons in seven cumulative chapters.\par}
+  {\large Starter edition --- forty-four short lessons in eight cumulative chapters.\par}
   \vspace{2cm}
   {\normalsize
     Copyright \copyright\ Adhithya Rajasekaran. Licensed under
@@ -71,6 +71,7 @@ are used. Nothing else is.
 \input{chapters/ch05-nihongo-kanji}
 \input{chapters/ch06-koohii-katakana}
 \input{chapters/ch07-doorway-exchange}
+\input{chapters/ch08-sayounara}
 
 \backmatter
 
@@ -87,6 +88,10 @@ Word histories follow Wiktionary's Japanese entries for
 \href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{arigatou},
 and
 \href{https://en.wiktionary.org/wiki/\%E3\%82\%B3\%E3\%83\%BC\%E3\%83\%92\%E3\%83\%BC}{\ja{コーヒー}}.
+The farewell chapter follows the Japan Foundation's
+\href{https://words.marugotoweb.jp/search_detail.php?cd=1\&id=435\&lang=en\&lv=A1\&source=cando}{Marugoto A1 vocabulary entry}
+and the context-sensitive Starter treatment in
+\href{https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X_L01_au.pdf}{Irodori lesson 1}.
 The companion Markdown lessons carry the per-lesson citations and are the
 canonical short-practice source for this edition; the chapter that follows is
 generated from them, so the two cannot drift apart.

--- a/code/learning/human-languages/japanese/book/chapter-modalities.tex
+++ b/code/learning/human-languages/japanese/book/chapter-modalities.tex
@@ -76,3 +76,10 @@
     \hlvoicesign{}~\textbf{Hands-free start:} all 1 lesson.%
     \par}\medskip
 }
+
+\expandafter\def\csname hlchaptermodality8\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlpensign{}~\textbf{pen} (4)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 6 lessons.%
+    \par}\medskip
+}

--- a/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 38
+% canonical-activities: 44
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -247,6 +247,44 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 \raggedright
 \hypertarget{review-JA-C01-practice-four-skills}{\textbf{7.1}} \emph{Practice — one daytime exchange, three scripts}\par
 \small From sound alone, write nihongo in its three kanji. Then take B's part in the doorway exchange without notes.
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C08-hear-sayounara-meaning}{\textbf{8.1}} \emph{Hear \emph{sayōnara} — one way to say goodbye}\par
+\small You hear sa-yō-na-ra at a parting. What social job does it do, and how many morae do you tap?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W08-yo-read}{\textbf{8.2}} \emph{\ja{よ} — the second sound gets a shape}\par
+\small Which mora does \ja{よ} write?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W08-na-read}{\textbf{8.3}} \emph{\ja{な} — one sign for \emph{na}}\par
+\small Read \ja{な} as one mora.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W08-ra-write}{\textbf{8.4}} \emph{\ja{ら} — the last new shape}\par
+\small After a five-second delay, write the hiragana for ra.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-W08-sayounara-read-build}{\textbf{8.5}} \emph{\ja{さようなら} — assemble what the hand already knows}\par
+\small From the five heard morae sa | yo | o | na | ra, write the complete word.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C08-sayounara-four-skills}{\textbf{8.6}} \emph{Practice — meet, thank, then part}\par
+\small From sound alone, write the taught farewell, then say it once on five morae for a parting cue.
 \end{minipage}\par\medskip
 
 \chapter*{Answer Key}
@@ -533,4 +571,48 @@ The first response is the canonical display answer. When a question accepts othe
 \hyperlink{review-JA-C01-practice-four-skills}{\textbf{7.1}} \emph{Practice — one daytime exchange, three scripts}\par
 \small \textbf{Answer:} \ja{日本語}; \ja{こんにちは。はい。いいえ。}\par
 \footnotesize \textbf{Also accepted:} \ja{日本語}
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C08-hear-sayounara-meaning}{\textbf{8.1}} \emph{Hear \emph{sayōnara} — one way to say goodbye}\par
+\small \textbf{Answer:} It says goodbye; five morae.\par
+\footnotesize \textbf{Also accepted:} goodbye, five; farewell, five morae; goodbye; 5
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W08-yo-read}{\textbf{8.2}} \emph{\ja{よ} — the second sound gets a shape}\par
+\small \textbf{Answer:} yo\par
+\footnotesize \textbf{Also accepted:} \ja{よ} is yo; yo, one mora
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W08-na-read}{\textbf{8.3}} \emph{\ja{な} — one sign for \emph{na}}\par
+\small \textbf{Answer:} na\par
+\footnotesize \textbf{Also accepted:} \ja{な} is na; na, one mora
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W08-ra-write}{\textbf{8.4}} \emph{\ja{ら} — the last new shape}\par
+\small \textbf{Answer:} \ja{ら}\par
+\footnotesize \textbf{Also accepted:} \ja{ら} ra
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-W08-sayounara-read-build}{\textbf{8.5}} \emph{\ja{さようなら} — assemble what the hand already knows}\par
+\small \textbf{Answer:} \ja{さようなら}\par
+\footnotesize \textbf{Also accepted:} \ja{さようなら。}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C08-sayounara-four-skills}{\textbf{8.6}} \emph{Practice — meet, thank, then part}\par
+\small \textbf{Answer:} \ja{さようなら。}; sa | yo | o | na | ra\par
+\footnotesize \textbf{Also accepted:} \ja{さようなら}; \ja{さようなら。}
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/japanese/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 43
-% canonical-index-entries: 43
+% canonical-index-candidates: 48
+% canonical-index-entries: 48
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -58,6 +58,14 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{no; not at all}\enspace\emph{\ja{いいえ}}\enspace(iie)\par
 \footnotesize explicit focus: script, etymology; \hyperref[ch:ja-two-answers]{Chapter~1, p.~\pageref*{ch:ja-two-answers}}
+\end{minipage}\par\smallskip
+
+\section*{O}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{One Goodbye, Sign by Sign}\par
+\footnotesize chapter topic; \hyperref[ch:ja-sayounara]{Chapter~8, p.~\pageref*{ch:ja-sayounara}}
 \end{minipage}\par\smallskip
 
 \section*{P}
@@ -178,6 +186,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\ja{さようなら} — assemble what the hand already knows}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-sayounara]{Chapter~8, p.~\pageref*{ch:ja-sayounara}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\ja{す} — two strokes, and a vowel you barely hear}\par
 \footnotesize script and writing topic; explicit focus: script, usage and culture; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
 \end{minipage}\par\smallskip
@@ -196,6 +210,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\ja{な} — one sign for \emph{na}}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-sayounara]{Chapter~8, p.~\pageref*{ch:ja-sayounara}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\ja{に} — three strokes, and a shape you half know}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-daytime-greeting]{Chapter~2, p.~\pageref*{ch:ja-daytime-greeting}}
 \end{minipage}\par\smallskip
@@ -210,6 +230,18 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ja{ま} — three strokes, and a loop you have drawn before}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-polite-thanks]{Chapter~4, p.~\pageref*{ch:ja-polite-thanks}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{よ} — the second sound gets a shape}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-sayounara]{Chapter~8, p.~\pageref*{ch:ja-sayounara}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{ら} — the last new shape}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ja-sayounara]{Chapter~8, p.~\pageref*{ch:ja-sayounara}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/japanese/book/chapters/ch08-sayounara.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch08-sayounara.tex
@@ -1,0 +1,184 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d64e918691ac117b
+% canonical-lessons: JA-C08-hear-sayounara, JA-W08-yo, JA-W08-na, JA-W08-ra, JA-W08-sayounara-read, JA-C08-sayounara
+
+\chapter{One Goodbye, Sign by Sign}
+\label{ch:ja-sayounara}
+\hlchaptermodality{8}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can hear and say sayōnara on five morae, write its three new hiragana signs, and read and write the complete farewell independently.}
+
+A context-dependent farewell whose sound and meaning arrive before three separately taught new signs and whose payoff scores all four skills.
+\end{chapteropening}
+
+\section[sayōnara]{Hear \emph{sayōnara} — one way to say goodbye}
+
+\label{lesson:JA-C08-hear-sayounara}
+
+
+
+\begin{quote}
+Write katakana \textbf{\ja{コ}}, give the daytime greeting, then run one doorway exchange aloud. Close the text before the new expression begins.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\emph{sa-yō-na-ra} — \textbf{goodbye}, at a parting
+\end{quote}
+
+Hear five morae: \emph{sa | yo | o | na | ra}. The held \emph{ō} occupies two beats, just as the final long vowel did in \emph{arigatō}. Listen twice. Tap five even beats, then say the expression once. Its writing waits for the next four tiny sessions.
+
+This is \textbf{one} Japanese farewell, not a universal line for every departure. Relationship and situation can call for other expressions; those will receive their own lessons rather than being smuggled into this one.
+
+\subsection*{Your turn}
+Choose the parting cue rather than the meeting cue. Say \emph{sayōnara} on five beats, then stop before trying to spell it.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the five beats once with no writing visible.
+
+Sources: \href{https://words.marugotoweb.jp/search\_detail.php?cd=1\&id=435\&lang=en\&lv=A1\&source=cando}{Japan Foundation Marugoto A1 vocabulary} and \href{https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X\_L01\_au.pdf}{Japan Foundation Irodori Starter lesson 1}.
+\end{tcolorbox}
+\section[yo]{\ja{よ} — the second sound gets a shape}
+
+\label{lesson:JA-W08-yo}
+
+
+
+\begin{quote}
+Read \textbf{\ja{ありがとう}}, then point to \textbf{\ja{ー}} in \textbf{\ja{コーヒー}} and say what it does. Tap \emph{sayōnara} on five beats. Today adds one shape only.
+\end{quote}
+
+\subsection*{Script — one sign}
+\begin{quote}
+\textbf{\ja{よ}} — \emph{yo}
+\end{quote}
+
+Keep the printed sign visible. Notice the short upper mark, then the longer line that falls, turns, and loops at the lower right. Finger-trace the whole route slowly. Say \emph{yo} only after the finger stops.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Trace it:} \textbf{\ja{よ}}, once with the model visible
+  \item \emph{Copy:} \textbf{\ja{よ}}, once beside the model
+  \item \emph{Say it:} \emph{yo}, one mora
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Cover the model, wait five seconds, and write \textbf{\ja{よ}} once.
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
+\end{tcolorbox}
+\section[na]{\ja{な} — one sign for \emph{na}}
+
+\label{lesson:JA-W08-na}
+
+
+
+\begin{quote}
+Write \textbf{\ja{よ}} from memory. Say why \emph{arigatō} once meant “hard to exist,” then point to the dakuten in \textbf{\ja{が}}. One new hiragana sign follows.
+\end{quote}
+
+\subsection*{Script — one sign}
+\begin{quote}
+\textbf{\ja{な}} — \emph{na}
+\end{quote}
+
+Keep \textbf{\ja{な}} visible. Find its compact left side first, then the separate right side with the small crossing mark and low loop. Trace each part without rushing; the two sides must not collapse into one blob.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Copy:} \textbf{\ja{な}}, with the model visible
+  \item \emph{Check:} compact left side; open right side
+  \item \emph{Say it:} \emph{na}, one mora
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Look away, say \emph{na}, and write \textbf{\ja{な}} once.
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
+\end{tcolorbox}
+\section[ra]{\ja{ら} — the last new shape}
+
+\label{lesson:JA-W08-ra}
+
+
+
+\begin{quote}
+Write \textbf{\ja{よ}} and \textbf{\ja{な}} from memory, then write katakana \textbf{\ja{ヒ}} and say why \textbf{\ja{コーヒー}} uses katakana. Do not force the new hiragana into that borrowed-word script.
+\end{quote}
+
+\subsection*{Script — one sign}
+\begin{quote}
+\textbf{\ja{ら}} — \emph{ra}
+\end{quote}
+
+Keep \textbf{\ja{ら}} visible. It begins with a short top mark. The lower stroke starts separately, descends, bends right, and opens rather than closing into a circle. Japanese \emph{r} is a light tongue tap; one careful tap is enough here.
+
+\subsection*{Your turn}
+Look at \textbf{\ja{ら}} for five seconds. Cover it, wait five seconds, and write it once. Uncover only to compare the open lower curve.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read the sign once, then stop.
+
+Source: \href{https://www.unicode.org/charts/PDF/U3040.pdf}{Unicode Hiragana chart}.
+\end{tcolorbox}
+\section[sayōnara]{\ja{さようなら} — assemble what the hand already knows}
+
+\label{lesson:JA-W08-sayounara-read}
+
+
+
+\begin{quote}
+Run the doorway exchange once, write \textbf{\ja{ま}}, then say the farewell on five beats. Write \textbf{\ja{よ}}, \textbf{\ja{な}}, and \textbf{\ja{ら}} separately.
+\end{quote}
+
+\subsection*{Script — join five known signs}
+\begin{quote}
+\textbf{\ja{さ} | \ja{よ} | \ja{う} | \ja{な} | \ja{ら}}
+\end{quote}
+
+>
+
+\begin{quote}
+\emph{sa | yo | o | na | ra}
+\end{quote}
+
+The five signs are all known. \textbf{\ja{さ}} and \textbf{\ja{う}} return from the thank-you chapters; \textbf{\ja{よ}}, \textbf{\ja{な}}, and \textbf{\ja{ら}} are the three new shapes. In this word, \textbf{\ja{よう}} carries the held \emph{yō}: the written \textbf{\ja{う}} owns the extra beat.
+
+\subsection*{Your turn}
+1. Point and read: \textbf{\ja{さ} | \ja{よ} | \ja{う} | \ja{な} | \ja{ら}}. 2. Cover the romanization and read \textbf{\ja{さようなら}}. 3. Cover everything, wait ten seconds, and write the five signs.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Circle \textbf{\ja{う}} and tap the beat it contributes.
+
+Source: \href{https://words.marugotoweb.jp/search\_detail.php?cd=1\&id=435\&lang=en\&lv=A1\&source=cando}{Japan Foundation Marugoto A1 vocabulary}.
+\end{tcolorbox}
+\section[Practice]{Practice — meet, thank, then part}
+
+\label{lesson:JA-C08-sayounara}
+
+
+
+\begin{quote}
+Write \textbf{\ja{す}}, then give the daytime greeting and plain thanks. Those two social jobs are already secure. The new third job is leaving.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\textbf{\ja{さようなら。}}
+\end{quote}
+
+Use this line for the parting situation practised here. Japanese has other exit formulae for other relationships and settings; success means choosing and producing this taught farewell, not claiming that it fits every goodbye.
+
+\subsection*{Your turn}
+1. \textbf{Listen:} hear \emph{konnichiwa} or \emph{sayōnara} and identify meeting or parting. 2. \textbf{Speak:} answer a parting cue with \emph{sayōnara} on five morae. 3. \textbf{Read:} cover the romanization and read \textbf{\ja{さようなら}} sign by sign. 4. \textbf{Write:} hear the word, wait ten seconds, and write all five signs.
+
+Score the four actions separately. A remembered sound cannot cover missing writing, and a copied form cannot cover a missing spoken response.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Stop after one accurate four-skill pass. Speed and alternate farewells come later.
+
+Sources: \href{https://words.marugotoweb.jp/search\_detail.php?cd=1\&id=435\&lang=en\&lv=A1\&source=cando}{Japan Foundation Marugoto A1 vocabulary} and \href{https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X\_L01\_au.pdf}{Japan Foundation Irodori Starter lesson 1}.
+\end{tcolorbox}

--- a/code/learning/human-languages/japanese/chapters.json
+++ b/code/learning/human-languages/japanese/chapters.json
@@ -92,6 +92,19 @@
         "summary": "A six-line doorway exchange using only words and signs already taught in the preceding six chapters.",
         "assesses": ["JA-LEX-KONNICHIWA", "JA-LEX-NIHONGO", "JA-LEX-HAI", "JA-LEX-IIE", "JA-LEX-ARIGATOU-GOZAIMASU", "JA-DIALOGUE-DOORWAY"]
       }
+    },
+    {
+      "chapter": 8,
+      "title": "One Goodbye, Sign by Sign",
+      "label": "ch:ja-sayounara",
+      "canDo": "I can hear and say sayōnara on five morae, write its three new hiragana signs, and read and write the complete farewell independently.",
+      "spineNodes": ["SPINE-TAKE-LEAVE"],
+      "payoff": {
+        "lesson": "JA-C08-sayounara",
+        "kind": "dialogue",
+        "summary": "A context-dependent farewell whose sound and meaning arrive before three separately taught new signs and whose payoff scores all four skills.",
+        "assesses": ["JA-LEX-SAYOUNARA", "JA-SAYOUNARA-HEARD-01", "JA-SCRIPT-YO-01", "JA-SCRIPT-NA-01", "JA-SCRIPT-RA-01", "JA-SCRIPT-SAYOUNARA-READ-01", "JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01"]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/japanese/curriculum.json
+++ b/code/learning/human-languages/japanese/curriculum.json
@@ -125,6 +125,23 @@
         "JA-EXT-007-MIXED-SCRIPT-CONSOLIDATION"
       ],
       "after": []
+    },
+    {
+      "id": "JA-PATH-008",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "JA-C08-hear-sayounara",
+        "JA-W08-yo",
+        "JA-W08-na",
+        "JA-W08-ra",
+        "JA-W08-sayounara-read",
+        "JA-C08-sayounara"
+      ],
+      "before": [],
+      "inline": [
+        "JA-EXT-015-SAYOUNARA-FAREWELL"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -199,7 +216,9 @@
       "relocates": {}
     },
     "SPINE-TAKE-LEAVE": {
-      "segments": [],
+      "segments": [
+        "JA-PATH-008"
+      ],
       "omits": [
         "FAREWELL",
         "FAREWELL-CASUAL",
@@ -699,6 +718,24 @@
         "JA-W06-ko-katakana",
         "JA-W06-long-mark",
         "JA-W06-hi-katakana"
+      ]
+    },
+    {
+      "id": "JA-EXT-015-SAYOUNARA-FAREWELL",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "communication",
+      "canDo": "I can hear and say one context-dependent farewell, write its three new hiragana signs after a gentle trace-copy-recall ramp, and read and write the complete five-sign word independently.",
+      "prerequisites": [
+        "JA-EXT-007-MIXED-SCRIPT-CONSOLIDATION"
+      ],
+      "lessons": [
+        "JA-C08-hear-sayounara",
+        "JA-W08-yo",
+        "JA-W08-na",
+        "JA-W08-ra",
+        "JA-W08-sayounara-read",
+        "JA-C08-sayounara"
       ]
     }
   ]

--- a/code/learning/human-languages/japanese/lessons/JA-C08-hear-sayounara.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C08-hear-sayounara.md
@@ -1,0 +1,65 @@
+---
+schema_version: 2
+id: JA-C08-hear-sayounara
+spine_node: SPINE-TAKE-LEAVE
+sequence: 390
+chapter: 8
+type: listening-speaking
+headword: sayōnara
+romanization: sayōnara
+gloss: goodbye; one farewell used at a parting
+concept_tag: FAREWELL
+prerequisites: [JA-C01-practice]
+sounds: [mora, long-o]
+roots: []
+etymology_hook: Learn the five beats and the social job before the three new signs reach the page.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [JA-DIALOGUE-DOORWAY, JA-SCRIPT-HIRAGANA-MORA, JA-SCRIPT-MORA-LENGTH]
+introduces:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01]
+practises:
+  knowledge: [JA-LEX-KONNICHIWA, JA-DIALOGUE-DOORWAY, JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-KATAKANA-KO-01]
+skills: [listening, speaking]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output]
+register: neutral-context-dependent
+variety: standard-japanese-tokyo
+reviews_of: [JA-C01-practice, JA-C01-konnichiwa]
+---
+
+# Hear *sayōnara* — one way to say goodbye
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-DIALOGUE-DOORWAY, JA-SCRIPT-KATAKANA-KO-01] -->
+
+[PAUSE 10s] Write katakana **コ**, give the daytime greeting, then run one
+doorway exchange aloud. Close the text before the new expression begins.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01]; assesses=[] -->
+
+> *sa-yō-na-ra* — **goodbye**, at a parting
+
+Hear five morae: *sa | yo | o | na | ra*. The held *ō* occupies two beats, just
+as the final long vowel did in *arigatō*. Listen twice. Tap five even beats, then
+say the expression once. Its writing waits for the next four tiny sessions.
+
+This is **one** Japanese farewell, not a universal line for every departure.
+Relationship and situation can call for other expressions; those will receive
+their own lessons rather than being smuggled into this one.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01] -->
+
+Choose the parting cue rather than the meeting cue. Say *sayōnara* on five beats,
+then stop before trying to spell it.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01] -->
+<!-- hl-activity: {"id":"JA-C08-hear-sayounara-meaning","kind":"text","assesses":["JA-LEX-SAYOUNARA","JA-SAYOUNARA-HEARD-01"],"prompt":"You hear sa-yō-na-ra at a parting. What social job does it do, and how many morae do you tap?","answer":"It says goodbye; five morae.","accepted":["goodbye, five","farewell, five morae","goodbye; 5"],"feedback":{"correct":"Right: a farewell on five even morae.","incorrect":"It is one way to say goodbye: sa | yo | o | na | ra, five morae."},"response_seconds":10} -->
+
+Say the five beats once with no writing visible.
+
+Sources: [Japan Foundation Marugoto A1 vocabulary](https://words.marugotoweb.jp/search_detail.php?cd=1&id=435&lang=en&lv=A1&source=cando) and [Japan Foundation Irodori Starter lesson 1](https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X_L01_au.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-C08-sayounara.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C08-sayounara.md
@@ -1,0 +1,66 @@
+---
+schema_version: 2
+id: JA-C08-sayounara
+spine_node: SPINE-TAKE-LEAVE
+sequence: 440
+chapter: 8
+type: practice-mix
+headword: さようなら
+romanization: sayōnara
+gloss: goodbye; one context-dependent farewell
+concept_tag: FAREWELL
+prerequisites: [JA-W08-sayounara-read]
+sounds: [mora, long-o, japanese-r]
+roots: []
+etymology_hook: The sound, social job, and five written signs now meet in one independently scored farewell.
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-SAYOUNARA-READ-01]
+introduces:
+  knowledge: [JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01]
+practises:
+  knowledge: [JA-LEX-KONNICHIWA, JA-LEX-ARIGATOU, JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-SAYOUNARA-READ-01, JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01, JA-SCRIPT-SU-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: neutral-context-dependent
+variety: standard-japanese-tokyo
+reviews_of: [JA-C01-konnichiwa, JA-C01-arigatou, JA-C08-hear-sayounara, JA-W08-sayounara-read]
+---
+
+# Practice — meet, thank, then part
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-KONNICHIWA, JA-LEX-ARIGATOU, JA-SCRIPT-SU-01] -->
+
+[PAUSE 12s] Write **す**, then give the daytime greeting and plain thanks. Those
+two social jobs are already secure. The new third job is leaving.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SAYOUNARA-READ-01] -->
+
+> **さようなら。**
+
+Use this line for the parting situation practised here. Japanese has other exit
+formulae for other relationships and settings; success means choosing and
+producing this taught farewell, not claiming that it fits every goodbye.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-SAYOUNARA-READ-01, JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01] -->
+
+1. **Listen:** hear *konnichiwa* or *sayōnara* and identify meeting or parting.
+2. **Speak:** answer a parting cue with *sayōnara* on five morae.
+3. **Read:** cover the romanization and read **さようなら** sign by sign.
+4. **Write:** hear the word, wait ten seconds, and write all five signs.
+
+Score the four actions separately. A remembered sound cannot cover missing
+writing, and a copied form cannot cover a missing spoken response.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SCRIPT-SAYOUNARA-READ-01, JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01] -->
+<!-- hl-activity: {"id":"JA-C08-sayounara-four-skills","kind":"text","assesses":["JA-LEX-SAYOUNARA","JA-SCRIPT-SAYOUNARA-READ-01","JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01"],"prompt":"From sound alone, write the taught farewell, then say it once on five morae for a parting cue.","answer":"さようなら。; sa | yo | o | na | ra","accepted":["さようなら","さようなら。"],"feedback":{"correct":"Writing and speech both complete the farewell.","incorrect":"Repair the written blocks さ | よ | う | な | ら, then say the five morae."},"response_seconds":30} -->
+
+Stop after one accurate four-skill pass. Speed and alternate farewells come later.
+
+Sources: [Japan Foundation Marugoto A1 vocabulary](https://words.marugotoweb.jp/search_detail.php?cd=1&id=435&lang=en&lv=A1&source=cando) and [Japan Foundation Irodori Starter lesson 1](https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X_L01_au.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-W08-na.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W08-na.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: JA-W08-na
+spine_node: SPINE-TAKE-LEAVE
+sequence: 410
+delivery: script
+chapter: 8
+type: writing
+headword: な
+romanization: na
+gloss: the hiragana sign for the mora na
+prerequisites: [JA-W08-yo]
+sounds: [mora]
+roots: []
+etymology_hook: One new sign secures the fourth beat; the complete word still waits.
+duration:
+  max_seconds: 160
+requires:
+  knowledge: [JA-SAYOUNARA-HEARD-01, JA-SCRIPT-YO-01]
+introduces:
+  knowledge: [JA-SCRIPT-NA-01]
+practises:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SCRIPT-YO-01, JA-SCRIPT-NA-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-ETYMON-ARIGATASHI, JA-SCRIPT-DAKUTEN]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: standard-japanese-tokyo
+reviews_of: [JA-W08-yo, JA-W06-long-mark]
+---
+
+# な — one sign for *na*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SCRIPT-YO-01, JA-SCRIPT-KATAKANA-LONG-MARK-01, JA-ETYMON-ARIGATASHI, JA-SCRIPT-DAKUTEN] -->
+
+[PAUSE 15s] Write **よ** from memory. Say why *arigatō* once meant “hard to
+exist,” then point to the dakuten in **が**. One new hiragana sign follows.
+
+## Script — one sign
+<!-- hl-knowledge: introduces=[JA-SCRIPT-NA-01]; assesses=[] -->
+
+> **な** — *na*
+
+Keep **な** visible. Find its compact left side first, then the separate right
+side with the small crossing mark and low loop. Trace each part without rushing;
+the two sides must not collapse into one blob.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-NA-01] -->
+- [YOU COPY: **な**, with the model visible]
+- [YOU CHECK: compact left side; open right side]
+- [YOU SAY: *na*, one mora]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-NA-01] -->
+<!-- hl-activity: {"id":"JA-W08-na-read","kind":"text","assesses":["JA-SCRIPT-NA-01"],"prompt":"Read な as one mora.","answer":"na","accepted":["な is na","na, one mora"],"feedback":{"correct":"Right: な writes na.","incorrect":"This sign is na."},"response_seconds":8} -->
+
+Look away, say *na*, and write **な** once.
+
+Source: [Unicode Hiragana chart](https://www.unicode.org/charts/PDF/U3040.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-W08-ra.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W08-ra.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: JA-W08-ra
+spine_node: SPINE-TAKE-LEAVE
+sequence: 420
+delivery: script
+chapter: 8
+type: writing
+headword: ら
+romanization: ra
+gloss: the hiragana sign for the mora ra
+prerequisites: [JA-W08-na]
+sounds: [mora, japanese-r]
+roots: []
+etymology_hook: The last new shape completes the sound inventory before any full-word decoding.
+duration:
+  max_seconds: 160
+requires:
+  knowledge: [JA-SAYOUNARA-HEARD-01, JA-SCRIPT-YO-01, JA-SCRIPT-NA-01]
+introduces:
+  knowledge: [JA-SCRIPT-RA-01]
+practises:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SCRIPT-YO-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-KATAKANA-HI-01, JA-SCRIPT-KATAKANA-LOANWORDS]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: standard-japanese-tokyo
+reviews_of: [JA-W08-na, JA-W06-hi-katakana]
+---
+
+# ら — the last new shape
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SCRIPT-YO-01, JA-SCRIPT-NA-01, JA-SCRIPT-KATAKANA-HI-01, JA-SCRIPT-KATAKANA-LOANWORDS] -->
+
+[PAUSE 15s] Write **よ** and **な** from memory, then write katakana **ヒ** and
+say why **コーヒー** uses katakana. Do not force the new hiragana into that
+borrowed-word script.
+
+## Script — one sign
+<!-- hl-knowledge: introduces=[JA-SCRIPT-RA-01]; assesses=[] -->
+
+> **ら** — *ra*
+
+Keep **ら** visible. It begins with a short top mark. The lower stroke starts
+separately, descends, bends right, and opens rather than closing into a circle.
+Japanese *r* is a light tongue tap; one careful tap is enough here.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-RA-01] -->
+Look at **ら** for five seconds. Cover it, wait five seconds, and write it once.
+Uncover only to compare the open lower curve.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-RA-01] -->
+<!-- hl-activity: {"id":"JA-W08-ra-write","kind":"text","assesses":["JA-SCRIPT-RA-01"],"prompt":"After a five-second delay, write the hiragana for ra.","answer":"ら","accepted":["ら ra"],"feedback":{"correct":"Right: the top mark and open lower curve make ら.","incorrect":"Repair one feature at a time: short top mark, then the open lower stroke."},"response_seconds":12} -->
+
+Read the sign once, then stop.
+
+Source: [Unicode Hiragana chart](https://www.unicode.org/charts/PDF/U3040.pdf).

--- a/code/learning/human-languages/japanese/lessons/JA-W08-sayounara-read.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W08-sayounara-read.md
@@ -1,0 +1,64 @@
+---
+schema_version: 2
+id: JA-W08-sayounara-read
+spine_node: SPINE-TAKE-LEAVE
+sequence: 430
+delivery: script
+chapter: 8
+type: writing
+headword: さようなら
+romanization: sayōnara
+gloss: goodbye, assembled from five known hiragana signs
+prerequisites: [JA-W08-ra]
+sounds: [mora, long-o, japanese-r]
+roots: []
+etymology_hook: Five already-owned signs now become one readable word; nothing new is hidden in the join.
+duration:
+  max_seconds: 190
+requires:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01]
+introduces:
+  knowledge: [JA-SCRIPT-SAYOUNARA-READ-01]
+practises:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-SAYOUNARA-READ-01, JA-LEX-KOOHII, JA-DIALOGUE-DOORWAY, JA-SCRIPT-MA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus, meaning-input]
+register: neutral-context-dependent
+variety: standard-japanese-tokyo
+reviews_of: [JA-W08-yo, JA-W08-na, JA-W08-ra, JA-C01-koohii]
+---
+
+# さようなら — assemble what the hand already knows
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-YO-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-LEX-KOOHII, JA-DIALOGUE-DOORWAY, JA-SCRIPT-MA-01] -->
+
+[PAUSE 18s] Run the doorway exchange once, write **ま**, then say the farewell
+on five beats. Write **よ**, **な**, and **ら** separately.
+
+## Script — join five known signs
+<!-- hl-knowledge: introduces=[JA-SCRIPT-SAYOUNARA-READ-01]; assesses=[JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01] -->
+
+> **さ | よ | う | な | ら**
+>
+> *sa | yo | o | na | ra*
+
+The five signs are all known. **さ** and **う** return from the thank-you
+chapters; **よ**, **な**, and **ら** are the three new shapes. In this word,
+**よう** carries the held *yō*: the written **う** owns the extra beat.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SCRIPT-SA-01, JA-SCRIPT-YO-01, JA-SCRIPT-U-01, JA-SCRIPT-NA-01, JA-SCRIPT-RA-01, JA-SCRIPT-SAYOUNARA-READ-01] -->
+
+1. Point and read: **さ | よ | う | な | ら**.
+2. Cover the romanization and read **さようなら**.
+3. Cover everything, wait ten seconds, and write the five signs.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SCRIPT-SAYOUNARA-READ-01] -->
+<!-- hl-activity: {"id":"JA-W08-sayounara-read-build","kind":"text","assesses":["JA-LEX-SAYOUNARA","JA-SCRIPT-SAYOUNARA-READ-01"],"prompt":"From the five heard morae sa | yo | o | na | ra, write the complete word.","answer":"さようなら","accepted":["さようなら。"],"feedback":{"correct":"All five signs are in order, including う for the held vowel.","incorrect":"Repair one known block at a time: さ | よ | う | な | ら."},"response_seconds":20} -->
+
+Circle **う** and tap the beat it contributes.
+
+Source: [Japan Foundation Marugoto A1 vocabulary](https://words.marugotoweb.jp/search_detail.php?cd=1&id=435&lang=en&lv=A1&source=cando).

--- a/code/learning/human-languages/japanese/lessons/JA-W08-yo.md
+++ b/code/learning/human-languages/japanese/lessons/JA-W08-yo.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: JA-W08-yo
+spine_node: SPINE-TAKE-LEAVE
+sequence: 400
+delivery: script
+chapter: 8
+type: writing
+headword: よ
+romanization: yo
+gloss: the hiragana sign for the mora yo
+prerequisites: [JA-C08-hear-sayounara]
+sounds: [mora]
+roots: []
+etymology_hook: The first new shape secures the second beat of a farewell already known by ear.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [JA-SAYOUNARA-HEARD-01]
+introduces:
+  knowledge: [JA-SCRIPT-YO-01]
+practises:
+  knowledge: [JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-YO-01, JA-SCRIPT-SU-01, JA-SCRIPT-CHOUON, JA-SCRIPT-ARIGATOU-READ-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: standard-japanese-tokyo
+reviews_of: [JA-C08-hear-sayounara, JA-W03-su]
+---
+
+# よ — the second sound gets a shape
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[JA-LEX-SAYOUNARA, JA-SAYOUNARA-HEARD-01, JA-SCRIPT-SU-01, JA-SCRIPT-CHOUON, JA-SCRIPT-ARIGATOU-READ-01] -->
+
+[PAUSE 12s] Read **ありがとう**, then point to **ー** in **コーヒー** and say
+what it does. Tap *sayōnara* on five beats. Today adds one shape only.
+
+## Script — one sign
+<!-- hl-knowledge: introduces=[JA-SCRIPT-YO-01]; assesses=[] -->
+
+> **よ** — *yo*
+
+Keep the printed sign visible. Notice the short upper mark, then the longer line
+that falls, turns, and loops at the lower right. Finger-trace the whole route
+slowly. Say *yo* only after the finger stops.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-YO-01] -->
+- [YOU TRACE: **よ**, once with the model visible]
+- [YOU COPY: **よ**, once beside the model]
+- [YOU SAY: *yo*, one mora]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[JA-SCRIPT-YO-01] -->
+<!-- hl-activity: {"id":"JA-W08-yo-read","kind":"text","assesses":["JA-SCRIPT-YO-01"],"prompt":"Which mora does よ write?","answer":"yo","accepted":["よ is yo","yo, one mora"],"feedback":{"correct":"Right: よ writes yo, one mora.","incorrect":"Read this sign as yo."},"response_seconds":8} -->
+
+Cover the model, wait five seconds, and write **よ** once.
+
+Source: [Unicode Hiragana chart](https://www.unicode.org/charts/PDF/U3040.pdf).

--- a/code/learning/human-languages/japanese/narration/ch08.json
+++ b/code/learning/human-languages/japanese/narration/ch08.json
@@ -1,0 +1,705 @@
+{
+  "version": 1,
+  "language": "japanese",
+  "chapter": 8,
+  "title": "One Goodbye, Sign by Sign",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:bd93a1ad38841025",
+  "lessons": [
+    {
+      "id": "JA-C08-hear-sayounara",
+      "sequence": 390,
+      "title": "Hear sayōnara — one way to say goodbye",
+      "headword": "sayōnara",
+      "romanization": "sayōnara",
+      "gloss": "goodbye; one farewell used at a parting",
+      "script": "japanese",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:fe8f2516981477bf",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 10,
+              "perItem": false,
+              "source": "[PAUSE 10s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write katakana コ, give the daytime greeting, then run one doorway exchange aloud. Close the text before the new expression begins."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sa-yō-na-ra — goodbye, at a parting."
+            },
+            {
+              "kind": "speech",
+              "text": "Hear five morae: sa | yo | o | na | ra. The held ō occupies two beats, just as the final long vowel did in arigatō. Listen twice. Tap five even beats, then say the expression once. Its writing waits for the next four tiny sessions."
+            },
+            {
+              "kind": "speech",
+              "text": "This is one Japanese farewell, not a universal line for every departure. Relationship and situation can call for other expressions; those will receive their own lessons rather than being smuggled into this one."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Choose the parting cue rather than the meeting cue. Say sayōnara on five beats, then stop before trying to spell it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say the five beats once with no writing visible."
+            },
+            {
+              "kind": "speech",
+              "text": "Sources: Japan Foundation Marugoto A1 vocabulary and Japan Foundation Irodori Starter lesson 1."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C08-hear-sayounara-meaning",
+              "prompt": "You hear sa-yō-na-ra at a parting. What social job does it do, and how many morae do you tap?",
+              "assesses": [
+                "JA-LEX-SAYOUNARA",
+                "JA-SAYOUNARA-HEARD-01"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "it says goodbye; five morae.",
+                "goodbye, five",
+                "farewell, five morae",
+                "goodbye; 5"
+              ],
+              "feedback": {
+                "correct": "Right: a farewell on five even morae.",
+                "incorrect": "It is one way to say goodbye: sa | yo | o | na | ra, five morae."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W08-yo",
+      "sequence": 400,
+      "title": "よ (yo) — the second sound gets a shape",
+      "headword": "よ",
+      "romanization": "yo",
+      "gloss": "the hiragana sign for the mora yo",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7adf3796c5f5cfbd",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one sign",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — one sign and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ありがとう, then point to ー in コーヒー and say what it does. Tap sayōnara on five beats. Today adds one shape only."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "よ — yo."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep the printed sign visible. Notice the short upper mark, then the longer line that falls, turns, and loops at the lower right. Finger-trace the whole route slowly. Say yo only after the finger stops."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "よ (yo), once with the model visible",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: **よ**, once with the model visible]"
+            },
+            {
+              "kind": "prompt",
+              "action": "COPY",
+              "instruction": "よ (yo), once beside the model",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU COPY: **よ**, once beside the model]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "yo, one mora",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *yo*, one mora]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the model, wait five seconds, and write よ (yo) once."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W08-yo-read",
+              "prompt": "Which mora does よ (yo) write?",
+              "assesses": [
+                "JA-SCRIPT-YO-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "yo",
+                "よ is yo",
+                "yo, one mora"
+              ],
+              "feedback": {
+                "correct": "Right: よ writes yo, one mora.",
+                "incorrect": "Read this sign as yo."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W08-na",
+      "sequence": 410,
+      "title": "な — one sign for na",
+      "headword": "な",
+      "romanization": "na",
+      "gloss": "the hiragana sign for the mora na",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f8702b9da343b4be",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one sign"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write よ (yo) from memory. Say why arigatō once meant “hard to exist,” then point to the dakuten in が. One new hiragana sign follows."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "な — na."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep な (na) visible. Find its compact left side first, then the separate right side with the small crossing mark and low loop. Trace each part without rushing; the two sides must not collapse into one blob."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "prompt",
+              "action": "COPY",
+              "instruction": "な (na), with the model visible",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU COPY: **な**, with the model visible]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CHECK",
+              "instruction": "compact left side; open right side",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CHECK: compact left side; open right side]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "na, one mora",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *na*, one mora]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look away, say na, and write な once."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W08-na-read",
+              "prompt": "Read な (na) as one mora.",
+              "assesses": [
+                "JA-SCRIPT-NA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "na",
+                "な is na",
+                "na, one mora"
+              ],
+              "feedback": {
+                "correct": "Right: な writes na.",
+                "incorrect": "This sign is na."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W08-ra",
+      "sequence": 420,
+      "title": "ら (ra) — the last new shape",
+      "headword": "ら",
+      "romanization": "ra",
+      "gloss": "the hiragana sign for the mora ra",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:d24535b05993d433",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script — one sign"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write よ (yo) and な from memory, then write katakana ヒ and say why コーヒー uses katakana. Do not force the new hiragana into that borrowed-word script."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ら — ra."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep ら visible. It begins with a short top mark. The lower stroke starts separately, descends, bends right, and opens rather than closing into a circle. Japanese r is a light tongue tap; one careful tap is enough here."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look at ら (ra) for five seconds. Cover it, wait five seconds, and write it once. Uncover only to compare the open lower curve."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read the sign once, then stop."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Hiragana chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W08-ra-write",
+              "prompt": "After a five-second delay, write the hiragana for ra.",
+              "assesses": [
+                "JA-SCRIPT-RA-01"
+              ],
+              "responseSeconds": 12,
+              "acceptedResponses": [
+                "ら",
+                "ら ra"
+              ],
+              "feedback": {
+                "correct": "Right: the top mark and open lower curve make ら.",
+                "incorrect": "Repair one feature at a time: short top mark, then the open lower stroke."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-W08-sayounara-read",
+      "sequence": 430,
+      "title": "さようなら (sayōnara) — assemble what the hand already knows",
+      "headword": "さようなら",
+      "romanization": "sayōnara",
+      "gloss": "goodbye, assembled from five known hiragana signs",
+      "script": "japanese",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4fa49efb9d3a15fc",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — join five known signs"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — join five known signs until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 18,
+              "perItem": false,
+              "source": "[PAUSE 18s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Run the doorway exchange once, write ま, then say the farewell on five beats. Write よ (yo), な (na), and ら separately."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — join five known signs",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "さ | よ | う | な | ら sa | yo | o | na | ra."
+            },
+            {
+              "kind": "speech",
+              "text": "The five signs are all known. さ and う return from the thank-you chapters; よ, な (na), and ら are the three new shapes. In this word, よう carries the held yō: the written う owns the extra beat."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Point and read: さ | よ (yo) | う | な (na) | ら (ra)."
+            },
+            {
+              "kind": "speech",
+              "text": "Cover the romanization and read さようなら (sayōnara)."
+            },
+            {
+              "kind": "speech",
+              "text": "Cover everything, wait ten seconds, and write the five signs."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Circle う and tap the beat it contributes."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Japan Foundation Marugoto A1 vocabulary."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-W08-sayounara-read-build",
+              "prompt": "From the five heard morae sa | yo | o | na | ra, write the complete word.",
+              "assesses": [
+                "JA-LEX-SAYOUNARA",
+                "JA-SCRIPT-SAYOUNARA-READ-01"
+              ],
+              "responseSeconds": 20,
+              "acceptedResponses": [
+                "さようなら",
+                "さようなら。"
+              ],
+              "feedback": {
+                "correct": "All five signs are in order, including う for the held vowel.",
+                "incorrect": "Repair one known block at a time: さ | よ | う | な | ら."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JA-C08-sayounara",
+      "sequence": 440,
+      "title": "Practice — meet, thank, then part",
+      "headword": "さようなら",
+      "romanization": "sayōnara",
+      "gloss": "goodbye; one context-dependent farewell",
+      "script": "japanese",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c45ebbecebac9936",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write す, then give the daytime greeting and plain thanks. Those two social jobs are already secure. The new third job is leaving."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "さようなら (sayōnara)。"
+            },
+            {
+              "kind": "speech",
+              "text": "Use this line for the parting situation practised here. Japanese has other exit formulae for other relationships and settings; success means choosing and producing this taught farewell, not claiming that it fits every goodbye."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Listen: hear konnichiwa or sayōnara and identify meeting or parting."
+            },
+            {
+              "kind": "speech",
+              "text": "Speak: answer a parting cue with sayōnara on five morae."
+            },
+            {
+              "kind": "speech",
+              "text": "Read: cover the romanization and read さようなら (sayōnara) sign by sign."
+            },
+            {
+              "kind": "speech",
+              "text": "Write: hear the word, wait ten seconds, and write all five signs."
+            },
+            {
+              "kind": "speech",
+              "text": "Score the four actions separately. A remembered sound cannot cover missing writing, and a copied form cannot cover a missing spoken response."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Stop after one accurate four-skill pass. Speed and alternate farewells come later."
+            },
+            {
+              "kind": "speech",
+              "text": "Sources: Japan Foundation Marugoto A1 vocabulary and Japan Foundation Irodori Starter lesson 1."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "JA-C08-sayounara-four-skills",
+              "prompt": "From sound alone, write the taught farewell, then say it once on five morae for a parting cue.",
+              "assesses": [
+                "JA-LEX-SAYOUNARA",
+                "JA-SCRIPT-SAYOUNARA-READ-01",
+                "JA-PERFORMANCE-SAYOUNARA-FOUR-SKILL-01"
+              ],
+              "responseSeconds": 30,
+              "acceptedResponses": [
+                "さようなら。; sa | yo | o | na | ra",
+                "さようなら",
+                "さようなら。"
+              ],
+              "feedback": {
+                "correct": "Writing and speech both complete the farewell.",
+                "incorrect": "Repair the written blocks さ | よ | う | な | ら, then say the five morae."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/japanese/narration/ch08.txt
+++ b/code/learning/human-languages/japanese/narration/ch08.txt
@@ -1,0 +1,152 @@
+Japanese, chapter 8: One Goodbye, Sign by Sign.
+6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 6.
+Hear sayōnara — one way to say goodbye.
+
+Warm-up.
+[pause 10 seconds]
+Write katakana コ, give the daytime greeting, then run one doorway exchange aloud. Close the text before the new expression begins.
+
+You'll want to know.
+sa-yō-na-ra — goodbye, at a parting.
+Hear five morae: sa | yo | o | na | ra. The held ō occupies two beats, just as the final long vowel did in arigatō. Listen twice. Tap five even beats, then say the expression once. Its writing waits for the next four tiny sessions.
+This is one Japanese farewell, not a universal line for every departure. Relationship and situation can call for other expressions; those will receive their own lessons rather than being smuggled into this one.
+
+Guided Practice.
+Choose the parting cue rather than the meeting cue. Say sayōnara on five beats, then stop before trying to spell it.
+
+Wrap-up Recall.
+Say the five beats once with no writing visible.
+Sources: Japan Foundation Marugoto A1 vocabulary and Japan Foundation Irodori Starter lesson 1.
+[question — say your answer, then pause 10 seconds]
+You hear sa-yō-na-ra at a parting. What social job does it do, and how many morae do you tap?
+
+
+Lesson 2 of 6.
+よ (yo) — the second sound gets a shape.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script — one sign and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Read ありがとう, then point to ー in コーヒー and say what it does. Tap sayōnara on five beats. Today adds one shape only.
+
+Script — one sign.
+よ — yo.
+Keep the printed sign visible. Notice the short upper mark, then the longer line that falls, turns, and loops at the lower right. Finger-trace the whole route slowly. Say yo only after the finger stops.
+
+Guided Practice.
+[once you have stopped driving — trace: よ (yo), once with the model visible]
+[your turn — copy: よ (yo), once beside the model]
+[pause 8 seconds for the answer]
+[your turn — say: yo, one mora]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Cover the model, wait five seconds, and write よ (yo) once.
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 8 seconds]
+Which mora does よ (yo) write?
+
+
+Lesson 3 of 6.
+な — one sign for na.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 15 seconds]
+Write よ (yo) from memory. Say why arigatō once meant “hard to exist,” then point to the dakuten in が. One new hiragana sign follows.
+
+Script — one sign.
+な — na.
+Keep な (na) visible. Find its compact left side first, then the separate right side with the small crossing mark and low loop. Trace each part without rushing; the two sides must not collapse into one blob.
+
+Guided Practice.
+[your turn — copy: な (na), with the model visible]
+[pause 8 seconds for the answer]
+[your turn — check: compact left side; open right side]
+[pause 8 seconds for the answer]
+[your turn — say: na, one mora]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+Look away, say na, and write な once.
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 8 seconds]
+Read な (na) as one mora.
+
+
+Lesson 4 of 6.
+ら (ra) — the last new shape.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 15 seconds]
+Write よ (yo) and な from memory, then write katakana ヒ and say why コーヒー uses katakana. Do not force the new hiragana into that borrowed-word script.
+
+Script — one sign.
+ら — ra.
+Keep ら visible. It begins with a short top mark. The lower stroke starts separately, descends, bends right, and opens rather than closing into a circle. Japanese r is a light tongue tap; one careful tap is enough here.
+
+Guided Practice.
+Look at ら (ra) for five seconds. Cover it, wait five seconds, and write it once. Uncover only to compare the open lower curve.
+
+Wrap-up Recall.
+Read the sign once, then stop.
+Source: Unicode Hiragana chart.
+[question — say your answer, then pause 12 seconds]
+After a five-second delay, write the hiragana for ra.
+
+
+Lesson 5 of 6.
+さようなら (sayōnara) — assemble what the hand already knows.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — join five known signs until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 18 seconds]
+Run the doorway exchange once, write ま, then say the farewell on five beats. Write よ (yo), な (na), and ら separately.
+
+Script — join five known signs.
+さ | よ | う | な | ら sa | yo | o | na | ra.
+The five signs are all known. さ and う return from the thank-you chapters; よ, な (na), and ら are the three new shapes. In this word, よう carries the held yō: the written う owns the extra beat.
+
+Guided Practice.
+Point and read: さ | よ (yo) | う | な (na) | ら (ra).
+Cover the romanization and read さようなら (sayōnara).
+Cover everything, wait ten seconds, and write the five signs.
+
+Wrap-up Recall.
+Circle う and tap the beat it contributes.
+Source: Japan Foundation Marugoto A1 vocabulary.
+[question — say your answer, then pause 20 seconds]
+From the five heard morae sa | yo | o | na | ra, write the complete word.
+
+
+Lesson 6 of 6.
+Practice — meet, thank, then part.
+
+Warm-up.
+[pause 12 seconds]
+Write す, then give the daytime greeting and plain thanks. Those two social jobs are already secure. The new third job is leaving.
+
+You'll want to know.
+さようなら (sayōnara)。
+Use this line for the parting situation practised here. Japanese has other exit formulae for other relationships and settings; success means choosing and producing this taught farewell, not claiming that it fits every goodbye.
+
+Guided Practice.
+Listen: hear konnichiwa or sayōnara and identify meeting or parting.
+Speak: answer a parting cue with sayōnara on five morae.
+Read: cover the romanization and read さようなら (sayōnara) sign by sign.
+Write: hear the word, wait ten seconds, and write all five signs.
+Score the four actions separately. A remembered sound cannot cover missing writing, and a copied form cannot cover a missing spoken response.
+
+Wrap-up Recall.
+Stop after one accurate four-skill pass. Speed and alternate farewells come later.
+Sources: Japan Foundation Marugoto A1 vocabulary and Japan Foundation Irodori Starter lesson 1.
+[question — say your answer, then pause 30 seconds]
+From sound alone, write the taught farewell, then say it once on five morae for a parting cue.

--- a/code/learning/human-languages/japanese/session-map.md
+++ b/code/learning/human-languages/japanese/session-map.md
@@ -51,6 +51,12 @@ given in romanization and postponed.
 | **S36** | 6 | [`JA-W06-hi-katakana`](./lessons/JA-W06-hi-katakana.md) | write katakana **ヒ** |
 | **S37** | 6 | [`JA-C01-koohii`](./lessons/JA-C01-koohii.md) | read **コーヒー** as four morae |
 | **S38** | 7 | [`JA-C01-practice`](./lessons/JA-C01-practice.md) | run the complete doorway exchange |
+| **S39** | 8 | [`JA-C08-hear-sayounara`](./lessons/JA-C08-hear-sayounara.md) | hear and say one farewell before seeing it |
+| **S40** | 8 | [`JA-W08-yo`](./lessons/JA-W08-yo.md) | trace and write **よ** |
+| **S41** | 8 | [`JA-W08-na`](./lessons/JA-W08-na.md) | copy and recall **な** |
+| **S42** | 8 | [`JA-W08-ra`](./lessons/JA-W08-ra.md) | recall and write **ら** |
+| **S43** | 8 | [`JA-W08-sayounara-read`](./lessons/JA-W08-sayounara-read.md) | assemble **さようなら** from known signs |
+| **S44** | 8 | [`JA-C08-sayounara`](./lessons/JA-C08-sayounara.md) | pass the farewell in all four skills |
 
 ## Review rule
 
@@ -63,4 +69,6 @@ new-sign lesson to grow beyond five minutes.
 
 The six chapter payoffs at S6, S13, S21, S26, S33 and S37 are cumulative review
 points. S38 checks listening, speaking, reading and writing separately rather
-than letting recognition stand in for production.
+than letting recognition stand in for production. S39--S44 extend the same rule:
+sound and social meaning first, three new signs one at a time, then a separately
+scored four-skill farewell.

--- a/code/learning/human-languages/progress/japanese.md
+++ b/code/learning/human-languages/progress/japanese.md
@@ -2,8 +2,8 @@
 
 - Track: [Japanese](../japanese/README.md)
 - Family / script: Japonic / Japanese
-- Canonical lessons: 38
-- Mapped lessons: 38
-- Book progress: 7 chapters; through Ch. 7; 7 generated
+- Canonical lessons: 44
+- Mapped lessons: 44
+- Book progress: 8 chapters; through Ch. 8; 8 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -302,14 +302,14 @@ describe("real curriculum", () => {
 
   it("keeps the Japanese script-before-decoding chain closed and under five minutes", () => {
     // Japanese needs three writing systems, but putting all three in Chapter 1 made
-    // the learner decode before the sign lessons. Pin the repaired structure: seven
+    // the learner decode before the sign lessons. Pin the repaired structure: eight
     // small chapters, one objective activity per lesson, and a final mixed-script
     // exchange only after the hiragana, kanji and katakana ramps.
     const report = buildCurriculumGapReport({ registry, lessons, books });
     const japanese = lessons.filter((lesson) => lesson.language === "japanese");
-    expect(japanese).toHaveLength(38);
+    expect(japanese).toHaveLength(44);
     expect(new Set(japanese.map((lesson) => lesson.realization.chapter))).toEqual(
-      new Set([1, 2, 3, 4, 5, 6, 7]),
+      new Set([1, 2, 3, 4, 5, 6, 7, 8]),
     );
     expect(japanese.every((lesson) => lesson.frontmatter.schema_version === "2")).toBe(true);
     expect(japanese.every((lesson) => compileLessonActivities(lesson.blocks).length === 1)).toBe(true);


### PR DESCRIPTION
## Summary
- add six <=5-minute Japanese sessions for **さようなら**: sound and social meaning first, then three individual signs, assembly, and a four-skill payoff
- reuse already-taught **さ** and **う** while introducing only **よ**, **な**, and **ら**
- realize the shared `FAREWELL` function without presenting this context-dependent expression as the only Japanese exit formula
- add learner-visible retrieval for all nine old R2/R3 windows made measurable by the longer runway
- regenerate the standalone book, narration, modality, progress, and gentle-ramp artifacts

## Gentle-ramp evidence
- 44 total Japanese sessions across 8 chapters
- 0 lessons over five minutes
- 0 atom-load or chapter-load spikes
- 0 unexplained script signs or decode violations
- 0 forward references
- 0 reinforcement-window misses
- 0 chapter-payoff findings
- 0 Japanese gentle-ramp findings overall

## Sources
- [Japan Foundation Marugoto A1 vocabulary](https://words.marugotoweb.jp/search_detail.php?cd=1&id=435&lang=en&lv=A1&source=cando) for **さようなら** as an A1 goodbye
- [Japan Foundation Irodori Starter lesson 1](https://www.irodori.jpf.go.jp/assets/data/starter/pdf/X_L01_au.pdf) for the starter goodbye can-do and contextual alternatives

## Validation
- `npx vitest run --maxWorkers=1` — 93 files, 957 tests passed
- post-rebase focused suite — 5 files, 48 tests passed
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`

Closes #12475