### PR TITLE
feat(human-languages): add Marwadi later farewell

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -1732,6 +1732,12 @@
       "scriptSet": "marwadi-main"
     },
     {
+      "language": "marwadi",
+      "chapter": 9,
+      "output": "marwadi/book/chapters/ch09-see-you-later.tex",
+      "scriptSet": "marwadi-main"
+    },
+    {
       "language": "kannada",
       "chapter": 6,
       "output": "kannada/book/chapters/ch06-dative-case.tex",

--- a/code/learning/human-languages/core/generated-book-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-book-hashes/marwadi.json
@@ -112,6 +112,21 @@
         "MW-C06-practice"
       ],
       "tex": "marwadi/book/chapters/ch08-wellbeing-answer.tex"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:e7057768cec2f9b6",
+      "lessonIds": [
+        "MW-C07-hear-later",
+        "MW-W07-chha",
+        "MW-W07-e-matra",
+        "MW-W07-i-matra",
+        "MW-W07-la",
+        "MW-C07-read-later",
+        "MW-C07-practice"
+      ],
+      "tex": "marwadi/book/chapters/ch09-see-you-later.tex"
     }
   ]
 }

--- a/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
+++ b/code/learning/human-languages/core/generated-narration-hashes/marwadi.json
@@ -153,6 +153,26 @@
       "json": "marwadi/narration/ch08.json",
       "textHash": "fnv1a64:fbe7aee098259530",
       "jsonHash": "fnv1a64:51aebbc82dca9e75"
+    },
+    {
+      "language": "marwadi",
+      "chapter": 9,
+      "sourceHash": "fnv1a64:b121afde028b4574",
+      "lessonIds": [
+        "MW-C07-hear-later",
+        "MW-W07-chha",
+        "MW-W07-e-matra",
+        "MW-W07-i-matra",
+        "MW-W07-la",
+        "MW-C07-read-later",
+        "MW-C07-practice"
+      ],
+      "voiceLessons": 2,
+      "drivablePrefix": 1,
+      "text": "marwadi/narration/ch09.txt",
+      "json": "marwadi/narration/ch09.json",
+      "textHash": "fnv1a64:eef02c40d84fb6ec",
+      "jsonHash": "fnv1a64:103d3a96fa314257"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
+++ b/code/learning/human-languages/core/gentle-ramp-snapshots/marwadi.json
@@ -1,7 +1,7 @@
 {
   "language": "marwadi",
-  "lessonCount": 47,
-  "atomMeasurableLessons": 47,
+  "lessonCount": 54,
+  "atomMeasurableLessons": 54,
   "atomMeasurementBlindLessons": 0,
   "durationViolations": 0,
   "atomLessonSpikes": 0,
@@ -16,7 +16,7 @@
   "forwardPrerequisites": 0,
   "forwardReviews": 0,
   "forwardReferences": 0,
-  "atomsTaught": 60,
+  "atomsTaught": 69,
   "atomsNeverRevisited": 1,
   "reinforcementWindowMisses": 0,
   "reinforcementMissesByWindow": {
@@ -26,7 +26,7 @@
     "R4": 0
   },
   "payoffSurprises": 0,
-  "writingPracticeLessons": 26,
+  "writingPracticeLessons": 31,
   "firstWritingPracticeAt": 0,
   "lessonsBeforeWritingPractice": 0,
   "findings": [],

--- a/code/learning/human-languages/core/lesson-modality/marwadi.json
+++ b/code/learning/human-languages/core/lesson-modality/marwadi.json
@@ -7,17 +7,17 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:a6103c888d014026",
+  "sourceHash": "fnv1a64:e45a7915c1da259c",
   "summary": {
-    "totalLessons": 47,
-    "voice": 21,
+    "totalLessons": 54,
+    "voice": 23,
     "sight": 2,
-    "pen": 24,
-    "drivableLessons": 21,
-    "drivablePercent": 45,
+    "pen": 29,
+    "drivableLessons": 23,
+    "drivablePercent": 43,
     "trackCount": 1,
-    "chapterCount": 8,
-    "drivablePrefixTotal": 5,
+    "chapterCount": 9,
+    "drivablePrefixTotal": 6,
     "fullyDrivableChapters": 0,
     "unstartableChapters": 3,
     "overriddenLessons": 0,
@@ -26,12 +26,12 @@
   "tracks": [
     {
       "language": "marwadi",
-      "lessonCount": 47,
-      "voice": 21,
+      "lessonCount": 54,
+      "voice": 23,
       "sight": 2,
-      "pen": 24,
-      "drivablePercent": 45,
-      "drivablePrefixTotal": 5,
+      "pen": 29,
+      "drivablePercent": 43,
+      "drivablePrefixTotal": 6,
       "modalities": [
         "voice",
         "sight",
@@ -173,6 +173,24 @@
           "drivable": false,
           "drivableLessonIds": [
             "MW-C06-hear-answer"
+          ]
+        },
+        {
+          "chapter": 9,
+          "lessonCount": 7,
+          "voice": 2,
+          "sight": 0,
+          "pen": 5,
+          "modalities": [
+            "voice",
+            "sight",
+            "pen"
+          ],
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "MW-W07-chha",
+          "drivable": false,
+          "drivableLessonIds": [
+            "MW-C07-hear-later"
           ]
         }
       ]
@@ -1173,6 +1191,157 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:920fdc110ecb88f1"
+    },
+    {
+      "id": "MW-C07-hear-later",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 480,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e4a4aefac408c939"
+    },
+    {
+      "id": "MW-W07-chha",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 490,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:608443db9f073b3e",
+      "detachableSegments": [
+        "Script — one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W07-e-matra",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 500,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7aef7dbbe1f8a367",
+      "detachableSegments": [
+        "Script — one vowel mark"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W07-i-matra",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 510,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:1147e982285d226c",
+      "detachableSegments": [
+        "Script — one vowel mark"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-W07-la",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 520,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0822aa290d317765",
+      "detachableSegments": [
+        "Script — one sign"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-C07-read-later",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 530,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:2674723a77a856cf",
+      "detachableSegments": [
+        "Script — join only known units"
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "MW-C07-practice",
+      "language": "marwadi",
+      "chapter": 9,
+      "sequence": 540,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fde9431085efb7dd"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/marwadi/CHANGELOG.md
+++ b/code/learning/human-languages/marwadi/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased — see you later
+
+- Added seven <=5-minute sessions for **पाछे मिलसू**: sound and meaning first,
+  four new written units one at a time, assembly, and a four-skill payoff.
+- Reused known **प**, **ा**, **म**, **स**, and **ू** rather than reteaching them.
+- Contrasted the new later-meeting line with already-known **राम राम सा**, while
+  keeping regional and relationship variation explicit.
+- Grounded both parting expressions in Marwari Pathshala lesson 2 and retained
+  the SIL dictionary as the track's orthographic context.
+
 ## Unreleased — ask how someone is
 
 - Added a seven-session Chapter 7 for **आप कैसो हो? — हूं ठीक हूं.**, securing

--- a/code/learning/human-languages/marwadi/book/book.tex
+++ b/code/learning/human-languages/marwadi/book/book.tex
@@ -17,7 +17,7 @@
   \vspace{1.5cm}
   {\large Adhithya Rajasekaran\par}
   \vfill
-  {\large Starter edition --- forty-seven lessons, each no longer than five minutes.\par}
+  {\large Starter edition --- fifty-four lessons, each no longer than five minutes.\par}
   \vspace{2cm}
   {\normalsize Copyright \copyright\ Adhithya Rajasekaran. Licensed under
     \href{https://creativecommons.org/licenses/by-sa/4.0/}%
@@ -61,6 +61,7 @@ These are real pre-A1 steps, not a claim that the level is complete.
 \input{chapters/ch06-name-question}
 \input{chapters/ch07-wellbeing-question}
 \input{chapters/ch08-wellbeing-answer}
+\input{chapters/ch09-see-you-later}
 
 \backmatter
 \input{chapters/appendix-pronunciation}

--- a/code/learning/human-languages/marwadi/book/chapter-modalities.tex
+++ b/code/learning/human-languages/marwadi/book/chapter-modalities.tex
@@ -83,3 +83,10 @@
     \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 5 lessons.%
     \par}\medskip
 }
+
+\expandafter\def\csname hlchaptermodality9\endcsname{%
+  {\small\noindent
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlpensign{}~\textbf{pen} (5)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 7 lessons.%
+    \par}\medskip
+}

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-answer-key.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
-% canonical-activities: 47
+% canonical-activities: 54
 
 \chapter*{Review Questions}
 \addcontentsline{toc}{chapter}{Review Questions}
@@ -303,6 +303,50 @@ Try these without looking ahead. Every prompt comes from the same canonical less
 \raggedright
 \hypertarget{review-MW-C06-practice-wellbeing}{\textbf{8.5}} \emph{Practice — ask how someone is and answer}\par
 \small From sound alone, write I am fine, then ask the polite wellbeing question aloud.
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C07-hear-later-meaning}{\textbf{9.1}} \emph{Hear \emph{pāchhe milsū} — see you later}\par
+\small You hear pāchhe milsū at the end of a conversation. What does it promise?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W07-chha-read}{\textbf{9.2}} \emph{\mw{छ} — one aspirated consonant}\par
+\small Which sound does \mw{छ} carry in the taught farewell?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W07-e-matra-build}{\textbf{9.3}} \emph{\mw{े} — attach \emph{e} to a consonant}\par
+\small Which vowel mark turns \mw{छ} into \mw{छे}?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W07-i-matra-order}{\textbf{9.4}} \emph{\mw{ि} — written before, heard after}\par
+\small The short-i mark is visible before \mw{म}. How do you read \mw{मि}?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-W07-la-write}{\textbf{9.5}} \emph{\mw{ल} — the last new consonant}\par
+\small Write the Devanagari consonant sign for la.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C07-read-later-build}{\textbf{9.6}} \emph{\mw{पाछे} \mw{मिलसू} — assemble the two sound groups}\par
+\small From pāchhe | milsū, write the complete two-word phrase.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MW-C07-practice-later}{\textbf{9.7}} \emph{Practice — goodbye, with or without “later”}\par
+\small From sound alone, write see you later, then say the common farewell aloud.
 \end{minipage}\par\medskip
 
 \chapter*{Answer Key}
@@ -649,4 +693,55 @@ The first response is the canonical display answer. When a question accepts othe
 \hyperlink{review-MW-C06-practice-wellbeing}{\textbf{8.5}} \emph{Practice — ask how someone is and answer}\par
 \small \textbf{Answer:} \mw{हूं} \mw{ठीक} \mw{हूं}. — \mw{आप} \mw{कैसो} \mw{हो}?\par
 \footnotesize \textbf{Also accepted:} \mw{हूं} \mw{ठीक} \mw{हूं}; \mw{हूं} \mw{ठीक} \mw{हूं।}
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C07-hear-later-meaning}{\textbf{9.1}} \emph{Hear \emph{pāchhe milsū} — see you later}\par
+\small \textbf{Answer:} See you later.\par
+\footnotesize \textbf{Also accepted:} meet again later; see you again; see you later
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W07-chha-read}{\textbf{9.2}} \emph{\mw{छ} — one aspirated consonant}\par
+\small \textbf{Answer:} chha\par
+\footnotesize \textbf{Also accepted:} chh; aspirated chha
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W07-e-matra-build}{\textbf{9.3}} \emph{\mw{े} — attach \emph{e} to a consonant}\par
+\small \textbf{Answer:} \mw{े}\par
+\footnotesize \textbf{Also accepted:} e matra; dependent e
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W07-i-matra-order}{\textbf{9.4}} \emph{\mw{ि} — written before, heard after}\par
+\small \textbf{Answer:} mi\par
+\footnotesize \textbf{Also accepted:} m-i; \mw{मि} is mi
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-W07-la-write}{\textbf{9.5}} \emph{\mw{ल} — the last new consonant}\par
+\small \textbf{Answer:} \mw{ल}\par
+\footnotesize \textbf{Also accepted:} \mw{ल} la
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C07-read-later-build}{\textbf{9.6}} \emph{\mw{पाछे} \mw{मिलसू} — assemble the two sound groups}\par
+\small \textbf{Answer:} \mw{पाछे} \mw{मिलसू}\par
+\footnotesize \textbf{Also accepted:} \mw{पाछे} \mw{मिलसू।}; \mw{पाछे} \mw{मिलसू}.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MW-C07-practice-later}{\textbf{9.7}} \emph{Practice — goodbye, with or without “later”}\par
+\small \textbf{Answer:} \mw{पाछे} \mw{मिलसू} — \mw{राम} \mw{राम} \mw{सा}\par
+\footnotesize \textbf{Also accepted:} \mw{पाछे} \mw{मिलसू}; \mw{पाछे} \mw{मिलसू।}
 \end{minipage}\par\medskip

--- a/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 39
-% canonical-index-entries: 39
+% canonical-index-candidates: 45
+% canonical-index-entries: 45
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -26,6 +26,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{Aabhaar: Formal Thanks, Two New Signs}\par
 \footnotesize chapter topic; \hyperref[ch:mw-aabhaar]{Chapter~2, p.~\pageref*{ch:mw-aabhaar}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{े} — attach \emph{e} to a consonant}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
 \end{minipage}\par\smallskip
 
 \section*{F}
@@ -114,6 +120,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \footnotesize chapter topic; \hyperref[ch:mw-paani]{Chapter~4, p.~\pageref*{ch:mw-paani}}
 \end{minipage}\par\smallskip
 
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Pachhe Milsu: See You Later}\par
+\footnotesize chapter topic; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
+\end{minipage}\par\smallskip
+
 \section*{R}
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -176,6 +188,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \footnotesize \hyperref[ch:mw-name-question]{Chapter~6, p.~\pageref*{ch:mw-name-question}}
 \end{minipage}\par\smallskip
 
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ि} — written before, heard after}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
+\end{minipage}\par\smallskip
+
 \section*{Y}
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -212,6 +230,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\mw{छ} — one aspirated consonant}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\mw{ठ} — curl back, then release breath}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-wellbeing-answer]{Chapter~8, p.~\pageref*{ch:mw-wellbeing-answer}}
 \end{minipage}\par\smallskip
@@ -242,6 +266,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\mw{पाछे} \mw{मिलसू} — assemble the two sound groups}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\mw{भ} — \emph{bha}, with a small breath}\par
 \footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-aabhaar]{Chapter~2, p.~\pageref*{ch:mw-aabhaar}}
 \end{minipage}\par\smallskip
@@ -250,6 +280,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\mw{र} — one sign, and the beginning of a greeting}\par
 \footnotesize script and writing topic; explicit focus: script, writing; \hyperref[ch:mw-ram-ram-sa]{Chapter~1, p.~\pageref*{ch:mw-ram-ram-sa}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mw{ल} — the last new consonant}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:mw-see-you-later]{Chapter~9, p.~\pageref*{ch:mw-see-you-later}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/marwadi/book/chapters/ch09-see-you-later.tex
+++ b/code/learning/human-languages/marwadi/book/chapters/ch09-see-you-later.tex
@@ -1,0 +1,215 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:e7057768cec2f9b6
+% canonical-lessons: MW-C07-hear-later, MW-W07-chha, MW-W07-e-matra, MW-W07-i-matra, MW-W07-la, MW-C07-read-later, MW-C07-practice
+
+\chapter{Pachhe Milsu: See You Later}
+\label{ch:mw-see-you-later}
+\hlchaptermodality{9}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can hear and say pāchhe milsū, write its four new units, and distinguish it from the common farewell \mw{राम} \mw{राम} \mw{सा} in all four skills.}
+
+A source-attested see-you-later line taught sound-first, written through four isolated units, and scored separately in all four skills.
+\end{chapteropening}
+
+\section[pāchhe milsū]{Hear \emph{pāchhe milsū} — see you later}
+
+\label{lesson:MW-C07-hear-later}
+
+
+
+\begin{quote}
+Ask how someone is, answer \emph{hū̃ ṭhīk hū̃}, then say \textbf{\mw{राम} \mw{राम} \mw{सा}} once. Close the text before the new parting line begins.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\emph{pāchhe milsū} — \textbf{see you later}
+\end{quote}
+
+Hear two groups: \emph{pā-chhe | mil-sū}. The first points later/back; the second carries meeting again. Listen twice, tap the two groups, and say them once. Do not spell the line yet.
+
+\subsection*{Your turn}
+Choose the cue that promises another meeting, not the cue that starts a conversation. Answer it with \emph{pāchhe milsū}.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the two sound groups once, then stop.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}
+\section[chha]{\mw{छ} — one aspirated consonant}
+
+\label{lesson:MW-W07-chha}
+
+
+
+\begin{quote}
+Write \textbf{\mw{नाम}}, say \emph{pāchhe} once, then write known \textbf{\mw{ठ}}. The new sign carries a different consonant and keeps the released breath.
+\end{quote}
+
+\subsection*{Script — one sign}
+\begin{quote}
+\textbf{\mw{छ}} — \emph{chha}
+\end{quote}
+
+Keep the sign visible. Finger-trace the main body first and add the headline last. Say \emph{chha} with a small breath after the consonant.
+
+\subsection*{Your turn}
+Trace \textbf{\mw{छ}} once, copy it once, then cover the model and write it once.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Write \textbf{\mw{छ}} once from memory.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[e]{\mw{े} — attach \emph{e} to a consonant}
+
+\label{lesson:MW-W07-e-matra}
+
+
+
+\begin{quote}
+Complete \emph{mhāro nām Rām hai}, write \textbf{\mw{छ}}, then write known \textbf{\mw{ू}}. Today's mark attaches above a consonant instead.
+\end{quote}
+
+\subsection*{Script — one vowel mark}
+\begin{quote}
+\textbf{\mw{े}} — dependent \emph{e}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\mw{छ} + \mw{े} = \mw{छे}} — \emph{chhe}
+\end{quote}
+
+The mark cannot stand as the word's consonant. Add it above and to the right of \textbf{\mw{छ}}; read the result \emph{chhe}.
+
+\subsection*{Your turn}
+Copy \textbf{\mw{छे}} twice. Point to the consonant, then to the vowel mark.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Cover the model and write \textbf{\mw{छे}} once.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[i]{\mw{ि} — written before, heard after}
+
+\label{lesson:MW-W07-i-matra}
+
+
+
+\begin{quote}
+Write \textbf{\mw{है}}, then known \textbf{\mw{म}} and the long-\emph{ī} mark from \textbf{\mw{णी}}. The new mark is short \emph{i} and has a placement rule worth noticing.
+\end{quote}
+
+\subsection*{Script — one vowel mark}
+\begin{quote}
+\textbf{\mw{ि}} — dependent short \emph{i}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\mw{म} + \mw{ि} = \mw{मि}} — \emph{mi}
+\end{quote}
+
+The visible mark sits to the \textbf{left} of \textbf{\mw{म}}, but the sound follows the consonant: read \textbf{\mw{मि}} as \emph{mi}, never \emph{im}.
+
+\subsection*{Your turn}
+Build \textbf{\mw{मि}} twice. Each time, point left-to-right on the page, then say the sounds in their spoken order: \emph{m-i}.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Write \textbf{\mw{मि}} once from memory.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[la]{\mw{ल} — the last new consonant}
+
+\label{lesson:MW-W07-la}
+
+
+
+\begin{quote}
+Write the full my-name statement, then ask and answer wellbeing once. Write \textbf{\mw{मि}} and known \textbf{\mw{न}}. Today adds only \textbf{\mw{ल}}.
+\end{quote}
+
+\subsection*{Script — one sign}
+\begin{quote}
+\textbf{\mw{ल}} — \emph{la}
+\end{quote}
+
+Keep the sign visible. Trace the open lower body before adding the headline. Say \emph{la} once the hand stops.
+
+\subsection*{Your turn}
+Copy \textbf{\mw{ल}} once beside the model. Cover it, wait five seconds, and write it once.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\mw{ल}} once, then stop.
+
+Source: \href{https://www.unicode.org/charts/PDF/U0900.pdf}{Unicode Devanagari chart}.
+\end{tcolorbox}
+\section[pāchhe milsū]{\mw{पाछे} \mw{मिलसू} — assemble the two sound groups}
+
+\label{lesson:MW-C07-read-later}
+
+
+
+\begin{quote}
+Say \emph{thāro}, then write \textbf{\mw{हूं} \mw{ठीक} \mw{हूं}} and circle \textbf{\mw{ठ}}. Say \emph{pāchhe | milsū}, then write \textbf{\mw{छे}}, \textbf{\mw{मि}}, and \textbf{\mw{ल}} separately.
+\end{quote}
+
+\subsection*{Script — join only known units}
+\begin{quote}
+\textbf{\mw{पा} | \mw{छे}   \mw{मि} | \mw{ल} | \mw{सू}}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\mw{पाछे} \mw{मिलसू}}
+\end{quote}
+
+Nothing new hides in the join. Read the two groups, then write them with one space between.
+
+\subsection*{Your turn}
+Cover the romanization. Read \textbf{\mw{पाछे} \mw{मिलसू}}, cover the line, wait ten seconds, and write it once.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Point to the short-\emph{i} mark and say why it appears before \textbf{\mw{म}} on the page.
+
+Source: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2}.
+\end{tcolorbox}
+\section[Practice]{Practice — goodbye, with or without “later”}
+
+\label{lesson:MW-C07-practice}
+
+
+
+\begin{quote}
+Write \textbf{\mw{थ}}, then say \textbf{\mw{राम} \mw{राम} \mw{सा}} once as the common farewell.
+\end{quote}
+
+\subsection*{What to know first}
+\begin{quote}
+\textbf{\mw{राम} \mw{राम} \mw{सा}.} — goodbye / farewell
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{\mw{पाछे} \mw{मिलसू}.} — see you later
+\end{quote}
+
+The second line explicitly points to meeting later. Other regions and relationships may choose another parting line; this payoff scores only the two source-attested choices it taught.
+
+\subsection*{Your turn}
+1. \textbf{Listen:} hear one line and identify common farewell or see-you-later. 2. \textbf{Speak:} answer a later-meeting cue with \emph{pāchhe milsū}. 3. \textbf{Read:} match both printed lines to their meanings. 4. \textbf{Write:} hear \emph{pāchhe milsū}, wait ten seconds, and write it without a model.
+
+Score all four separately. A spoken line does not replace missing writing.
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Stop after one accurate four-skill pass.
+
+Sources: \href{https://www.marwaripathshala.com/marwari-lesson-2-english}{Marwari Pathshala, Lesson 2} and \href{https://nepal.sil.org/resources/archives/63768}{SIL International, \emph{Marwari–English Dictionary} archive}.
+\end{tcolorbox}

--- a/code/learning/human-languages/marwadi/chapters.json
+++ b/code/learning/human-languages/marwadi/chapters.json
@@ -172,6 +172,19 @@
           "MW-DIALOGUE-WELLBEING-01"
         ]
       }
+    },
+    {
+      "chapter": 9,
+      "title": "Pachhe Milsu: See You Later",
+      "label": "ch:mw-see-you-later",
+      "canDo": "I can hear and say pāchhe milsū, write its four new units, and distinguish it from the common farewell राम राम सा in all four skills.",
+      "spineNodes": ["SPINE-TAKE-LEAVE"],
+      "payoff": {
+        "lesson": "MW-C07-practice",
+        "kind": "dialogue",
+        "summary": "A source-attested see-you-later line taught sound-first, written through four isolated units, and scored separately in all four skills.",
+        "assesses": ["MW-LEX-PACHHE-01", "MW-LEX-MILSOO-01", "MW-FAREWELL-LATER-HEARD-01", "MW-SCRIPT-CHHA-01", "MW-SCRIPT-E-MATRA-01", "MW-SCRIPT-I-MATRA-01", "MW-SCRIPT-LA-01", "MW-SCRIPT-PACHHE-MILSOO-01", "MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01"]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/curriculum.json
+++ b/code/learning/human-languages/marwadi/curriculum.json
@@ -49,6 +49,14 @@
       "before": [],
       "inline": ["MW-EXT-015-HEAR-WELLBEING-QUESTION", "MW-EXT-016-WRITE-WELLBEING-QUESTION", "MW-EXT-017-BUILD-WELLBEING-ANSWER", "MW-EXT-018-WELLBEING-EXCHANGE"],
       "after": []
+    },
+    {
+      "id": "MW-PATH-007",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": ["MW-C07-hear-later", "MW-W07-chha", "MW-W07-e-matra", "MW-W07-i-matra", "MW-W07-la", "MW-C07-read-later", "MW-C07-practice"],
+      "before": [],
+      "inline": ["MW-EXT-019-HEAR-LATER", "MW-EXT-020-WRITE-LATER", "MW-EXT-021-FAREWELL-LATER"],
+      "after": []
     }
   ],
   "spine": {
@@ -58,7 +66,7 @@
     "SPINE-EXCHANGE-NAMES": { "segments": ["MW-PATH-005"], "omits": ["PRONOUN-I", "PRONOUN-ME", "PRONOUN-YOU", "WORD-IS", "INTRO-WHATS-YOUR-NAME", "INTRO-NICE-TO-MEET-YOU"], "relocates": {} },
     "SPINE-CHECK-WELLBEING": { "segments": ["MW-PATH-006"], "omits": ["QUESTION-HOW", "WORD-GOOD", "WORD-SOSO"], "relocates": {} },
     "SPINE-POLITE-REQUEST-REPAIR": { "segments": ["MW-PATH-004"], "omits": ["COURTESY-PLEASE", "COURTESY-SORRY"], "relocates": {} },
-    "SPINE-TAKE-LEAVE": { "segments": [], "omits": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"], "relocates": {} },
+    "SPINE-TAKE-LEAVE": { "segments": ["MW-PATH-007"], "omits": ["FAREWELL", "FAREWELL-CASUAL", "FAREWELL-LATER", "FAREWELL-SOON", "FAREWELL-TOMORROW", "GREETING-GOODNIGHT"], "relocates": {} },
     "SPINE-TIME-OF-DAY": { "segments": [], "omits": ["TIME-DAY", "TIME-MORNING", "TIME-AFTERNOON", "TIME-EVENING", "TIME-NIGHT", "GREETING-DAY", "GREETING-MORNING", "GREETING-AFTERNOON", "GREETING-EVENING"], "relocates": {} },
     "SPINE-ASK-LOCATION": { "segments": [], "omits": ["QUESTION-WHERE"], "relocates": {} },
     "SPINE-DEFINITE-REFERENCE": { "segments": [], "omits": ["GRAMMAR-THE"], "relocates": {} },
@@ -248,6 +256,33 @@
       "canDo": "I can ask how a person is and answer that I am fine in independently scored listening, speaking, reading, and writing tasks.",
       "prerequisites": ["MW-EXT-017-BUILD-WELLBEING-ANSWER"],
       "lessons": ["MW-C06-practice"]
+    },
+    {
+      "id": "MW-EXT-019-HEAR-LATER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "communication",
+      "canDo": "I can recognise and say pāchhe milsū as see you later before seeing its spelling.",
+      "prerequisites": ["MW-EXT-018-WELLBEING-EXCHANGE"],
+      "lessons": ["MW-C07-hear-later"]
+    },
+    {
+      "id": "MW-EXT-020-WRITE-LATER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "script",
+      "canDo": "I can isolate छ, े, ि, and ल, then assemble and write पाछे मिलसू from sound.",
+      "prerequisites": ["MW-EXT-019-HEAR-LATER"],
+      "lessons": ["MW-W07-chha", "MW-W07-e-matra", "MW-W07-i-matra", "MW-W07-la", "MW-C07-read-later"]
+    },
+    {
+      "id": "MW-EXT-021-FAREWELL-LATER",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "consolidation",
+      "canDo": "I can distinguish a common farewell from see you later and pass the latter in independently scored listening, speaking, reading, and writing tasks.",
+      "prerequisites": ["MW-EXT-020-WRITE-LATER"],
+      "lessons": ["MW-C07-practice"]
     }
   ]
 }

--- a/code/learning/human-languages/marwadi/lessons/MW-C07-hear-later.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C07-hear-later.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-C07-hear-later
+spine_node: SPINE-TAKE-LEAVE
+sequence: 480
+chapter: 9
+type: listening-speaking
+headword: pāchhe milsū
+romanization: pāchhe milsū
+gloss: see you later
+concept_tag: FAREWELL-LATER
+prerequisites: [MW-C06-practice]
+sounds: [long-aa, aspirated-chh, short-i, long-uu]
+roots: []
+etymology_hook: Learn the parting meaning and sound groups before four new written units arrive.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-DIALOGUE-WELLBEING-01]
+introduces:
+  knowledge: [MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01]
+practises:
+  knowledge: [MW-DIALOGUE-WELLBEING-01, MW-ANSWER-WELLBEING-HEARD-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-LEX-RAAM-RAAM-SAA, MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01]
+skills: [listening, speaking]
+modes: [interpretive, interpersonal]
+strands: [meaning-input, meaning-output]
+register: neutral-friendly
+variety: central-marwari-devanagari
+reviews_of: [MW-C06-practice, MW-C01-raam-raam-saa]
+---
+
+# Hear *pāchhe milsū* — see you later
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-DIALOGUE-WELLBEING-01, MW-ANSWER-WELLBEING-HEARD-01, MW-LEX-HOON-01, MW-LEX-THIK-01, MW-LEX-RAAM-RAAM-SAA] -->
+
+[PAUSE 15s] Ask how someone is, answer *hū̃ ṭhīk hū̃*, then say **राम राम सा** once.
+Close the text before the new parting line begins.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01]; assesses=[] -->
+
+> *pāchhe milsū* — **see you later**
+
+Hear two groups: *pā-chhe | mil-sū*. The first points later/back; the second
+carries meeting again. Listen twice, tap the two groups, and say them once. Do
+not spell the line yet.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01] -->
+
+Choose the cue that promises another meeting, not the cue that starts a
+conversation. Answer it with *pāchhe milsū*.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01] -->
+<!-- hl-activity: {"id":"MW-C07-hear-later-meaning","kind":"text","assesses":["MW-FAREWELL-LATER-HEARD-01"],"prompt":"You hear pāchhe milsū at the end of a conversation. What does it promise?","answer":"See you later.","accepted":["meet again later","see you again","see you later"],"feedback":{"correct":"Right: it points to meeting again later.","incorrect":"This is the taught see-you-later line."},"response_seconds":8} -->
+
+Say the two sound groups once, then stop.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-C07-practice.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C07-practice.md
@@ -1,0 +1,66 @@
+---
+schema_version: 2
+id: MW-C07-practice
+spine_node: SPINE-TAKE-LEAVE
+sequence: 540
+chapter: 9
+type: practice-mix
+headword: राम राम सा — पाछे मिलसू
+romanization: rām rām sā — pāchhe milsū
+gloss: goodbye — see you later
+concept_tag: FAREWELL-LATER
+prerequisites: [MW-C07-read-later]
+sounds: [long-aa, aspirated-chh, short-i, long-uu]
+roots: []
+etymology_hook: A known common farewell and a new see-you-later line now separate two useful parting intentions.
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [MW-LEX-RAAM-RAAM-SAA, MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-PACHHE-MILSOO-01]
+introduces:
+  knowledge: [MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01]
+practises:
+  knowledge: [MW-LEX-RAAM-RAAM-SAA, MW-REGISTER-SAA, MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-PACHHE-MILSOO-01, MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01, MW-SCRIPT-THA-01]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, fluency]
+register: neutral-friendly
+variety: central-marwari-devanagari
+reviews_of: [MW-C01-raam-raam-saa, MW-C07-hear-later, MW-C07-read-later]
+---
+
+# Practice — goodbye, with or without “later”
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-RAAM-RAAM-SAA, MW-REGISTER-SAA, MW-SCRIPT-THA-01] -->
+
+[PAUSE 12s] Write **थ**, then say **राम राम सा** once as the common farewell.
+
+## You'll want to know
+<!-- hl-knowledge: introduces=[MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-PACHHE-MILSOO-01] -->
+
+> **राम राम सा.** — goodbye / farewell
+>
+> **पाछे मिलसू.** — see you later
+
+The second line explicitly points to meeting later. Other regions and
+relationships may choose another parting line; this payoff scores only the two
+source-attested choices it taught.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-RAAM-RAAM-SAA, MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-PACHHE-MILSOO-01, MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01] -->
+
+1. **Listen:** hear one line and identify common farewell or see-you-later.
+2. **Speak:** answer a later-meeting cue with *pāchhe milsū*.
+3. **Read:** match both printed lines to their meanings.
+4. **Write:** hear *pāchhe milsū*, wait ten seconds, and write it without a model.
+
+Score all four separately. A spoken line does not replace missing writing.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-SCRIPT-PACHHE-MILSOO-01, MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01] -->
+<!-- hl-activity: {"id":"MW-C07-practice-later","kind":"text","assesses":["MW-LEX-PACHHE-01","MW-LEX-MILSOO-01","MW-SCRIPT-PACHHE-MILSOO-01","MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01"],"prompt":"From sound alone, write see you later, then say the common farewell aloud.","answer":"पाछे मिलसू — राम राम सा","accepted":["पाछे मिलसू","पाछे मिलसू।"],"feedback":{"correct":"Writing and speech complete the two parting intentions.","incorrect":"Repair पाछे | मिलसू, then say राम राम सा aloud."},"response_seconds":30} -->
+
+Stop after one accurate four-skill pass.
+
+Sources: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english) and [SIL International, *Marwari–English Dictionary* archive](https://nepal.sil.org/resources/archives/63768).

--- a/code/learning/human-languages/marwadi/lessons/MW-C07-read-later.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-C07-read-later.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-C07-read-later
+spine_node: SPINE-TAKE-LEAVE
+sequence: 530
+delivery: script
+chapter: 9
+type: writing
+headword: पाछे मिलसू
+romanization: pāchhe milsū
+gloss: see you later, assembled from known written units
+prerequisites: [MW-W07-la]
+sounds: [long-aa, aspirated-chh, long-e, short-i, long-uu]
+roots: []
+etymology_hook: Four new units and five older ones now become a readable two-word farewell.
+duration:
+  max_seconds: 210
+requires:
+  knowledge: [MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-MA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-SA-01, MW-SCRIPT-UU-MATRA-01]
+introduces:
+  knowledge: [MW-SCRIPT-PACHHE-MILSOO-01]
+practises:
+  knowledge: [MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-MA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-SA-01, MW-SCRIPT-UU-MATRA-01, MW-SCRIPT-PACHHE-MILSOO-01, MW-LEX-THARO-01, MW-ANSWER-WELLBEING-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-SCRIPT-TTHA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, language-focus]
+register: neutral-friendly
+variety: central-marwari-devanagari
+reviews_of: [MW-C07-hear-later, MW-W07-chha, MW-W07-e-matra, MW-W07-i-matra, MW-W07-la]
+---
+
+# पाछे मिलसू — assemble the two sound groups
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-LEX-THARO-01, MW-ANSWER-WELLBEING-01, MW-SCRIPT-HOON-01, MW-SCRIPT-THIK-01, MW-SCRIPT-TTHA-01] -->
+
+[PAUSE 20s] Say *thāro*, then write **हूं ठीक हूं** and circle **ठ**. Say
+*pāchhe | milsū*, then write **छे**, **मि**, and **ल** separately.
+
+## Script — join only known units
+<!-- hl-knowledge: introduces=[MW-SCRIPT-PACHHE-MILSOO-01]; assesses=[MW-SCRIPT-PA-01, MW-SCRIPT-AA-MATRA-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-MA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-SA-01, MW-SCRIPT-UU-MATRA-01] -->
+
+> **पा | छे   मि | ल | सू**
+>
+> **पाछे मिलसू**
+
+Nothing new hides in the join. Read the two groups, then write them with one
+space between.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-SCRIPT-PACHHE-MILSOO-01] -->
+
+Cover the romanization. Read **पाछे मिलसू**, cover the line, wait ten seconds,
+and write it once.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-LEX-MILSOO-01, MW-SCRIPT-PACHHE-MILSOO-01] -->
+<!-- hl-activity: {"id":"MW-C07-read-later-build","kind":"text","assesses":["MW-LEX-PACHHE-01","MW-LEX-MILSOO-01","MW-SCRIPT-PACHHE-MILSOO-01"],"prompt":"From pāchhe | milsū, write the complete two-word phrase.","answer":"पाछे मिलसू","accepted":["पाछे मिलसू।","पाछे मिलसू."],"feedback":{"correct":"Both sound groups are complete with one space between.","incorrect":"Repair one known block at a time: पा | छे   मि | ल | सू."},"response_seconds":20} -->
+
+Point to the short-*i* mark and say why it appears before **म** on the page.
+
+Source: [Marwari Pathshala, Lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english).

--- a/code/learning/human-languages/marwadi/lessons/MW-W07-chha.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W07-chha.md
@@ -1,0 +1,59 @@
+---
+schema_version: 2
+id: MW-W07-chha
+spine_node: SPINE-TAKE-LEAVE
+sequence: 490
+delivery: script
+chapter: 9
+type: writing
+headword: छ
+romanization: chha
+gloss: the Devanagari consonant sign for aspirated chha
+prerequisites: [MW-C07-hear-later]
+sounds: [aspirated-chh]
+roots: []
+etymology_hook: One new consonant secures the middle of the first sound group.
+duration:
+  max_seconds: 150
+requires:
+  knowledge: [MW-FAREWELL-LATER-HEARD-01]
+introduces:
+  knowledge: [MW-SCRIPT-CHHA-01]
+practises:
+  knowledge: [MW-LEX-PACHHE-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-NAAM-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-C07-hear-later, MW-W06-ttha]
+---
+
+# छ — one aspirated consonant
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-FAREWELL-LATER-HEARD-01, MW-SCRIPT-TTHA-01, MW-SCRIPT-NAAM-01] -->
+
+[PAUSE 12s] Write **नाम**, say *pāchhe* once, then write known **ठ**. The new sign carries a
+different consonant and keeps the released breath.
+
+## Script — one sign
+<!-- hl-knowledge: introduces=[MW-SCRIPT-CHHA-01]; assesses=[] -->
+
+> **छ** — *chha*
+
+Keep the sign visible. Finger-trace the main body first and add the headline
+last. Say *chha* with a small breath after the consonant.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-CHHA-01] -->
+
+Trace **छ** once, copy it once, then cover the model and write it once.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-CHHA-01] -->
+<!-- hl-activity: {"id":"MW-W07-chha-read","kind":"text","assesses":["MW-SCRIPT-CHHA-01"],"prompt":"Which sound does छ carry in the taught farewell?","answer":"chha","accepted":["chh","aspirated chha"],"feedback":{"correct":"Right: छ carries aspirated chha.","incorrect":"Read this sign as chha, with a small breath."},"response_seconds":8} -->
+
+Write **छ** once from memory.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/lessons/MW-W07-e-matra.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W07-e-matra.md
@@ -1,0 +1,61 @@
+---
+schema_version: 2
+id: MW-W07-e-matra
+spine_node: SPINE-TAKE-LEAVE
+sequence: 500
+delivery: script
+chapter: 9
+type: writing
+headword: े
+romanization: e
+gloss: the dependent e vowel sign
+prerequisites: [MW-W07-chha]
+sounds: [long-e]
+roots: []
+etymology_hook: One attached vowel mark completes chhe without adding another consonant.
+duration:
+  max_seconds: 145
+requires:
+  knowledge: [MW-SCRIPT-CHHA-01]
+introduces:
+  knowledge: [MW-SCRIPT-E-MATRA-01]
+practises:
+  knowledge: [MW-LEX-PACHHE-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-E-MATRA-01, MW-SCRIPT-UU-MATRA-01, MW-LEX-HAI-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-W07-chha, MW-W06-uu-matra]
+---
+
+# े — attach *e* to a consonant
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-PACHHE-01, MW-SCRIPT-CHHA-01, MW-SCRIPT-UU-MATRA-01, MW-LEX-HAI-01] -->
+
+[PAUSE 12s] Complete *mhāro nām Rām hai*, write **छ**, then write known **ू**.
+Today's mark attaches above a consonant instead.
+
+## Script — one vowel mark
+<!-- hl-knowledge: introduces=[MW-SCRIPT-E-MATRA-01]; assesses=[MW-SCRIPT-CHHA-01] -->
+
+> **े** — dependent *e*
+>
+> **छ + े = छे** — *chhe*
+
+The mark cannot stand as the word's consonant. Add it above and to the right of
+**छ**; read the result *chhe*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-E-MATRA-01] -->
+
+Copy **छे** twice. Point to the consonant, then to the vowel mark.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-E-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W07-e-matra-build","kind":"text","assesses":["MW-SCRIPT-E-MATRA-01"],"prompt":"Which vowel mark turns छ into छे?","answer":"े","accepted":["e matra","dependent e"],"feedback":{"correct":"Right: छ + े makes छे.","incorrect":"Use the dependent e sign े."},"response_seconds":8} -->
+
+Cover the model and write **छे** once.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/lessons/MW-W07-i-matra.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W07-i-matra.md
@@ -1,0 +1,62 @@
+---
+schema_version: 2
+id: MW-W07-i-matra
+spine_node: SPINE-TAKE-LEAVE
+sequence: 510
+delivery: script
+chapter: 9
+type: writing
+headword: ि
+romanization: i
+gloss: the dependent short-i vowel sign, written before its consonant
+prerequisites: [MW-W07-e-matra]
+sounds: [short-i]
+roots: []
+etymology_hook: The mark appears before the consonant on the page but is pronounced after it.
+duration:
+  max_seconds: 160
+requires:
+  knowledge: [MW-SCRIPT-E-MATRA-01, MW-SCRIPT-MA-01]
+introduces:
+  knowledge: [MW-SCRIPT-I-MATRA-01]
+practises:
+  knowledge: [MW-LEX-MILSOO-01, MW-SCRIPT-MA-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-II-MATRA-01, MW-SCRIPT-AI-MATRA-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-W07-e-matra, MW-W04-ii-matra]
+---
+
+# ि — written before, heard after
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-MILSOO-01, MW-SCRIPT-MA-01, MW-SCRIPT-II-MATRA-01, MW-SCRIPT-AI-MATRA-01] -->
+
+[PAUSE 12s] Write **है**, then known **म** and the long-*ī* mark from **णी**. The new mark is
+short *i* and has a placement rule worth noticing.
+
+## Script — one vowel mark
+<!-- hl-knowledge: introduces=[MW-SCRIPT-I-MATRA-01]; assesses=[MW-SCRIPT-MA-01] -->
+
+> **ि** — dependent short *i*
+>
+> **म + ि = मि** — *mi*
+
+The visible mark sits to the **left** of **म**, but the sound follows the
+consonant: read **मि** as *mi*, never *im*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-I-MATRA-01] -->
+
+Build **मि** twice. Each time, point left-to-right on the page, then say the
+sounds in their spoken order: *m-i*.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-I-MATRA-01] -->
+<!-- hl-activity: {"id":"MW-W07-i-matra-order","kind":"text","assesses":["MW-SCRIPT-I-MATRA-01"],"prompt":"The short-i mark is visible before म. How do you read मि?","answer":"mi","accepted":["m-i","मि is mi"],"feedback":{"correct":"Right: the mark is written before but pronounced after the consonant.","incorrect":"Read consonant then vowel: मि is mi."},"response_seconds":8} -->
+
+Write **मि** once from memory.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/lessons/MW-W07-la.md
+++ b/code/learning/human-languages/marwadi/lessons/MW-W07-la.md
@@ -1,0 +1,59 @@
+---
+schema_version: 2
+id: MW-W07-la
+spine_node: SPINE-TAKE-LEAVE
+sequence: 520
+delivery: script
+chapter: 9
+type: writing
+headword: ल
+romanization: la
+gloss: the Devanagari consonant sign for la
+prerequisites: [MW-W07-i-matra]
+sounds: [dental-l]
+roots: []
+etymology_hook: The fourth and last new written unit closes the middle of milsū.
+duration:
+  max_seconds: 145
+requires:
+  knowledge: [MW-SCRIPT-I-MATRA-01]
+introduces:
+  knowledge: [MW-SCRIPT-LA-01]
+practises:
+  knowledge: [MW-LEX-MILSOO-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-LA-01, MW-SCRIPT-NA-01, MW-PHRASE-MY-NAME-IS-01, MW-SCRIPT-HAI-01, MW-DIALOGUE-WELLBEING-01]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [language-focus]
+register: neutral
+variety: central-marwari-devanagari
+reviews_of: [MW-W07-i-matra, MW-W05-na]
+---
+
+# ल — the last new consonant
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[MW-LEX-MILSOO-01, MW-SCRIPT-I-MATRA-01, MW-SCRIPT-NA-01, MW-PHRASE-MY-NAME-IS-01, MW-SCRIPT-HAI-01, MW-DIALOGUE-WELLBEING-01] -->
+
+[PAUSE 18s] Write the full my-name statement, then ask and answer wellbeing once.
+Write **मि** and known **न**. Today adds only **ल**.
+
+## Script — one sign
+<!-- hl-knowledge: introduces=[MW-SCRIPT-LA-01]; assesses=[] -->
+
+> **ल** — *la*
+
+Keep the sign visible. Trace the open lower body before adding the headline.
+Say *la* once the hand stops.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-LA-01] -->
+
+Copy **ल** once beside the model. Cover it, wait five seconds, and write it once.
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[MW-SCRIPT-LA-01] -->
+<!-- hl-activity: {"id":"MW-W07-la-write","kind":"text","assesses":["MW-SCRIPT-LA-01"],"prompt":"Write the Devanagari consonant sign for la.","answer":"ल","accepted":["ल la"],"feedback":{"correct":"Right: ल carries la.","incorrect":"Repair the open lower body, then add the headline: ल."},"response_seconds":10} -->
+
+Read **ल** once, then stop.
+
+Source: [Unicode Devanagari chart](https://www.unicode.org/charts/PDF/U0900.pdf).

--- a/code/learning/human-languages/marwadi/narration/ch09.json
+++ b/code/learning/human-languages/marwadi/narration/ch09.json
@@ -1,0 +1,752 @@
+{
+  "version": 1,
+  "language": "marwadi",
+  "chapter": 9,
+  "title": "Pachhe Milsu: See You Later",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:b121afde028b4574",
+  "lessons": [
+    {
+      "id": "MW-C07-hear-later",
+      "sequence": 480,
+      "title": "Hear pāchhe milsū — see you later",
+      "headword": "pāchhe milsū",
+      "romanization": "pāchhe milsū",
+      "gloss": "see you later",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e4a4aefac408c939",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 15,
+              "perItem": false,
+              "source": "[PAUSE 15s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask how someone is, answer hū̃ ṭhīk hū̃, then say राम राम सा once. Close the text before the new parting line begins."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "pāchhe milsū — see you later."
+            },
+            {
+              "kind": "speech",
+              "text": "Hear two groups: pā-chhe | mil-sū. The first points later/back; the second carries meeting again. Listen twice, tap the two groups, and say them once. Do not spell the line yet."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Choose the cue that promises another meeting, not the cue that starts a conversation. Answer it with pāchhe milsū."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say the two sound groups once, then stop."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C07-hear-later-meaning",
+              "prompt": "You hear pāchhe milsū at the end of a conversation. What does it promise?",
+              "assesses": [
+                "MW-FAREWELL-LATER-HEARD-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "see you later.",
+                "meet again later",
+                "see you again",
+                "see you later"
+              ],
+              "feedback": {
+                "correct": "Right: it points to meeting again later.",
+                "incorrect": "This is the taught see-you-later line."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W07-chha",
+      "sequence": 490,
+      "title": "छ (chha) — one aspirated consonant",
+      "headword": "छ",
+      "romanization": "chha",
+      "gloss": "the Devanagari consonant sign for aspirated chha",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:608443db9f073b3e",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one sign"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write नाम, say pāchhe once, then write known ठ. The new sign carries a different consonant and keeps the released breath."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "छ — chha."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep the sign visible. Finger-trace the main body first and add the headline last. Say chha with a small breath after the consonant."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Trace छ (chha) once, copy it once, then cover the model and write it once."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Write छ (chha) once from memory."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W07-chha-read",
+              "prompt": "Which sound does छ (chha) carry in the taught farewell?",
+              "assesses": [
+                "MW-SCRIPT-CHHA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "chha",
+                "chh",
+                "aspirated chha"
+              ],
+              "feedback": {
+                "correct": "Right: छ carries aspirated chha.",
+                "incorrect": "Read this sign as chha, with a small breath."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W07-e-matra",
+      "sequence": 500,
+      "title": "े — attach e to a consonant",
+      "headword": "े",
+      "romanization": "e",
+      "gloss": "the dependent e vowel sign",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7aef7dbbe1f8a367",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one vowel mark"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Complete mhāro nām Rām hai, write छ (chha), then write known ू. Today's mark attaches above a consonant instead."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one vowel mark",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "े — dependent e छ (chha) + े = छे — chhe."
+            },
+            {
+              "kind": "speech",
+              "text": "The mark cannot stand as the word's consonant. Add it above and to the right of छ (chha); read the result chhe."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Copy छे twice. Point to the consonant, then to the vowel mark."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the model and write छे once."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W07-e-matra-build",
+              "prompt": "Which vowel mark turns छ (chha) into छे?",
+              "assesses": [
+                "MW-SCRIPT-E-MATRA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "े",
+                "e matra",
+                "dependent e"
+              ],
+              "feedback": {
+                "correct": "Right: छ + े makes छे.",
+                "incorrect": "Use the dependent e sign े."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W07-i-matra",
+      "sequence": 510,
+      "title": "ि — written before, heard after",
+      "headword": "ि",
+      "romanization": "i",
+      "gloss": "the dependent short-i vowel sign, written before its consonant",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:1147e982285d226c",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one vowel mark"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write है, then known म and the long-ī mark from णी. The new mark is short i and has a placement rule worth noticing."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one vowel mark",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ि — dependent short i म + ि = मि — mi."
+            },
+            {
+              "kind": "speech",
+              "text": "The visible mark sits to the left of म, but the sound follows the consonant: read मि as mi, never im."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Build मि twice. Each time, point left-to-right on the page, then say the sounds in their spoken order: m-i."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Write मि once from memory."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W07-i-matra-order",
+              "prompt": "The short-i mark is visible before म. How do you read मि?",
+              "assesses": [
+                "MW-SCRIPT-I-MATRA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "mi",
+                "m-i",
+                "मि is mi"
+              ],
+              "feedback": {
+                "correct": "Right: the mark is written before but pronounced after the consonant.",
+                "incorrect": "Read consonant then vowel: मि is mi."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-W07-la",
+      "sequence": 520,
+      "title": "ल — the last new consonant",
+      "headword": "ल",
+      "romanization": "la",
+      "gloss": "the Devanagari consonant sign for la",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0822aa290d317765",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — one sign"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 18,
+              "perItem": false,
+              "source": "[PAUSE 18s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write the full my-name statement, then ask and answer wellbeing once. Write मि and known न. Today adds only ल (la)."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — one sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ल — la."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep the sign visible. Trace the open lower body before adding the headline. Say la once the hand stops."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Copy ल (la) once beside the model. Cover it, wait five seconds, and write it once."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Read ल (la) once, then stop."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Unicode Devanagari chart."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-W07-la-write",
+              "prompt": "Write the Devanagari consonant sign for la.",
+              "assesses": [
+                "MW-SCRIPT-LA-01"
+              ],
+              "responseSeconds": 10,
+              "acceptedResponses": [
+                "ल",
+                "ल la"
+              ],
+              "feedback": {
+                "correct": "Right: ल carries la.",
+                "incorrect": "Repair the open lower body, then add the headline: ल."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C07-read-later",
+      "sequence": 530,
+      "title": "पाछे मिलसू (pāchhe milsū) — assemble the two sound groups",
+      "headword": "पाछे मिलसू",
+      "romanization": "pāchhe milsū",
+      "gloss": "see you later, assembled from known written units",
+      "script": "devanagari",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:2674723a77a856cf",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script — join only known units"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — join only known units until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 20,
+              "perItem": false,
+              "source": "[PAUSE 20s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say thāro, then write हूं ठीक हूं and circle ठ. Say pāchhe | milsū, then write छे, मि, and ल (la) separately."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script — join only known units",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पा | छे मि | ल (la) | सू पाछे मिलसू (pāchhe milsū)."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing new hides in the join. Read the two groups, then write them with one space between."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Cover the romanization. Read पाछे मिलसू (pāchhe milsū), cover the line, wait ten seconds, and write it once."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Point to the short-i mark and say why it appears before म on the page."
+            },
+            {
+              "kind": "speech",
+              "text": "Source: Marwari Pathshala, Lesson 2."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C07-read-later-build",
+              "prompt": "From pāchhe | milsū, write the complete two-word phrase.",
+              "assesses": [
+                "MW-LEX-PACHHE-01",
+                "MW-LEX-MILSOO-01",
+                "MW-SCRIPT-PACHHE-MILSOO-01"
+              ],
+              "responseSeconds": 20,
+              "acceptedResponses": [
+                "पाछे मिलसू",
+                "पाछे मिलसू।",
+                "पाछे मिलसू."
+              ],
+              "feedback": {
+                "correct": "Both sound groups are complete with one space between.",
+                "incorrect": "Repair one known block at a time: पा | छे मि | ल | सू."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MW-C07-practice",
+      "sequence": 540,
+      "title": "Practice — goodbye, with or without “later”",
+      "headword": "राम राम सा — पाछे मिलसू",
+      "romanization": "rām rām sā — pāchhe milsū",
+      "gloss": "goodbye — see you later",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:fde9431085efb7dd",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 12,
+              "perItem": false,
+              "source": "[PAUSE 12s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write थ, then say राम राम सा once as the common farewell."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "राम राम सा. — goodbye / farewell पाछे मिलसू (pāchhe milsū). — see you later."
+            },
+            {
+              "kind": "speech",
+              "text": "The second line explicitly points to meeting later. Other regions and relationships may choose another parting line; this payoff scores only the two source-attested choices it taught."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Listen: hear one line and identify common farewell or see-you-later."
+            },
+            {
+              "kind": "speech",
+              "text": "Speak: answer a later-meeting cue with pāchhe milsū."
+            },
+            {
+              "kind": "speech",
+              "text": "Read: match both printed lines to their meanings."
+            },
+            {
+              "kind": "speech",
+              "text": "Write: hear pāchhe milsū, wait ten seconds, and write it without a model."
+            },
+            {
+              "kind": "speech",
+              "text": "Score all four separately. A spoken line does not replace missing writing."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Stop after one accurate four-skill pass."
+            },
+            {
+              "kind": "speech",
+              "text": "Sources: Marwari Pathshala, Lesson 2 and SIL International, Marwari–English Dictionary archive."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "MW-C07-practice-later",
+              "prompt": "From sound alone, write see you later, then say the common farewell aloud.",
+              "assesses": [
+                "MW-LEX-PACHHE-01",
+                "MW-LEX-MILSOO-01",
+                "MW-SCRIPT-PACHHE-MILSOO-01",
+                "MW-PERFORMANCE-FAREWELL-LATER-FOUR-SKILL-01"
+              ],
+              "responseSeconds": 30,
+              "acceptedResponses": [
+                "पाछे मिलसू — राम राम सा",
+                "पाछे मिलसू",
+                "पाछे मिलसू।"
+              ],
+              "feedback": {
+                "correct": "Writing and speech complete the two parting intentions.",
+                "incorrect": "Repair पाछे | मिलसू, then say राम राम सा aloud."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/marwadi/narration/ch09.txt
+++ b/code/learning/human-languages/marwadi/narration/ch09.txt
@@ -1,0 +1,163 @@
+Marwadi (Marwari), chapter 9: Pachhe Milsu: See You Later.
+7 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 7.
+Hear pāchhe milsū — see you later.
+
+Warm-up.
+[pause 15 seconds]
+Ask how someone is, answer hū̃ ṭhīk hū̃, then say राम राम सा once. Close the text before the new parting line begins.
+
+You'll want to know.
+pāchhe milsū — see you later.
+Hear two groups: pā-chhe | mil-sū. The first points later/back; the second carries meeting again. Listen twice, tap the two groups, and say them once. Do not spell the line yet.
+
+Guided Practice.
+Choose the cue that promises another meeting, not the cue that starts a conversation. Answer it with pāchhe milsū.
+
+Wrap-up Recall.
+Say the two sound groups once, then stop.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 8 seconds]
+You hear pāchhe milsū at the end of a conversation. What does it promise?
+
+
+Lesson 2 of 7.
+छ (chha) — one aspirated consonant.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Write नाम, say pāchhe once, then write known ठ. The new sign carries a different consonant and keeps the released breath.
+
+Script — one sign.
+छ — chha.
+Keep the sign visible. Finger-trace the main body first and add the headline last. Say chha with a small breath after the consonant.
+
+Guided Practice.
+Trace छ (chha) once, copy it once, then cover the model and write it once.
+
+Wrap-up Recall.
+Write छ (chha) once from memory.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 8 seconds]
+Which sound does छ (chha) carry in the taught farewell?
+
+
+Lesson 3 of 7.
+े — attach e to a consonant.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Complete mhāro nām Rām hai, write छ (chha), then write known ू. Today's mark attaches above a consonant instead.
+
+Script — one vowel mark.
+े — dependent e छ (chha) + े = छे — chhe.
+The mark cannot stand as the word's consonant. Add it above and to the right of छ (chha); read the result chhe.
+
+Guided Practice.
+Copy छे twice. Point to the consonant, then to the vowel mark.
+
+Wrap-up Recall.
+Cover the model and write छे once.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 8 seconds]
+Which vowel mark turns छ (chha) into छे?
+
+
+Lesson 4 of 7.
+ि — written before, heard after.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one vowel mark until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 12 seconds]
+Write है, then known म and the long-ī mark from णी. The new mark is short i and has a placement rule worth noticing.
+
+Script — one vowel mark.
+ि — dependent short i म + ि = मि — mi.
+The visible mark sits to the left of म, but the sound follows the consonant: read मि as mi, never im.
+
+Guided Practice.
+Build मि twice. Each time, point left-to-right on the page, then say the sounds in their spoken order: m-i.
+
+Wrap-up Recall.
+Write मि once from memory.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 8 seconds]
+The short-i mark is visible before म. How do you read मि?
+
+
+Lesson 5 of 7.
+ल — the last new consonant.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — one sign until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 18 seconds]
+Write the full my-name statement, then ask and answer wellbeing once. Write मि and known न. Today adds only ल (la).
+
+Script — one sign.
+ल — la.
+Keep the sign visible. Trace the open lower body before adding the headline. Say la once the hand stops.
+
+Guided Practice.
+Copy ल (la) once beside the model. Cover it, wait five seconds, and write it once.
+
+Wrap-up Recall.
+Read ल (la) once, then stop.
+Source: Unicode Devanagari chart.
+[question — say your answer, then pause 10 seconds]
+Write the Devanagari consonant sign for la.
+
+
+Lesson 6 of 7.
+पाछे मिलसू (pāchhe milsū) — assemble the two sound groups.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script — join only known units until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 20 seconds]
+Say thāro, then write हूं ठीक हूं and circle ठ. Say pāchhe | milsū, then write छे, मि, and ल (la) separately.
+
+Script — join only known units.
+पा | छे मि | ल (la) | सू पाछे मिलसू (pāchhe milsū).
+Nothing new hides in the join. Read the two groups, then write them with one space between.
+
+Guided Practice.
+Cover the romanization. Read पाछे मिलसू (pāchhe milsū), cover the line, wait ten seconds, and write it once.
+
+Wrap-up Recall.
+Point to the short-i mark and say why it appears before म on the page.
+Source: Marwari Pathshala, Lesson 2.
+[question — say your answer, then pause 20 seconds]
+From pāchhe | milsū, write the complete two-word phrase.
+
+
+Lesson 7 of 7.
+Practice — goodbye, with or without “later”.
+
+Warm-up.
+[pause 12 seconds]
+Write थ, then say राम राम सा once as the common farewell.
+
+You'll want to know.
+राम राम सा. — goodbye / farewell पाछे मिलसू (pāchhe milsū). — see you later.
+The second line explicitly points to meeting later. Other regions and relationships may choose another parting line; this payoff scores only the two source-attested choices it taught.
+
+Guided Practice.
+Listen: hear one line and identify common farewell or see-you-later.
+Speak: answer a later-meeting cue with pāchhe milsū.
+Read: match both printed lines to their meanings.
+Write: hear pāchhe milsū, wait ten seconds, and write it without a model.
+Score all four separately. A spoken line does not replace missing writing.
+
+Wrap-up Recall.
+Stop after one accurate four-skill pass.
+Sources: Marwari Pathshala, Lesson 2 and SIL International, Marwari–English Dictionary archive.
+[question — say your answer, then pause 30 seconds]
+From sound alone, write see you later, then say the common farewell aloud.

--- a/code/learning/human-languages/marwadi/session-map.md
+++ b/code/learning/human-languages/marwadi/session-map.md
@@ -53,6 +53,13 @@ memory demand at a time.
 | S45 | `MW-W06-ttha` | distinguish retroflex **ठ** from dental **थ** | observe, trace, copy one consonant |
 | S46 | `MW-C06-answer` | assemble **हूं | ठीक | हूं** | delayed copy of the answer |
 | S47 | `MW-C06-practice` | ask and answer about wellbeing in four separate skills | answer dictation plus spoken question |
+| S48 | `MW-C07-hear-later` | recognise *pāchhe milsū* as see you later | none; sound and meaning only |
+| S49 | `MW-W07-chha` | trace and write **छ** | one consonant only |
+| S50 | `MW-W07-e-matra` | attach **े** to make **छे** | one vowel mark only |
+| S51 | `MW-W07-i-matra` | write **ि** before **म** but read *mi* | one vowel mark only |
+| S52 | `MW-W07-la` | recall and write **ल** | one consonant only |
+| S53 | `MW-C07-read-later` | assemble **पाछे मिलसू** from known units | delayed phrase writing |
+| S54 | `MW-C07-practice` | distinguish goodbye from see you later in four skills | phrase dictation plus spoken farewell |
 
 Reviews use expanding spacing: repeat S7 the next day, after three days, after
 one week, and after two weeks. A failed written recall sends the learner back to

--- a/code/learning/human-languages/progress/marwadi.md
+++ b/code/learning/human-languages/progress/marwadi.md
@@ -2,8 +2,8 @@
 
 - Track: [Marwadi (Marwari)](../marwadi/README.md)
 - Family / script: Indo-Aryan / Devanagari
-- Canonical lessons: 47
-- Mapped lessons: 47
-- Book progress: 8 chapters; through Ch. 8; 8 generated
+- Canonical lessons: 54
+- Mapped lessons: 54
+- Book progress: 9 chapters; through Ch. 9; 9 generated
 
 This file is generated from canonical curriculum data. Do not edit it by hand.

--- a/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
+++ b/code/packages/typescript/human-language-data/tests/corpus/marwadi.test.ts
@@ -56,7 +56,7 @@ it("pins Marwadi's complete pre-A1 writing ramp", () => {
 it("pins Marwadi-owned chapters and objective activities", () => {
   const lessons = loadTrackLessons("marwadi");
   expect(new Set(lessons.map((lesson) => Number(lesson.frontmatter.chapter)))).toEqual(
-    new Set([1, 2, 3, 4, 5, 6, 7, 8]),
+    new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]),
   );
   expect(
     lessons
@@ -90,6 +90,9 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-C06-hear-question-meaning",
     "MW-C06-practice-wellbeing",
     "MW-C06-question-write",
+    "MW-C07-hear-later-meaning",
+    "MW-C07-practice-later",
+    "MW-C07-read-later-build",
     "MW-W01-aa-matra-change",
     "MW-W01-ra-read",
     "MW-W01-raam-build",
@@ -111,5 +114,9 @@ it("pins Marwadi-owned chapters and objective activities", () => {
     "MW-W05-virama-function",
     "MW-W06-ttha-read",
     "MW-W06-uu-matra-build",
+    "MW-W07-chha-read",
+    "MW-W07-e-matra-build",
+    "MW-W07-i-matra-order",
+    "MW-W07-la-write",
   ]);
 });


### PR DESCRIPTION
## Summary
- add seven <=5-minute Marwadi sessions for **पाछे मिलसू**: sound and meaning first, four written units, assembly, and a four-skill payoff
- reuse known **प**, **ा**, **म**, **स**, and **ू** while introducing only **छ**, **े**, **ि**, and **ल**
- contrast the new see-you-later line with already-known **राम राम सा**, both attested in the source lesson
- add learner-visible retrieval for all 15 old R2/R3 windows made measurable by the longer runway
- regenerate the standalone book, narration, modality, progress, and gentle-ramp artifacts

## Gentle-ramp evidence
- 54 total Marwadi sessions across 9 chapters
- 0 lessons over five minutes
- 0 atom-load or chapter-load spikes
- 0 unexplained script signs or decode violations
- 0 forward references
- 0 reinforcement-window misses
- 0 chapter-payoff findings
- 0 Marwadi gentle-ramp findings overall

## Sources
- [Marwari Pathshala lesson 2](https://www.marwaripathshala.com/marwari-lesson-2-english) for **राम राम सा** as a common farewell and **पाछे मिलसू** as “See you later”
- [SIL Marwari-English Dictionary](https://nepal.sil.org/resources/archives/63768) for Devanagari/Latin orthographic context

## Validation
- `npx vitest run --maxWorkers=1` — 93 files, 957 tests passed
- post-rebase focused suite — 5 files, 49 tests passed
- `npm run check:books`
- `npm run check:figures`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run check:gentle-snapshots`

Closes #12477